### PR TITLE
perf(dolt): reduce remote-Dolt round trips (showcase — do not merge)

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/steveyegge/beads/internal/atomicfile"
@@ -77,7 +78,19 @@ func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) 
 	state := loadExportAutoState(beadsDir)
 	interval := config.GetDuration("export.interval")
 	if interval == 0 {
-		interval = 60 * time.Second
+		// Default throttle: 60 s for the embedded backend, 5 min for the
+		// remote-Dolt backend. The remote case rebuilds the JSONL with a
+		// full SearchIssues + 5 hydration queries every fire, which costs
+		// 5-10 s on a 200 ms RTT link. With dolt_mode=server the database
+		// is already the source of truth and the JSONL is a convenience
+		// for git-tracking and offline replay — a 5-minute lag is fine
+		// for that role and skips most per-write rebuild churn.
+		// Users can override by setting export.interval explicitly.
+		if serverMode {
+			interval = 5 * time.Minute
+		} else {
+			interval = 60 * time.Second
+		}
 	}
 
 	// Change detection via Dolt commit hash. This is cheap, so do it before
@@ -368,11 +381,27 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 		for i, issue := range issues {
 			issueIDs[i] = issue.ID
 		}
-		labelsMap, _ := store.GetLabelsForIssues(ctx, issueIDs)
-		allDeps, _ := store.GetDependencyRecordsForIssues(ctx, issueIDs)
-		commentsMap, _ := store.GetCommentsForIssues(ctx, issueIDs)
-		commentCounts, _ := store.GetCommentCounts(ctx, issueIDs)
-		depCounts, _ := store.GetDependencyCounts(ctx, issueIDs)
+		// Parallelize the five independent bulk-load calls. On a remote Dolt
+		// connection each is a full BEGIN/SELECT/ROLLBACK round trip (~1.2 s
+		// on a 200 ms RTT link); running them sequentially was ~6 s of pure
+		// wall-clock waste inside maybeAutoExport. The pool's MaxOpenConns
+		// is 10 by default so five concurrent reads share the warm pool
+		// without forcing extra handshakes.
+		var (
+			labelsMap     map[string][]string
+			allDeps       map[string][]*types.Dependency
+			commentsMap   map[string][]*types.Comment
+			commentCounts map[string]int
+			depCounts     map[string]*types.DependencyCounts
+			wg            sync.WaitGroup
+		)
+		wg.Add(5)
+		go func() { defer wg.Done(); labelsMap, _ = store.GetLabelsForIssues(ctx, issueIDs) }()
+		go func() { defer wg.Done(); allDeps, _ = store.GetDependencyRecordsForIssues(ctx, issueIDs) }()
+		go func() { defer wg.Done(); commentsMap, _ = store.GetCommentsForIssues(ctx, issueIDs) }()
+		go func() { defer wg.Done(); commentCounts, _ = store.GetCommentCounts(ctx, issueIDs) }()
+		go func() { defer wg.Done(); depCounts, _ = store.GetDependencyCounts(ctx, issueIDs) }()
+		wg.Wait()
 
 		for _, issue := range issues {
 			issue.Labels = labelsMap[issue.ID]

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -1021,9 +1021,14 @@ var listCmd = &cobra.Command{
 			}
 
 			// Regular tree display (no parent filter)
-			// Load dependencies for tree structure
-			// Best effort: display gracefully degrades with empty data
-			allDeps, _ := activeStore.GetAllDependencyRecords(ctx)
+			// Load dependencies for tree structure (skipped when there are no
+			// issues — the dependency query would otherwise burn a full read
+			// transaction against the remote server for an empty result set).
+			// Best effort: display gracefully degrades with empty data.
+			var allDeps map[string][]*types.Dependency
+			if len(issues) > 0 {
+				allDeps, _ = activeStore.GetAllDependencyRecords(ctx)
+			}
 			displayPrettyListWithDeps(issues, false, allDeps)
 			printTruncationHint(truncated, effectiveLimit)
 			return

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1147,8 +1147,14 @@ var rootCmd = &cobra.Command{
 				}
 			}
 
-			// Auto-backup: sync a Dolt-native backup if enabled and due
-			maybeAutoBackup(rootCtx)
+			// Auto-backup: sync a Dolt-native backup if enabled and due.
+			// Gate behind !isReadOnlyCommand so that bd list / show / ready
+			// don't pay an extra GetCurrentCommit round trip on every call —
+			// a read can't have produced data worth backing up. The auto-export
+			// gate just below covers the same intent for its JSONL pass.
+			if !isReadOnlyCommand(cmd.Name()) {
+				maybeAutoBackup(rootCtx)
+			}
 
 			// Auto-export: write git-tracked JSONL for portability if enabled and due.
 			// Read-only commands must not perform post-run maintenance writes or emit
@@ -1174,6 +1180,18 @@ var rootCmd = &cobra.Command{
 			if store != nil {
 				_ = store.Close() // Best effort cleanup
 			}
+
+			// Auto-push: push to Dolt remote if enabled and due.
+			maybeAutoPush(rootCtx)
+		}
+
+		// Signal that store is closing (prevents background flush from accessing closed store)
+		storeMutex.Lock()
+		storeActive = false
+		storeMutex.Unlock()
+
+		if store != nil {
+			_ = store.Close() // Best effort cleanup
 		}
 
 		// End the command span and flush OTel data before process exit.

--- a/internal/storage/dolt/config.go
+++ b/internal/storage/dolt/config.go
@@ -56,9 +56,9 @@ func (s *DoltStore) SetConfig(ctx context.Context, key, value string) error {
 // GetConfig retrieves a configuration value
 func (s *DoltStore) GetConfig(ctx context.Context, key string) (string, error) {
 	var value string
-	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+	err := s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
 		var err error
-		value, err = issueops.GetConfigInTx(ctx, tx, key)
+		value, err = issueops.GetConfigInTx(ctx, q, key)
 		return err
 	})
 	return value, err
@@ -67,9 +67,9 @@ func (s *DoltStore) GetConfig(ctx context.Context, key string) (string, error) {
 // GetAllConfig retrieves all configuration values
 func (s *DoltStore) GetAllConfig(ctx context.Context) (map[string]string, error) {
 	var result map[string]string
-	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+	err := s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
 		var err error
-		result, err = issueops.GetAllConfigInTx(ctx, tx)
+		result, err = issueops.GetAllConfigInTx(ctx, q)
 		return err
 	})
 	return result, err
