### PR TITLE
bd-91bzp: make issue prefix mutations explicit

### DIFF
--- a/cmd/bd/rename_prefix.go
+++ b/cmd/bd/rename_prefix.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 	"github.com/steveyegge/beads/internal/utils"
@@ -124,7 +125,9 @@ NOTE: This is a rare operation. Most users never need this command.`,
 		if len(issues) == 0 {
 			fmt.Printf("No issues to rename. Updating prefix to %s\n", newPrefix)
 			if !dryRun {
-				if err := store.SetConfig(ctx, "issue_prefix", newPrefix); err != nil {
+				if err := withPrefixMutationAllowed(func() error {
+					return store.SetConfig(ctx, "issue_prefix", newPrefix)
+				}); err != nil {
 					FatalError("failed to update prefix: %v", err)
 				}
 				commandDidWrite.Store(true)
@@ -168,6 +171,21 @@ NOTE: This is a rare operation. Most users never need this command.`,
 
 		commandDidWrite.Store(true)
 	},
+}
+
+func withPrefixMutationAllowed(fn func() error) error {
+	previous, hadPrevious := os.LookupEnv(issueops.AllowPrefixMutationEnv)
+	if err := os.Setenv(issueops.AllowPrefixMutationEnv, "1"); err != nil {
+		return err
+	}
+	defer func() {
+		if hadPrevious {
+			_ = os.Setenv(issueops.AllowPrefixMutationEnv, previous)
+		} else {
+			_ = os.Unsetenv(issueops.AllowPrefixMutationEnv)
+		}
+	}()
+	return fn()
 }
 
 func validatePrefix(prefix string) error {
@@ -324,7 +342,9 @@ func repairPrefixes(ctx context.Context, st storage.DoltStorage, actorName strin
 	}
 
 	// Set the new prefix in config
-	if err := st.SetConfig(ctx, "issue_prefix", targetPrefix); err != nil {
+	if err := withPrefixMutationAllowed(func() error {
+		return st.SetConfig(ctx, "issue_prefix", targetPrefix)
+	}); err != nil {
 		return fmt.Errorf("failed to update config: %w", err)
 	}
 
@@ -383,7 +403,9 @@ func renamePrefixInDB(ctx context.Context, oldPrefix, newPrefix string, issues [
 		}
 	}
 
-	if err := store.SetConfig(ctx, "issue_prefix", newPrefix); err != nil {
+	if err := withPrefixMutationAllowed(func() error {
+		return store.SetConfig(ctx, "issue_prefix", newPrefix)
+	}); err != nil {
 		return fmt.Errorf("failed to update config: %w", err)
 	}
 

--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/testutil"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -327,6 +328,55 @@ func TestSetConfigNormalizesIssuePrefix(t *testing.T) {
 	}
 	if value != "gt" {
 		t.Errorf("expected issue_prefix 'gt' (trailing hyphen stripped), got %q", value)
+	}
+}
+
+func TestSetConfigRejectsIssuePrefixMutation(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
+		t.Fatalf("initial SetConfig failed: %v", err)
+	}
+	if err := store.SetConfig(ctx, "issue_prefix", "bds"); err == nil {
+		t.Fatal("expected issue_prefix mutation to fail without break-glass env")
+	} else if !strings.Contains(err.Error(), issueops.AllowPrefixMutationEnv) {
+		t.Fatalf("expected error to mention %s, got: %v", issueops.AllowPrefixMutationEnv, err)
+	}
+
+	value, err := store.GetConfig(ctx, "issue_prefix")
+	if err != nil {
+		t.Fatalf("GetConfig failed: %v", err)
+	}
+	if value != "bd" {
+		t.Fatalf("issue_prefix mutated despite rejection: got %q", value)
+	}
+}
+
+func TestSetConfigAllowsIssuePrefixMutationWithBreakGlass(t *testing.T) {
+	t.Setenv(issueops.AllowPrefixMutationEnv, "1")
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
+		t.Fatalf("initial SetConfig failed: %v", err)
+	}
+	if err := store.SetConfig(ctx, "issue_prefix", "bds"); err != nil {
+		t.Fatalf("break-glass SetConfig failed: %v", err)
+	}
+
+	value, err := store.GetConfig(ctx, "issue_prefix")
+	if err != nil {
+		t.Fatalf("GetConfig failed: %v", err)
+	}
+	if value != "bds" {
+		t.Fatalf("issue_prefix = %q, want bds", value)
 	}
 }
 

