### PR TITLE
Import Jira ticket relationships

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -634,6 +634,14 @@ bd config set jira.type_map.feature "Story"
 bd config set jira.type_map.task "Task"
 ```
 
+Jira pull sync imports ticket relationships when the linked tickets are also
+available locally or included in the same pull result:
+
+- Jira parent/subtask hierarchy becomes `parent-child` dependencies.
+- Jira "blocks" links become `blocks` dependencies, with direction preserved.
+- Jira duplicate links become `duplicates` dependencies.
+- Other Jira issue links become `related` dependencies.
+
 ### Example: Linear Integration
 
 Linear integration provides bidirectional sync between bd and Linear via GraphQL API.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -399,6 +399,14 @@ bd config set jira.custom_fields.customfield_10042 '{"value":"AI Platform"}'
 bd config set jira.custom_fields.Story.customfield_10042 '{"value":"AI Platform"}'
 ```
 
+Jira pull sync imports ticket relationships when the linked tickets are also
+available locally or included in the same pull result:
+
+- Jira parent/subtask hierarchy becomes `parent-child` dependencies.
+- Jira "blocks" links become `blocks` dependencies, with direction preserved.
+- Jira duplicate links become `duplicates` dependencies.
+- Other Jira issue links become `related` dependencies.
+
 `jira.custom_fields.<field>` applies to every issue pushed to Jira. `jira.custom_fields.<JiraType>.<field>` applies only when the mapped Jira issue type matches `<JiraType>`; per-type fields override global fields with the same field key. Values beginning with `{` or `[` are sent as JSON (useful for select-like fields); other values are sent as strings. `jira.url`, `jira.project`/`jira.projects`, and `jira.api_token` fall back to the `JIRA_URL`, `JIRA_PROJECT`/`JIRA_PROJECTS`, and `JIRA_API_TOKEN` environment variables. See [bd jira](/cli-reference/jira).
 
 ### Linear

--- a/internal/jira/client.go
+++ b/internal/jira/client.go
@@ -35,6 +35,9 @@ type IssueFields struct {
 	Project     *ProjectField    `json:"project"`
 	Assignee    *UserField       `json:"assignee"`
 	Labels      []string         `json:"labels"`
+	Parent      *IssueRef        `json:"parent"`
+	Subtasks    []IssueRef       `json:"subtasks"`
+	IssueLinks  []IssueLinkField `json:"issuelinks"`
 	Created     string           `json:"created"`
 	Updated     string           `json:"updated"`
 	Resolution  *ResolutionField `json:"resolution"`
@@ -75,6 +78,30 @@ type UserField struct {
 type ResolutionField struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+}
+
+// IssueRef is the compact issue shape Jira embeds for parent, subtasks, and links.
+type IssueRef struct {
+	ID   string `json:"id"`
+	Key  string `json:"key"`
+	Self string `json:"self"`
+}
+
+// IssueLinkType describes the direction labels Jira stores for issue links.
+type IssueLinkType struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Inward  string `json:"inward"`
+	Outward string `json:"outward"`
+}
+
+// IssueLinkField represents a Jira issue link. Exactly one of InwardIssue or
+// OutwardIssue is normally present from the perspective of the current issue.
+type IssueLinkField struct {
+	ID           string         `json:"id"`
+	Type         *IssueLinkType `json:"type"`
+	InwardIssue  *IssueRef      `json:"inwardIssue"`
+	OutwardIssue *IssueRef      `json:"outwardIssue"`
 }
 
 // Transition represents a Jira workflow transition.
@@ -160,7 +187,7 @@ func (c *Client) FetchIssueTimestamp(ctx context.Context, jiraKey string) (time.
 }
 
 // searchFields is the default set of fields to request in search/get queries.
-const searchFields = "summary,description,status,priority,issuetype,project,assignee,labels,created,updated,resolution"
+const searchFields = "summary,description,status,priority,issuetype,project,assignee,labels,parent,subtasks,issuelinks,created,updated,resolution"
 
 // SearchIssues queries Jira using JQL and returns all matching issues, handling pagination.
 func (c *Client) SearchIssues(ctx context.Context, jql string) ([]Issue, error) {

--- a/internal/jira/fieldmapper.go
+++ b/internal/jira/fieldmapper.go
@@ -180,8 +180,11 @@ func (m *jiraFieldMapper) IssueToBeads(ti *tracker.TrackerIssue) *tracker.IssueC
 		issue.ExternalRef = &ref
 	}
 