@@ -92,9 +92,9 @@ func (s *DoltStore) SetMetadata(ctx context.Context, key, value string) error {
 // GetMetadata retrieves a metadata value
 func (s *DoltStore) GetMetadata(ctx context.Context, key string) (string, error) {
 	var value string
-	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+	err := s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
 		var err error
-		value, err = issueops.GetMetadataInTx(ctx, tx, key)
+		value, err = issueops.GetMetadataInTx(ctx, q, key)
 		return err
 	})
 	return value, err
@@ -112,9 +112,9 @@ func (s *DoltStore) SetLocalMetadata(ctx context.Context, key, value string) err
 // Returns ("", nil) if the key does not exist.
 func (s *DoltStore) GetLocalMetadata(ctx context.Context, key string) (string, error) {
 	var value string
-	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+	err := s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
 		var err error
-		value, err = issueops.GetLocalMetadataInTx(ctx, tx, key)
+		value, err = issueops.GetLocalMetadataInTx(ctx, q, key)
 		return err
 	})
 	return value, err

--- a/internal/storage/dolt/config.go
+++ b/internal/storage/dolt/config.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
@@ -34,7 +35,10 @@ func (s *DoltStore) SetConfig(ctx context.Context, key, value string) error {
 		return err
 	}
 
-	// Invalidate caches for keys that affect cached data
+	// Invalidate caches for keys that affect cached data. The all-config
+	// cache is also invalidated on every SetConfig because keys outside the
+	// switch list (routing.*, contributor.*, custom.*) are read via
+	// GetAllConfig from the routing module.
 	s.cacheMu.Lock()
 	switch key {
 	case "status.custom":
@@ -48,13 +52,26 @@ func (s *DoltStore) SetConfig(ctx context.Context, key, value string) error {
 		s.infraTypeCached = false
 		s.infraTypeCache = nil
 	}
+	s.allConfigCached = false
+	s.allConfigCache = nil
 	s.cacheMu.Unlock()
 
 	return nil
 }
 
-// GetConfig retrieves a configuration value
+// GetConfig retrieves a configuration value. Honors the per-store cache
+// populated by preloadSessionCaches so write commands (which typically
+// look up half a dozen config keys in their PreRun + PostRun hooks) do
+// not pay a round trip per key once the cache is warm.
 func (s *DoltStore) GetConfig(ctx context.Context, key string) (string, error) {
+	s.cacheMu.Lock()
+	if s.allConfigCached {
+		v := s.allConfigCache[key]
+		s.cacheMu.Unlock()
+		return v, nil
+	}
+	s.cacheMu.Unlock()
+
 	var value string
 	err := s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
 		var err error
@@ -64,8 +81,22 @@ func (s *DoltStore) GetConfig(ctx context.Context, key string) (string, error) {
 	return value, err
 }
 
-// GetAllConfig retrieves all configuration values
+// GetAllConfig retrieves all configuration values. Honors the per-store
+// cache populated by preloadSessionCaches so the routing module and other
+// repeat callers do not incur a round trip after store-open.
 func (s *DoltStore) GetAllConfig(ctx context.Context) (map[string]string, error) {
+	s.cacheMu.Lock()
+	if s.allConfigCached {
+		// Copy so callers can mutate without poisoning the cache.
+		out := make(map[string]string, len(s.allConfigCache))
+		for k, v := range s.allConfigCache {
+			out[k] = v
+		}
+		s.cacheMu.Unlock()
+		return out, nil
+	}
+	s.cacheMu.Unlock()
+
 	var result map[string]string
 	err := s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
 		var err error
@@ -77,9 +108,102 @@ func (s *DoltStore) GetAllConfig(ctx context.Context) (map[string]string, error)
 
 // DeleteConfig removes a configuration value
 func (s *DoltStore) DeleteConfig(ctx context.Context, key string) error {
-	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+	err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
 		return issueops.DeleteConfigInTx(ctx, tx, key)
 	})
+	if err == nil {
+		s.cacheMu.Lock()
+		s.allConfigCached = false
+		s.allConfigCache = nil
+		s.cacheMu.Unlock()
+	}
+	return err
+}
+
+// preloadSessionCaches warms the per-store caches that bd commands would
+// otherwise populate via separate round trips on every invocation. Best
+// effort: any failure leaves the caches cold and the lazy loaders take
+// over. Designed to be called once, from newServerMode, on a freshly
+// established connection — adds at most one round trip up front in exchange
+// for eliminating ~4-6 round trips spread across the rest of the command.
+func (s *DoltStore) preloadSessionCaches(ctx context.Context) {
+	_ = s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
+		rows, err := q.QueryContext(ctx,
+			"SELECT `key`, value FROM config; "+
+				"SELECT 1 FROM wisps LIMIT 1")
+		if err != nil {
+			return nil
+		}
+		defer rows.Close()
+
+		// --- result set 1: config table ---
+		all := make(map[string]string)
+		for rows.Next() {
+			var k, v sql.NullString
+			if scanErr := rows.Scan(&k, &v); scanErr == nil && k.Valid {
+				all[k.String] = v.String
+			}
+		}
+
+		// --- result set 2: wisps probe (may not exist on old schemas) ---
+		wispsEmpty := true
+		if rows.NextResultSet() {
+			if rows.Next() {
+				wispsEmpty = false
+			}
+		}
+
+		s.cacheMu.Lock()
+		s.allConfigCache = all
+		s.allConfigCached = true
+
+		// Derive custom-* caches from config string values (the resolver's
+		// fallback path; identical to the normalized-table source because
+		// SyncCustomStatusesTable keeps them in sync on every SetConfig).
+		if v := all["status.custom"]; v != "" {
+			if parsed, perr := types.ParseCustomStatusConfig(v); perr == nil {
+				s.customStatusDetailedCache = parsed
+				s.customStatusCache = types.CustomStatusNames(parsed)
+			}
+		}
+		s.customStatusCached = true
+
+		if v := all["types.custom"]; v != "" {
+			s.customTypeCache = parseCommaListFromConfig(v)
+		}
+		s.customTypeCached = true
+
+		var infraList []string
+		if v := all["types.infra"]; v != "" {
+			infraList = parseCommaListFromConfig(v)
+		} else {
+			infraList = storage.DefaultInfraTypes()
+		}
+		m := make(map[string]bool, len(infraList))
+		for _, t := range infraList {
+			if t = strings.TrimSpace(t); t != "" {
+				m[t] = true
+			}
+		}
+		s.infraTypeCache = m
+		s.infraTypeCached = true
+
+		s.wispsEmpty = wispsEmpty
+		s.wispsStateKnown = true
+		s.cacheMu.Unlock()
+		return nil
+	})
+}
+
+func parseCommaListFromConfig(value string) []string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // SetMetadata sets a metadata value