--- a/internal/storage/domain/db/config.go
+++ b/internal/storage/domain/db/config.go
@@ -5,9 +5,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 )
 
 func NewConfigSQLRepository(runner Runner) domain.ConfigSQLRepository {
@@ -61,6 +63,13 @@ func (r *configSQLRepositoryImpl) GetConfig(ctx context.Context, key string) (st
 func (r *configSQLRepositoryImpl) SetConfig(ctx context.Context, key, value string) error {
 	if key == "issue_prefix" {
 		value = strings.TrimSuffix(value, "-")
+		existing, err := r.GetConfig(ctx, "issue_prefix")
+		if err != nil {
+			return err
+		}
+		if existing != "" && existing != value && os.Getenv(issueops.AllowPrefixMutationEnv) != "1" {
+			return fmt.Errorf("db: SetConfig issue_prefix: issue_prefix is identity state and cannot be changed from %q to %q without %s=1; use bd rename-prefix for migrations", existing, value, issueops.AllowPrefixMutationEnv)
+		}
 	}
 	if _, err := r.runner.ExecContext(ctx, "REPLACE INTO config (`key`, value) VALUES (?, ?)", key, value); err != nil {
 		return fmt.Errorf("db: SetConfig %s: %w", key, err)

--- a/internal/storage/domain/db/config_test.go
+++ b/internal/storage/domain/db/config_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 )
 
 func (s *testSuite) TestConfigSQLRepository() {
@@ -23,6 +24,8 @@ func (s *testSuite) TestConfigSQLRepository() {
 		s.Run("Overwrite", s.configSetConfigOverwrite)
 		s.Run("IssuePrefixTrimsTrailingHyphen", s.configSetConfigIssuePrefixTrim)
 		s.Run("IssuePrefixWithoutHyphenUnchanged", s.configSetConfigIssuePrefixUnchanged)
+		s.Run("IssuePrefixRejectsMutation", s.configSetConfigIssuePrefixRejectsMutation)
+		s.Run("IssuePrefixAllowsBreakGlassMutation", s.configSetConfigIssuePrefixAllowsBreakGlassMutation)
 	})
 }
 
@@ -102,4 +105,27 @@ func (s *testSuite) configSetConfigIssuePrefixUnchanged() {
 	v, err := r.GetConfig(s.Ctx(), "issue_prefix")
 	s.Require().NoError(err)
 	s.Equal("bd", v)
+}
+
+func (s *testSuite) configSetConfigIssuePrefixRejectsMutation() {
+	r := s.configRepo()
+	s.Require().NoError(r.SetConfig(s.Ctx(), "issue_prefix", "bd"))
+	err := r.SetConfig(s.Ctx(), "issue_prefix", "bds")
+	s.Require().Error(err)
+	s.Contains(err.Error(), issueops.AllowPrefixMutationEnv)
+
+	v, getErr := r.GetConfig(s.Ctx(), "issue_prefix")
+	s.Require().NoError(getErr)
+	s.Equal("bd", v)
+}
+
+func (s *testSuite) configSetConfigIssuePrefixAllowsBreakGlassMutation() {
+	s.T().Setenv(issueops.AllowPrefixMutationEnv, "1")
+	r := s.configRepo()
+	s.Require().NoError(r.SetConfig(s.Ctx(), "issue_prefix", "bd"))
+	s.Require().NoError(r.SetConfig(s.Ctx(), "issue_prefix", "bds"))
+
+	v, err := r.GetConfig(s.Ctx(), "issue_prefix")
+	s.Require().NoError(err)
+	s.Equal("bds", v)
 }

--- a/internal/storage/issueops/config_metadata.go
+++ b/internal/storage/issueops/config_metadata.go
@@ -4,20 +4,37 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"strings"
 )
+
+const AllowPrefixMutationEnv = "BEADS_ALLOW_PREFIX_MUTATION"
 
 // SetConfigInTx sets a configuration value within an existing transaction.
 // Normalizes issue_prefix by stripping trailing hyphens.
 func SetConfigInTx(ctx context.Context, tx *sql.Tx, key, value string) error {
 	if key == "issue_prefix" {
 		value = strings.TrimSuffix(value, "-")
+		if err := rejectPrefixMutationUnlessAllowed(ctx, tx, value); err != nil {
+			return err
+		}
 	}
 	_, err := tx.ExecContext(ctx, "REPLACE INTO config (`key`, value) VALUES (?, ?)", key, value)
 	if err != nil {
 		return fmt.Errorf("set config %s: %w", key, err)
 	}
 	return nil
+}
+
+func rejectPrefixMutationUnlessAllowed(ctx context.Context, tx *sql.Tx, value string) error {
+	existing, err := GetConfigInTx(ctx, tx, "issue_prefix")
+	if err != nil {
+		return err
+	}
+	if existing == "" || existing == value || os.Getenv(AllowPrefixMutationEnv) == "1" {
+		return nil
+	}
+	return fmt.Errorf("issue_prefix is identity state and cannot be changed from %q to %q without %s=1; use bd rename-prefix for migrations", existing, value, AllowPrefixMutationEnv)
 }
 
 // GetConfigInTx retrieves a configuration value within an existing transaction.


### PR DESCRIPTION
Agent: codex-desktop

Feature-Key: bd-91bzp

## Summary
- Treat `issue_prefix` as identity state after initialization.
- Allow initial/idempotent prefix writes, but reject existing-prefix changes unless `BEADS_ALLOW_PREFIX_MUTATION=1`.
- Let the dedicated `rename-prefix` command set that break-glass internally for legitimate migrations.
- Cover both Dolt storage paths and the SQL domain config repository.

## Verification
- `go test ./internal/storage/domain/db`
- `go test ./internal/storage/dolt -run 'TestSetConfig(NormalizesIssuePrefix|RejectsIssuePrefixMutation|AllowsIssuePrefixMutationWithBreakGlass)'`\n- `go test -tags gms_pure_go ./cmd/bd -run 'TestConfig|TestRenamePrefix|TestSetConfig|TestConfigSetMany'`\n- `go test -tags gms_pure_go ./cmd/bd ./internal/storage/domain/db ./internal/storage/dolt -run 'TestConfig|TestRenamePrefix|TestSetConfig(NormalizesIssuePrefix|RejectsIssuePrefixMutation|AllowsIssuePrefixMutationWithBreakGlass)'`\n- `go build -tags gms_pure_go -o /tmp/agents/bd-91bzp/bd ./cmd/bd`\n- temp repo smoke: init/create/show/close/config get, blocked `config set issue_prefix`, custom config set, `rename-prefix` migration\n\n## Note\nA bare `go build ./cmd/bd` on this host fails on missing ICU headers (`unicode/uregex.h`). The repo CI and docs require `-tags gms_pure_go` for normal builds; tagged build passed. A candidate binary direct-open against the shared live Beads runtime hit a pre-existing schema/migration mismatch, so I did not deploy the candidate binary to live. The installed production `bdx` path remains healthy.