+	deps := jiraIssueDependencies(ji)
+
 	return &tracker.IssueConversion{
-		Issue: issue,
+		Issue:        issue,
+		Dependencies: deps,
 	}
 }
 
@@ -253,4 +256,86 @@ func extractBrowseURL(ji *Issue) string {
 		return ji.Self[:idx] + "/browse/" + ji.Key
 	}
 	return ""
+}
+
+func jiraIssueDependencies(ji *Issue) []tracker.DependencyInfo {
+	if ji == nil || strings.TrimSpace(ji.Key) == "" {
+		return nil
+	}
+
+	currentKey := strings.TrimSpace(ji.Key)
+	var deps []tracker.DependencyInfo
+	seen := make(map[string]struct{})
+
+	addDep := func(from, to, depType string, source tracker.DependencySource) {
+		from = strings.TrimSpace(from)
+		to = strings.TrimSpace(to)
+		depType = strings.TrimSpace(depType)
+		if from == "" || to == "" || from == to || depType == "" {
+			return
+		}
+		key := from + "\x00" + to + "\x00" + depType
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		deps = append(deps, tracker.DependencyInfo{
+			FromExternalID: from,
+			ToExternalID:   to,
+			Type:           depType,
+			Source:         source,
+		})
+	}
+
+	if ji.Fields.Parent != nil {
+		addDep(currentKey, ji.Fields.Parent.Key, string(types.DepParentChild), tracker.DependencySourceParent)
+	}
+
+	for _, subtask := range ji.Fields.Subtasks {
+		addDep(subtask.Key, currentKey, string(types.DepParentChild), tracker.DependencySourceParent)
+	}
+
+	for _, link := range ji.Fields.IssueLinks {
+		if link.OutwardIssue != nil {
+			from, to, depType := jiraLinkDependency(currentKey, link.OutwardIssue.Key, linkPhrase(link.Type, true))
+			addDep(from, to, depType, tracker.DependencySourceRelation)
+		}
+		if link.InwardIssue != nil {
+			from, to, depType := jiraLinkDependency(currentKey, link.InwardIssue.Key, linkPhrase(link.Type, false))
+			addDep(from, to, depType, tracker.DependencySourceRelation)
+		}
+	}
+
+	return deps
+}
+
+func linkPhrase(linkType *IssueLinkType, outward bool) string {
+	if linkType == nil {
+		return ""
+	}
+	if outward {
+		return linkType.Outward
+	}
+	return linkType.Inward
+}
+
+func jiraLinkDependency(currentKey, linkedKey, phrase string) (string, string, string) {
+	normalized := strings.ToLower(strings.TrimSpace(phrase))
+	switch {
+	case normalized == "":
+		return currentKey, linkedKey, string(types.DepRelated)
+	case strings.Contains(normalized, "block"):
+		if strings.Contains(normalized, "blocked by") || strings.Contains(normalized, "is blocked") {
+			return currentKey, linkedKey, string(types.DepBlocks)
+		}
+		return linkedKey, currentKey, string(types.DepBlocks)
+	case strings.Contains(normalized, "duplicate") || strings.Contains(normalized, "clone"):
+		return currentKey, linkedKey, string(types.DepDuplicates)
+	case strings.Contains(normalized, "parent of"):
+		return linkedKey, currentKey, string(types.DepParentChild)
+	case strings.Contains(normalized, "child of") || strings.Contains(normalized, "subtask of"):
+		return currentKey, linkedKey, string(types.DepParentChild)
+	default:
+		return currentKey, linkedKey, string(types.DepRelated)
+	}
 }

--- a/internal/jira/fieldmapper.go
+++ b/internal/jira/fieldmapper.go
@@ -182,8 +182,11 @@ func (m *jiraFieldMapper) IssueToBeads(ti *tracker.TrackerIssue) *tracker.IssueC
 		issue.ExternalRef = &ref
 	}
 
+	deps := jiraIssueDependencies(ji)
+
 	return &tracker.IssueConversion{
-		Issue: issue,
+		Issue:        issue,
+		Dependencies: deps,
 	}
 }
 
@@ -270,4 +273,86 @@ func extractBrowseURL(ji *Issue) string {
 		return ji.Self[:idx] + "/browse/" + ji.Key
 	}
 	return ""
