### PR TITLE
fix: bound embedded Dolt opens

### DIFF
--- a/cmd/bd/store_factory_nocgo.go
+++ b/cmd/bd/store_factory_nocgo.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage"
@@ -75,6 +76,12 @@ func newReadOnlyStoreFromConfig(ctx context.Context, beadsDir string) (storage.D
 		return dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	}
 	return nil, fmt.Errorf("%s", nocgoEmbeddedErrMsg)
+}
+
+func sanitizeDBName(name string) string {
+	name = strings.ReplaceAll(name, "-", "_")
+	name = strings.ReplaceAll(name, ".", "_")
+	return name
 }
 
 const nocgoEmbeddedErrMsg = `embedded Dolt requires a CGO build, but this bd binary was built with CGO_ENABLED=0.

--- a/internal/storage/embeddeddolt/open.go
+++ b/internal/storage/embeddeddolt/open.go
@@ -23,13 +23,21 @@ import (
 var validIdentifier = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
 const (
-	commitName  = "beads"
-	commitEmail = "beads@local"
+	commitName                 = "beads"
+	commitEmail                = "beads@local"
+	defaultEmbeddedOpenTimeout = 30 * time.Second
 )
 
 // OpenSQL opens an embedded Dolt database at dir. The returned cleanup
 // function closes both the *sql.DB and the underlying connector.
 func OpenSQL(ctx context.Context, dir, database, branch string) (*sql.DB, func() error, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	openTimeout := embeddedOpenTimeout(ctx)
+	openCtx, cancel := context.WithTimeout(ctx, openTimeout)
+	defer cancel()
+
 	dsn := buildDSN(dir, database)
 
 	cfg, err := doltembed.ParseDSN(dsn)
@@ -38,7 +46,7 @@ func OpenSQL(ctx context.Context, dir, database, branch string) (*sql.DB, func()
 	}
 
 	bo := backoff.NewExponentialBackOff()
-	bo.MaxElapsedTime = 0 // wait until ctx cancellation
+	bo.MaxElapsedTime = openTimeout
 	bo.MaxInterval = 5 * time.Second
 	cfg.BackOff = bo
 
@@ -70,7 +78,7 @@ func OpenSQL(ctx context.Context, dir, database, branch string) (*sql.DB, func()
 		return errors.Join(dbErr, connErr)
 	}
 
-	if err := db.PingContext(ctx); err != nil {
+	if err := db.PingContext(openCtx); err != nil {
 		return nil, nil, errors.Join(err, cleanup())
 	}
 
@@ -82,17 +90,46 @@ func OpenSQL(ctx context.Context, dir, database, branch string) (*sql.DB, func()
 			}
 			return nil, nil, errors.Join(errors.New(msg), cleanup())
 		}
-		if _, err := db.ExecContext(ctx, "USE `"+database+"`"); err != nil {
+		if _, err := db.ExecContext(openCtx, "USE `"+database+"`"); err != nil {
 			return nil, nil, errors.Join(err, cleanup())
 		}
 		if strings.TrimSpace(branch) != "" {
-			if _, err := db.ExecContext(ctx, fmt.Sprintf("SET @@%s_head_ref = %s", database, sqlStringLiteral(branch))); err != nil {
+			if _, err := db.ExecContext(openCtx, fmt.Sprintf("SET @@%s_head_ref = %s", database, sqlStringLiteral(branch))); err != nil {
 				return nil, nil, errors.Join(err, cleanup())
 			}
 		}
 	}
 
 	return db, cleanup, nil
+}
+
+func embeddedOpenTimeout(parent context.Context) time.Duration {
+	timeout := configuredEmbeddedOpenTimeout()
+	if deadline, ok := parent.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return time.Nanosecond
+		}
+		if remaining < timeout {
+			return remaining
+		}
+	}
+	return timeout
+}
+
+func configuredEmbeddedOpenTimeout() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("BEADS_EMBEDDED_OPEN_TIMEOUT"))
+	if raw == "" {
+		raw = strings.TrimSpace(os.Getenv("BEADS_EMBEDDED_LOCK_TIMEOUT"))
+	}
+	if raw == "" {
+		return defaultEmbeddedOpenTimeout
+	}
+	timeout, err := time.ParseDuration(raw)
+	if err != nil || timeout <= 0 {
+		return defaultEmbeddedOpenTimeout
+	}
+	return timeout
 }
 
 func buildDSN(dir, database string) string {

--- a/internal/storage/embeddeddolt/open_test.go
+++ b/internal/storage/embeddeddolt/open_test.go
@@ -3,9 +3,57 @@
 package embeddeddolt
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestConfiguredEmbeddedOpenTimeoutFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{name: "empty", env: "", want: defaultEmbeddedOpenTimeout},
+		{name: "whitespace", env: " \t", want: defaultEmbeddedOpenTimeout},
+		{name: "valid", env: "75ms", want: 75 * time.Millisecond},
+		{name: "invalid", env: "not-a-duration", want: defaultEmbeddedOpenTimeout},
+		{name: "zero", env: "0s", want: defaultEmbeddedOpenTimeout},
+		{name: "negative", env: "-1s", want: defaultEmbeddedOpenTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BEADS_EMBEDDED_OPEN_TIMEOUT", tt.env)
+			t.Setenv("BEADS_EMBEDDED_LOCK_TIMEOUT", "")
+			if got := configuredEmbeddedOpenTimeout(); got != tt.want {
+				t.Fatalf("configuredEmbeddedOpenTimeout() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfiguredEmbeddedOpenTimeoutLegacyEnv(t *testing.T) {
+	t.Setenv("BEADS_EMBEDDED_OPEN_TIMEOUT", "")
+	t.Setenv("BEADS_EMBEDDED_LOCK_TIMEOUT", "90ms")
+
+	if got := configuredEmbeddedOpenTimeout(); got != 90*time.Millisecond {
+		t.Fatalf("configuredEmbeddedOpenTimeout() = %s, want 90ms", got)
+	}
+}
+
+func TestEmbeddedOpenTimeoutUsesSoonerParentDeadline(t *testing.T) {
+	t.Setenv("BEADS_EMBEDDED_OPEN_TIMEOUT", "5s")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	got := embeddedOpenTimeout(ctx)
+	if got <= 0 || got > time.Second {
+		t.Fatalf("embeddedOpenTimeout() = %s, want positive duration below 1s", got)
+	}
+}
 
 func TestBuildDSN_SpacesInPath(t *testing.T) {
 	// Regression test for #2920: paths with spaces must not be


### PR DESCRIPTION
## Summary
- add a default 30s timeout around embedded Dolt opens so lock/connect waits cannot run forever without a parent deadline
- support `BEADS_EMBEDDED_OPEN_TIMEOUT`, with `BEADS_EMBEDDED_LOCK_TIMEOUT` as a compatibility fallback
- keep the no-CGO `sanitizeDBName` helper available after the storage refactor

## Verification
- `go test -tags gms_pure_go ./cmd/bd -run '^$'`
- `go test -tags gms_pure_go ./internal/storage/embeddeddolt`
- installed locally with `make install-force`
- live town-root smoke: bounded `bd list`, `gt hook --json`, and `gt mail inbox --identity mayor/ --json` returned without hanging

Note: a broader `go test -tags gms_pure_go ./cmd/bd ./internal/storage/embeddeddolt` run was stopped after `cmd/bd` sat in its test binary for over two minutes with negligible CPU; replaced with the build-only `cmd/bd` check above plus focused embedded-Dolt tests.