--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -10,15 +10,39 @@ import (
 )
 
 // SearchIssues finds issues matching query and filters.
-// Delegates to issueops.SearchIssuesInTx for shared query logic.
+// Delegates to issueops.SearchIssuesInTx for shared query logic, except when
+// the session-scoped cache (populated by preloadSessionCaches) tells us the
+// wisps table is empty or missing — in that case the wisps merge step is a
+// guaranteed no-op and we skip it to save a round trip per search.
 func (s *DoltStore) SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	skipWispsMerge := s.canSkipWispsMerge(filter)
+
 	var result []*types.Issue
 	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
 		var err error
-		result, err = issueops.SearchIssuesInTx(ctx, tx, query, filter)
+		if skipWispsMerge {
+			result, err = issueops.SearchIssuesNonWispInTx(ctx, tx, query, filter)
+		} else {
+			result, err = issueops.SearchIssuesInTx(ctx, tx, query, filter)
+		}
 		return err
 	})
 	return result, err
+}
+
+// canSkipWispsMerge reports whether the wisps merge step in SearchIssues can
+// be skipped safely. True when the per-store cache knows the wisps table is
+// empty or missing AND the caller is not explicitly asking for ephemeral
+// rows (which would route directly to wisps).
+func (s *DoltStore) canSkipWispsMerge(filter types.IssueFilter) bool {
+	if filter.Ephemeral != nil && *filter.Ephemeral {
+		return false
+	}
+	s.cacheMu.Lock()
+	known := s.wispsStateKnown
+	empty := s.wispsEmpty
+	s.cacheMu.Unlock()
+	return known && empty
 }
 
 func (s *DoltStore) SearchIssuesWithCounts(ctx context.Context, query string, filter types.IssueFilter) ([]*types.IssueWithCounts, error) {

--- a/internal/storage/dolt/sqltrace.go
+++ b/internal/storage/dolt/sqltrace.go
@@ -1,0 +1,116 @@
+package dolt
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// traceSQL is true when BD_DOLT_TRACE_SQL=1. It enables coarse per-call
+// stderr logging of SQL operations so we can count round trips and identify
+// hot spots on slow remote-Dolt connections. Off by default.
+var traceSQL = os.Getenv("BD_DOLT_TRACE_SQL") == "1"
+
+var traceStart = time.Now()
+var traceSeq atomic.Int64
+
+// helperFrames are the internal helper functions we want to skip past when
+// reporting the caller of a SQL op. We want to surface the DoltStore method
+// (e.g. GetMetadata) or the cmd/bd caller, not the helper itself.
+var helperFrames = []string{
+	".withReadTx", ".withReadConn", ".withWriteTx", ".withRetryTx",
+	".queryContext", ".execContext", ".queryRowContext",
+	".sqlTraceStart", ".callerLabel",
+}
+
+// callerLabel walks up the stack and returns a short pkg.Func label for
+// the first frame that isn't one of our internal SQL helpers.
+func callerLabel(skip int) string {
+	pcs := make([]uintptr, 16)
+	n := runtime.Callers(skip+1, pcs)
+	if n == 0 {
+		return "?"
+	}
+	frames := runtime.CallersFrames(pcs[:n])
+	for {
+		fr, more := frames.Next()
+		isHelper := false
+		for _, h := range helperFrames {
+			if strings.HasSuffix(fr.Function, h) || strings.Contains(fr.Function, h+".") {
+				isHelper = true
+				break
+			}
+		}
+		if !isHelper {
+			short := fr.Function
+			if idx := strings.LastIndex(short, "/"); idx >= 0 {
+				short = short[idx+1:]
+			}
+			return short
+		}
+		if !more {
+			break
+		}
+	}
+	return "?"
+}
+
+func sqlTraceStart(op string) func(extraFmt string, args ...any) {
+	if !traceSQL {
+		return func(string, ...any) {}
+	}
+	seq := traceSeq.Add(1)
+	t0 := time.Now()
+	rel := t0.Sub(traceStart)
+	caller := callerLabel(2)
+	stack := ""
+	if os.Getenv("BD_DOLT_TRACE_STACK") == "1" {
+		stack = "\n" + callerStack(2)
+	}
+	fmt.Fprintf(os.Stderr, "[sqltrace %4d] %8.1fms BEGIN %-36s via %s%s\n",
+		seq, float64(rel.Microseconds())/1000.0, op, caller, stack)
+	return func(extraFmt string, args ...any) {
+		dt := time.Since(t0)
+		extra := ""
+		if extraFmt != "" {
+			extra = " " + strings.TrimSpace(fmt.Sprintf(extraFmt, args...))
+		}
+		fmt.Fprintf(os.Stderr, "[sqltrace %4d] +%7.1fms END   %-36s%s\n",
+			seq, float64(dt.Microseconds())/1000.0, op, extra)
+	}
+}
+
+func callerStack(skip int) string {
+	pcs := make([]uintptr, 24)
+	n := runtime.Callers(skip+1, pcs)
+	frames := runtime.CallersFrames(pcs[:n])
+	var sb strings.Builder
+	for {
+		fr, more := frames.Next()
+		short := fr.Function
+		if idx := strings.LastIndex(short, "/"); idx >= 0 {
+			short = short[idx+1:]
+		}
+		// skip runtime frames
+		if strings.HasPrefix(short, "runtime.") {
+			if !more {
+				break
+			}
+			continue
+		}
+		sb.WriteString("    ")
+		sb.WriteString(short)
+		sb.WriteString("  (")
+		sb.WriteString(fr.File)
+		sb.WriteString(":")
+		fmt.Fprintf(&sb, "%d", fr.Line)
+		sb.WriteString(")\n")
+		if !more {
+			break
+		}
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -170,6 +170,10 @@ type DoltStore struct {
 	customTypeCached          bool
 	infraTypeCache            map[string]bool
 	infraTypeCached           bool
+	allConfigCache            map[string]string // cached result of GetAllConfig (populated by preloadSessionCaches)
+	allConfigCached           bool              // true once allConfigCache has been populated
+	wispsEmpty                bool              // true if wisps table is missing or empty (skip wisps probe in SearchIssues)
+	wispsStateKnown           bool              // true once wispsEmpty has been resolved
 	cacheMu                   sync.Mutex
 
 	// OTel span attribute cache (avoids per-call allocation)
@@ -1169,6 +1173,15 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 			return nil, verifyErr
 		}
 	}
+
+	// Warm the per-store metadata caches (config map, custom statuses /
+	// types, infra types, wisps existence) in one round trip so the rest
+	// of the command does not pay 3-5 separate trips for data that almost
+	// never changes within a session. Best effort: failures leave the
+	// caches cold and lazy loaders cope.
+	preloadDone := sqlTraceStart("newServerMode.preloadSessionCaches")
+	store.preloadSessionCaches(ctx)
+	preloadDone("")
 
 	if isLocalHost(cfg.ServerHost) {
 		beadsDir := cfg.BeadsDir

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -41,6 +41,7 @@ import (
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
 	"github.com/steveyegge/beads/internal/types"
@@ -609,6 +610,28 @@ func (s *DoltStore) withReadTx(ctx context.Context, fn func(tx *sql.Tx) error) e
 	}
 	defer func() { _ = tx.Rollback() }()
 	return fn(tx)
+}
+
+// withReadConn runs fn against a single pooled connection without wrapping
+// it in a transaction. For simple single-statement reads against a Dolt SQL
+// server in autocommit mode this saves 2 round trips per call (BEGIN +
+// ROLLBACK) compared to withReadTx — a 2-3x speedup on high-latency links.
+//
+// Use this only for reads that do not need snapshot isolation across multiple
+// statements. For multi-statement read groups (e.g. SearchIssues + label
+// hydration) keep using withReadTx so the queries see a consistent view.
+func (s *DoltStore) withReadConn(ctx context.Context, fn func(q issueops.SQLQuerier) error) error {
+	if s.closed.Load() {
+		return ErrStoreClosed
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire read conn: %w", err)
+	}
+	defer func() { _ = conn.Close() }() // releases the conn back to the pool
+	return fn(conn)
 }
 
 func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) error {
@@ -1341,20 +1364,29 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	// pairs in dolt-server.log).
 	applyPoolLimits(db, cfg)
 
-	// Ensure database exists (may need to create it)
-	// First connect without database to create it
-	initConnStr := buildServerDSN(cfg, "")
-	initDB, err := sql.Open("mysql", initConnStr)
-	if err != nil {
-		_ = db.Close()
-		return nil, "", fmt.Errorf("failed to open init connection: %w", err)
-	}
-	defer func() { _ = initDB.Close() }()
-
 	// Validate database name to prevent SQL injection via backtick escaping
 	if err := ValidateDatabaseName(cfg.Database); err != nil {
 		_ = db.Close()
 		return nil, "", fmt.Errorf("invalid database name %q: %w", cfg.Database, err)
+	}
+
+	// Fast path: when we are not allowed to create the database, the SHOW
+	// DATABASES probe is wasted work in the common case where the database
+	// exists. Just ping the main pool — the MySQL handshake will fail with
+	// error 1049 ("Unknown database") if it does not exist. This saves a
+	// full MySQL handshake + SHOW DATABASES round trip on every read-only
+	// command (≈3 RTT on high-latency links). For init/bootstrap paths
+	// (CreateIfMissing=true) we still run the dual-pool dance below.
+	if !cfg.CreateIfMissing {
+		if err := db.PingContext(ctx); err != nil {
+			_ = db.Close()
+			if isDatabaseNotFoundError(err) {
+				return nil, "", databaseNotFoundError(cfg)
+			}
+			return nil, "", fmt.Errorf("failed to connect to Dolt server at %s:%d: %w",
+				cfg.ServerHost, cfg.ServerPort, err)
+		}
+		return db, connStr, nil
 	}
 
 	// FIREWALL: Never create test databases on the production server.
@@ -1367,6 +1399,17 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 				"this is a test database name on the production server (see DOLT-WAR-ROOM.md)",
 			cfg.Database, cfg.ServerPort)
 	}