+}
+
+func jiraIssueDependencies(ji *Issue) []tracker.DependencyInfo {
+	if ji == nil || strings.TrimSpace(ji.Key) == "" {
+		return nil
+	}
+
+	currentKey := strings.TrimSpace(ji.Key)
+	var deps []tracker.DependencyInfo
+	seen := make(map[string]struct{})
+
+	addDep := func(from, to, depType string, source tracker.DependencySource) {
+		from = strings.TrimSpace(from)
+		to = strings.TrimSpace(to)
+		depType = strings.TrimSpace(depType)
+		if from == "" || to == "" || from == to || depType == "" {
+			return
+		}
+		key := from + "\x00" + to + "\x00" + depType
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		deps = append(deps, tracker.DependencyInfo{
+			FromExternalID: from,
+			ToExternalID:   to,
+			Type:           depType,
+			Source:         source,
+		})
+	}
+
+	if ji.Fields.Parent != nil {
+		addDep(currentKey, ji.Fields.Parent.Key, string(types.DepParentChild), tracker.DependencySourceParent)
+	}
+
+	for _, subtask := range ji.Fields.Subtasks {
+		addDep(subtask.Key, currentKey, string(types.DepParentChild), tracker.DependencySourceParent)
+	}
+
+	for _, link := range ji.Fields.IssueLinks {
+		if link.OutwardIssue != nil {
+			from, to, depType := jiraLinkDependency(currentKey, link.OutwardIssue.Key, linkPhrase(link.Type, true))
+			addDep(from, to, depType, tracker.DependencySourceRelation)
+		}
+		if link.InwardIssue != nil {
+			from, to, depType := jiraLinkDependency(currentKey, link.InwardIssue.Key, linkPhrase(link.Type, false))
+			addDep(from, to, depType, tracker.DependencySourceRelation)
+		}
+	}
+
+	return deps
+}
+
+func linkPhrase(linkType *IssueLinkType, outward bool) string {
+	if linkType == nil {
+		return ""
+	}
+	if outward {
+		return linkType.Outward
+	}
+	return linkType.Inward
+}
+
+func jiraLinkDependency(currentKey, linkedKey, phrase string) (string, string, string) {
+	normalized := strings.ToLower(strings.TrimSpace(phrase))
+	switch {
+	case normalized == "":
+		return currentKey, linkedKey, string(types.DepRelated)
+	case strings.Contains(normalized, "block"):
+		if strings.Contains(normalized, "blocked by") || strings.Contains(normalized, "is blocked") {
+			return currentKey, linkedKey, string(types.DepBlocks)
+		}
+		return linkedKey, currentKey, string(types.DepBlocks)
+	case strings.Contains(normalized, "duplicate") || strings.Contains(normalized, "clone"):
+		return currentKey, linkedKey, string(types.DepDuplicates)
+	case strings.Contains(normalized, "parent of"):
+		return linkedKey, currentKey, string(types.DepParentChild)
+	case strings.Contains(normalized, "child of") || strings.Contains(normalized, "subtask of"):
+		return currentKey, linkedKey, string(types.DepParentChild)
+	default:
+		return currentKey, linkedKey, string(types.DepRelated)
+	}
 }

--- a/internal/jira/tracker.go
+++ b/internal/jira/tracker.go
@@ -331,6 +331,12 @@ func jiraToTrackerIssue(ji *Issue, priorityMap map[string]string) tracker.Tracke
 		ti.Type = ji.Fields.IssueType.Name
 	}
 
+	// Parent relationship
+	if ji.Fields.Parent != nil {
+		ti.ParentID = ji.Fields.Parent.Key
+		ti.ParentInternalID = ji.Fields.Parent.ID
+	}
+
 	// Assignee
 	if ji.Fields.Assignee != nil {
 		ti.Assignee = ji.Fields.Assignee.DisplayName

--- a/internal/jira/tracker.go
+++ b/internal/jira/tracker.go
@@ -411,6 +411,12 @@ func jiraToTrackerIssue(ji *Issue, priorityMap map[string]string) tracker.Tracke
 		ti.Type = ji.Fields.IssueType.Name
 	}
 
