### PR TITLE
feat(linear): persistent sync audit log with history CLI and rollback

### DIFF
--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"regexp"
@@ -9,11 +10,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/linear"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/tracker"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -354,7 +357,12 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 	}
 
 	// Run sync
+	syncStarted := time.Now().UTC()
 	result, err := engine.Sync(ctx, opts)
+
+	// Record sync history (best-effort, do not fail the sync on history write errors).
+	recordSyncHistory(ctx, syncStarted, opts, result, err)
+
 	if err != nil {
 		if jsonOutput {
 			outputJSON(result)
@@ -662,6 +670,59 @@ func runLinearTeams(cmd *cobra.Command, args []string) {
 	fmt.Println("To configure:")
 	fmt.Println("  bd config set linear.team_id \"<ID>\"")
 	fmt.Println("  bd config set linear.team_ids \"<ID1>,<ID2>\"  # multiple teams")
+}
+
+// recordSyncHistory persists the sync result to the linear_sync_history tables.
+// Best-effort: errors are logged to stderr but do not fail the sync operation.
+func recordSyncHistory(ctx context.Context, started time.Time, opts tracker.SyncOptions, result *tracker.SyncResult, syncErr error) {
+	rawDB := getSyncHistoryDB()
+	if rawDB == nil {
+		return
+	}
+
+	direction := syncDirection(opts)
+	conflictRes := string(opts.ConflictResolution)
+	runID := uuid.New().String()
+
+	run := linear.BuildSyncRunFromResult(runID, started, direction, opts.DryRun, conflictRes, result)
+	if syncErr != nil && (result == nil || result.Error == "") {
+		run.ErrorMessage = syncErr.Error()
+	}
+
+	var items []linear.SyncItem
+	if result != nil {
+		items = linear.BuildSyncItemsFromResult(result)
+	}
+
+	histDB := linear.NewSyncHistoryDB(rawDB)
+	if err := histDB.RecordSyncRun(ctx, run, items); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to record sync history: %v\n", err)
+	}
+}
+
+func syncDirection(opts tracker.SyncOptions) string {
+	switch {
+	case opts.Pull && opts.Push:
+		return "both"
+	case opts.Pull:
+		return "pull"
+	case opts.Push:
+		return "push"
+	default:
+		return "both"
+	}
+}
+
+// getSyncHistoryDB returns a *sql.DB for writing sync history, or nil if unavailable.
+func getSyncHistoryDB() *sql.DB {
+	if store == nil {
+		return nil
+	}
+	unwrapped := storage.UnwrapStore(store)
+	if accessor, ok := unwrapped.(storage.RawDBAccessor); ok {
+		return accessor.UnderlyingDB()
+	}
+	return nil
 }
 
 // resolveBeadsDirForStaleness returns the active beads directory for

--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
@@ -368,7 +370,12 @@ func runLinearSync(cmd *cobra.Command, args []string) error {
 		opts.ConflictResolution = tracker.ConflictTimestamp
 	}
 
+	syncStarted := time.Now().UTC()
 	result, err := engine.Sync(ctx, opts)
+
+	// Record sync history (best-effort, do not fail the sync on history write errors).
+	recordSyncHistory(ctx, syncStarted, opts, result, err)
+
 	if err != nil {
 		if jsonOutput {
 			if jerr := outputJSON(result); jerr != nil {
@@ -912,6 +919,59 @@ func runLinearTeams(cmd *cobra.Command, args []string) error {
 	fmt.Println("To configure:")
 	fmt.Println("  bd config set linear.team_id \"<ID>\"")
 	fmt.Println("  bd config set linear.team_ids \"<ID1>,<ID2>\"  # multiple teams")
+	return nil
+}
+
+// recordSyncHistory persists the sync result to the linear_sync_history tables.
+// Best-effort: errors are logged to stderr but do not fail the sync operation.
+func recordSyncHistory(ctx context.Context, started time.Time, opts tracker.SyncOptions, result *tracker.SyncResult, syncErr error) {
+	rawDB := getSyncHistoryDB()
+	if rawDB == nil {
+		return
+	}
+
+	direction := syncDirection(opts)
+	conflictRes := string(opts.ConflictResolution)
+	runID := uuid.New().String()
+
+	run := linear.BuildSyncRunFromResult(runID, started, direction, opts.DryRun, conflictRes, result)
+	if syncErr != nil && (result == nil || result.Error == "") {
+		run.ErrorMessage = syncErr.Error()
+	}
+
+	var items []linear.SyncItem
+	if result != nil {
+		items = linear.BuildSyncItemsFromResult(result)
+	}
+
+	histDB := linear.NewSyncHistoryDB(rawDB)
+	if err := histDB.RecordSyncRun(ctx, run, items); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to record sync history: %v\n", err)
+	}
+}
+
+func syncDirection(opts tracker.SyncOptions) string {
+	switch {
+	case opts.Pull && opts.Push:
+		return "both"
+	case opts.Pull:
+		return "pull"
+	case opts.Push:
+		return "push"
+	default:
+		return "both"
+	}
+}
+
+// getSyncHistoryDB returns a *sql.DB for writing sync history, or nil if unavailable.
+func getSyncHistoryDB() *sql.DB {
+	if store == nil {
+		return nil
+	}
+	unwrapped := storage.UnwrapStore(store)
+	if accessor, ok := unwrapped.(storage.RawDBAccessor); ok {
+		return accessor.UnderlyingDB()
+	}
 	return nil
 }
 

--- a/cmd/bd/linear_history.go
+++ b/cmd/bd/linear_history.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/linear"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+var linearHistoryCmd = &cobra.Command{
+	Use:   "history",
+	Short: "Show Linear sync history",
+	Long: `Show the history of Linear sync operations.
+
+By default, shows the most recent sync runs in summary form.
+
+Flags:
+  --since DATE      Show sync runs since DATE (YYYY-MM-DD or RFC3339)
+  --detail ID       Show per-issue outcomes for a specific sync run
+  --rollback ID     Generate a rollback script for a specific sync run
+  --limit N         Limit the number of runs shown (default 20)
+
+Examples:
+  bd linear history                           # Recent sync runs
+  bd linear history --since=2026-05-01        # Runs since May 1st
+  bd linear history --detail <run-id>         # Per-issue detail for a run
+  bd linear history --rollback <run-id>       # Generate rollback script
+  bd linear history --since=2026-05-01 --json # JSON output`,
+	Run: runLinearHistory,
+}
+
+func init() {
+	linearHistoryCmd.Flags().String("since", "", "Show sync runs since this date (YYYY-MM-DD or RFC3339)")
+	linearHistoryCmd.Flags().String("detail", "", "Show per-issue outcomes for this sync run ID")
+	linearHistoryCmd.Flags().String("rollback", "", "Generate a rollback script for this sync run ID")
+	linearHistoryCmd.Flags().Int("limit", 20, "Maximum number of sync runs to show")
+	linearCmd.AddCommand(linearHistoryCmd)
+}
+
+func runLinearHistory(cmd *cobra.Command, args []string) {
+	sinceStr, _ := cmd.Flags().GetString("since")
+	detailRunID, _ := cmd.Flags().GetString("detail")
+	rollbackRunID, _ := cmd.Flags().GetString("rollback")
+	limit, _ := cmd.Flags().GetInt("limit")
+
+	ctx := rootCtx
+
+	rawDB := getSyncHistoryDB()
+	if rawDB == nil {
+		FatalError("database not available for sync history")
+	}
+
+	histDB := linear.NewSyncHistoryDB(rawDB)
+
+	if rollbackRunID != "" {
+		showRollback(ctx, histDB, rollbackRunID)
+		return
+	}
+
+	if detailRunID != "" {
+		showRunDetail(ctx, histDB, detailRunID)
+		return
+	}
+
+	var since *time.Time
+	if sinceStr != "" {
+		t, err := parseDateArg(sinceStr)
+		if err != nil {
+			FatalError("invalid --since value %q: %v", sinceStr, err)
+		}
+		since = &t
+	}
+
+	runs, err := histDB.ListSyncRuns(ctx, since, limit)
+	if err != nil {
+		FatalError("querying sync history: %v", err)
+	}
+
+	if len(runs) == 0 {
+		if jsonOutput {
+			outputJSON([]interface{}{})
+		} else {
+			fmt.Println("No sync history found.")
+			if sinceStr != "" {
+				fmt.Printf("Try a broader --since range or omit --since to see all runs.\n")
+			}
+		}
+		return
+	}
+
+	if jsonOutput {
+		outputJSON(runs)
+		return
+	}
+
+	fmt.Printf("\n%s Linear Sync History (%d runs)\n\n", ui.RenderAccent("📋"), len(runs))
+	fmt.Printf("%-36s  %-19s  %-6s  %5s  %5s  %5s  %5s  %s\n",
+		"Run ID", "Started", "Dir", "New", "Upd", "Skip", "Fail", "Error")
+	fmt.Println(strings.Repeat("─", 110))
+
+	for _, run := range runs {
+		errIndicator := ""
+		if run.ErrorMessage != "" {
+			errIndicator = truncateHistStr(run.ErrorMessage, 30)
+		}
+		dryTag := ""
+		if run.DryRun {
+			dryTag = " (dry)"
+		}
+		fmt.Printf("%-36s  %-19s  %-6s  %5d  %5d  %5d  %5d  %s\n",
+			run.SyncRunID,
+			run.StartedAt.Format("2006-01-02 15:04:05"),
+			run.Direction+dryTag,
+			run.IssuesCreated, run.IssuesUpdated, run.IssuesSkipped, run.IssuesFailed,
+			errIndicator)
+	}
+	fmt.Printf("\nUse 'bd linear history --detail <run-id>' for per-issue details.\n\n")
+}
+
+func showRunDetail(ctx context.Context, histDB *linear.SyncHistoryDB, runID string) {
+	run, err := histDB.GetSyncRun(ctx, runID)
+	if err != nil {
+		FatalError("fetching sync run: %v", err)
+	}
+	if run == nil {
+		FatalError("sync run %s not found", runID)
+	}
+
+	items, err := histDB.GetSyncRunItems(ctx, runID)
+	if err != nil {
+		FatalError("fetching sync items: %v", err)
+	}
+
+	if jsonOutput {
+		outputJSON(map[string]interface{}{
+			"run":   run,
+			"items": items,
+		})
+		return
+	}
+
+	fmt.Printf("\n%s Sync Run Detail\n\n", ui.RenderAccent("🔍"))
+	fmt.Printf("  Run ID:     %s\n", run.SyncRunID)
+	fmt.Printf("  Started:    %s\n", run.StartedAt.Format(time.RFC3339))
+	fmt.Printf("  Completed:  %s\n", run.CompletedAt.Format(time.RFC3339))
+	dur := run.CompletedAt.Sub(run.StartedAt)
+	fmt.Printf("  Duration:   %s\n", dur.Truncate(time.Millisecond))
+	fmt.Printf("  Direction:  %s\n", run.Direction)
+	if run.DryRun {
+		fmt.Printf("  Dry Run:    yes\n")
+	}
+	if run.ConflictResolution != "" {
+		fmt.Printf("  Conflicts:  %s\n", run.ConflictResolution)
+	}
+	fmt.Printf("  Created:    %d\n", run.IssuesCreated)
+	fmt.Printf("  Updated:    %d\n", run.IssuesUpdated)
+	fmt.Printf("  Skipped:    %d\n", run.IssuesSkipped)
+	fmt.Printf("  Failed:     %d\n", run.IssuesFailed)
+	if run.ErrorMessage != "" {
+		fmt.Printf("  Error:      %s\n", run.ErrorMessage)
+	}
+
+	if len(items) == 0 {
+		fmt.Printf("\n  No per-issue items recorded.\n\n")
+		return
+	}
+
+	fmt.Printf("\n  Per-Issue Outcomes (%d items):\n\n", len(items))
+	fmt.Printf("  %-20s  %-20s  %-6s  %-10s  %8s  %s\n",
+		"Bead ID", "Linear ID", "Dir", "Outcome", "Duration", "Error")
+	fmt.Println("  " + strings.Repeat("─", 90))
+
+	for _, item := range items {
+		durStr := ""
+		if item.DurationMs > 0 {
+			durStr = fmt.Sprintf("%dms", item.DurationMs)
+		}
+		errStr := ""
+		if item.ErrorMessage != "" {
+			errStr = truncateHistStr(item.ErrorMessage, 30)
+		}
+		fmt.Printf("  %-20s  %-20s  %-6s  %-10s  %8s  %s\n",
+			truncateHistStr(item.BeadID, 20),
+			truncateHistStr(item.LinearID, 20),
+			item.Direction, item.Outcome, durStr, errStr)
+
+		if len(item.BeforeValues) > 0 || len(item.AfterValues) > 0 {
+			renderFieldDiff(item.BeforeValues, item.AfterValues)
+		}
+	}
+	fmt.Println()
+}
+
+func renderFieldDiff(before, after map[string]string) {
+	allKeys := make(map[string]bool)
+	for k := range before {
+		allKeys[k] = true
+	}
+	for k := range after {
+		allKeys[k] = true
+	}
+	for k := range allKeys {
+		bv := before[k]
+		av := after[k]
+		if bv != av {
+			fmt.Printf("    %s: %q → %q\n", k, truncateHistStr(bv, 50), truncateHistStr(av, 50))
+		}
+	}
+}
+
+func truncateHistStr(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-1] + "…"
+}
+
+func showRollback(ctx context.Context, histDB *linear.SyncHistoryDB, runID string) {
+	mutations, err := linear.GenerateRollbackMutations(ctx, histDB, runID)
+	if err != nil {
+		FatalError("generating rollback: %v", err)
+	}
+
+	if jsonOutput {
+		outputJSON(mutations)
+		return
+	}
+
+	fmt.Print(linear.RollbackScript(mutations))
+}
+
+func parseDateArg(s string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse("2006-01-02T15:04:05", s); err == nil {
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("expected YYYY-MM-DD or RFC3339 format, got %q", s)
+}
+

--- a/cmd/bd/linear_history.go
+++ b/cmd/bd/linear_history.go
@@ -245,4 +245,3 @@ func parseDateArg(s string) (time.Time, error) {
 	}
 	return time.Time{}, fmt.Errorf("expected YYYY-MM-DD or RFC3339 format, got %q", s)
 }
-

--- a/internal/linear/history.go
+++ b/internal/linear/history.go
@@ -1,0 +1,274 @@
+package linear
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/steveyegge/beads/internal/tracker"
+)
+
+// SyncRun represents a single sync invocation persisted to linear_sync_runs.
+type SyncRun struct {
+	SyncRunID          string    `json:"sync_run_id"`
+	StartedAt          time.Time `json:"started_at"`
+	CompletedAt        time.Time `json:"completed_at"`
+	Direction          string    `json:"direction"`
+	DryRun             bool      `json:"dry_run"`
+	IssuesCreated      int       `json:"issues_created"`
+	IssuesUpdated      int       `json:"issues_updated"`
+	IssuesSkipped      int       `json:"issues_skipped"`
+	IssuesFailed       int       `json:"issues_failed"`
+	IssuesArchived     int       `json:"issues_archived"`
+	ConflictResolution string    `json:"conflict_resolution,omitempty"`
+	ErrorMessage       string    `json:"error_message,omitempty"`
+}
+
+// SyncItem represents a per-issue outcome row in linear_sync_items.
+type SyncItem struct {
+	ID            string            `json:"id"`
+	SyncRunID     string            `json:"sync_run_id"`
+	BeadID        string            `json:"bead_id"`
+	LinearID      string            `json:"linear_id"`
+	Direction     string            `json:"direction"`
+	AttemptNumber int               `json:"attempt_number"`
+	Outcome       string            `json:"outcome"`
+	StatusCode    int               `json:"status_code"`
+	DurationMs    int64             `json:"duration_ms"`
+	BeforeValues  map[string]string `json:"before_values,omitempty"`
+	AfterValues   map[string]string `json:"after_values,omitempty"`
+	ErrorMessage  string            `json:"error_message,omitempty"`
+}
+
+// SyncHistoryDB provides read/write access to the linear_sync_history tables.
+// Requires a *sql.DB because it uses Dolt-specific SQL outside the Storage interface.
+type SyncHistoryDB struct {
+	db *sql.DB
+}
+
+// NewSyncHistoryDB creates a SyncHistoryDB from a raw database connection.
+func NewSyncHistoryDB(db *sql.DB) *SyncHistoryDB {
+	return &SyncHistoryDB{db: db}
+}
+
+// RecordSyncRun writes a complete sync result (run + items) to the history tables.
+func (h *SyncHistoryDB) RecordSyncRun(ctx context.Context, run *SyncRun, items []SyncItem) error {
+	tx, err := h.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO linear_sync_runs (sync_run_id, started_at, completed_at, direction, dry_run,
+			issues_created, issues_updated, issues_skipped, issues_failed, issues_archived,
+			conflict_resolution, error_message)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		run.SyncRunID, run.StartedAt, run.CompletedAt, run.Direction, run.DryRun,
+		run.IssuesCreated, run.IssuesUpdated, run.IssuesSkipped, run.IssuesFailed, run.IssuesArchived,
+		run.ConflictResolution, run.ErrorMessage,
+	)
+	if err != nil {
+		return fmt.Errorf("insert sync run: %w", err)
+	}
+
+	if len(items) > 0 {
+		stmt, err := tx.PrepareContext(ctx,
+			`INSERT INTO linear_sync_items (sync_run_id, bead_id, linear_id, direction,
+				attempt_number, outcome, status_code, duration_ms,
+				before_values, after_values, error_message)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		if err != nil {
+			return fmt.Errorf("prepare item insert: %w", err)
+		}
+		defer stmt.Close()
+
+		for _, item := range items {
+			beforeJSON, _ := marshalFieldValues(item.BeforeValues)
+			afterJSON, _ := marshalFieldValues(item.AfterValues)
+
+			_, err := stmt.ExecContext(ctx,
+				run.SyncRunID, item.BeadID, item.LinearID, item.Direction,
+				item.AttemptNumber, item.Outcome, item.StatusCode, item.DurationMs,
+				beforeJSON, afterJSON, item.ErrorMessage,
+			)
+			if err != nil {
+				return fmt.Errorf("insert sync item for bead %s: %w", item.BeadID, err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sync history: %w", err)
+	}
+	return nil
+}
+
+// ListSyncRuns returns sync runs matching the filter criteria.
+func (h *SyncHistoryDB) ListSyncRuns(ctx context.Context, since *time.Time, limit int) ([]SyncRun, error) {
+	query := `SELECT sync_run_id, started_at, completed_at, direction, dry_run,
+		issues_created, issues_updated, issues_skipped, issues_failed, issues_archived,
+		conflict_resolution, error_message
+		FROM linear_sync_runs`
+	var args []interface{}
+	if since != nil {
+		query += " WHERE started_at >= ?"
+		args = append(args, *since)
+	}
+	query += " ORDER BY started_at DESC"
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+
+	rows, err := h.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query sync runs: %w", err)
+	}
+	defer rows.Close()
+
+	var runs []SyncRun
+	for rows.Next() {
+		var r SyncRun
+		if err := rows.Scan(&r.SyncRunID, &r.StartedAt, &r.CompletedAt, &r.Direction, &r.DryRun,
+			&r.IssuesCreated, &r.IssuesUpdated, &r.IssuesSkipped, &r.IssuesFailed, &r.IssuesArchived,
+			&r.ConflictResolution, &r.ErrorMessage); err != nil {
+			return nil, fmt.Errorf("scan sync run: %w", err)
+		}
+		runs = append(runs, r)
+	}
+	return runs, rows.Err()
+}
+
+// GetSyncRunItems returns per-issue outcomes for a given sync run.
+func (h *SyncHistoryDB) GetSyncRunItems(ctx context.Context, syncRunID string) ([]SyncItem, error) {
+	rows, err := h.db.QueryContext(ctx,
+		`SELECT id, sync_run_id, bead_id, linear_id, direction,
+			attempt_number, outcome, status_code, duration_ms,
+			before_values, after_values, error_message
+		FROM linear_sync_items
+		WHERE sync_run_id = ?
+		ORDER BY bead_id`, syncRunID)
+	if err != nil {
+		return nil, fmt.Errorf("query sync items: %w", err)
+	}
+	defer rows.Close()
+
+	var items []SyncItem
+	for rows.Next() {
+		var item SyncItem
+		var beforeJSON, afterJSON sql.NullString
+		if err := rows.Scan(&item.ID, &item.SyncRunID, &item.BeadID, &item.LinearID,
+			&item.Direction, &item.AttemptNumber, &item.Outcome, &item.StatusCode,
+			&item.DurationMs, &beforeJSON, &afterJSON, &item.ErrorMessage); err != nil {
+			return nil, fmt.Errorf("scan sync item: %w", err)
+		}
+		if beforeJSON.Valid {
+			item.BeforeValues = unmarshalFieldValues(beforeJSON.String)
+		}
+		if afterJSON.Valid {
+			item.AfterValues = unmarshalFieldValues(afterJSON.String)
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+// GetSyncRun returns a single sync run by ID.
+func (h *SyncHistoryDB) GetSyncRun(ctx context.Context, syncRunID string) (*SyncRun, error) {
+	var r SyncRun
+	err := h.db.QueryRowContext(ctx,
+		`SELECT sync_run_id, started_at, completed_at, direction, dry_run,
+			issues_created, issues_updated, issues_skipped, issues_failed, issues_archived,
+			conflict_resolution, error_message
+		FROM linear_sync_runs WHERE sync_run_id = ?`, syncRunID).
+		Scan(&r.SyncRunID, &r.StartedAt, &r.CompletedAt, &r.Direction, &r.DryRun,
+			&r.IssuesCreated, &r.IssuesUpdated, &r.IssuesSkipped, &r.IssuesFailed, &r.IssuesArchived,
+			&r.ConflictResolution, &r.ErrorMessage)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get sync run %s: %w", syncRunID, err)
+	}
+	return &r, nil
+}
+
+// BuildSyncRunFromResult creates a SyncRun from a tracker.SyncResult plus
+// additional metadata collected during the sync invocation.
+func BuildSyncRunFromResult(runID string, started time.Time, direction string, dryRun bool,
+	conflictRes string, result *tracker.SyncResult) *SyncRun {
+	run := &SyncRun{
+		SyncRunID:          runID,
+		StartedAt:          started,
+		CompletedAt:        time.Now().UTC(),
+		Direction:          direction,
+		DryRun:             dryRun,
+		ConflictResolution: conflictRes,
+	}
+	if result != nil {
+		run.IssuesCreated = result.Stats.Created
+		run.IssuesUpdated = result.Stats.Updated
+		run.IssuesSkipped = result.Stats.Skipped
+		run.IssuesFailed = result.Stats.Errors
+		if result.Error != "" {
+			run.ErrorMessage = result.Error
+		}
+	}
+	return run
+}
+
+// BuildSyncItemsFromResult extracts per-issue SyncItem records from a SyncResult.
+func BuildSyncItemsFromResult(result *tracker.SyncResult) []SyncItem {
+	if result == nil {
+		return nil
+	}
+	var items []SyncItem
+
+	for _, detail := range result.PullStats.Items {
+		items = append(items, syncItemFromDetail(detail))
+	}
+	for _, detail := range result.PushStats.Items {
+		items = append(items, syncItemFromDetail(detail))
+	}
+	return items
+}
+
+func syncItemFromDetail(d tracker.SyncItemDetail) SyncItem {
+	return SyncItem{
+		BeadID:        d.BeadID,
+		LinearID:      d.ExternalID,
+		Direction:     d.Direction,
+		AttemptNumber: 1,
+		Outcome:       d.Outcome,
+		StatusCode:    d.StatusCode,
+		DurationMs:    d.DurationMs,
+		BeforeValues:  d.BeforeValues,
+		AfterValues:   d.AfterValues,
+		ErrorMessage:  d.ErrorMsg,
+	}
+}
+
+func marshalFieldValues(vals map[string]string) (string, error) {
+	if len(vals) == 0 {
+		return "{}", nil
+	}
+	b, err := json.Marshal(vals)
+	if err != nil {
+		return "{}", err
+	}
+	return string(b), nil
+}
+
+func unmarshalFieldValues(s string) map[string]string {
+	if s == "" || s == "{}" {
+		return nil
+	}
+	var m map[string]string
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		return nil
+	}
+	return m
+}

--- a/internal/linear/history.go
+++ b/internal/linear/history.go
@@ -21,25 +21,22 @@ type SyncRun struct {
 	IssuesUpdated      int       `json:"issues_updated"`
 	IssuesSkipped      int       `json:"issues_skipped"`
 	IssuesFailed       int       `json:"issues_failed"`
-	IssuesArchived     int       `json:"issues_archived"`
 	ConflictResolution string    `json:"conflict_resolution,omitempty"`
 	ErrorMessage       string    `json:"error_message,omitempty"`
 }
 
 // SyncItem represents a per-issue outcome row in linear_sync_items.
 type SyncItem struct {
-	ID            string            `json:"id"`
-	SyncRunID     string            `json:"sync_run_id"`
-	BeadID        string            `json:"bead_id"`
-	LinearID      string            `json:"linear_id"`
-	Direction     string            `json:"direction"`
-	AttemptNumber int               `json:"attempt_number"`
-	Outcome       string            `json:"outcome"`
-	StatusCode    int               `json:"status_code"`
-	DurationMs    int64             `json:"duration_ms"`
-	BeforeValues  map[string]string `json:"before_values,omitempty"`
-	AfterValues   map[string]string `json:"after_values,omitempty"`
-	ErrorMessage  string            `json:"error_message,omitempty"`
+	ID           string            `json:"id"`
+	SyncRunID    string            `json:"sync_run_id"`
+	BeadID       string            `json:"bead_id"`
+	LinearID     string            `json:"linear_id"`
+	Direction    string            `json:"direction"`
+	Outcome      string            `json:"outcome"`
+	DurationMs   int64             `json:"duration_ms"`
+	BeforeValues map[string]string `json:"before_values,omitempty"`
+	AfterValues  map[string]string `json:"after_values,omitempty"`
+	ErrorMessage string            `json:"error_message,omitempty"`
 }
 
 // SyncHistoryDB provides read/write access to the linear_sync_history tables.
@@ -63,11 +60,11 @@ func (h *SyncHistoryDB) RecordSyncRun(ctx context.Context, run *SyncRun, items [
 
 	_, err = tx.ExecContext(ctx,
 		`INSERT INTO linear_sync_runs (sync_run_id, started_at, completed_at, direction, dry_run,
-			issues_created, issues_updated, issues_skipped, issues_failed, issues_archived,
+			issues_created, issues_updated, issues_skipped, issues_failed,
 			conflict_resolution, error_message)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		run.SyncRunID, run.StartedAt, run.CompletedAt, run.Direction, run.DryRun,
-		run.IssuesCreated, run.IssuesUpdated, run.IssuesSkipped, run.IssuesFailed, run.IssuesArchived,
+		run.IssuesCreated, run.IssuesUpdated, run.IssuesSkipped, run.IssuesFailed,
 		run.ConflictResolution, run.ErrorMessage,
 	)
 	if err != nil {
@@ -77,9 +74,9 @@ func (h *SyncHistoryDB) RecordSyncRun(ctx context.Context, run *SyncRun, items [
 	if len(items) > 0 {
 		stmt, err := tx.PrepareContext(ctx,
 			`INSERT INTO linear_sync_items (sync_run_id, bead_id, linear_id, direction,
-				attempt_number, outcome, status_code, duration_ms,
+				outcome, duration_ms,
 				before_values, after_values, error_message)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 		if err != nil {
 			return fmt.Errorf("prepare item insert: %w", err)
 		}
@@ -91,7 +88,7 @@ func (h *SyncHistoryDB) RecordSyncRun(ctx context.Context, run *SyncRun, items [
 
 			_, err := stmt.ExecContext(ctx,
 				run.SyncRunID, item.BeadID, item.LinearID, item.Direction,
-				item.AttemptNumber, item.Outcome, item.StatusCode, item.DurationMs,
+				item.Outcome, item.DurationMs,
 				beforeJSON, afterJSON, item.ErrorMessage,
 			)
 			if err != nil {
@@ -109,7 +106,7 @@ func (h *SyncHistoryDB) RecordSyncRun(ctx context.Context, run *SyncRun, items [
 // ListSyncRuns returns sync runs matching the filter criteria.
 func (h *SyncHistoryDB) ListSyncRuns(ctx context.Context, since *time.Time, limit int) ([]SyncRun, error) {
 	query := `SELECT sync_run_id, started_at, completed_at, direction, dry_run,
-		issues_created, issues_updated, issues_skipped, issues_failed, issues_archived,
+		issues_created, issues_updated, issues_skipped, issues_failed,
 		conflict_resolution, error_message
 		FROM linear_sync_runs`
 	var args []interface{}
@@ -133,7 +130,7 @@ func (h *SyncHistoryDB) ListSyncRuns(ctx context.Context, since *time.Time, limi
 	for rows.Next() {
 		var r SyncRun
 		if err := rows.Scan(&r.SyncRunID, &r.StartedAt, &r.CompletedAt, &r.Direction, &r.DryRun,
-			&r.IssuesCreated, &r.IssuesUpdated, &r.IssuesSkipped, &r.IssuesFailed, &r.IssuesArchived,
+			&r.IssuesCreated, &r.IssuesUpdated, &r.IssuesSkipped, &r.IssuesFailed,
 			&r.ConflictResolution, &r.ErrorMessage); err != nil {
 			return nil, fmt.Errorf("scan sync run: %w", err)
 		}
@@ -146,7 +143,7 @@ func (h *SyncHistoryDB) ListSyncRuns(ctx context.Context, since *time.Time, limi
 func (h *SyncHistoryDB) GetSyncRunItems(ctx context.Context, syncRunID string) ([]SyncItem, error) {
 	rows, err := h.db.QueryContext(ctx,
 		`SELECT id, sync_run_id, bead_id, linear_id, direction,
-			attempt_number, outcome, status_code, duration_ms,
+			outcome, duration_ms,
 			before_values, after_values, error_message
 		FROM linear_sync_items
 		WHERE sync_run_id = ?
@@ -161,7 +158,7 @@ func (h *SyncHistoryDB) GetSyncRunItems(ctx context.Context, syncRunID string) (
 		var item SyncItem
 		var beforeJSON, afterJSON sql.NullString
 		if err := rows.Scan(&item.ID, &item.SyncRunID, &item.BeadID, &item.LinearID,
-			&item.Direction, &item.AttemptNumber, &item.Outcome, &item.StatusCode,
+			&item.Direction, &item.Outcome,
 			&item.DurationMs, &beforeJSON, &afterJSON, &item.ErrorMessage); err != nil {
 			return nil, fmt.Errorf("scan sync item: %w", err)
 		}
@@ -181,11 +178,11 @@ func (h *SyncHistoryDB) GetSyncRun(ctx context.Context, syncRunID string) (*Sync
 	var r SyncRun
 	err := h.db.QueryRowContext(ctx,
 		`SELECT sync_run_id, started_at, completed_at, direction, dry_run,
-			issues_created, issues_updated, issues_skipped, issues_failed, issues_archived,
+			issues_created, issues_updated, issues_skipped, issues_failed,
 			conflict_resolution, error_message
 		FROM linear_sync_runs WHERE sync_run_id = ?`, syncRunID).
 		Scan(&r.SyncRunID, &r.StartedAt, &r.CompletedAt, &r.Direction, &r.DryRun,
-			&r.IssuesCreated, &r.IssuesUpdated, &r.IssuesSkipped, &r.IssuesFailed, &r.IssuesArchived,
+			&r.IssuesCreated, &r.IssuesUpdated, &r.IssuesSkipped, &r.IssuesFailed,
 			&r.ConflictResolution, &r.ErrorMessage)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -238,16 +235,14 @@ func BuildSyncItemsFromResult(result *tracker.SyncResult) []SyncItem {
 
 func syncItemFromDetail(d tracker.SyncItemDetail) SyncItem {
 	return SyncItem{
-		BeadID:        d.BeadID,
-		LinearID:      d.ExternalID,
-		Direction:     d.Direction,
-		AttemptNumber: 1,
-		Outcome:       d.Outcome,
-		StatusCode:    d.StatusCode,
-		DurationMs:    d.DurationMs,
-		BeforeValues:  d.BeforeValues,
-		AfterValues:   d.AfterValues,
-		ErrorMessage:  d.ErrorMsg,
+		BeadID:       d.BeadID,
+		LinearID:     d.ExternalID,
+		Direction:    d.Direction,
+		Outcome:      d.Outcome,
+		DurationMs:   d.DurationMs,
+		BeforeValues: d.BeforeValues,
+		AfterValues:  d.AfterValues,
+		ErrorMessage: d.ErrorMsg,
 	}
 }
 

--- a/internal/linear/history_test.go
+++ b/internal/linear/history_test.go
@@ -1,0 +1,167 @@
+package linear
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/tracker"
+)
+
+func TestBuildSyncRunFromResult(t *testing.T) {
+	started := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	result := &tracker.SyncResult{
+		Success: true,
+		Stats: tracker.SyncStats{
+			Created: 3,
+			Updated: 2,
+			Skipped: 5,
+			Errors:  1,
+		},
+	}
+
+	run := BuildSyncRunFromResult("run-123", started, "push", false, "timestamp", result)
+
+	if run.SyncRunID != "run-123" {
+		t.Errorf("SyncRunID = %q, want %q", run.SyncRunID, "run-123")
+	}
+	if run.Direction != "push" {
+		t.Errorf("Direction = %q, want %q", run.Direction, "push")
+	}
+	if run.DryRun {
+		t.Error("DryRun = true, want false")
+	}
+	if run.IssuesCreated != 3 {
+		t.Errorf("IssuesCreated = %d, want 3", run.IssuesCreated)
+	}
+	if run.IssuesUpdated != 2 {
+		t.Errorf("IssuesUpdated = %d, want 2", run.IssuesUpdated)
+	}
+	if run.IssuesSkipped != 5 {
+		t.Errorf("IssuesSkipped = %d, want 5", run.IssuesSkipped)
+	}
+	if run.IssuesFailed != 1 {
+		t.Errorf("IssuesFailed = %d, want 1", run.IssuesFailed)
+	}
+	if run.ConflictResolution != "timestamp" {
+		t.Errorf("ConflictResolution = %q, want %q", run.ConflictResolution, "timestamp")
+	}
+	if !run.StartedAt.Equal(started) {
+		t.Errorf("StartedAt = %v, want %v", run.StartedAt, started)
+	}
+	if run.CompletedAt.Before(started) {
+		t.Error("CompletedAt should be after StartedAt")
+	}
+}
+
+func TestBuildSyncRunFromResult_WithError(t *testing.T) {
+	result := &tracker.SyncResult{
+		Success: false,
+		Error:   "rate limit exceeded",
+	}
+	run := BuildSyncRunFromResult("run-err", time.Now().UTC(), "pull", false, "", result)
+	if run.ErrorMessage != "rate limit exceeded" {
+		t.Errorf("ErrorMessage = %q, want %q", run.ErrorMessage, "rate limit exceeded")
+	}
+}
+
+func TestBuildSyncRunFromResult_NilResult(t *testing.T) {
+	run := BuildSyncRunFromResult("run-nil", time.Now().UTC(), "both", true, "local", nil)
+	if run.IssuesCreated != 0 {
+		t.Errorf("IssuesCreated = %d, want 0", run.IssuesCreated)
+	}
+	if !run.DryRun {
+		t.Error("DryRun = false, want true")
+	}
+}
+
+func TestBuildSyncItemsFromResult(t *testing.T) {
+	result := &tracker.SyncResult{
+		PullStats: tracker.PullStats{
+			Items: []tracker.SyncItemDetail{
+				{BeadID: "bd-001", ExternalID: "TEAM-1", Direction: "pull", Outcome: "created", DurationMs: 100},
+				{BeadID: "bd-002", ExternalID: "TEAM-2", Direction: "pull", Outcome: "updated", DurationMs: 50,
+					BeforeValues: map[string]string{"title": "Old"}, AfterValues: map[string]string{"title": "New"}},
+			},
+		},
+		PushStats: tracker.PushStats{
+			Items: []tracker.SyncItemDetail{
+				{BeadID: "bd-003", ExternalID: "TEAM-3", Direction: "push", Outcome: "created", DurationMs: 200},
+				{BeadID: "bd-004", Direction: "push", Outcome: "failed", ErrorMsg: "timeout"},
+			},
+		},
+	}
+
+	items := BuildSyncItemsFromResult(result)
+	if len(items) != 4 {
+		t.Fatalf("len(items) = %d, want 4", len(items))
+	}
+
+	// Pull items
+	if items[0].BeadID != "bd-001" || items[0].Outcome != "created" {
+		t.Errorf("items[0] = %+v, want bead_id=bd-001 outcome=created", items[0])
+	}
+	if items[1].BeforeValues["title"] != "Old" || items[1].AfterValues["title"] != "New" {
+		t.Errorf("items[1] before/after mismatch: before=%v after=%v", items[1].BeforeValues, items[1].AfterValues)
+	}
+
+	// Push items
+	if items[2].BeadID != "bd-003" || items[2].DurationMs != 200 {
+		t.Errorf("items[2] = %+v, want bead_id=bd-003 duration=200", items[2])
+	}
+	if items[3].ErrorMessage != "timeout" {
+		t.Errorf("items[3].ErrorMessage = %q, want %q", items[3].ErrorMessage, "timeout")
+	}
+}
+
+func TestBuildSyncItemsFromResult_Nil(t *testing.T) {
+	items := BuildSyncItemsFromResult(nil)
+	if len(items) != 0 {
+		t.Errorf("len(items) = %d, want 0", len(items))
+	}
+}
+
+func TestMarshalFieldValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]string
+		wantOK bool
+	}{
+		{"nil map", nil, true},
+		{"empty map", map[string]string{}, true},
+		{"with values", map[string]string{"title": "Test", "status": "open"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := marshalFieldValues(tt.input)
+			if (err == nil) != tt.wantOK {
+				t.Errorf("marshalFieldValues() error = %v, wantOK = %v", err, tt.wantOK)
+			}
+			if result == "" {
+				t.Error("marshalFieldValues() returned empty string")
+			}
+		})
+	}
+}
+
+func TestUnmarshalFieldValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{"empty string", "", 0},
+		{"empty object", "{}", 0},
+		{"with values", `{"title":"Test","status":"open"}`, 2},
+		{"invalid json", "not json", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := unmarshalFieldValues(tt.input)
+			if len(result) != tt.want {
+				t.Errorf("unmarshalFieldValues(%q) len = %d, want %d", tt.input, len(result), tt.want)
+			}
+		})
+	}
+}

--- a/internal/linear/rollback.go
+++ b/internal/linear/rollback.go
@@ -1,0 +1,125 @@
+package linear
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// RollbackMutation describes a compensating operation to undo a sync item.
+type RollbackMutation struct {
+	BeadID    string            `json:"bead_id"`
+	LinearID  string            `json:"linear_id,omitempty"`
+	Action    string            `json:"action"`
+	Direction string            `json:"direction"`
+	Fields    map[string]string `json:"fields,omitempty"`
+}
+
+// GenerateRollbackMutations reads sync history for a given run and produces
+// compensating mutations that would undo the sync's effects.
+//
+// For created issues: generates a delete mutation.
+// For updated issues: generates an update mutation restoring before_values.
+// For failed/skipped items: no mutation needed.
+func GenerateRollbackMutations(ctx context.Context, histDB *SyncHistoryDB, syncRunID string) ([]RollbackMutation, error) {
+	run, err := histDB.GetSyncRun(ctx, syncRunID)
+	if err != nil {
+		return nil, fmt.Errorf("fetching sync run: %w", err)
+	}
+	if run == nil {
+		return nil, fmt.Errorf("sync run %s not found", syncRunID)
+	}
+
+	items, err := histDB.GetSyncRunItems(ctx, syncRunID)
+	if err != nil {
+		return nil, fmt.Errorf("fetching sync items: %w", err)
+	}
+
+	var mutations []RollbackMutation
+	for _, item := range items {
+		switch item.Outcome {
+		case "created":
+			mutations = append(mutations, rollbackCreated(item))
+		case "updated":
+			if m := rollbackUpdated(item); m != nil {
+				mutations = append(mutations, *m)
+			}
+		}
+	}
+	return mutations, nil
+}
+
+// RollbackScript generates a human-readable script (bd commands) that would
+// undo the effects of a sync run.
+func RollbackScript(mutations []RollbackMutation) string {
+	if len(mutations) == 0 {
+		return "# No rollback actions needed for this sync run.\n"
+	}
+
+	var b strings.Builder
+	b.WriteString("#!/bin/bash\n")
+	b.WriteString("# Rollback script generated from sync history.\n")
+	b.WriteString("# Review each command before executing.\n\n")
+
+	for _, m := range mutations {
+		b.WriteString(fmt.Sprintf("# %s: %s (direction: %s)\n", m.Action, m.BeadID, m.Direction))
+		switch m.Action {
+		case "delete_local":
+			b.WriteString(fmt.Sprintf("bd delete %s\n", m.BeadID))
+		case "restore_local":
+			b.WriteString(fmt.Sprintf("bd update %s", m.BeadID))
+			for k, v := range m.Fields {
+				b.WriteString(fmt.Sprintf(" --%s=%q", k, v))
+			}
+			b.WriteString("\n")
+		case "delete_remote":
+			b.WriteString(fmt.Sprintf("# Manual action: delete issue %s from Linear\n", m.LinearID))
+		case "restore_remote":
+			b.WriteString(fmt.Sprintf("# Manual action: restore issue %s in Linear to previous state\n", m.LinearID))
+			for k, v := range m.Fields {
+				b.WriteString(fmt.Sprintf("#   %s = %q\n", k, v))
+			}
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func rollbackCreated(item SyncItem) RollbackMutation {
+	if item.Direction == "pull" {
+		return RollbackMutation{
+			BeadID:    item.BeadID,
+			LinearID:  item.LinearID,
+			Action:    "delete_local",
+			Direction: item.Direction,
+		}
+	}
+	return RollbackMutation{
+		BeadID:    item.BeadID,
+		LinearID:  item.LinearID,
+		Action:    "delete_remote",
+		Direction: item.Direction,
+	}
+}
+
+func rollbackUpdated(item SyncItem) *RollbackMutation {
+	if len(item.BeforeValues) == 0 {
+		return nil
+	}
+	if item.Direction == "pull" {
+		return &RollbackMutation{
+			BeadID:    item.BeadID,
+			LinearID:  item.LinearID,
+			Action:    "restore_local",
+			Direction: item.Direction,
+			Fields:    item.BeforeValues,
+		}
+	}
+	return &RollbackMutation{
+		BeadID:    item.BeadID,
+		LinearID:  item.LinearID,
+		Action:    "restore_remote",
+		Direction: item.Direction,
+		Fields:    item.BeforeValues,
+	}
+}

--- a/internal/linear/rollback_test.go
+++ b/internal/linear/rollback_test.go
@@ -1,0 +1,113 @@
+package linear
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRollbackScript_NoMutations(t *testing.T) {
+	script := RollbackScript(nil)
+	if !strings.Contains(script, "No rollback") {
+		t.Errorf("empty mutations should produce 'No rollback' message, got: %s", script)
+	}
+}
+
+func TestRollbackScript_CreatedPull(t *testing.T) {
+	mutations := []RollbackMutation{
+		{BeadID: "bd-001", LinearID: "TEAM-1", Action: "delete_local", Direction: "pull"},
+	}
+	script := RollbackScript(mutations)
+	if !strings.Contains(script, "bd delete bd-001") {
+		t.Errorf("expected 'bd delete bd-001' in script, got:\n%s", script)
+	}
+}
+
+func TestRollbackScript_CreatedPush(t *testing.T) {
+	mutations := []RollbackMutation{
+		{BeadID: "bd-002", LinearID: "TEAM-2", Action: "delete_remote", Direction: "push"},
+	}
+	script := RollbackScript(mutations)
+	if !strings.Contains(script, "delete issue TEAM-2 from Linear") {
+		t.Errorf("expected manual delete instruction for TEAM-2, got:\n%s", script)
+	}
+}
+
+func TestRollbackScript_UpdatedPull(t *testing.T) {
+	mutations := []RollbackMutation{
+		{
+			BeadID:    "bd-003",
+			LinearID:  "TEAM-3",
+			Action:    "restore_local",
+			Direction: "pull",
+			Fields:    map[string]string{"title": "Old Title", "status": "open"},
+		},
+	}
+	script := RollbackScript(mutations)
+	if !strings.Contains(script, "bd update bd-003") {
+		t.Errorf("expected 'bd update bd-003' in script, got:\n%s", script)
+	}
+}
+
+func TestRollbackCreated_Pull(t *testing.T) {
+	item := SyncItem{BeadID: "bd-010", LinearID: "TEAM-10", Direction: "pull", Outcome: "created"}
+	m := rollbackCreated(item)
+	if m.Action != "delete_local" {
+		t.Errorf("Action = %q, want %q", m.Action, "delete_local")
+	}
+	if m.BeadID != "bd-010" {
+		t.Errorf("BeadID = %q, want %q", m.BeadID, "bd-010")
+	}
+}
+
+func TestRollbackCreated_Push(t *testing.T) {
+	item := SyncItem{BeadID: "bd-020", LinearID: "TEAM-20", Direction: "push", Outcome: "created"}
+	m := rollbackCreated(item)
+	if m.Action != "delete_remote" {
+		t.Errorf("Action = %q, want %q", m.Action, "delete_remote")
+	}
+}
+
+func TestRollbackUpdated_NoBeforeValues(t *testing.T) {
+	item := SyncItem{BeadID: "bd-030", Direction: "pull", Outcome: "updated"}
+	m := rollbackUpdated(item)
+	if m != nil {
+		t.Error("expected nil mutation when no before_values")
+	}
+}
+
+func TestRollbackUpdated_WithBeforeValues(t *testing.T) {
+	item := SyncItem{
+		BeadID:       "bd-040",
+		LinearID:     "TEAM-40",
+		Direction:    "pull",
+		Outcome:      "updated",
+		BeforeValues: map[string]string{"title": "Original", "priority": "1"},
+	}
+	m := rollbackUpdated(item)
+	if m == nil {
+		t.Fatal("expected non-nil mutation")
+	}
+	if m.Action != "restore_local" {
+		t.Errorf("Action = %q, want %q", m.Action, "restore_local")
+	}
+	if m.Fields["title"] != "Original" {
+		t.Errorf("Fields[title] = %q, want %q", m.Fields["title"], "Original")
+	}
+}
+
+func TestRollbackUpdated_Push(t *testing.T) {
+	item := SyncItem{
+		BeadID:       "bd-050",
+		LinearID:     "TEAM-50",
+		Direction:    "push",
+		Outcome:      "updated",
+		BeforeValues: map[string]string{"status": "open"},
+	}
+	m := rollbackUpdated(item)
+	if m == nil {
+		t.Fatal("expected non-nil mutation")
+	}
+	if m.Action != "restore_remote" {
+		t.Errorf("Action = %q, want %q", m.Action, "restore_remote")
+	}
+}

--- a/internal/storage/schema/migrations/0033_create_linear_sync_history.up.sql
+++ b/internal/storage/schema/migrations/0033_create_linear_sync_history.up.sql
@@ -1,0 +1,41 @@
+-- Migration 0033: Create linear_sync_history tables for persistent sync audit log.
+--
+-- Two tables store sync results: linear_sync_runs (one row per invocation)
+-- and linear_sync_items (one row per issue per sync). Together they enable
+-- audit, debugging, and rollback scripting.
+
+CREATE TABLE IF NOT EXISTS linear_sync_runs (
+    sync_run_id CHAR(36) NOT NULL PRIMARY KEY DEFAULT (UUID()),
+    started_at DATETIME NOT NULL,
+    completed_at DATETIME NOT NULL,
+    direction VARCHAR(16) NOT NULL,
+    dry_run TINYINT(1) NOT NULL DEFAULT 0,
+    issues_created INT NOT NULL DEFAULT 0,
+    issues_updated INT NOT NULL DEFAULT 0,
+    issues_skipped INT NOT NULL DEFAULT 0,
+    issues_failed INT NOT NULL DEFAULT 0,
+    issues_archived INT NOT NULL DEFAULT 0,
+    conflict_resolution VARCHAR(16) DEFAULT '',
+    error_message TEXT DEFAULT '',
+    INDEX idx_sync_runs_started (started_at),
+    INDEX idx_sync_runs_direction (direction)
+);
+
+CREATE TABLE IF NOT EXISTS linear_sync_items (
+    id CHAR(36) NOT NULL PRIMARY KEY DEFAULT (UUID()),
+    sync_run_id CHAR(36) NOT NULL,
+    bead_id VARCHAR(255) NOT NULL DEFAULT '',
+    linear_id VARCHAR(255) NOT NULL DEFAULT '',
+    direction VARCHAR(16) NOT NULL,
+    attempt_number INT NOT NULL DEFAULT 1,
+    outcome VARCHAR(32) NOT NULL,
+    status_code INT NOT NULL DEFAULT 0,
+    duration_ms BIGINT NOT NULL DEFAULT 0,
+    before_values JSON DEFAULT NULL,
+    after_values JSON DEFAULT NULL,
+    error_message TEXT DEFAULT '',
+    INDEX idx_sync_items_run (sync_run_id),
+    INDEX idx_sync_items_bead (bead_id),
+    INDEX idx_sync_items_outcome (outcome),
+    CONSTRAINT fk_sync_items_run FOREIGN KEY (sync_run_id) REFERENCES linear_sync_runs(sync_run_id) ON DELETE CASCADE
+);

--- a/internal/storage/schema/migrations/0033_create_linear_sync_history.up.sql
+++ b/internal/storage/schema/migrations/0033_create_linear_sync_history.up.sql
@@ -36,6 +36,5 @@ CREATE TABLE IF NOT EXISTS linear_sync_items (
     error_message TEXT DEFAULT '',
     INDEX idx_sync_items_run (sync_run_id),
     INDEX idx_sync_items_bead (bead_id),
-    INDEX idx_sync_items_outcome (outcome),
-    CONSTRAINT fk_sync_items_run FOREIGN KEY (sync_run_id) REFERENCES linear_sync_runs(sync_run_id) ON DELETE CASCADE
+    INDEX idx_sync_items_outcome (outcome)
 );

--- a/internal/storage/schema/migrations/0033_create_linear_sync_history.up.sql
+++ b/internal/storage/schema/migrations/0033_create_linear_sync_history.up.sql
@@ -14,11 +14,9 @@ CREATE TABLE IF NOT EXISTS linear_sync_runs (
     issues_updated INT NOT NULL DEFAULT 0,
     issues_skipped INT NOT NULL DEFAULT 0,
     issues_failed INT NOT NULL DEFAULT 0,
-    issues_archived INT NOT NULL DEFAULT 0,
     conflict_resolution VARCHAR(16) DEFAULT '',
     error_message TEXT DEFAULT '',
-    INDEX idx_sync_runs_started (started_at),
-    INDEX idx_sync_runs_direction (direction)
+    INDEX idx_sync_runs_started (started_at)
 );
 
 CREATE TABLE IF NOT EXISTS linear_sync_items (
@@ -27,14 +25,11 @@ CREATE TABLE IF NOT EXISTS linear_sync_items (
     bead_id VARCHAR(255) NOT NULL DEFAULT '',
     linear_id VARCHAR(255) NOT NULL DEFAULT '',
     direction VARCHAR(16) NOT NULL,
-    attempt_number INT NOT NULL DEFAULT 1,
     outcome VARCHAR(32) NOT NULL,
-    status_code INT NOT NULL DEFAULT 0,
     duration_ms BIGINT NOT NULL DEFAULT 0,
     before_values JSON DEFAULT NULL,
     after_values JSON DEFAULT NULL,
     error_message TEXT DEFAULT '',
     INDEX idx_sync_items_run (sync_run_id),
-    INDEX idx_sync_items_bead (bead_id),
-    INDEX idx_sync_items_outcome (outcome)
+    INDEX idx_sync_items_bead (bead_id)
 );

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -45,8 +45,8 @@ func TestMigration0032ToleratesMissingAppliedAtColumn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runMigrations returned error for already-missing applied_at: %v", err)
 	}
-	if applied != 1 {
-		t.Fatalf("applied migrations = %d, want 1", applied)
+	if applied < 1 {
+		t.Fatalf("applied migrations = %d, want at least 1 (migration 0032 must have run)", applied)
 	}
 	if !recorded {
 		t.Fatal("migration 0032 was not recorded after already-missing applied_at")

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -481,6 +481,8 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 				updates["metadata"] = raw
 			}
 
+			beforeVals := snapshotIssueFields(existing)
+			itemStart := time.Now()
 			if err := e.Store.RunInTransaction(ctx, fmt.Sprintf("bd: pull update %s", existing.ID), func(tx storage.Transaction) error {
 				if err := tx.UpdateIssue(ctx, existing.ID, updates, e.Actor); err != nil {
 					return err
@@ -488,20 +490,41 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 				return syncIssueLabels(ctx, tx, existing.ID, conv.Issue.Labels, e.Actor)
 			}); err != nil {
 				e.warn("Failed to update %s: %v", existing.ID, err)
+				stats.Items = append(stats.Items, SyncItemDetail{
+					BeadID: existing.ID, ExternalID: extIssue.Identifier, Direction: "pull",
+					Outcome: OutcomeFailed, DurationMs: time.Since(itemStart).Milliseconds(),
+					ErrorMsg: err.Error(),
+				})
 				continue
 			}
 			stats.Updated++
+			stats.Items = append(stats.Items, SyncItemDetail{
+				BeadID: existing.ID, ExternalID: extIssue.Identifier, Direction: "pull",
+				Outcome: OutcomeUpdated, DurationMs: time.Since(itemStart).Milliseconds(),
+				BeforeValues: beforeVals, AfterValues: snapshotIssueFields(conv.Issue),
+			})
 		} else {
 			// Create new issue
 			conv.Issue.ExternalRef = strPtr(ref)
 			if raw, ok := marshalTrackerMetadata(extIssue.Metadata); ok {
 				conv.Issue.Metadata = raw
 			}
+			itemStart := time.Now()
 			if err := e.Store.CreateIssue(ctx, conv.Issue, e.Actor); err != nil {
 				e.warn("Failed to create issue for %s: %v", extIssue.Identifier, err)
+				stats.Items = append(stats.Items, SyncItemDetail{
+					BeadID: conv.Issue.ID, ExternalID: extIssue.Identifier, Direction: "pull",
+					Outcome: OutcomeFailed, DurationMs: time.Since(itemStart).Milliseconds(),
+					ErrorMsg: err.Error(),
+				})
 				continue
 			}
 			stats.Created++
+			stats.Items = append(stats.Items, SyncItemDetail{
+				BeadID: conv.Issue.ID, ExternalID: extIssue.Identifier, Direction: "pull",
+				Outcome: OutcomeCreated, DurationMs: time.Since(itemStart).Milliseconds(),
+				AfterValues: snapshotIssueFields(conv.Issue),
+			})
 		}
 	}
 
@@ -856,6 +879,7 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 			stats.Skipped += len(batchResult.Skipped)
 			stats.Errors += len(batchResult.Errors)
 			stats.Warnings = append(stats.Warnings, batchResult.Warnings...)
+			stats.Items = batchPushResultToItems(batchResult)
 			for _, item := range batchResult.Errors {
 				if item.LocalID != "" {
 					e.warn("Failed to push %s in %s: %s", item.LocalID, e.Tracker.DisplayName(), item.Message)
@@ -917,8 +941,14 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 
 		if willCreate {
 			// Create in external tracker
+			itemStart := time.Now()
 			created, err := e.Tracker.CreateIssue(ctx, pushIssue)
+			itemDur := time.Since(itemStart).Milliseconds()
 			if err != nil {
+				stats.Items = append(stats.Items, SyncItemDetail{
+					BeadID: issue.ID, Direction: "push", Outcome: OutcomeFailed,
+					DurationMs: itemDur, ErrorMsg: err.Error(),
+				})
 				if isRateLimitExhausted(err) {
 					return stats, fmt.Errorf("sync aborted: %w", err)
 				}
@@ -937,10 +967,12 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 			if err := e.Store.UpdateIssue(ctx, issue.ID, updates, e.Actor); err != nil {
 				e.warn("Failed to update external_ref for %s: %v", issue.ID, err)
 				stats.Errors++
-				// Note: issue WAS created externally, so we still count Created
-				// but also flag the error so the user knows the link is broken
 			}
 			stats.Created++
+			stats.Items = append(stats.Items, SyncItemDetail{
+				BeadID: issue.ID, ExternalID: created.Identifier, Direction: "push",
+				Outcome: OutcomeCreated, DurationMs: itemDur,
+			})
 		} else if !opts.CreateOnly || forceIDs[issue.ID] {
 			// Update existing external issue
 			extID := e.Tracker.ExtractIdentifier(extRef)
@@ -960,16 +992,30 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 					if e.PushHooks != nil && e.PushHooks.ContentEqual != nil {
 						if e.PushHooks.ContentEqual(issue, extIssue) {
 							stats.Skipped++
+							stats.Items = append(stats.Items, SyncItemDetail{
+								BeadID: issue.ID, ExternalID: extID, Direction: "push",
+								Outcome: OutcomeSkipped,
+							})
 							continue
 						}
 					} else if !extIssue.UpdatedAt.Before(issue.UpdatedAt) {
-						stats.Skipped++ // Default: external is same or newer
+						stats.Skipped++
+						stats.Items = append(stats.Items, SyncItemDetail{
+							BeadID: issue.ID, ExternalID: extID, Direction: "push",
+							Outcome: OutcomeSkipped,
+						})
 						continue
 					}
 				}
 			}
 
+			itemStart := time.Now()
 			if _, err := e.Tracker.UpdateIssue(ctx, extID, pushIssue); err != nil {
+				itemDur := time.Since(itemStart).Milliseconds()
+				stats.Items = append(stats.Items, SyncItemDetail{
+					BeadID: issue.ID, ExternalID: extID, Direction: "push",
+					Outcome: OutcomeFailed, DurationMs: itemDur, ErrorMsg: err.Error(),
+				})
 				if isRateLimitExhausted(err) {
 					return stats, fmt.Errorf("sync aborted: %w", err)
 				}
@@ -982,6 +1028,10 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 				continue
 			}
 			stats.Updated++
+			stats.Items = append(stats.Items, SyncItemDetail{
+				BeadID: issue.ID, ExternalID: extID, Direction: "push",
+				Outcome: OutcomeUpdated, DurationMs: time.Since(itemStart).Milliseconds(),
+			})
 		} else {
 			stats.Skipped++
 		}
@@ -1411,4 +1461,58 @@ func (e *Engine) warn(format string, args ...interface{}) {
 	if e.OnWarning != nil {
 		e.OnWarning(msg)
 	}
+}
+
+// batchPushResultToItems converts a BatchPushResult to SyncItemDetail records.
+func batchPushResultToItems(result *BatchPushResult) []SyncItemDetail {
+	if result == nil {
+		return nil
+	}
+	items := make([]SyncItemDetail, 0, len(result.Created)+len(result.Updated)+len(result.Skipped)+len(result.Errors))
+	for _, c := range result.Created {
+		items = append(items, SyncItemDetail{
+			BeadID: c.LocalID, ExternalID: c.ExternalRef, Direction: "push", Outcome: OutcomeCreated,
+		})
+	}
+	for _, u := range result.Updated {
+		items = append(items, SyncItemDetail{
+			BeadID: u.LocalID, ExternalID: u.ExternalRef, Direction: "push", Outcome: OutcomeUpdated,
+		})
+	}
+	for _, s := range result.Skipped {
+		items = append(items, SyncItemDetail{
+			BeadID: s, Direction: "push", Outcome: OutcomeSkipped,
+		})
+	}
+	for _, e := range result.Errors {
+		items = append(items, SyncItemDetail{
+			BeadID: e.LocalID, Direction: "push", Outcome: OutcomeFailed, ErrorMsg: e.Message,
+		})
+	}
+	return items
+}
+
+// snapshotIssueFields captures the key fields of an issue for before/after comparison.
+func snapshotIssueFields(issue *types.Issue) map[string]string {
+	if issue == nil {
+		return nil
+	}
+	m := map[string]string{
+		"title":      issue.Title,
+		"status":     string(issue.Status),
+		"priority":   fmt.Sprintf("%d", issue.Priority),
+		"issue_type": string(issue.IssueType),
+		"assignee":   issue.Assignee,
+	}
+	if issue.Description != "" {
+		if len(issue.Description) > 200 {
+			m["description"] = issue.Description[:200] + "..."
+		} else {
+			m["description"] = issue.Description
+		}
+	}
+	if issue.ExternalRef != nil {
+		m["external_ref"] = *issue.ExternalRef
+	}
+	return m
 }

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -504,6 +504,8 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 				updates["metadata"] = raw
 			}
 
+			beforeVals := snapshotIssueFields(existing)
+			itemStart := time.Now()
 			if err := e.Store.RunInTransaction(ctx, fmt.Sprintf("bd: pull update %s", existing.ID), func(tx storage.Transaction) error {
 				if err := tx.UpdateIssue(ctx, existing.ID, updates, e.Actor); err != nil {
 					return err
@@ -511,26 +513,47 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 				return syncIssueLabels(ctx, tx, existing.ID, conv.Issue.Labels, e.Actor)
 			}); err != nil {
 				e.warn("Failed to update %s: %v", existing.ID, err)
+				stats.Items = append(stats.Items, SyncItemDetail{
+					BeadID: existing.ID, ExternalID: extIssue.Identifier, Direction: "pull",
+					Outcome: OutcomeFailed, DurationMs: time.Since(itemStart).Milliseconds(),
+					ErrorMsg: err.Error(),
+				})
 				continue
 			}
 			stats.Updated++
 			if pulledIDs != nil {
 				pulledIDs[existing.ID] = true
 			}
+			stats.Items = append(stats.Items, SyncItemDetail{
+				BeadID: existing.ID, ExternalID: extIssue.Identifier, Direction: "pull",
+				Outcome: OutcomeUpdated, DurationMs: time.Since(itemStart).Milliseconds(),
+				BeforeValues: beforeVals, AfterValues: snapshotIssueFields(conv.Issue),
+			})
 		} else {
 			// Create new issue
 			conv.Issue.ExternalRef = strPtr(ref)
 			if raw, ok := marshalTrackerMetadata(extIssue.Metadata); ok {
 				conv.Issue.Metadata = raw
 			}
+			itemStart := time.Now()
 			if err := e.Store.CreateIssue(ctx, conv.Issue, e.Actor); err != nil {
 				e.warn("Failed to create issue for %s: %v", extIssue.Identifier, err)
+				stats.Items = append(stats.Items, SyncItemDetail{
+					BeadID: conv.Issue.ID, ExternalID: extIssue.Identifier, Direction: "pull",
+					Outcome: OutcomeFailed, DurationMs: time.Since(itemStart).Milliseconds(),
+					ErrorMsg: err.Error(),
+				})
 				continue
 			}
 			stats.Created++
 			if pulledIDs != nil {
 				pulledIDs[conv.Issue.ID] = true
 			}
+			stats.Items = append(stats.Items, SyncItemDetail{
+				BeadID: conv.Issue.ID, ExternalID: extIssue.Identifier, Direction: "pull",
+				Outcome: OutcomeCreated, DurationMs: time.Since(itemStart).Milliseconds(),
+				AfterValues: snapshotIssueFields(conv.Issue),
+			})
 		}
 	}
 
@@ -885,6 +908,7 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 			stats.Skipped += len(batchResult.Skipped)
 			stats.Errors += len(batchResult.Errors)
 			stats.Warnings = append(stats.Warnings, batchResult.Warnings...)
+			stats.Items = batchPushResultToItems(batchResult)
 			for _, item := range batchResult.Errors {
 				if item.LocalID != "" {
 					e.warn("Failed to push %s in %s: %s", item.LocalID, e.Tracker.DisplayName(), item.Message)
@@ -946,8 +970,14 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 
 		if willCreate {
 			// Create in external tracker
+			itemStart := time.Now()
 			created, err := e.Tracker.CreateIssue(ctx, pushIssue)
+			itemDur := time.Since(itemStart).Milliseconds()
 			if err != nil {
+				stats.Items = append(stats.Items, SyncItemDetail{
+					BeadID: issue.ID, Direction: "push", Outcome: OutcomeFailed,
+					DurationMs: itemDur, ErrorMsg: err.Error(),
+				})
 				if isRateLimitExhausted(err) {
 					return stats, fmt.Errorf("sync aborted: %w", err)
 				}
@@ -966,10 +996,12 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 			if err := e.Store.UpdateIssue(ctx, issue.ID, updates, e.Actor); err != nil {
 				e.warn("Failed to update external_ref for %s: %v", issue.ID, err)
 				stats.Errors++
-				// Note: issue WAS created externally, so we still count Created
-				// but also flag the error so the user knows the link is broken
 			}
 			stats.Created++
+			stats.Items = append(stats.Items, SyncItemDetail{
+				BeadID: issue.ID, ExternalID: created.Identifier, Direction: "push",
+				Outcome: OutcomeCreated, DurationMs: itemDur,
+			})
 		} else if !opts.CreateOnly || forceIDs[issue.ID] {
 			// Update existing external issue
 			extID := e.Tracker.ExtractIdentifier(extRef)
@@ -989,16 +1021,30 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 					if e.PushHooks != nil && e.PushHooks.ContentEqual != nil {
 						if e.PushHooks.ContentEqual(issue, extIssue) {
 							stats.Skipped++
+							stats.Items = append(stats.Items, SyncItemDetail{
+								BeadID: issue.ID, ExternalID: extID, Direction: "push",
+								Outcome: OutcomeSkipped,
+							})
 							continue
 						}
 					} else if !extIssue.UpdatedAt.Before(issue.UpdatedAt) {
-						stats.Skipped++ // Default: external is same or newer
+						stats.Skipped++
+						stats.Items = append(stats.Items, SyncItemDetail{
+							BeadID: issue.ID, ExternalID: extID, Direction: "push",
+							Outcome: OutcomeSkipped,
+						})
 						continue
 					}
 				}
 			}
 
+			itemStart := time.Now()
 			if _, err := e.Tracker.UpdateIssue(ctx, extID, pushIssue); err != nil {
+				itemDur := time.Since(itemStart).Milliseconds()
+				stats.Items = append(stats.Items, SyncItemDetail{
+					BeadID: issue.ID, ExternalID: extID, Direction: "push",
+					Outcome: OutcomeFailed, DurationMs: itemDur, ErrorMsg: err.Error(),
+				})
 				if isRateLimitExhausted(err) {
 					return stats, fmt.Errorf("sync aborted: %w", err)
 				}
@@ -1011,6 +1057,10 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 				continue
 			}
 			stats.Updated++
+			stats.Items = append(stats.Items, SyncItemDetail{
+				BeadID: issue.ID, ExternalID: extID, Direction: "push",
+				Outcome: OutcomeUpdated, DurationMs: time.Since(itemStart).Milliseconds(),
+			})
 		} else {
 			stats.Skipped++
 		}
@@ -1456,4 +1506,58 @@ func (e *Engine) warn(format string, args ...interface{}) {
 	if e.OnWarning != nil {
 		e.OnWarning(msg)
 	}
+}
+
+// batchPushResultToItems converts a BatchPushResult to SyncItemDetail records.
+func batchPushResultToItems(result *BatchPushResult) []SyncItemDetail {
+	if result == nil {
+		return nil
+	}
+	items := make([]SyncItemDetail, 0, len(result.Created)+len(result.Updated)+len(result.Skipped)+len(result.Errors))
+	for _, c := range result.Created {
+		items = append(items, SyncItemDetail{
+			BeadID: c.LocalID, ExternalID: c.ExternalRef, Direction: "push", Outcome: OutcomeCreated,
+		})
+	}
+	for _, u := range result.Updated {
+		items = append(items, SyncItemDetail{
+			BeadID: u.LocalID, ExternalID: u.ExternalRef, Direction: "push", Outcome: OutcomeUpdated,
+		})
+	}
+	for _, s := range result.Skipped {
+		items = append(items, SyncItemDetail{
+			BeadID: s, Direction: "push", Outcome: OutcomeSkipped,
+		})
+	}
+	for _, e := range result.Errors {
+		items = append(items, SyncItemDetail{
+			BeadID: e.LocalID, Direction: "push", Outcome: OutcomeFailed, ErrorMsg: e.Message,
+		})
+	}
+	return items
+}
+
+// snapshotIssueFields captures the key fields of an issue for before/after comparison.
+func snapshotIssueFields(issue *types.Issue) map[string]string {
+	if issue == nil {
+		return nil
+	}
+	m := map[string]string{
+		"title":      issue.Title,
+		"status":     string(issue.Status),
+		"priority":   fmt.Sprintf("%d", issue.Priority),
+		"issue_type": string(issue.IssueType),
+		"assignee":   issue.Assignee,
+	}
+	if issue.Description != "" {
+		if len(issue.Description) > 200 {
+			m["description"] = issue.Description[:200] + "..."
+		} else {
+			m["description"] = issue.Description
+		}
+	}
+	if issue.ExternalRef != nil {
+		m["external_ref"] = *issue.ExternalRef
+	}
+	return m
 }

--- a/internal/tracker/sync_audit_test.go
+++ b/internal/tracker/sync_audit_test.go
@@ -1,0 +1,113 @@
+package tracker
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestSnapshotIssueFields(t *testing.T) {
+	extRef := "https://linear.app/team/issue/TEAM-123"
+	issue := &types.Issue{
+		Title:       "Fix bug",
+		Description: "Something is broken",
+		Status:      types.StatusOpen,
+		Priority:    1,
+		IssueType:   types.TypeTask,
+		Assignee:    "alice",
+		ExternalRef: &extRef,
+	}
+
+	snapshot := snapshotIssueFields(issue)
+	if snapshot["title"] != "Fix bug" {
+		t.Errorf("title = %q, want %q", snapshot["title"], "Fix bug")
+	}
+	if snapshot["status"] != "open" {
+		t.Errorf("status = %q, want %q", snapshot["status"], "open")
+	}
+	if snapshot["priority"] != "1" {
+		t.Errorf("priority = %q, want %q", snapshot["priority"], "1")
+	}
+	if snapshot["assignee"] != "alice" {
+		t.Errorf("assignee = %q, want %q", snapshot["assignee"], "alice")
+	}
+	if snapshot["external_ref"] != extRef {
+		t.Errorf("external_ref = %q, want %q", snapshot["external_ref"], extRef)
+	}
+}
+
+func TestSnapshotIssueFields_Nil(t *testing.T) {
+	snapshot := snapshotIssueFields(nil)
+	if snapshot != nil {
+		t.Errorf("expected nil snapshot for nil issue, got %v", snapshot)
+	}
+}
+
+func TestSnapshotIssueFields_LongDescription(t *testing.T) {
+	longDesc := ""
+	for i := 0; i < 300; i++ {
+		longDesc += "x"
+	}
+	issue := &types.Issue{
+		Title:       "Test",
+		Description: longDesc,
+		Status:      types.StatusOpen,
+	}
+	snapshot := snapshotIssueFields(issue)
+	if len(snapshot["description"]) > 204 {
+		t.Errorf("description should be truncated, got len=%d", len(snapshot["description"]))
+	}
+}
+
+func TestBatchPushResultToItems(t *testing.T) {
+	result := &BatchPushResult{
+		Created: []BatchPushItem{
+			{LocalID: "bd-001", ExternalRef: "https://linear.app/team/issue/TEAM-1"},
+		},
+		Updated: []BatchPushItem{
+			{LocalID: "bd-002", ExternalRef: "https://linear.app/team/issue/TEAM-2"},
+		},
+		Skipped: []string{"bd-003"},
+		Errors: []BatchPushError{
+			{LocalID: "bd-004", Message: "API error"},
+		},
+	}
+
+	items := batchPushResultToItems(result)
+	if len(items) != 4 {
+		t.Fatalf("len(items) = %d, want 4", len(items))
+	}
+
+	if items[0].Outcome != OutcomeCreated || items[0].BeadID != "bd-001" {
+		t.Errorf("items[0] = %+v, want created/bd-001", items[0])
+	}
+	if items[1].Outcome != OutcomeUpdated || items[1].BeadID != "bd-002" {
+		t.Errorf("items[1] = %+v, want updated/bd-002", items[1])
+	}
+	if items[2].Outcome != OutcomeSkipped || items[2].BeadID != "bd-003" {
+		t.Errorf("items[2] = %+v, want skipped/bd-003", items[2])
+	}
+	if items[3].Outcome != OutcomeFailed || items[3].ErrorMsg != "API error" {
+		t.Errorf("items[3] = %+v, want failed/API error", items[3])
+	}
+
+	for _, item := range items {
+		if item.Direction != "push" {
+			t.Errorf("item %s direction = %q, want %q", item.BeadID, item.Direction, "push")
+		}
+	}
+}
+
+func TestBatchPushResultToItems_Nil(t *testing.T) {
+	items := batchPushResultToItems(nil)
+	if items != nil {
+		t.Errorf("expected nil for nil result, got %v", items)
+	}
+}
+
+func TestBatchPushResultToItems_Empty(t *testing.T) {
+	items := batchPushResultToItems(&BatchPushResult{})
+	if len(items) != 0 {
+		t.Errorf("expected empty items for empty result, got %d", len(items))
+	}
+}

--- a/internal/tracker/types.go
+++ b/internal/tracker/types.go
@@ -131,6 +131,7 @@ type PullStats struct {
 	Errors      int
 	Incremental bool
 	SyncedSince string
+	Items       []SyncItemDetail `json:"-"`
 }
 
 // PushStats tracks push operation results.
@@ -140,7 +141,31 @@ type PushStats struct {
 	Skipped  int
 	Errors   int
 	Warnings []string
+	Items    []SyncItemDetail `json:"-"`
 }
+
+// SyncItemDetail records the outcome of a single issue during sync.
+// Used by the audit log to persist per-issue outcomes with before/after values.
+type SyncItemDetail struct {
+	BeadID       string            `json:"bead_id"`
+	ExternalID   string            `json:"external_id"`
+	Direction    string            `json:"direction"`
+	Outcome      string            `json:"outcome"`
+	StatusCode   int               `json:"status_code,omitempty"`
+	DurationMs   int64             `json:"duration_ms,omitempty"`
+	BeforeValues map[string]string `json:"before_values,omitempty"`
+	AfterValues  map[string]string `json:"after_values,omitempty"`
+	ErrorMsg     string            `json:"error_msg,omitempty"`
+}
+
+// Sync item outcome constants.
+const (
+	OutcomeCreated  = "created"
+	OutcomeUpdated  = "updated"
+	OutcomeSkipped  = "skipped"
+	OutcomeFailed   = "failed"
+	OutcomeArchived = "archived"
+)
 
 // BatchPushItem describes one local issue handled by a tracker batch push.
 type BatchPushItem struct {

--- a/internal/tracker/types.go
+++ b/internal/tracker/types.go
@@ -151,7 +151,6 @@ type SyncItemDetail struct {
 	ExternalID   string            `json:"external_id"`
 	Direction    string            `json:"direction"`
 	Outcome      string            `json:"outcome"`
-	StatusCode   int               `json:"status_code,omitempty"`
 	DurationMs   int64             `json:"duration_ms,omitempty"`
 	BeforeValues map[string]string `json:"before_values,omitempty"`
 	AfterValues  map[string]string `json:"after_values,omitempty"`
@@ -160,11 +159,10 @@ type SyncItemDetail struct {
 
 // Sync item outcome constants.
 const (
-	OutcomeCreated  = "created"
-	OutcomeUpdated  = "updated"
-	OutcomeSkipped  = "skipped"
-	OutcomeFailed   = "failed"
-	OutcomeArchived = "archived"
+	OutcomeCreated = "created"
+	OutcomeUpdated = "updated"
+	OutcomeSkipped = "skipped"
+	OutcomeFailed  = "failed"
 )
 
 // BatchPushItem describes one local issue handled by a tracker batch push.


### PR DESCRIPTION
## Summary

Adds persistent sync history tracking so every `bd linear sync` run is auditable, debuggable, and rollback-capable.

- **New Dolt table** `linear_sync_runs` + `linear_sync_items` (migration 0033) — stores per-run metadata and per-issue outcomes with before/after field snapshots
- **Per-item tracking** in the sync engine — captures title, status, priority, assignee, and description before and after each sync operation
- **`bd linear history`** CLI — `--since` for run summaries, `--detail <run-id>` for per-issue outcomes, `--rollback <run-id>` for compensating mutations
- **Rollback helper** — generates `bd update` commands and manual Linear API instructions to undo a sync run

## Motivation

Production sync operations need an audit trail. When a sync pushes unexpected changes to Linear (or pulls bad data back), operators need to:
1. See exactly what changed (before/after per field per issue)
2. Identify which sync run caused the problem
3. Generate compensating mutations to undo it

This is table stakes for org-wide rollout where multiple repos sync to the same Linear workspace.

## Schema

```sql
CREATE TABLE linear_sync_runs (
    sync_run_id VARCHAR(36) PRIMARY KEY,
    started_at  DATETIME NOT NULL,
    completed_at DATETIME,
    direction   VARCHAR(10) NOT NULL,  -- push/pull/both
    issues_created INT DEFAULT 0,
    issues_updated INT DEFAULT 0,
    issues_failed  INT DEFAULT 0,
    issues_skipped INT DEFAULT 0,
    issues_archived INT DEFAULT 0,
    error_message TEXT
);

CREATE TABLE linear_sync_items (
    id           VARCHAR(36) PRIMARY KEY,
    sync_run_id  VARCHAR(36) NOT NULL,
    bead_id      VARCHAR(64),
    linear_id    VARCHAR(64),
    outcome      VARCHAR(20) NOT NULL,  -- created/updated/skipped/failed/archived
    direction    VARCHAR(10) NOT NULL,
    attempt_number INT DEFAULT 1,
    duration_ms  INT DEFAULT 0,
    status_code  INT DEFAULT 0,
    error_message TEXT,
    before_values JSON,
    after_values  JSON,
    FOREIGN KEY (sync_run_id) REFERENCES linear_sync_runs(sync_run_id)
);
```

## Test plan

- [x] `TestBuildSyncRun` — run metadata from SyncResult
- [x] `TestBuildSyncItems*` — per-item detail extraction
- [x] `TestRollbackScript*` — compensating mutation generation for created/updated issues
- [x] `TestSnapshotIssueFields` — before/after field capture
- [x] `TestBatchPushResultToItems` — batch push result mapping
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] `make test-upgrade` (migration compatibility — needs CI)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->