+
+	// Slow path (init/bootstrap): connect without a database selected so we
+	// can SHOW DATABASES / CREATE DATABASE without depending on the target
+	// existing yet.
+	initConnStr := buildServerDSN(cfg, "")
+	initDB, err := sql.Open("mysql", initConnStr)
+	if err != nil {
+		_ = db.Close()
+		return nil, "", fmt.Errorf("failed to open init connection: %w", err)
+	}
+	defer func() { _ = initDB.Close() }()
 
 	// Check if the database already exists before deciding whether to create it.
 	// This prevents the shadow database bug: without CreateIfMissing, connecting
@@ -1384,11 +1427,6 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	}
 
 	if !dbExists {
-		if !cfg.CreateIfMissing {
-			_ = db.Close()
-			return nil, "", databaseNotFoundError(cfg)
-		}
-
 		_, err = initDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", cfg.Database)) //nolint:gosec // G201: cfg.Database validated by ValidateDatabaseName above
 		if err != nil {
 			// Dolt may return error 1007 even with IF NOT EXISTS - ignore if database already exists
@@ -1429,6 +1467,20 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	}
 
 	return db, connStr, nil
+}
+
+// isDatabaseNotFoundError reports whether err is a MySQL error 1049
+// ("Unknown database"). Used by the fast-path open to map a missing-DB
+// handshake failure to the project-level databaseNotFoundError.
+func isDatabaseNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if me, ok := err.(*mysql.MySQLError); ok && me.Number == 1049 {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "error 1049") || strings.Contains(msg, "unknown database")
 }
 
 // databaseExistsOnServer checks if a database with the exact given name exists

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -604,12 +604,21 @@ func (s *DoltStore) withReadTx(ctx context.Context, fn func(tx *sql.Tx) error) e
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	beginDone := sqlTraceStart("withReadTx.BeginTx")
 	tx, err := s.db.BeginTx(ctx, nil)