+	// Parent relationship
+	if ji.Fields.Parent != nil {
+		ti.ParentID = ji.Fields.Parent.Key
+		ti.ParentInternalID = ji.Fields.Parent.ID
+	}
+
 	// Assignee
 	if ji.Fields.Assignee != nil {
 		ti.Assignee = ji.Fields.Assignee.DisplayName

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -117,6 +117,9 @@ func TestJiraToTrackerIssue(t *testing.T) {
 	if ti.AssigneeEmail != "alice@example.com" {
 		t.Errorf("AssigneeEmail = %q, want %q", ti.AssigneeEmail, "alice@example.com")
 	}
+	if ti.ParentID != "" {
+		t.Errorf("ParentID = %q, want empty", ti.ParentID)
+	}
 	if ti.CreatedAt.IsZero() {
 		t.Error("CreatedAt should not be zero")
 	}
@@ -235,6 +238,81 @@ func TestFieldMapperIssueToBeads(t *testing.T) {
 	}
 }
 
+func TestFieldMapperIssueToBeadsParentChildDependencies(t *testing.T) {
+	ji := &Issue{
+		ID:   "10001",
+		Key:  "PROJ-42",
+		Self: "https://company.atlassian.net/rest/api/3/issue/10001",
+		Fields: IssueFields{
+			Summary:   "Child issue",
+			IssueType: &IssueTypeField{Name: "Task"},
+			Parent:    &IssueRef{ID: "10000", Key: "PROJ-1"},
+			Subtasks: []IssueRef{
+				{ID: "10002", Key: "PROJ-43"},
+				{ID: "10003", Key: "PROJ-44"},
+			},
+		},
+	}
+
+	ti := jiraToTrackerIssue(ji, nil)
+	if ti.ParentID != "PROJ-1" {
+		t.Errorf("ParentID = %q, want %q", ti.ParentID, "PROJ-1")
+	}
+	if ti.ParentInternalID != "10000" {
+		t.Errorf("ParentInternalID = %q, want %q", ti.ParentInternalID, "10000")
+	}
+
+	conv := (&jiraFieldMapper{}).IssueToBeads(&ti)
+	if conv == nil {
+		t.Fatal("IssueToBeads returned nil")
+	}
+
+	assertDependency(t, conv.Dependencies, "PROJ-42", "PROJ-1", string(types.DepParentChild), tracker.DependencySourceParent)
+	assertDependency(t, conv.Dependencies, "PROJ-43", "PROJ-42", string(types.DepParentChild), tracker.DependencySourceParent)
+	assertDependency(t, conv.Dependencies, "PROJ-44", "PROJ-42", string(types.DepParentChild), tracker.DependencySourceParent)
+}
+
+func TestFieldMapperIssueToBeadsIssueLinkDependencies(t *testing.T) {
+	ji := &Issue{
+		ID:   "10001",
+		Key:  "PROJ-42",
+		Self: "https://company.atlassian.net/rest/api/3/issue/10001",
+		Fields: IssueFields{
+			Summary:   "Linked issue",
+			IssueType: &IssueTypeField{Name: "Task"},
+			IssueLinks: []IssueLinkField{
+				{
+					Type:         &IssueLinkType{Name: "Blocks", Outward: "blocks", Inward: "is blocked by"},
+					OutwardIssue: &IssueRef{ID: "10002", Key: "PROJ-43"},
+				},
+				{
+					Type:        &IssueLinkType{Name: "Blocks", Outward: "blocks", Inward: "is blocked by"},
+					InwardIssue: &IssueRef{ID: "10003", Key: "PROJ-44"},
+				},
+				{
+					Type:         &IssueLinkType{Name: "Relates", Outward: "relates to", Inward: "relates to"},
+					OutwardIssue: &IssueRef{ID: "10004", Key: "PROJ-45"},
+				},
+				{
+					Type:         &IssueLinkType{Name: "Duplicate", Outward: "duplicates", Inward: "is duplicated by"},
+					OutwardIssue: &IssueRef{ID: "10005", Key: "PROJ-46"},
+				},
+			},
+		},
+	}
+
+	ti := jiraToTrackerIssue(ji, nil)
+	conv := (&jiraFieldMapper{}).IssueToBeads(&ti)
+	if conv == nil {
+		t.Fatal("IssueToBeads returned nil")
+	}
+
+	assertDependency(t, conv.Dependencies, "PROJ-43", "PROJ-42", string(types.DepBlocks), tracker.DependencySourceRelation)
+	assertDependency(t, conv.Dependencies, "PROJ-42", "PROJ-44", string(types.DepBlocks), tracker.DependencySourceRelation)
+	assertDependency(t, conv.Dependencies, "PROJ-42", "PROJ-45", string(types.DepRelated), tracker.DependencySourceRelation)
+	assertDependency(t, conv.Dependencies, "PROJ-42", "PROJ-46", string(types.DepDuplicates), tracker.DependencySourceRelation)
+}
+
 func TestFieldMapperIssueToTracker(t *testing.T) {
 	mapper := &jiraFieldMapper{}
 
@@ -316,6 +394,14 @@ func TestTrackerFieldMapperPropagatesVersion(t *testing.T) {
 	mapper := tr.FieldMapper().(*jiraFieldMapper)
 	if mapper.apiVersion != "2" {
 		t.Errorf("FieldMapper apiVersion = %q, want %q", mapper.apiVersion, "2")
+	}
+}
+
+func TestSearchFieldsIncludesRelationshipFields(t *testing.T) {
+	for _, field := range []string{"parent", "subtasks", "issuelinks"} {
+		if !strings.Contains(searchFields, field) {
+			t.Errorf("searchFields missing %q: %s", field, searchFields)
+		}
 	}
 }
 
@@ -893,4 +979,14 @@ func TestPriorityMapCaseInsensitiveMatch(t *testing.T) {
 			t.Errorf("PriorityToBeads(%q) = %d, want %d", tt.name, got, tt.want)
 		}
 	}
+}
+
+func assertDependency(t *testing.T, deps []tracker.DependencyInfo, from, to, depType string, source tracker.DependencySource) {
+	t.Helper()
+	for _, dep := range deps {
+		if dep.FromExternalID == from && dep.ToExternalID == to && dep.Type == depType && dep.Source == source {
+			return
+		}
+	}
+	t.Fatalf("dependency %s -> %s type %s source %s not found in %#v", from, to, depType, source, deps)
 }

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -121,6 +121,9 @@ func TestJiraToTrackerIssue(t *testing.T) {
 	if ti.AssigneeEmail != "alice@example.com" {
 		t.Errorf("AssigneeEmail = %q, want %q", ti.AssigneeEmail, "alice@example.com")
 	}
+	if ti.ParentID != "" {
+		t.Errorf("ParentID = %q, want empty", ti.ParentID)
+	}
 	if ti.CreatedAt.IsZero() {
 		t.Error("CreatedAt should not be zero")
 	}
@@ -237,6 +240,81 @@ func TestFieldMapperIssueToBeads(t *testing.T) {
 	if conv.Issue.Owner != "Bob" {
 		t.Errorf("Owner = %q, want %q", conv.Issue.Owner, "Bob")
 	}
+}
+
+func TestFieldMapperIssueToBeadsParentChildDependencies(t *testing.T) {
+	ji := &Issue{
+		ID:   "10001",
+		Key:  "PROJ-42",
+		Self: "https://company.atlassian.net/rest/api/3/issue/10001",
+		Fields: IssueFields{
+			Summary:   "Child issue",
+			IssueType: &IssueTypeField{Name: "Task"},
+			Parent:    &IssueRef{ID: "10000", Key: "PROJ-1"},
+			Subtasks: []IssueRef{
+				{ID: "10002", Key: "PROJ-43"},
+				{ID: "10003", Key: "PROJ-44"},
+			},
+		},
+	}
+
+	ti := jiraToTrackerIssue(ji, nil)
+	if ti.ParentID != "PROJ-1" {
+		t.Errorf("ParentID = %q, want %q", ti.ParentID, "PROJ-1")
+	}
+	if ti.ParentInternalID != "10000" {
+		t.Errorf("ParentInternalID = %q, want %q", ti.ParentInternalID, "10000")
+	}
+
+	conv := (&jiraFieldMapper{}).IssueToBeads(&ti)
+	if conv == nil {
+		t.Fatal("IssueToBeads returned nil")
+	}
+
+	assertDependency(t, conv.Dependencies, "PROJ-42", "PROJ-1", string(types.DepParentChild), tracker.DependencySourceParent)
+	assertDependency(t, conv.Dependencies, "PROJ-43", "PROJ-42", string(types.DepParentChild), tracker.DependencySourceParent)
+	assertDependency(t, conv.Dependencies, "PROJ-44", "PROJ-42", string(types.DepParentChild), tracker.DependencySourceParent)
+}
+
+func TestFieldMapperIssueToBeadsIssueLinkDependencies(t *testing.T) {
+	ji := &Issue{
+		ID:   "10001",
+		Key:  "PROJ-42",
+		Self: "https://company.atlassian.net/rest/api/3/issue/10001",
+		Fields: IssueFields{
+			Summary:   "Linked issue",
+			IssueType: &IssueTypeField{Name: "Task"},
+			IssueLinks: []IssueLinkField{
+				{
+					Type:         &IssueLinkType{Name: "Blocks", Outward: "blocks", Inward: "is blocked by"},
+					OutwardIssue: &IssueRef{ID: "10002", Key: "PROJ-43"},
+				},
+				{
+					Type:        &IssueLinkType{Name: "Blocks", Outward: "blocks", Inward: "is blocked by"},
+					InwardIssue: &IssueRef{ID: "10003", Key: "PROJ-44"},
+				},
+				{
+					Type:         &IssueLinkType{Name: "Relates", Outward: "relates to", Inward: "relates to"},
+					OutwardIssue: &IssueRef{ID: "10004", Key: "PROJ-45"},
+				},
+				{
+					Type:         &IssueLinkType{Name: "Duplicate", Outward: "duplicates", Inward: "is duplicated by"},
+					OutwardIssue: &IssueRef{ID: "10005", Key: "PROJ-46"},
+				},
+			},
+		},
+	}
+
+	ti := jiraToTrackerIssue(ji, nil)
+	conv := (&jiraFieldMapper{}).IssueToBeads(&ti)
+	if conv == nil {
+		t.Fatal("IssueToBeads returned nil")
+	}
+
+	assertDependency(t, conv.Dependencies, "PROJ-43", "PROJ-42", string(types.DepBlocks), tracker.DependencySourceRelation)
+	assertDependency(t, conv.Dependencies, "PROJ-42", "PROJ-44", string(types.DepBlocks), tracker.DependencySourceRelation)
+	assertDependency(t, conv.Dependencies, "PROJ-42", "PROJ-45", string(types.DepRelated), tracker.DependencySourceRelation)
+	assertDependency(t, conv.Dependencies, "PROJ-42", "PROJ-46", string(types.DepDuplicates), tracker.DependencySourceRelation)
 }
 
 func TestFieldMapperIssueToTracker(t *testing.T) {
@@ -423,6 +501,14 @@ func TestTrackerFieldMapperPropagatesVersion(t *testing.T) {
 	mapper := tr.FieldMapper().(*jiraFieldMapper)
 	if mapper.apiVersion != "2" {
 		t.Errorf("FieldMapper apiVersion = %q, want %q", mapper.apiVersion, "2")
+	}
+}
+
+func TestSearchFieldsIncludesRelationshipFields(t *testing.T) {
+	for _, field := range []string{"parent", "subtasks", "issuelinks"} {
+		if !strings.Contains(searchFields, field) {
+			t.Errorf("searchFields missing %q: %s", field, searchFields)
+		}
 	}
 }
 
@@ -1354,4 +1440,14 @@ func TestGetConfig_YamlOnlyKeyReadsFromYaml(t *testing.T) {
 	if got != wantToken {
 		t.Errorf("getConfig(jira.api_token) = %q, want %q (yaml value)", got, wantToken)
 	}
+}
+
+func assertDependency(t *testing.T, deps []tracker.DependencyInfo, from, to, depType string, source tracker.DependencySource) {
+	t.Helper()
+	for _, dep := range deps {
+		if dep.FromExternalID == from && dep.ToExternalID == to && dep.Type == depType && dep.Source == source {
+			return
+		}
+	}
+	t.Fatalf("dependency %s -> %s type %s source %s not found in %#v", from, to, depType, source, deps)
 }


### PR DESCRIPTION
## Summary
- request Jira relationship fields during pull sync
- map Jira parent/subtask hierarchy into parent-child dependencies
- map Jira issue links into blocks, duplicates, or related dependencies
- document the imported relationship behavior

## Rebase notes
- rebased onto current `main`
- moved relationship documentation from the retired `docs/CONFIG.md` page to `docs/reference/configuration.md`
- preserved the contributor relationship tests alongside newer Jira configuration tests

## Validation
- `go test ./internal/jira ./internal/tracker`
- `CGO_ENABLED=1 go test -tags gms_pure_go ./internal/jira ./internal/tracker`
- `make test` (39.0% aggregate coverage)
- `golangci-lint run ./...` (0 issues)