+	beginDone("")
 	if err != nil {
 		return fmt.Errorf("begin read tx: %w", err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	return fn(tx)
+	defer func() {
+		rbDone := sqlTraceStart("withReadTx.Rollback")
+		_ = tx.Rollback()
+		rbDone("")
+	}()
+	fnDone := sqlTraceStart("withReadTx.fn")
+	err = fn(tx)
+	fnDone("")
+	return err
 }
 
 // withReadConn runs fn against a single pooled connection without wrapping
@@ -626,12 +635,17 @@ func (s *DoltStore) withReadConn(ctx context.Context, fn func(q issueops.SQLQuer
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	connDone := sqlTraceStart("withReadConn.Conn")
 	conn, err := s.db.Conn(ctx)
+	connDone("")
 	if err != nil {
 		return fmt.Errorf("acquire read conn: %w", err)
 	}
 	defer func() { _ = conn.Close() }() // releases the conn back to the pool
-	return fn(conn)
+	fnDone := sqlTraceStart("withReadConn.fn")
+	err = fn(conn)
+	fnDone("")
+	return err
 }
 
 func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) error {
@@ -798,6 +812,7 @@ func (s *DoltStore) queryContext(ctx context.Context, query string, args ...any)
 			attribute.String("db.statement", spanSQL(query)),
 		)...),
 	)
+	traceDone := sqlTraceStart("DoltStore.queryContext")
 	var rows *sql.Rows
 	err := s.withRetry(ctx, func() error {
 		// Close any Rows from a previous failed attempt to avoid leaking connections.
@@ -809,6 +824,7 @@ func (s *DoltStore) queryContext(ctx context.Context, query string, args ...any)
 		rows, queryErr = s.db.QueryContext(ctx, query, args...)
 		return queryErr
 	})
+	traceDone("q=%s", spanSQL(query))
 	finalErr := wrapLockError(err)
 	endSpan(span, finalErr)
 	return rows, finalErr
@@ -991,16 +1007,29 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 
 	// Fail-fast connectivity check before MySQL protocol initialization.
 	// This gives an immediate, clear error if the Dolt server isn't running,
-	// rather than waiting for MySQL driver timeouts.
+	// rather than waiting for MySQL driver timeouts, and is what triggers the
+	// auto-start path for local repo-managed servers.
+	//
+	// For remote, non-local TCP servers the preflight dial just burns one
+	// round trip every command — the MySQL driver's own Timeout already
+	// fast-fails when the server is unreachable, and auto-start is not an
+	// option anyway. Skip the preflight in that case.
 	var addr string
 	var conn net.Conn
 	var dialErr error
-	if cfg.ServerSocket != "" {
-		addr = cfg.ServerSocket
-		conn, dialErr = net.DialTimeout("unix", cfg.ServerSocket, 500*time.Millisecond)
+	skipPreflight := cfg.ServerSocket == "" && !isLocalHost(cfg.ServerHost)
+	if !skipPreflight {
+		dialDone := sqlTraceStart("newServerMode.preflightDial")
+		if cfg.ServerSocket != "" {
+			addr = cfg.ServerSocket
+			conn, dialErr = net.DialTimeout("unix", cfg.ServerSocket, 500*time.Millisecond)
+		} else {
+			addr = net.JoinHostPort(cfg.ServerHost, fmt.Sprintf("%d", cfg.ServerPort))
+			conn, dialErr = net.DialTimeout("tcp", addr, 500*time.Millisecond)
+		}
+		dialDone("addr=%s", addr)
 	} else {
 		addr = net.JoinHostPort(cfg.ServerHost, fmt.Sprintf("%d", cfg.ServerPort))
-		conn, dialErr = net.DialTimeout("tcp", addr, 500*time.Millisecond)
 	}
 	if dialErr != nil {
 		// Auto-start: if enabled and connecting locally via TCP, start a server.
@@ -1069,7 +1098,9 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 				addr, dialErr, hint)
 		}
 	}
-	_ = conn.Close()
+	if conn != nil {
+		_ = conn.Close()
+	}
 
 	// If this process already owns a test-started auto-start server, later
 	// stores sharing it must participate in the refcount so one Close() does
@@ -1084,16 +1115,16 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	}
 
 	// Server mode: connect via MySQL protocol to dolt sql-server
+	openDone := sqlTraceStart("newServerMode.openServerConnection")
 	db, connStr, err := openServerConnection(ctx, cfg)
+	openDone("")
 	if err != nil {
 		return nil, err
 	}
-
-	// Test connection
-	if err := db.PingContext(ctx); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("failed to ping Dolt database: %w", err)
-	}
+	// openServerConnection already pinged on the fast (read-only) path and
+	// already ran the catalog-wait ping on the create-if-missing path, so a
+	// second PingContext here would be a wasted ~1 RTT (~200 ms on a remote
+	// Dolt connection).
 
 	beadsDir := cfg.BeadsDir
 	if beadsDir == "" && cfg.Path != "" {
@@ -1125,12 +1156,14 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	}
 
 	if !cfg.CreateIfMissing {
+		vidDone := sqlTraceStart("newServerMode.verifyProjectIdentity")
 		var verifyErr error
 		if cfg.Database == doltserver.GlobalDatabaseName {
 			verifyErr = store.verifyGlobalProjectIdentity(ctx, cfg.BeadsDir)
 		} else {
 			verifyErr = store.verifyProjectIdentity(ctx, cfg.BeadsDir)
 		}
+		vidDone("")
 		if verifyErr != nil {
 			_ = db.Close()
 			return nil, verifyErr
@@ -1378,7 +1411,10 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	// command (≈3 RTT on high-latency links). For init/bootstrap paths
 	// (CreateIfMissing=true) we still run the dual-pool dance below.
 	if !cfg.CreateIfMissing {
-		if err := db.PingContext(ctx); err != nil {
+		pingDone := sqlTraceStart("openServerConnection.fastPath.Ping")
+		err := db.PingContext(ctx)
+		pingDone("")
+		if err != nil {
 			_ = db.Close()
 			if isDatabaseNotFoundError(err) {
 				return nil, "", databaseNotFoundError(cfg)

--- a/internal/storage/doltutil/dsn.go
+++ b/internal/storage/doltutil/dsn.go
@@ -45,6 +45,10 @@ func (d ServerDSN) String() string {
 		MultiStatements:      true,
 		Timeout:              timeout,
 		AllowNativePasswords: true,
+		// Client-side param substitution avoids a COM_STMT_PREPARE round trip
+		// per parameterized query. On high-latency links this halves the cost
+		// of a typical SELECT … WHERE k = ? from 2 RTT to 1 RTT.
+		InterpolateParams: true,
 	}
 	if d.TLS {
 		cfg.TLSConfig = "true"

--- a/internal/storage/issueops/config_metadata.go
+++ b/internal/storage/issueops/config_metadata.go
@@ -20,9 +20,12 @@ func SetConfigInTx(ctx context.Context, tx *sql.Tx, key, value string) error {
 	return nil
 }
 
-// GetConfigInTx retrieves a configuration value within an existing transaction.
-// Returns ("", nil) if the key does not exist.
-func GetConfigInTx(ctx context.Context, tx *sql.Tx, key string) (string, error) {
+// GetConfigInTx retrieves a configuration value within an existing transaction
+// or pooled connection. Returns ("", nil) if the key does not exist.
+// Accepts any SQLQuerier (*sql.Tx, *sql.Conn, *sql.DB) so callers can avoid
+// wrapping a single read in BEGIN/ROLLBACK when snapshot isolation is not
+// needed.
+func GetConfigInTx(ctx context.Context, tx SQLQuerier, key string) (string, error) {
 	var value string
 	err := tx.QueryRowContext(ctx, "SELECT value FROM config WHERE `key` = ?", key).Scan(&value)
 	if err == sql.ErrNoRows {
@@ -34,8 +37,9 @@ func GetConfigInTx(ctx context.Context, tx *sql.Tx, key string) (string, error) 
 	return value, nil
 }
 
-// GetAllConfigInTx retrieves all configuration key-value pairs within an existing transaction.
-func GetAllConfigInTx(ctx context.Context, tx *sql.Tx) (map[string]string, error) {
+// GetAllConfigInTx retrieves all configuration key-value pairs.
+// Accepts any SQLQuerier so callers can choose tx or pooled conn.
+func GetAllConfigInTx(ctx context.Context, tx SQLQuerier) (map[string]string, error) {
 	rows, err := tx.QueryContext(ctx, "SELECT `key`, value FROM config")
 	if err != nil {
 		return nil, fmt.Errorf("get all config: %w", err)
@@ -62,9 +66,10 @@ func SetMetadataInTx(ctx context.Context, tx *sql.Tx, key, value string) error {
 	return nil
 }
 
-// GetMetadataInTx retrieves a metadata value within an existing transaction.
+// GetMetadataInTx retrieves a metadata value.
+// Accepts any SQLQuerier so callers can choose tx or pooled conn.
 // Returns ("", nil) if the key does not exist.
-func GetMetadataInTx(ctx context.Context, tx *sql.Tx, key string) (string, error) {
+func GetMetadataInTx(ctx context.Context, tx SQLQuerier, key string) (string, error) {
 	var value string
 	err := tx.QueryRowContext(ctx, "SELECT value FROM metadata WHERE `key` = ?", key).Scan(&value)
 	if err == sql.ErrNoRows {
@@ -88,8 +93,9 @@ func SetLocalMetadataInTx(ctx context.Context, tx *sql.Tx, key, value string) er
 }
 
 // GetLocalMetadataInTx retrieves a value from the dolt-ignored local_metadata
-// table within an existing transaction. Returns ("", nil) if the key does not exist.
-func GetLocalMetadataInTx(ctx context.Context, tx *sql.Tx, key string) (string, error) {
+// table. Accepts any SQLQuerier so callers can choose tx or pooled conn.
+// Returns ("", nil) if the key does not exist.
+func GetLocalMetadataInTx(ctx context.Context, tx SQLQuerier, key string) (string, error) {
 	var value string
 	err := tx.QueryRowContext(ctx, "SELECT value FROM local_metadata WHERE `key` = ?", key).Scan(&value)
 	if err == sql.ErrNoRows {

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -9,6 +9,19 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+// SearchIssuesNonWispInTx runs a filtered search against the issues table only,
+// skipping the wisps merge step entirely (no per-call wisps-empty probe).
+// Callers that already know the wisps table is empty or missing via a
+// session-scoped cache can use this to save the probe round trip — main's
+// SearchIssuesInTx still pays it on every call before deciding to skip.
+func SearchIssuesNonWispInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	results, err := searchTableInTx(ctx, tx, query, filter, IssuesFilterTables)
+	if err != nil {
+		return nil, fmt.Errorf("search issues: %w", err)
+	}
+	return results, nil
+}
+
 // SearchIssuesInTx executes a filtered issue search within an existing transaction.
 // It queries the issues table, optionally merges wisps, and returns hydrated issues
 // with labels populated.


### PR DESCRIPTION
## What

Cuts wall-clock cost of `bd` against an external Dolt SQL server (`dolt_mode=server`). On a connection with ~200 ms RTT to a remote host, the changes drop:

- `bd list` over 200 issues: **~12 s → ~3 s**
- `bd create` warm: **>2 min on stock v1.0.4 → ~8 s** on this branch

Four focused commits on top of current `main`. Each is independently reviewable.

## Why

I (Hans) was running `bd 1.0.4` in `dolt_mode=server` against a remote Dolt server (not localhost). Every command took 5–30 s wall-clock despite the server itself answering a single `SELECT 1` in ~200 ms. CPU on the client was ~1 %; the rest was serial network waits. Writes were worse — `bd create` regularly timed out. Same symptom as #4102, adjacent to #3239 and #3760. For teams using a shared Dolt server, this gap is the blocker for actually adopting beads in `dolt_mode=server`.

A separate, parallel investigation against **v1.0.4** built up a 9-commit showcase (closed-but-linked PR #4165, with a full Notion writeup). After tracing the same paths against current `main`, two ideas from the v1.0.4 work had already landed here with different mechanisms:

- Read-only PostRun gating on `maybeAutoExport` / `maybeAutoPush` (already on `main` via `shouldRunPostCommandAutoExport(cmd)`).
- `maybeAutoImportJSONL` emptiness check (already on `main` via a top-level `GetStatistics(ctx)` guard). **Heads-up from the v1.0.4 investigation**: against a remote Dolt server `bd stats` (and therefore `GetStatistics`) hangs on a single metric query that never returns within 30 s. The emptiness guard may not actually short-circuit in `dolt_mode=server`. A cheaper probe (`SELECT 1 FROM issues LIMIT 1`) doesn't hit that hang. Worth a separate look.
- `GetCommentCountsInTx` batched wisp partition (already on `main`).
- `routing_read.go` batched `GetAllConfig` (already on `main`).
- `RunCompatMigrations` + `EnsureIgnoredTables` chain (already removed on `main` — schema is consolidated under the embedded migration system).

This PR keeps only the changes that `main` does **not** already have.

## How (four commits)

A per-call SQL trace (`BD_DOLT_TRACE_SQL=1`, see below) drove the work:

1. **`perf(dolt): cut remote-Dolt round trips on metadata reads + connection open`**
   - New `withReadConn` helper: `GetConfig`, `GetAllConfig`, `GetMetadata`, `GetLocalMetadata` borrow a pooled `*sql.Conn` instead of opening a `BEGIN/ROLLBACK` transaction. Saves 2 round trips per simple read.
   - Widen four `issueops` `Get*InTx` helpers from `*sql.Tx` to a small `SQLQuerier` interface so callers can pass either tx or conn. `*sql.Tx` still satisfies it, so existing callers compile unchanged.
   - DSN: pin `MaxAllowedPacket = 64 MiB` so the driver skips its `SELECT @@max_allowed_packet` discovery query (–1 RTT per cold conn).
   - DSN: `InterpolateParams = true` so the driver substitutes parameters client-side instead of `COM_STMT_PREPARE` + `COM_STMT_EXECUTE` (halves parameterized-read cost: 2 RTT → 1 RTT).
   - `openServerConnection` fast path: when `CreateIfMissing=false` (every read-only command), skip the second init-only pool and the `SHOW DATABASES` probe. Just ping the main pool and translate MySQL error 1049 (Unknown database) to `databaseNotFoundError`. Saves a handshake + a probe per command.

2. **`perf(dolt): trace harness + gate maybeAutoBackup + skip empty-list deps + skip preflight dial`**
   - `cmd/bd/main.go`: gate `maybeAutoBackup` behind `!isReadOnlyCommand`. `main` already gates `maybeAutoExport` and `maybeAutoPush`; this extends the same intent to backup, which still runs on every command and pays a `GetCurrentCommit` round trip.
   - `cmd/bd/list.go`: skip `GetAllDependencyRecords` when the issue list is empty. Default tree-mode display would otherwise pay 3 RTT for an empty result set on a remote link.
   - `internal/storage/dolt/sqltrace.go`: new env-gated per-call SQL trace (`BD_DOLT_TRACE_SQL=1`, `BD_DOLT_TRACE_STACK=1`). Off by default; lets reviewers verify per-RTT timing themselves. This is the harness that drove every other change.
   - `internal/storage/dolt/store.go`: skip the `net.DialTimeout` preflight for non-local TCP servers. The MySQL driver's own `Timeout` already fast-fails; preflight only matters when `AutoStart` can kick in on a local server.

3. **`perf(dolt): store-open prefetch + wisps-merge skip`**
   - `preloadSessionCaches` fires a 2-statement multi-query (`SELECT key,value FROM config; SELECT 1 FROM wisps LIMIT 1`) at store-open and populates five per-store caches (config map, custom statuses / types / infra types, wisps existence). One round trip up front in exchange for eliminating 3–5 round trips spread across the rest of the command.
   - `GetConfig(key)` and `GetAllConfig` honor `allConfigCache` so the routing module and other repeat callers do not pay a round trip per key once the cache is warm. `SetConfig` and `DeleteConfig` invalidate the cache.
   - Adds `SearchIssuesNonWispInTx`: sibling of `SearchIssuesInTx` that runs only the issues-table search and skips the wisps merge entirely. `DoltStore.SearchIssues` routes to it when `canSkipWispsMerge` reports the cache knows wisps is empty AND the caller is not explicitly asking for ephemeral rows. Saves the wisps-empty probe round trip that `main`'s `SearchIssuesInTx` pays on every call.

4. **`perf(auto-export): parallelize bulk-load reads, default to 5-min throttle in server mode`**
   - Inside `exportToFile`, the five independent bulk-load reads (labels, deps, comments, commentCounts, depCounts) run via `sync.WaitGroup` on the existing connection pool instead of back-to-back. Each was ~1.2 s on a remote link; ~6 s sequential → ~1.5 s parallel. Pool default `MaxOpenConns=10` covers the five concurrent reads.
   - `export.interval` default is now backend-aware: 60 s for embedded (rebuild costs ~150 ms), 5 min for `dolt_mode=server` (rebuild costs 5–10 s on a remote link). Users can override by setting `export.interval` explicitly.

A new optional `BD_DOLT_TRACE_SQL=1` env var emits per-call timings to stderr so anyone can verify these numbers themselves; `BD_DOLT_TRACE_STACK=1` adds full call stacks.

## ⚠️ Showcase only — please do not merge

A few pieces here are deliberately additive (new code next to old) so each change is reviewable in isolation:

- `SearchIssuesNonWispInTx` is a near-duplicate of `SearchIssuesInTx`. Proper version: one function with a `skipWispsMerge` hint.
- `withReadConn` is a sibling of `withReadTx`. Proper version: one helper that picks tx vs. conn from caller intent.
- `internal/storage/dolt/sqltrace.go` parallels the existing OTel `doltTracer`. Proper version: fold the few extra spans in and drop `sqltrace.go`.

The intent: land *this* PR to validate the numbers and approach with maintainers, then open a follow-up PR that collapses the duplicates and removes `sqltrace.go`. Marked as **draft**.

## Verification

### Output parity

`bd list`, `bd list --all`, `bd list --json`, `bd list --type bug`, `bd list --status in_progress`, `bd list --label …`, `bd list --flat`, `bd ready`, `bd count`, `bd show <id>`, `bd search …` all produce byte-for-byte identical output between stock `bd` and this branch on both backends. Use `bd export | bd import` to reproduce a seed on both.

### Wall-clock measurements

A 200-issue corpus (10 epics, 40 features, 110 tasks, 25 bugs, 15 chores; mixed statuses; parent-child hierarchy across 3 levels; `blocks` dependencies on every 5th task; ~10% closed) was seeded identically into:

- embedded Dolt (local disk)
- external Dolt server (~200 ms RTT TCP)

3 timed iterations after a warmup, timed with `time.monotonic()` from a Python wrapper.

These numbers come from the parallel v1.0.4 investigation (closed PR #4165 + the linked Notion writeup). The rebased branch in this PR was spot-checked against the same server and produced the same shape of result — `bd list` ~3 s, warm `bd create` ~8 s.

#### Verified against current `main` (`f8b940016`)

Spot-check on the same server and corpus, both binaries built with `CGO_ENABLED=0 -tags gms_pure_go` so the toolchain is identical (rules out driver / CGO compile-variance noise). 3 timed iterations after one warmup run per binary:

| binary | min | avg | max |
|---|---|---|---|
| stock `bd` from `origin/main` (`f8b940016`) | 8228 ms | **8257 ms** | 8288 ms |
| this branch (4 commits on top of `f8b940016`) | 3355 ms | **3424 ms** | 3481 ms |

**Speedup vs current `main`: 2.4×** on `bd list`. (For reference: stock v1.0.4 was ~12.3 s on the same corpus, so `main` has already absorbed ~32% of the speedup independently — most of that via its `GetCommentCountsInTx` batching, the routing-config batch, and the dropped `RunCompatMigrations` chain — and this PR adds another ~2.4× on top.)

#### Embedded backend — no regressions

Embedded mode is unchanged in shape; the no-op gating and cache changes save a small amount per command (~30–50 % on read paths, 0–10 % on writes). No command is slower outside measurement noise.

#### Remote-Dolt backend — major wins on every read command

| command | stock v1.0.4 (ms) | this branch (ms) | speedup |
|---|---|---|---|
| `bd list` | 12,281 | **~3,000** | **~4×** |
| `bd list --type bug` | 13,755 | **~3,000** | **~4.5×** |
| `bd list --status in_progress` | 12,523 | **~3,000** | **~4×** |
| `bd list --label …` | 12,664 | **~3,000** | **~4×** |
| `bd count` | 5,531 | **~2,400** | **~2.3×** |
| `bd ready` | 30,425 | **~15,000** | **~2×** |
| `bd show <id>` | 12,236 | **~5,500** | **~2.2×** |
| `bd search` | 6,989 | **~2,800** | **~2.5×** |

Write commands:

| command | stock v1.0.4 (ms) | this branch (ms) | speedup |
|---|---|---|---|
| `bd create` cold first | **>161,565** (timed out at 2:42, still running) | ~16,000 | ~10× |
| `bd create` warm avg | n/a — never completed | **~8,000** | **>20×** |

Full data + breakdown by phase: see Notion writeup linked in closed PR #4165.

### Unit tests

Existing test suites in the touched packages pass (`-short`):

- `internal/storage/doltutil`
- `internal/storage/issueops`
- `internal/storage/dolt/migrations`

Note: `internal/storage/dolt/TestPullWithAutoResolve_BranchTrackingFallbackSuccess` requires the `dolt` CLI on PATH and was failing on `main` before this PR — unchanged.

### Reproducing the numbers

`BD_DOLT_TRACE_SQL=1 bd-perf list` dumps a per-call trace to stderr — every round trip annotated with timing and caller info. `BD_DOLT_TRACE_STACK=1` adds full call stacks.

### How to try it locally

```bash
git clone https://github.com/gastownhall/beads
cd beads
git fetch origin pull/<this PR number>/head:perf-rebased
git checkout perf-rebased

# Full CGO build (lets you run against .beads/embeddeddolt/ too)
make build
mv bd ~/.local/bin/bd-perf

# Or server-mode-only (no CGO, faster build, no embedded backend)
CGO_ENABLED=0 go build -tags gms_pure_go -o ~/.local/bin/bd-perf ./cmd/bd
```

Then point an existing repo at it without disturbing your installed `bd`:

```bash
bd-perf -C /path/to/.beads/repo list
bd-perf -C /path/to/.beads/repo show <issue-id>

# Side-by-side compare against your stock bd
time bd list
time bd-perf list

# See the trace
BD_DOLT_TRACE_SQL=1 bd-perf list 2>&1 | head -40
```

`bd-perf` reads the same `.beads/metadata.json`, `.beads/dolt-server.port`, and `~/.config/beads/credentials` as stock `bd` — no extra configuration. Output is byte-for-byte identical to stock for the commands in the parity table, so it's safe to drop into existing workflows for read commands. **Writes work and are dramatically faster, but the patches are framed as a showcase — please don't merge or run them in production without a follow-up that absorbs the duplicates noted above.**

To revert, just delete `~/.local/bin/bd-perf` — your `~/.local/bin/bd` is untouched.

## Related issues

- **#4102** — `perf(server-mode): bd commands take 5-10s in remote dolt_mode due to cold connection + serial query pattern` — direct response.
- **#3239** — `Batch wisp routing checks to reduce WAN latency amplification in Dolt server mode` — addressed via the wisps-existence cache + the existing `PartitionWispIDsInTx` already landed on main.
- **#3760** — `Proposal: bd serve daemon to amortize dolt connection setup` — complementary; this PR demonstrates what's achievable *without* a daemon.
- **#3880** + **#4128** — server-mode write-path re-imports JSONL on every write — `main` has already fixed the emptiness check via `GetStatistics`. See "Why" section above for a heads-up about that guard not actually short-circuiting in `dolt_mode=server` (a `bd stats` hang issue we measured).
- Closed companion PR: **#4165** (against v1.0.4, contains the full investigation against the released version).

## Authorship

Mixed human + AI effort. Investigation, code, tests, and benchmarks were a back-and-forth between **Hans Boese** (human, account opening this PR) and **Claude** (Anthropic, via Claude Code, working as a paired contributor). Every commit has `Co-Authored-By: Claude <noreply@anthropic.com>`. The roles split roughly as: Hans set the goal and reviewed each step; Claude wrote the trace harness, ran the measurements, drafted the patches and the benchmark report, iterating in tight loops with Hans deciding what to keep at each round.

## Follow-up (not in this PR)

- Collapse `SearchIssuesNonWispInTx` into `SearchIssuesInTx` via a hint param.
- Replace `withReadTx` + `withReadConn` pair with a single helper that picks tx vs. conn from caller intent.
- Remove `internal/storage/dolt/sqltrace.go`; fold its handful of spans into the existing OTel `doltTracer`.
- Investigate why `bd stats` (and therefore the auto-import emptiness `GetStatistics` guard) hangs against a remote Dolt server.
- Combine `CreateIssueInTx` + `doltAddAndCommit` into one round trip via a stored procedure or multi-statement (currently two transactions per write).
