### PR TITLE
fix(dolt): proxied routed store must not clobber dolt-server.port

### DIFF
--- a/cmd/bd/db_proxy_child.go
+++ b/cmd/bd/db_proxy_child.go
@@ -29,6 +29,8 @@ var (
 	dbProxyChildExternalTLSCertPath string
 	dbProxyChildExternalTLSKeyPath  string
 	dbProxyChildExternalKeepAlive   time.Duration
+	dbProxyChildPoolSize            int
+	dbProxyChildBackendUser         string
 )
 
 var dbProxyChildCmd = &cobra.Command{
@@ -63,11 +65,24 @@ not intended to be invoked directly by users.`,
 			return err
 		}
 
+		// Backend credentials for pooled connections. The user arrives via
+		// flag (default root); the password is read from the environment so it
+		// never appears on the command line. Only the external backend has a
+		// non-empty password; the managed loopback server uses root with no
+		// password.
+		backendPassword := ""
+		if backend == proxy.BackendExternal {
+			backendPassword = os.Getenv(configfile.ExternalDoltPasswordEnvVar)
+		}
+
 		p := proxy.NewProxyServer(proxy.ProxyOpts{
-			RootDir:     dbProxyChildRoot,
-			Port:        dbProxyChildPort,
-			IdleTimeout: dbProxyChildIdleTimeout,
-			Server:      srv,
+			RootDir:         dbProxyChildRoot,
+			Port:            dbProxyChildPort,
+			IdleTimeout:     dbProxyChildIdleTimeout,
+			Server:          srv,
+			PoolSize:        dbProxyChildPoolSize,
+			BackendUser:     dbProxyChildBackendUser,
+			BackendPassword: backendPassword,
 		})
 		if err := p.ListenAndServe(cmd.Context()); err != nil {
 			if errors.Is(err, proxy.ErrLockHeld) {
@@ -107,6 +122,8 @@ func init() {
 	dbProxyChildCmd.Flags().StringVar(&dbProxyChildExternalTLSCertPath, "external-tls-cert-path", "", "external backend: absolute path to client TLS certificate (mTLS)")
 	dbProxyChildCmd.Flags().StringVar(&dbProxyChildExternalTLSKeyPath, "external-tls-key-path", "", "external backend: absolute path to client TLS private key (mTLS)")
 	dbProxyChildCmd.Flags().DurationVar(&dbProxyChildExternalKeepAlive, "external-keep-alive", 0, "external backend: TCP keepalive period (default 30s)")
+	dbProxyChildCmd.Flags().IntVar(&dbProxyChildPoolSize, "pool-size", 0, "if >0, pool up to N warm authenticated backend connections instead of dialing one per client")
+	dbProxyChildCmd.Flags().StringVar(&dbProxyChildBackendUser, "backend-user", "root", "user the proxy authenticates pooled backend connections as")
 	_ = dbProxyChildCmd.MarkFlagRequired("root")
 	_ = dbProxyChildCmd.MarkFlagRequired("port")
 	_ = dbProxyChildCmd.MarkFlagRequired("backend")

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -199,6 +199,17 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 			externalConfig = &cfg
 		}
+		if initProxiedServer && externalConfig == nil {
+			// Managed (local dolt sql-server) proxied mode still lacks a local
+			// Dolt init lifecycle — that path must mark any local .dolt/ it
+			// creates or acknowledges with doltserver.MarkDoltDirCompatible
+			// before it can be enabled. External proxied mode fronts an
+			// already-running sql-server and creates no local Dolt, so it is
+			// supported.
+			FatalError("--proxied-server currently supports external mode only; " +
+				"specify the backend with --proxied-server-external-host and --proxied-server-external-port " +
+				"(or --proxied-server-external-socket-path)")
+		}
 
 		// Handle --backend flag: "dolt" is the only supported backend.
 		// "sqlite" is accepted for backward compatibility but prints a

--- a/cmd/bd/init_proxied_external_integration_test.go
+++ b/cmd/bd/init_proxied_external_integration_test.go
@@ -1,0 +1,66 @@
+//go:build cgo
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/testutil"
+)
+
+// TestProxiedServerExternalStoreCommands locks in the routed-store wiring that
+// makes the legacy store-based commands (list/ready/update/close/stats) work in
+// proxied-server mode. Before that wiring these commands dereferenced a nil
+// store and panicked; only `bd create` (uow-based) worked. Gated on
+// BEADS_TEST_PROXIED_SERVER=1 + a dolt binary/container.
+func TestProxiedServerExternalStoreCommands(t *testing.T) {
+	requireProxiedServerEnv(t)
+
+	bd := buildEmbeddedBD(t)
+	port := testutil.StartIsolatedDoltContainer(t)
+
+	p := bdProxiedInit(t, bd, "pse",
+		"--proxied-server-external-host", "127.0.0.1",
+		"--proxied-server-external-port", port,
+	)
+
+	// Sanity: metadata records proxied-server external mode.
+	info, err := configfile.LoadProxiedServerClientInfo(p.beadsDir)
+	if err != nil || info == nil || info.External == nil {
+		t.Fatalf("expected external client info, err=%v info=%+v", err, info)
+	}
+
+	a := bdProxiedCreate(t, bd, p.dir, "first")
+	b := bdProxiedCreate(t, bd, p.dir, "second")
+
+	// list — exercises the routed store's GetReadyWork/GetStatistics path.
+	out, err := bdProxiedRun(t, bd, p.dir, "list")
+	if err != nil {
+		t.Fatalf("bd list failed (routed store): %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), a.ID) || !strings.Contains(string(out), b.ID) {
+		t.Fatalf("list missing created issues:\n%s", out)
+	}
+
+	// ready — both open issues with no blockers should be ready.
+	if out, err := bdProxiedRun(t, bd, p.dir, "ready"); err != nil {
+		t.Fatalf("bd ready failed (routed store): %v\n%s", err, out)
+	}
+
+	// update + close — write path through the routed store (DOLT_COMMIT via proxy).
+	if out, err := bdProxiedRun(t, bd, p.dir, "update", a.ID, "--status", "in_progress"); err != nil {
+		t.Fatalf("bd update failed: %v\n%s", err, out)
+	}
+	if out, err := bdProxiedRun(t, bd, p.dir, "close", b.ID, "--reason", "done"); err != nil {
+		t.Fatalf("bd close failed: %v\n%s", err, out)
+	}
+
+	// Confirm the writes are visible (b closed, a in progress) via a fresh
+	// invocation — proves the routed store reads committed state back.
+	got := bdProxiedShow(t, bd, p.dir, b.ID)
+	if got.Status != "closed" {
+		t.Fatalf("expected %s closed, got %q", b.ID, got.Status)
+	}
+}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1054,6 +1054,28 @@ var rootCmd = &cobra.Command{
 			}
 			uowProvider = p
 
+			// Also route a server-mode store through the proxy so the legacy
+			// store-based commands (list/ready/stats/update/close/...) work in
+			// proxied mode instead of dereferencing a nil store. Both the uow
+			// provider and this store connect through the same proxy and share
+			// its backend connection pool. Best-effort: `bd create` uses the uow
+			// provider and does not need the store, so a routing failure here
+			// must not break the proxied-create path.
+			if s, serr := newProxiedServerRoutedStore(rootCtx, beadsDir); serr == nil {
+				store = s
+				storeMutex.Lock()
+				storeActive = true
+				storeMutex.Unlock()
+				if dbPath != "" {
+					hookRunner = hooks.NewRunner(filepath.Join(filepath.Dir(dbPath), "hooks"))
+				}
+				if hookRunner != nil && !config.GetBool("no-hooks") {
+					store = storage.NewHookFiringStore(store, hookRunner)
+				}
+			} else {
+				debug.Logf("proxied-server: routed store unavailable, store-based commands disabled: %v", serr)
+			}
+
 			syncCommandContext()
 			return
 		}

--- a/cmd/bd/uow_factory.go
+++ b/cmd/bd/uow_factory.go
@@ -57,6 +57,14 @@ func newProxiedServerRoutedStore(ctx context.Context, beadsDir string) (storage.
 		ServerUser: "root",
 		// AutoStart stays false: the proxy owns the backend lifecycle. We must
 		// never try to spawn a dolt server for the proxy's listener port.
+		//
+		// RoutedThroughProxy stops newServerMode from persisting pf.Port (the
+		// ephemeral proxy listener) into .beads/dolt-server.port. That file is
+		// the canonical-server discovery hint; a proxy port written there is
+		// clobbered on the next reconcile and goes stale when the proxy respawns
+		// on a new port, breaking endpoint resolution for any reader that trusts
+		// it.
+		RoutedThroughProxy: true,
 	}
 	return dolt.New(ctx, cfg)
 }

--- a/cmd/bd/uow_factory.go
+++ b/cmd/bd/uow_factory.go
@@ -9,9 +9,57 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
+	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/uow"
 )
+
+// newProxiedServerRoutedStore builds a server-mode DoltStorage that connects
+// through the already-running db-proxy (the same proxy newProxiedServerUOWProvider
+// ensured). Proxied-server mode historically only wired the uow provider, which
+// covers `bd create` but leaves the legacy store-based commands (list, ready,
+// stats, update, close, ...) hitting a nil store. Routing a normal server-mode
+// store at the proxy endpoint makes every store-based command work in proxied
+// mode, and — crucially — those connections flow through the proxy's backend
+// pool just like the uow provider's.
+//
+// The proxy terminates the client handshake with skip-auth, so the user and
+// password sent here are irrelevant; root/empty is used. The real backend
+// credentials live in the proxy child (managed) or its inherited env (external).
+func newProxiedServerRoutedStore(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
+	if beadsDir == "" {
+		return nil, fmt.Errorf("newProxiedServerRoutedStore: beadsDir must be set")
+	}
+	rootPath, err := resolveProxiedServerRootPath(beadsDir)
+	if err != nil {
+		return nil, fmt.Errorf("newProxiedServerRoutedStore: resolve root path: %w", err)
+	}
+	pf, err := pidfile.Read(rootPath, proxy.PIDFileName)
+	if err != nil || pf == nil || pf.Port == 0 {
+		return nil, fmt.Errorf("newProxiedServerRoutedStore: read proxy endpoint from %s: %w", rootPath, err)
+	}
+
+	persisted, _ := configfile.Load(beadsDir)
+	database := configfile.DefaultDoltDatabase
+	if persisted != nil {
+		database = persisted.GetDoltDatabase()
+	}
+
+	cfg := &dolt.Config{
+		Path:       beadsDir,
+		BeadsDir:   beadsDir,
+		Database:   database,
+		ServerMode: true,
+		ServerHost: "127.0.0.1",
+		ServerPort: pf.Port,
+		ServerUser: "root",
+		// AutoStart stays false: the proxy owns the backend lifecycle. We must
+		// never try to spawn a dolt server for the proxy's listener port.
+	}
+	return dolt.New(ctx, cfg)
+}
 
 func newProxiedServerUOWProvider(ctx context.Context, beadsDir string) (uow.UnitOfWorkProvider, error) {
 	if beadsDir == "" {

--- a/docs/CONNECTION_POOLING.md
+++ b/docs/CONNECTION_POOLING.md
@@ -1,0 +1,148 @@
+# db-proxy connection pooling
+
+## Problem
+
+Multi-agent orchestrators (e.g. gascity/gc) run beads against a persistent
+`dolt sql-server` and fork the `bd` binary for **every** agent operation. Each
+`bd` process is short-lived: it opens a fresh `*sql.DB`, dials dolt (TCP + MySQL
+auth handshake + session setup), runs its query, and tears everything down at
+exit. The in-process pool in `internal/storage/dolt/store.go` (`applyPoolLimits`)
+never survives the process, so there is **zero** cross-invocation reuse.
+
+Measured on a 1-rig city (7 active agents):
+
+- **71 new connections/sec** to dolt (lifetime `Connections` ≈ 2.33M)
+- ~560 queries/sec
+- dolt sql-server at 85–170% CPU while a `processlist` snapshot is mostly
+  `Sleep`
+
+The CPU is not query work — it is the **per-call connection setup cost** paid
+71× per second. This is gascity #1978. Hard constraint: **keep Dolt** (bead
+versioning + cross-machine sync via dolt remotes); no migration to the SQLite
+coordstore.
+
+## Approach (chosen: pooling proxy)
+
+beads already ships a `db-proxy` (`internal/storage/dbproxy/proxy`) that fronts
+the dolt sql-server for lifecycle management (auto-start, idle-stop, multi-writer
+coordination). Historically it was a **byte-transparent 1:1 forwarder**: one
+backend dial per client, `io.Copy` both ways, `Close` on disconnect — so it did
+not reduce connection churn.
+
+The fix makes the proxy a **session-pooling, MySQL-protocol-aware** forwarder:
+
+1. The proxy terminates the client handshake itself (skip-auth — clients are
+   loopback-only and already trusted by the proxy's design).
+2. It borrows an already-authenticated backend connection from a pool of warm
+   connections to dolt.
+3. The command phase is forwarded **byte-transparently** (the proven `io.Copy`
+   path), so bd's storage / uow / transaction code is unchanged.
+4. On client disconnect the proxy sends `COM_RESET_CONNECTION` to the backend
+   (purging session variables, open transactions, temp tables, prepared
+   statements) and returns it to the pool instead of closing it.
+
+`bd` continues to speak MySQL exactly as before; the only change for a consumer
+is selecting ProxiedServerMode and setting one env var.
+
+### Why not a bd daemon (rejected)
+
+A long-lived `bd serve` holding the pool, with the CLI shipping operations over
+IPC, was rejected: it requires routing the entire domain layer over an RPC
+surface (or reinventing the MySQL wire protocol over a socket), the fallback
+path is complex, and transactions still force per-invocation session pinning —
+so it yields no advantage over pooling at the proxy while costing far more code.
+
+## Correctness
+
+### Capability-flag parity
+
+Byte-transparent command-phase forwarding requires the capability flags
+negotiated **client↔proxy** to equal those negotiated **proxy↔backend** —
+result-set encoding depends on flags such as `CLIENT_DEPRECATE_EOF`,
+`CLIENT_PROTOCOL_41`, `CLIENT_QUERY_ATTRIBUTES`, `CLIENT_SESSION_TRACK`. A
+mismatch would silently corrupt the wire stream. Therefore the pool is **keyed
+by `(capabilities, database)`**: the proxy authenticates each backend with
+exactly the caps the client negotiated, and only lends a backend to a client
+with an identical key. All `bd` clients share one driver and DSN, so they
+collapse onto a single key and reuse the same warm connections. A client with an
+unexpected key simply causes a fresh dial (still correct, just not reused).
+
+### Session isolation
+
+`COM_RESET_CONNECTION` is the isolation primitive. dolt's go-mysql-server
+handler releases all locks, closes the session, creates a fresh one, and
+restores the connection's default database. Note that go-sql-driver's
+`ResetSession` does **not** send `COM_RESET_CONNECTION` (it only does a liveness
+check), which is why the proxy sends the packet itself. If the reset fails the
+connection is destroyed rather than reused.
+
+The reset reply is **sequence-checked** (a reply to a fresh command is always
+sequence 1). If the proxy instead reads an out-of-sequence packet — e.g. a
+client was killed mid-result and unread result packets are still in the stream —
+the connection is treated as misaligned and destroyed, never lent out.
+
+### COM_QUIT interception
+
+go-sql-driver sends `COM_QUIT` when it closes a connection. Forwarding that to a
+pooled backend would terminate it. The client→backend direction is therefore
+frame-aware enough to detect a standalone `COM_QUIT` and reclaim the backend
+instead of forwarding it. All other frames pass through verbatim.
+
+## Configuration / opt-in
+
+Pooling is **opt-in** and off by default (`BEADS_PROXY_POOL_SIZE` unset or `0`
+preserves the original transparent forwarding). Embedded mode and direct
+ServerMode are unaffected.
+
+| Knob | Effect |
+|------|--------|
+| `BEADS_PROXY_POOL_SIZE=N` | Enable pooling; keep up to `N` warm idle backend connections per `(caps,db)` key. Read by the uow provider when it opens the proxy endpoint. |
+
+Internals (set automatically, listed for reference):
+
+- `proxy.OpenOpts.PoolSize` / `BackendUser` → spawned child flags
+  `--pool-size` / `--backend-user`. The backend password is inherited by the
+  child via the environment, never passed on the command line.
+- `proxy.ProxyOpts.{PoolSize,BackendUser,BackendPassword,PoolConnMaxLifetime}`.
+- `PoolConnMaxLifetime` defaults to 0 (unlimited): a short lifetime would
+  re-create the churn pooling exists to eliminate.
+
+Because the proxy is spawned once and reused, the pool size is fixed by the
+**first** `bd` invocation that starts the proxy; set `BEADS_PROXY_POOL_SIZE`
+consistently across a deployment.
+
+## gascity integration
+
+gascity currently points `bd` at its managed dolt sql-server in **ServerMode**
+(`BEADS_DOLT_SERVER_HOST`/`PORT`). To benefit from pooling:
+
+1. Switch `bd` to **ProxiedServerMode** with the **external** backend so the
+   proxy fronts the existing managed sql-server (rather than starting a second
+   dolt). ProxiedServerMode is selected via the workspace's `metadata.json`
+   `dolt_mode = proxied-server` (`configfile.IsDoltProxiedServerMode`); the
+   runtime path is live at `cmd/bd/main.go` → `newProxiedServerUOWProvider` →
+   `newExternalProxiedServerUOWProvider`. The external host/port/user (and
+   `BEADS_DOLT_PASSWORD` for auth) configure the backend the proxy connects to.
+2. Export **`BEADS_PROXY_POOL_SIZE`** in the environment of every forked `bd`
+   (e.g. `2 × max concurrent agents per rig`). The proxy is shared per workspace
+   root, so all agents in a rig share one warm pool.
+
+Effect: the per-`bd` connection churn against dolt collapses to the pool size
+(steady-state ~0 new connections/sec) instead of one new authenticated
+connection per agent operation, removing the connection-setup CPU load on the
+dolt sql-server while keeping Dolt and all its versioning/sync semantics intact.
+
+## Validation
+
+`internal/storage/dbproxy/proxy`:
+
+- Unit (`pool_test.go`, `mysqlwire_test.go`): pool reuse/cap/key-isolation/
+  drain/eviction/lifetime against a fake backend; wire round-trips. No dolt.
+- Integration (`proxy_pool_integration_test.go`, `mysqlwire_spike_test.go`;
+  cgo + dolt): real proxyServer — query/transaction/`DOLT_COMMIT` round-trip,
+  rollback leaves no row, 8 concurrent clients keep private sessions, and
+  session isolation (`@var`, `autocommit`, temp table purged between borrowers
+  sharing one backend).
+- Benchmark (`BenchmarkConnectionChurn`): dolt-side `Connections` delta over 50
+  sequential sessions — **pooling off = 50** (1:1 churn), **pooling on = 0**
+  (50 pool hits, 1 dial).

--- a/docs/CONNECTION_POOLING_DEPLOYMENT.md
+++ b/docs/CONNECTION_POOLING_DEPLOYMENT.md
@@ -1,0 +1,139 @@
+# Connection pooling — deployment, validation, gascity integration
+
+Companion to [CONNECTION_POOLING.md](CONNECTION_POOLING.md) (the design). This
+covers how to turn pooling on end-to-end, the real-CLI validation numbers, and
+the exact gascity wiring change needed to make it durable.
+
+## Deployment: `bd init --proxied-server` (external)
+
+Pooling only takes effect in **ProxiedServerMode** (the proxy must be in the
+path). Provision a workspace whose `metadata.json` records
+`dolt_mode=proxied-server` and whose `proxied_server_client_info.json` points at
+an already-running external dolt sql-server:
+
+```sh
+bd init --proxied-server \
+  --proxied-server-external-host 127.0.0.1 \
+  --proxied-server-external-port 42188 \
+  --proxied-server-external-user root \
+  --prefix pt --database pt --non-interactive
+# password (if any): export BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD=...
+```
+
+Unix socket is supported too (`--proxied-server-external-socket-path`).
+Managed-local proxied mode (proxy spawns its own dolt) is intentionally still
+rejected — it needs a local `.dolt` lifecycle (`MarkDoltDirCompatible`) that is
+out of scope here; external mode fronts an existing server and creates no local
+Dolt.
+
+Then enable pooling by exporting, in the environment of every forked `bd`:
+
+```sh
+export BEADS_PROXY_POOL_SIZE=4   # 0/unset = transparent (no pooling)
+```
+
+The proxy is spawned once per workspace root and reused, so the pool size is
+frozen by the first `bd` invocation that starts the proxy. Set it consistently
+and kill any pre-existing `bd db-proxy-child` when changing it.
+
+Two `cmd/bd` changes made this usable (both on `feat/connection-pooling`):
+- `bd init --proxied-server` external was unfenced (the full
+  `runInitProxiedServer` already existed behind a blanket "not yet implemented"
+  guard).
+- A server-mode store is now routed through the proxy in proxied mode
+  (`newProxiedServerRoutedStore`), so the legacy store-based commands
+  (list/ready/stats/update/close/...) work — previously only `bd create`
+  (uow-based) did; the rest dereferenced a nil store and panicked.
+
+## Real-CLI validation
+
+Two backends were used. **Functional** correctness was checked against the live
+gascity-managed dolt on **42188** (create/list/ready/update/close/dep all work
+through the proxy; writes commit via `DOLT_COMMIT`). **Quantitative** churn was
+measured against a **dedicated quiet dolt on 42199** (no background load, so the
+global `Connections` counter is uncontaminated; the 42188 counter is global and
+gascity itself generates tens of conns/sec).
+
+Method: kill any proxy, warm once (spawns proxy with the chosen pool size), then
+50 sequential `bd list` invocations; read dolt `SHOW GLOBAL STATUS LIKE
+'Connections'` before/after.
+
+| Mode | new dolt connections / 50 invocations | per invocation |
+|------|---------------------------------------|----------------|
+| pooling OFF (`BEADS_PROXY_POOL_SIZE` unset) | 351 | **7.02** |
+| pooling ON (`BEADS_PROXY_POOL_SIZE=4`)      | 51  | **1.02** |
+
+→ **~7× fewer new dolt connections** per `bd` invocation. The proxy log confirmed
+`connection pooling enabled (maxIdle=4)` with **zero** reset/misalignment errors
+(the only logged "errors" are benign readiness probes that dial+close the proxy
+before handshaking).
+
+Notes on the numbers:
+- The pure-pool ceiling is **0** new connections (see
+  `BenchmarkConnectionChurn`: a single raw client → 0 over 50 sessions). The CLI
+  residual (~1/invocation) is not a pool defect — it is per-process overhead
+  that the pool cannot remove: each `bd` invocation in proxied mode opens both a
+  uow-provider connection set (whose `openAndInitSchema` connects twice and
+  re-checks schema) and the routed store, and the schema-init connection is the
+  remaining ~1 fresh dolt connection that isn't reused across processes.
+- OFF is ~7/invocation precisely because of that same dual-connect ×
+  schema-init; pooling collapses 6 of the 7.
+- A future optimization (out of scope) — making the uow provider lazy so
+  read-only commands skip `openAndInitSchema` — would push ON toward ~0.
+
+Container-backed integration tests (`BEADS_TEST_PROXIED_SERVER=1`, real dolt):
+`TestProxiedServerExternalCreate` (now unblocked) and
+`TestProxiedServerExternalStoreCommands` (list/ready/update/close via the routed
+store) both pass.
+
+## gascity integration (Phase 2 — the durable wiring diff)
+
+gascity currently runs `bd` in **direct ServerMode** and **re-asserts
+`dolt_mode=server` on every reconcile**, so a manual metadata flip would be
+reverted. Three coordinated changes make proxied+pooling stick. All paths are in
+`/Users/cstar/rigs/gascity`.
+
+### 1. `cmd/gc/beads_provider_lifecycle.go` — write proxied-server, not server
+
+`normalizeCanonicalBdScopeFiles` / `normalizeCanonicalBdScopeFilesForInit` (and
+the `DoltMode: "server"` literal around line 1435) re-normalize each scope's
+`metadata.json` to `dolt_mode=server` on every reconcile. Change them to emit
+`dolt_mode=proxied-server` and to write `proxied_server_client_info.json` with
+an `external` block (host/port/user) pointing at the managed dolt (42188),
+instead of (or in addition to) the server-mode host/port. This is the load-
+bearing change: without it the scope is flipped back to server mode and the
+proxy is bypassed.
+
+### 2. `examples/bd/assets/scripts/gc-beads-bd.sh` — init + env
+
+- `run_bd_init_pinned` (≈ line 2189) runs
+  `bd init --server --server-host H --server-port P`. Switch to:
+  `bd init --proxied-server --proxied-server-external-host H
+  --proxied-server-external-port P --proxied-server-external-user "$DOLT_USER"`,
+  and pass the password via `BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD` (not
+  `BEADS_DOLT_PASSWORD`).
+- `run_bd_pinned` (≈ line 2179) exports `BEADS_DOLT_SERVER_HOST/PORT/USER/
+  PASSWORD` for every `bd` call, which forces direct server mode. For proxied
+  scopes, stop exporting `BEADS_DOLT_SERVER_*`/`BEADS_DOLT_SERVER_MODE` (they
+  select direct ServerMode and would shadow proxied mode) and instead export
+  `BEADS_PROXY_POOL_SIZE` (e.g. `2 × max concurrent agents per rig`) plus
+  `BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD` when the server requires auth.
+
+### 3. `cmd/gc/bd_env.go` — inject the pool size into projected env
+
+The bd command runners (`bdCommandRunnerForCity/Rig`,
+`controlBdCommandRunnerFor*`) and the canonical-target env projector
+(`applyCanonicalDoltTargetEnv`, ≈ line 256) build the env map for every `bd`
+invocation. Add `env["BEADS_PROXY_POOL_SIZE"] = <n>` there so both agent and
+**controller** bd calls front the pool. (The controller + order loop alone
+generates ~13 conns/sec even with no agents, so pooling helps the controller,
+not just agents.)
+
+### Why this matches the measured problem
+
+The managed dolt config (`/Users/cstar/portharbour/.gc/runtime/packs/dolt/
+dolt-config.yaml`) already documents the symptom — short-lived per-call
+connections piling up in `Sleep`, `read_timeout` cut to 30s to reap them — and
+gascity #1978 measured 71 new conns/sec. Routing every scope through the pooled
+proxy collapses that to roughly the pool size in steady state while keeping
+Dolt, its versioning, and `dolt remote` sync untouched.

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/beads/internal/configfile"
@@ -69,6 +70,13 @@ type OpenOpts struct {
 	LogFilePath    string
 	DoltBinPath    string
 	External       configfile.ExternalDoltConfig
+	// PoolSize, when > 0, makes the spawned proxy pool backend connections
+	// (see ProxyOpts.PoolSize). BackendUser is the user the proxy uses to
+	// authenticate those pooled connections; the password, when needed, is
+	// inherited by the child via the environment (it is never passed on the
+	// command line). 0 preserves the transparent, non-pooling proxy.
+	PoolSize    int
+	BackendUser string
 }
 
 const (
@@ -78,6 +86,26 @@ const (
 )
 
 var ResolveExecutable = os.Executable
+
+// PoolSizeEnvVar is the opt-in switch for backend connection pooling. When set
+// to a positive integer, a proxy spawned by this process pools up to that many
+// warm backend connections instead of dialing one per client. Unset or 0
+// disables pooling (transparent forwarding, the historical behavior).
+const PoolSizeEnvVar = "BEADS_PROXY_POOL_SIZE"
+
+// PoolSizeFromEnv reads PoolSizeEnvVar, returning 0 (pooling disabled) when
+// unset, empty, non-numeric, or negative.
+func PoolSizeFromEnv() int {
+	v := strings.TrimSpace(os.Getenv(PoolSizeEnvVar))
+	if v == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
 
 func PickFreePort() (int, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -254,6 +282,12 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*e
 	}
 	if opts.DoltBinPath != "" {
 		args = append(args, "--dolt-bin", opts.DoltBinPath)
+	}
+	if opts.PoolSize > 0 {
+		args = append(args, "--pool-size", strconv.Itoa(opts.PoolSize))
+		if opts.BackendUser != "" {
+			args = append(args, "--backend-user", opts.BackendUser)
+		}
 	}
 	if opts.Backend == BackendExternal {
 		ext := opts.External

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -107,6 +107,31 @@ func PoolSizeFromEnv() int {
 	return n
 }
 
+// IdleTimeoutEnvVar overrides how long a pooling proxy stays alive with no
+// active client connections before it shuts down. The default (30s) is tuned
+// for a single busy workspace; an orchestrator that touches many scopes
+// sparsely (e.g. gascity probing dozens of rigs once per patrol) starves each
+// proxy below that window, so it spawns, serves one op, idle-dies, and respawns
+// on the next touch — pure churn that never reaches the warm-pool steady state
+// pooling exists to provide. Raising the timeout (e.g. "10m") keeps proxies warm
+// across sparse bursts. Accepts a Go duration string.
+const IdleTimeoutEnvVar = "BEADS_PROXY_IDLE_TIMEOUT"
+
+// IdleTimeoutFromEnv reads IdleTimeoutEnvVar, returning fallback when unset,
+// empty, or unparseable. A parsed non-positive value (e.g. "0") is returned
+// verbatim, which disables the idle timeout (proxy stays up until stopped).
+func IdleTimeoutFromEnv(fallback time.Duration) time.Duration {
+	v := strings.TrimSpace(os.Getenv(IdleTimeoutEnvVar))
+	if v == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return fallback
+	}
+	return d
+}
+
 func PickFreePort() (int, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/storage/dbproxy/proxy/endpoint_env_test.go
+++ b/internal/storage/dbproxy/proxy/endpoint_env_test.go
@@ -1,0 +1,35 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIdleTimeoutFromEnv(t *testing.T) {
+	const fallback = 30 * time.Second
+	cases := []struct {
+		name string
+		set  bool
+		val  string
+		want time.Duration
+	}{
+		{"unset returns fallback", false, "", fallback},
+		{"blank returns fallback", true, "   ", fallback},
+		{"unparseable returns fallback", true, "soon", fallback},
+		{"valid minutes", true, "10m", 10 * time.Minute},
+		{"valid seconds", true, "90s", 90 * time.Second},
+		{"zero disables (verbatim)", true, "0", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(IdleTimeoutEnvVar, tc.val)
+			} else {
+				t.Setenv(IdleTimeoutEnvVar, "")
+			}
+			if got := IdleTimeoutFromEnv(fallback); got != tc.want {
+				t.Fatalf("IdleTimeoutFromEnv(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/storage/dbproxy/proxy/multidb_isolation_test.go
+++ b/internal/storage/dbproxy/proxy/multidb_isolation_test.go
@@ -1,0 +1,112 @@
+//go:build cgo
+
+package proxy
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpike_MultiDatabaseIsolation is the decisive check for multi-database
+// topologies (e.g. one dolt sql-server hosting one database per rig: hq, vw,
+// va, ...). The pool is keyed by (capabilities, database); a backend
+// authenticated to database A must NEVER be lent to a client that asked for
+// database B, because COM_RESET_CONNECTION restores the session to the
+// backend's *handshake* database — silent cross-store reads otherwise.
+//
+// This only holds if go-sql-driver carries the database in the MySQL handshake
+// (CONNECT_WITH_DB), so the proxy can read it from the client's handshake
+// response and key the pool by it. If the driver instead connected with an
+// empty schema and issued COM_INIT_DB afterwards, every client would key to
+// db="" and share one pool — the corruption this test is designed to catch.
+//
+// The test forces maximal reuse pressure (pool size effectively 1 per key) and
+// interleaves clients for two databases, asserting each reads only its own.
+func TestSpike_MultiDatabaseIsolation(t *testing.T) {
+	srv, _ := spikeDolt(t)
+	pool, stats := newSpikePool(t, srv, 1) // 1 idle per key
+	addr := servePooled(t, pool, stats)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Provision two databases, each with a sentinel row identifying itself.
+	admin := openThroughProxy(t, addr, "")
+	for _, db := range []string{"rig_a", "rig_b"} {
+		_, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS "+db)
+		require.NoError(t, err)
+	}
+	require.NoError(t, admin.Close())
+	for _, tc := range []struct{ db, who string }{{"rig_a", "A"}, {"rig_b", "B"}} {
+		c := openThroughProxy(t, addr, tc.db)
+		_, err := c.ExecContext(ctx, "CREATE TABLE marker (who VARCHAR(8))")
+		require.NoError(t, err)
+		_, err = c.ExecContext(ctx, "INSERT INTO marker VALUES (?)", tc.who)
+		require.NoError(t, err)
+		require.NoError(t, c.Close())
+	}
+
+	readWho := func(db string) string {
+		c := openThroughProxy(t, addr, db)
+		defer func() { _ = c.Close() }()
+		var who string
+		// Unqualified table name → resolves against the session's current
+		// database, i.e. exactly what a leaked backend would get wrong.
+		require.NoError(t, c.QueryRowContext(ctx, "SELECT who FROM marker").Scan(&who))
+		return who
+	}
+
+	// Interleave many times with single-connection clients so each open must
+	// reuse a pooled backend. A keying bug (shared db="") would surface as a
+	// client reading the other rig's marker.
+	for i := 0; i < 20; i++ {
+		require.Equal(t, "A", readWho("rig_a"), "rig_a read the wrong store on iter %d", i)
+		require.Equal(t, "B", readWho("rig_b"), "rig_b read the wrong store on iter %d", i)
+	}
+
+	// Also assert the two databases keep distinct backends (no accidental
+	// collapse): with reuse, hits should dominate and both keys stay warm.
+	snap := stats.Snapshot()
+	t.Logf("multi-db stats: %+v", snap)
+	require.GreaterOrEqual(t, snap.PoolHits, int64(30), "expected heavy reuse across both db keys")
+}
+
+// TestSpike_HandshakeCarriesDatabase nails the underlying assumption directly:
+// a client opened with a database in its DSN must surface that database to the
+// proxy via the handshake (so the pool key's db is non-empty). We observe it
+// indirectly: after a rig_a client runs, the pool holds an idle backend that,
+// when reused by another rig_a client, already resolves unqualified names to
+// rig_a without any explicit USE.
+func TestSpike_HandshakeCarriesDatabase(t *testing.T) {
+	srv, _ := spikeDolt(t)
+	pool, stats := newSpikePool(t, srv, 2)
+	addr := servePooled(t, pool, stats)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	admin := openThroughProxy(t, addr, "")
+	_, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS rig_h")
+	require.NoError(t, err)
+	require.NoError(t, admin.Close())
+
+	c1 := openThroughProxy(t, addr, "rig_h")
+	var cur sql.NullString
+	require.NoError(t, c1.QueryRowContext(ctx, "SELECT DATABASE()").Scan(&cur))
+	require.True(t, cur.Valid && cur.String == "rig_h",
+		"session current database must be the handshake db, got %v", cur)
+	require.NoError(t, c1.Close())
+
+	require.Eventually(t, func() bool { return pool.idleCount() >= 1 }, 5*time.Second, 20*time.Millisecond)
+
+	// Reused backend must still report rig_h (reset restores the handshake db).
+	c2 := openThroughProxy(t, addr, "rig_h")
+	defer func() { _ = c2.Close() }()
+	require.NoError(t, c2.QueryRowContext(ctx, "SELECT DATABASE()").Scan(&cur))
+	require.True(t, cur.Valid && cur.String == "rig_h", "reused backend lost its db, got %v", cur)
+	require.GreaterOrEqual(t, stats.Snapshot().PoolHits, int64(1))
+}

--- a/internal/storage/dbproxy/proxy/mysqlwire.go
+++ b/internal/storage/dbproxy/proxy/mysqlwire.go
@@ -183,10 +183,10 @@ func serverGreeting(connID uint32, salt []byte) []byte {
 	p = append(p, serverCharsetUTF8MB4)
 	p = append(p, byte(statusAutocommit), byte(statusAutocommit>>8))
 	p = append(p, byte(caps>>16), byte(caps>>24))
-	p = append(p, 21)             // auth-plugin-data len (20 salt + NUL)
+	p = append(p, 21)                  // auth-plugin-data len (20 salt + NUL)
 	p = append(p, make([]byte, 10)...) // reserved
-	p = append(p, salt[8:20]...)  // auth-plugin-data-part-2 (12 bytes)
-	p = append(p, 0)              // NUL terminator for part-2
+	p = append(p, salt[8:20]...)       // auth-plugin-data-part-2 (12 bytes)
+	p = append(p, 0)                   // NUL terminator for part-2
 	p = append(p, mysqlNativePassword...)
 	p = append(p, 0)
 	return p
@@ -257,9 +257,9 @@ func indexByte(p []byte, from int, b byte) int {
 // okPacket builds a minimal OK packet for the negotiated capabilities.
 func okPacket(caps uint32) []byte {
 	p := make([]byte, 0, 16)
-	p = append(p, 0x00)             // OK header
-	p = appendLenencInt(p, 0)       // affected rows
-	p = appendLenencInt(p, 0)       // last insert id
+	p = append(p, 0x00)       // OK header
+	p = appendLenencInt(p, 0) // affected rows
+	p = appendLenencInt(p, 0) // last insert id
 	if caps&capProtocol41 != 0 {
 		p = append(p, byte(statusAutocommit), byte(statusAutocommit>>8))
 		p = append(p, 0, 0) // warnings
@@ -371,7 +371,7 @@ func parseServerGreeting(p []byte) (salt []byte, plugin string, err error) {
 		// Pre-4.1 server: only lower caps present. Not expected from dolt.
 		return salt, mysqlNativePassword, nil
 	}
-	off++ // charset
+	off++    // charset
 	off += 2 // status flags
 	capHigh := uint32(p[off]) | uint32(p[off+1])<<8
 	off += 2

--- a/internal/storage/dbproxy/proxy/mysqlwire.go
+++ b/internal/storage/dbproxy/proxy/mysqlwire.go
@@ -1,0 +1,616 @@
+package proxy
+
+// MySQL wire-protocol helpers for the session-pooling proxy.
+//
+// The proxy terminates the client handshake itself (skip-auth: clients are
+// loopback-only and already trusted by today's design), then borrows a
+// pre-authenticated backend connection from a pool. After the handshake phase
+// completes on both sides the data path is byte-transparent (io.Copy), exactly
+// as the non-pooling proxy does today — command-phase packets do not depend on
+// connection id or salt, only on the negotiated capability flags, which the
+// proxy keeps in parity between the two sides (see pool keying).
+//
+// Byte layouts are hand-rolled rather than borrowed from dolthub/vitess because
+// vitess's handshake builders are unexported and its *mysql.Conn buffers
+// internally, which is incompatible with handing the raw net.Conn to io.Copy.
+// References: MySQL Client/Server Protocol; go-sql-driver/mysql packets.go;
+// dolthub/vitess go/mysql/{server,client,conn}.go.
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+// MySQL capability flags (subset we care about). Values match the protocol
+// constants used by every MySQL-compatible client/server.
+const (
+	capLongPassword     uint32 = 1 << 0
+	capFoundRows        uint32 = 1 << 1
+	capLongFlag         uint32 = 1 << 2
+	capConnectWithDB    uint32 = 1 << 3
+	capProtocol41       uint32 = 1 << 9
+	capSSL              uint32 = 1 << 11
+	capTransactions     uint32 = 1 << 13
+	capSecureConnection uint32 = 1 << 15
+	capMultiStatements  uint32 = 1 << 16
+	capMultiResults     uint32 = 1 << 17
+	capPluginAuth       uint32 = 1 << 19
+	capConnectAttrs     uint32 = 1 << 20
+	capPluginAuthLenenc uint32 = 1 << 21
+	capDeprecateEOF     uint32 = 1 << 24
+)
+
+// MySQL command bytes (command-phase first byte).
+const (
+	comQuery           byte = 0x03
+	comInitDB          byte = 0x02
+	comPing            byte = 0x0e
+	comResetConnection byte = 0x1f
+)
+
+const (
+	mysqlNativePassword = "mysql_native_password"
+	// serverCapabilities is what the proxy advertises to clients. It is a
+	// superset; the client narrows it in its response and the proxy mirrors
+	// the client's effective set onto the backend, keeping wire parity.
+	serverCapabilities = capLongPassword | capFoundRows | capLongFlag |
+		capConnectWithDB | capProtocol41 | capTransactions |
+		capSecureConnection | capMultiStatements | capMultiResults |
+		capPluginAuth | capPluginAuthLenenc | capDeprecateEOF
+	serverCharsetUTF8MB4 = 0x2d // utf8mb4_general_ci
+	statusAutocommit     = 0x0002
+)
+
+var errProtocol = errors.New("mysqlwire: protocol error")
+
+// ---- packet framing -------------------------------------------------------
+
+// readPacket reads one MySQL packet payload from r, returning the payload and
+// the sequence id of the (last) frame. It transparently reassembles packets
+// split across 16MiB frames.
+func readPacket(r io.Reader) (payload []byte, seq byte, err error) {
+	var hdr [4]byte
+	for {
+		if _, err = io.ReadFull(r, hdr[:]); err != nil {
+			return nil, 0, err
+		}
+		n := int(hdr[0]) | int(hdr[1])<<8 | int(hdr[2])<<16
+		seq = hdr[3]
+		if n > 0 {
+			buf := make([]byte, n)
+			if _, err = io.ReadFull(r, buf); err != nil {
+				return nil, 0, err
+			}
+			payload = append(payload, buf...)
+		}
+		if n < 0xffffff { // last frame of this packet
+			return payload, seq, nil
+		}
+	}
+}
+
+// writePacket frames payload as a single MySQL packet with the given sequence
+// id and writes it. Payloads larger than 16MiB are not expected during the
+// handshake/control exchanges this helper is used for.
+func writePacket(w io.Writer, seq byte, payload []byte) error {
+	n := len(payload)
+	if n >= 0xffffff {
+		return fmt.Errorf("mysqlwire: control packet too large (%d bytes)", n)
+	}
+	hdr := []byte{byte(n), byte(n >> 8), byte(n >> 16), seq}
+	if _, err := w.Write(append(hdr, payload...)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ---- length-encoded integers ---------------------------------------------
+
+func appendLenencInt(b []byte, v uint64) []byte {
+	switch {
+	case v < 251:
+		return append(b, byte(v))
+	case v < 1<<16:
+		return append(b, 0xfc, byte(v), byte(v>>8))
+	case v < 1<<24:
+		return append(b, 0xfd, byte(v), byte(v>>8), byte(v>>16))
+	default:
+		var tmp [8]byte
+		binary.LittleEndian.PutUint64(tmp[:], v)
+		return append(append(b, 0xfe), tmp[:]...)
+	}
+}
+
+// readLenencInt reads a length-encoded integer from p starting at off,
+// returning the value and the new offset.
+func readLenencInt(p []byte, off int) (val uint64, next int, err error) {
+	if off >= len(p) {
+		return 0, off, errProtocol
+	}
+	switch first := p[off]; {
+	case first < 251:
+		return uint64(first), off + 1, nil
+	case first == 0xfc:
+		if off+3 > len(p) {
+			return 0, off, errProtocol
+		}
+		return uint64(p[off+1]) | uint64(p[off+2])<<8, off + 3, nil
+	case first == 0xfd:
+		if off+4 > len(p) {
+			return 0, off, errProtocol
+		}
+		return uint64(p[off+1]) | uint64(p[off+2])<<8 | uint64(p[off+3])<<16, off + 4, nil
+	case first == 0xfe:
+		if off+9 > len(p) {
+			return 0, off, errProtocol
+		}
+		return binary.LittleEndian.Uint64(p[off+1 : off+9]), off + 9, nil
+	default:
+		return 0, off, errProtocol
+	}
+}
+
+// ---- server-side handshake (proxy → client) ------------------------------
+
+// clientHandshake holds the parts of a client's HandshakeResponse41 the proxy
+// needs to mirror onto a backend connection.
+type clientHandshake struct {
+	capabilities uint32 // effective caps (intersection with what we advertised)
+	database     string
+	username     string
+}
+
+// serverGreeting builds a HandshakeV10 packet advertising mysql_native_password
+// with the given 20-byte salt.
+func serverGreeting(connID uint32, salt []byte) []byte {
+	caps := serverCapabilities
+	p := make([]byte, 0, 128)
+	p = append(p, 10) // protocol version
+	p = append(p, "beads-proxy"...)
+	p = append(p, 0) // server version NUL
+	var idb [4]byte
+	binary.LittleEndian.PutUint32(idb[:], connID)
+	p = append(p, idb[:]...)
+	p = append(p, salt[:8]...) // auth-plugin-data-part-1
+	p = append(p, 0)           // filler
+	p = append(p, byte(caps), byte(caps>>8))
+	p = append(p, serverCharsetUTF8MB4)
+	p = append(p, byte(statusAutocommit), byte(statusAutocommit>>8))
+	p = append(p, byte(caps>>16), byte(caps>>24))
+	p = append(p, 21)             // auth-plugin-data len (20 salt + NUL)
+	p = append(p, make([]byte, 10)...) // reserved
+	p = append(p, salt[8:20]...)  // auth-plugin-data-part-2 (12 bytes)
+	p = append(p, 0)              // NUL terminator for part-2
+	p = append(p, mysqlNativePassword...)
+	p = append(p, 0)
+	return p
+}
+
+// parseClientHandshakeResponse extracts capabilities, username and database
+// from a HandshakeResponse41 payload.
+func parseClientHandshakeResponse(p []byte) (clientHandshake, error) {
+	var h clientHandshake
+	if len(p) < 32 {
+		return h, errProtocol
+	}
+	h.capabilities = binary.LittleEndian.Uint32(p[0:4])
+	if h.capabilities&capProtocol41 == 0 {
+		return h, fmt.Errorf("%w: client did not request PROTOCOL_41", errProtocol)
+	}
+	off := 32 // 4 caps + 4 maxpkt + 1 charset + 23 reserved
+	// username (NUL-terminated)
+	end := indexByte(p, off, 0)
+	if end < 0 {
+		return h, errProtocol
+	}
+	h.username = string(p[off:end])
+	off = end + 1
+	// auth-response
+	if h.capabilities&capPluginAuthLenenc != 0 {
+		alen, next, err := readLenencInt(p, off)
+		if err != nil {
+			return h, err
+		}
+		off = next + int(alen)
+	} else if h.capabilities&capSecureConnection != 0 {
+		if off >= len(p) {
+			return h, errProtocol
+		}
+		alen := int(p[off])
+		off += 1 + alen
+	} else {
+		end = indexByte(p, off, 0)
+		if end < 0 {
+			return h, errProtocol
+		}
+		off = end + 1
+	}
+	if off > len(p) {
+		return h, errProtocol
+	}
+	// database
+	if h.capabilities&capConnectWithDB != 0 {
+		end = indexByte(p, off, 0)
+		if end < 0 {
+			return h, errProtocol
+		}
+		h.database = string(p[off:end])
+	}
+	return h, nil
+}
+
+func indexByte(p []byte, from int, b byte) int {
+	for i := from; i < len(p); i++ {
+		if p[i] == b {
+			return i
+		}
+	}
+	return -1
+}
+
+// okPacket builds a minimal OK packet for the negotiated capabilities.
+func okPacket(caps uint32) []byte {
+	p := make([]byte, 0, 16)
+	p = append(p, 0x00)             // OK header
+	p = appendLenencInt(p, 0)       // affected rows
+	p = appendLenencInt(p, 0)       // last insert id
+	if caps&capProtocol41 != 0 {
+		p = append(p, byte(statusAutocommit), byte(statusAutocommit>>8))
+		p = append(p, 0, 0) // warnings
+	} else if caps&capTransactions != 0 {
+		p = append(p, byte(statusAutocommit), byte(statusAutocommit>>8))
+	}
+	return p
+}
+
+// acceptClient performs the server side of the handshake against an incoming
+// client connection, accepting any credentials (skip-auth). It returns the
+// negotiated client parameters needed to drive a matching backend.
+func acceptClient(conn net.Conn, connID uint32, deadline time.Time) (clientHandshake, error) {
+	if !deadline.IsZero() {
+		_ = conn.SetDeadline(deadline)
+		defer func() { _ = conn.SetDeadline(time.Time{}) }()
+	}
+	salt := makeSalt(connID)
+	if err := writePacket(conn, 0, serverGreeting(connID, salt)); err != nil {
+		return clientHandshake{}, fmt.Errorf("mysqlwire: write greeting: %w", err)
+	}
+	resp, seq, err := readPacket(conn)
+	if err != nil {
+		return clientHandshake{}, fmt.Errorf("mysqlwire: read handshake response: %w", err)
+	}
+	// Reject TLS upgrade requests: the proxy is loopback-only and does not
+	// terminate TLS. A client that set CLIENT_SSL would send a short SSL
+	// request packet and expect a TLS handshake next; fail clearly instead.
+	h, err := parseClientHandshakeResponse(resp)
+	if err != nil {
+		return clientHandshake{}, err
+	}
+	if h.capabilities&capSSL != 0 {
+		return clientHandshake{}, fmt.Errorf("%w: client requested TLS, unsupported by pooling proxy", errProtocol)
+	}
+	// Mirror only the capabilities we also advertised.
+	h.capabilities &= serverCapabilities
+	if err := writePacket(conn, seq+1, okPacket(h.capabilities)); err != nil {
+		return clientHandshake{}, fmt.Errorf("mysqlwire: write auth OK: %w", err)
+	}
+	return h, nil
+}
+
+func makeSalt(connID uint32) []byte {
+	// Deterministic, non-secret salt: auth is skipped, the salt only needs to
+	// be 20 well-formed non-NUL bytes. Math/rand is intentionally avoided
+	// (unavailable / nondeterministic); the value is irrelevant to security
+	// here because the proxy accepts any auth response.
+	salt := make([]byte, 20)
+	for i := range salt {
+		salt[i] = byte(1 + (int(connID)+i*7)%250) // 1..250, never NUL
+	}
+	return salt
+}
+
+// ---- client-side handshake (proxy → dolt backend) ------------------------
+
+// backendHandshake performs the client side of the MySQL handshake against a
+// freshly dialed backend connection, negotiating exactly caps so the resulting
+// session is wire-compatible with the client the proxy will forward. user is
+// typically "root" with an empty password (loopback dolt).
+func backendHandshake(conn net.Conn, caps uint32, database, user, password string, deadline time.Time) error {
+	if !deadline.IsZero() {
+		_ = conn.SetDeadline(deadline)
+		defer func() { _ = conn.SetDeadline(time.Time{}) }()
+	}
+	greeting, _, err := readPacket(conn)
+	if err != nil {
+		return fmt.Errorf("mysqlwire: read backend greeting: %w", err)
+	}
+	salt, plugin, err := parseServerGreeting(greeting)
+	if err != nil {
+		return err
+	}
+
+	authResp := scramble(plugin, password, salt)
+	resp := buildHandshakeResponse41(caps, database, user, authResp, plugin)
+	if err := writePacket(conn, 1, resp); err != nil {
+		return fmt.Errorf("mysqlwire: write backend handshake response: %w", err)
+	}
+	return readBackendAuthResult(conn, password, salt)
+}
+
+// parseServerGreeting extracts the 20-byte salt and auth plugin name from a
+// backend HandshakeV10 packet.
+func parseServerGreeting(p []byte) (salt []byte, plugin string, err error) {
+	if len(p) < 1 || p[0] != 10 {
+		return nil, "", fmt.Errorf("%w: unexpected protocol version", errProtocol)
+	}
+	off := 1
+	end := indexByte(p, off, 0) // server version NUL
+	if end < 0 {
+		return nil, "", errProtocol
+	}
+	off = end + 1
+	off += 4 // connection id
+	if off+8 > len(p) {
+		return nil, "", errProtocol
+	}
+	salt = append(salt, p[off:off+8]...)
+	off += 8
+	off++ // filler
+	if off+2 > len(p) {
+		return nil, "", errProtocol
+	}
+	capLow := uint32(p[off]) | uint32(p[off+1])<<8
+	off += 2
+	if off >= len(p) {
+		// Pre-4.1 server: only lower caps present. Not expected from dolt.
+		return salt, mysqlNativePassword, nil
+	}
+	off++ // charset
+	off += 2 // status flags
+	capHigh := uint32(p[off]) | uint32(p[off+1])<<8
+	off += 2
+	caps := capLow | capHigh<<16
+	authDataLen := int(p[off])
+	off++
+	off += 10 // reserved
+	if caps&capSecureConnection != 0 {
+		part2 := authDataLen - 8
+		if part2 < 13 {
+			part2 = 13
+		}
+		// part2 includes a NUL terminator; copy len-1 meaningful bytes but be
+		// defensive about bounds.
+		take := part2
+		if off+take > len(p) {
+			take = len(p) - off
+		}
+		seg := p[off : off+take]
+		// strip trailing NUL
+		for len(seg) > 0 && seg[len(seg)-1] == 0 {
+			seg = seg[:len(seg)-1]
+		}
+		salt = append(salt, seg...)
+		off += take
+	}
+	plugin = mysqlNativePassword
+	if caps&capPluginAuth != 0 && off < len(p) {
+		end = indexByte(p, off, 0)
+		if end < 0 {
+			end = len(p)
+		}
+		plugin = string(p[off:end])
+	}
+	return salt, plugin, nil
+}
+
+// buildHandshakeResponse41 builds the client HandshakeResponse41 packet.
+func buildHandshakeResponse41(caps uint32, database, user string, authResp []byte, plugin string) []byte {
+	// Always set the auth-related caps we rely on; never request TLS.
+	caps |= capProtocol41 | capSecureConnection | capPluginAuth
+	caps &^= capSSL
+	if database != "" {
+		caps |= capConnectWithDB
+	} else {
+		caps &^= capConnectWithDB
+	}
+	caps &^= capConnectAttrs // we send no connection attributes
+
+	p := make([]byte, 0, 64)
+	var capb [4]byte
+	binary.LittleEndian.PutUint32(capb[:], caps)
+	p = append(p, capb[:]...)
+	var maxpkt [4]byte
+	binary.LittleEndian.PutUint32(maxpkt[:], 1<<24-1)
+	p = append(p, maxpkt[:]...)
+	p = append(p, serverCharsetUTF8MB4)
+	p = append(p, make([]byte, 23)...) // reserved
+	p = append(p, user...)
+	p = append(p, 0)
+	if caps&capPluginAuthLenenc != 0 {
+		p = appendLenencInt(p, uint64(len(authResp)))
+		p = append(p, authResp...)
+	} else {
+		p = append(p, byte(len(authResp)))
+		p = append(p, authResp...)
+	}
+	if caps&capConnectWithDB != 0 {
+		p = append(p, database...)
+		p = append(p, 0)
+	}
+	if caps&capPluginAuth != 0 {
+		p = append(p, plugin...)
+		p = append(p, 0)
+	}
+	return p
+}
+
+// readBackendAuthResult reads the backend's reply to our handshake response,
+// handling OK, ERR, AuthSwitchRequest and caching_sha2 fast-auth flows for the
+// empty-password case.
+func readBackendAuthResult(conn net.Conn, password string, salt []byte) error {
+	for {
+		pkt, seq, err := readPacket(conn)
+		if err != nil {
+			return fmt.Errorf("mysqlwire: read backend auth result: %w", err)
+		}
+		if len(pkt) == 0 {
+			return fmt.Errorf("%w: empty backend auth packet", errProtocol)
+		}
+		switch pkt[0] {
+		case 0x00: // OK
+			return nil
+		case 0xff: // ERR
+			return backendErr(pkt)
+		case 0xfe: // AuthSwitchRequest
+			plugin, switchSalt := parseAuthSwitch(pkt)
+			authResp := scramble(plugin, password, switchSalt)
+			if err := writePacket(conn, seq+1, authResp); err != nil {
+				return fmt.Errorf("mysqlwire: write auth switch response: %w", err)
+			}
+		case 0x01: // AuthMoreData (caching_sha2_password)
+			// Empty password fast path: server sends 0x01 0x03 (fast auth
+			// success) then OK, or 0x01 0x04 (full auth) which over a plaintext
+			// loopback channel expects the cleartext password + NUL. We only
+			// support empty passwords for the managed loopback dolt.
+			if len(pkt) >= 2 && pkt[1] == 0x04 {
+				if password != "" {
+					return fmt.Errorf("%w: caching_sha2 full auth with password unsupported", errProtocol)
+				}
+				if err := writePacket(conn, seq+1, []byte{0x00}); err != nil {
+					return fmt.Errorf("mysqlwire: write cleartext auth: %w", err)
+				}
+			}
+			// otherwise (0x03 fast success) loop to read the following OK.
+		default:
+			return fmt.Errorf("%w: unexpected backend auth packet 0x%02x", errProtocol, pkt[0])
+		}
+	}
+}
+
+func parseAuthSwitch(pkt []byte) (plugin string, salt []byte) {
+	off := 1
+	end := indexByte(pkt, off, 0)
+	if end < 0 {
+		return mysqlNativePassword, nil
+	}
+	plugin = string(pkt[off:end])
+	off = end + 1
+	seg := pkt[off:]
+	for len(seg) > 0 && seg[len(seg)-1] == 0 {
+		seg = seg[:len(seg)-1]
+	}
+	return plugin, seg
+}
+
+func backendErr(pkt []byte) error {
+	if len(pkt) < 3 {
+		return fmt.Errorf("%w: malformed backend error", errProtocol)
+	}
+	code := uint16(pkt[1]) | uint16(pkt[2])<<8
+	msg := pkt[3:]
+	if len(msg) > 6 && msg[0] == '#' {
+		msg = msg[6:] // skip '#' + 5-byte sqlstate
+	}
+	return fmt.Errorf("mysqlwire: backend rejected handshake (%d): %s", code, string(msg))
+}
+
+// scramble computes the auth response for the given plugin and salt. For
+// mysql_native_password with an empty password the result is empty.
+func scramble(plugin, password string, salt []byte) []byte {
+	if password == "" {
+		return nil
+	}
+	switch plugin {
+	case mysqlNativePassword, "":
+		return nativeScramble(password, salt)
+	default:
+		// caching_sha2_password and others with a real password are not used
+		// by the managed loopback dolt; empty-password path above covers it.
+		return nativeScramble(password, salt)
+	}
+}
+
+// nativeScramble implements mysql_native_password:
+// SHA1(password) XOR SHA1(salt + SHA1(SHA1(password))).
+func nativeScramble(password string, salt []byte) []byte {
+	h1 := sha1.Sum([]byte(password))
+	h2 := sha1.Sum(h1[:])
+	h := sha1.New()
+	_, _ = h.Write(salt)
+	_, _ = h.Write(h2[:])
+	mixed := h.Sum(nil)
+	out := make([]byte, len(h1))
+	for i := range h1 {
+		out[i] = h1[i] ^ mixed[i]
+	}
+	return out
+}
+
+// ---- control commands on a pooled backend --------------------------------
+
+// resetBackend sends COM_RESET_CONNECTION and waits for the OK reply. This is
+// the isolation primitive: it discards session variables, open transactions,
+// temp tables and prepared statements before the connection is reused by the
+// next client. (database/sql's ResetSession does NOT send this — it only does
+// a liveness check — which is why the proxy must send it explicitly.)
+func resetBackend(ctx context.Context, conn net.Conn) error {
+	if dl, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(dl)
+		defer func() { _ = conn.SetDeadline(time.Time{}) }()
+	}
+	if err := writePacket(conn, 0, []byte{comResetConnection}); err != nil {
+		return fmt.Errorf("mysqlwire: write COM_RESET_CONNECTION: %w", err)
+	}
+	pkt, seq, err := readPacket(conn)
+	if err != nil {
+		return fmt.Errorf("mysqlwire: read reset reply: %w", err)
+	}
+	// The reply to a fresh command (seq 0) is always seq 1. If we instead read
+	// a packet at some other sequence, the connection was misaligned — e.g. a
+	// client was killed mid-result and unread result packets are still in the
+	// stream. Treat that as a hard failure so the pool destroys the connection
+	// rather than lending a corrupted one to the next borrower.
+	if seq != 1 {
+		return fmt.Errorf("%w: reset reply out of sequence (seq=%d) — connection misaligned", errProtocol, seq)
+	}
+	if len(pkt) > 0 && pkt[0] == 0xff {
+		return backendErr(pkt)
+	}
+	if len(pkt) == 0 || pkt[0] != 0x00 {
+		return fmt.Errorf("%w: unexpected reset reply (first byte 0x%02x)", errProtocol, firstByte(pkt))
+	}
+	return nil
+}
+
+func firstByte(p []byte) byte {
+	if len(p) == 0 {
+		return 0
+	}
+	return p[0]
+}
+
+// pingBackend sends COM_PING and waits for OK; used as a cheap liveness check
+// before lending a pooled connection.
+func pingBackend(ctx context.Context, conn net.Conn) error {
+	if dl, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(dl)
+		defer func() { _ = conn.SetDeadline(time.Time{}) }()
+	}
+	if err := writePacket(conn, 0, []byte{comPing}); err != nil {
+		return err
+	}
+	pkt, _, err := readPacket(conn)
+	if err != nil {
+		return err
+	}
+	if len(pkt) > 0 && pkt[0] == 0xff {
+		return backendErr(pkt)
+	}
+	return nil
+}

--- a/internal/storage/dbproxy/proxy/mysqlwire_spike_test.go
+++ b/internal/storage/dbproxy/proxy/mysqlwire_spike_test.go
@@ -1,0 +1,283 @@
+//go:build cgo
+
+package proxy
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
+)
+
+// These spike tests validate the core hypothesis of the pooling proxy against a
+// real dolt sql-server: (1) a go-sql-driver client can run queries and
+// transactions through a handshake-terminating, connection-pooling proxy;
+// (2) COM_RESET_CONNECTION isolates session state between successive borrowers;
+// (3) the dolt-side Connections counter stays flat across many sequential
+// client sessions instead of growing 1:1.
+//
+// They are gated on dolt being installed (skip otherwise) and require cgo
+// (servercfg). Run: go test ./internal/storage/dbproxy/proxy -run Spike.
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
+func spikeDolt(t *testing.T) (srv *server.DoltServer, port int) {
+	t.Helper()
+	bin, err := exec.LookPath("dolt")
+	if err != nil {
+		t.Skipf("dolt not on PATH: %v", err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	rootDir := t.TempDir()
+	port = freeTCPPort(t)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	body := fmt.Sprintf("log_level: warning\nlistener:\n  host: 127.0.0.1\n  port: %d\n", port)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(body), 0o600))
+	logPath := filepath.Join(t.TempDir(), "server.log")
+	srv, err = server.NewDoltServer(bin, rootDir, cfgPath, logPath, 0)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	require.NoError(t, srv.Start(ctx))
+	t.Cleanup(func() {
+		sctx, scancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer scancel()
+		_ = srv.Stop(sctx)
+	})
+	return srv, port
+}
+
+// servePooled runs a minimal pooling accept loop in the background and returns
+// the address clients should dial. It mirrors what proxyServer.handleConn will
+// do in pooling mode.
+func servePooled(t *testing.T, pool *backendPool, stats *Stats) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	var connID atomic.Uint32
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(client net.Conn) {
+				defer func() { _ = client.Close() }()
+				id := connID.Add(1)
+				res, err := runPooledSession(context.Background(), stats, pool, client, id)
+				if err != nil {
+					return
+				}
+				if res.backend == nil {
+					return
+				}
+				if res.reusable {
+					pool.put(res.backend)
+				} else {
+					_ = res.backend.conn.Close()
+				}
+			}(c)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+func newSpikePool(t *testing.T, srv *server.DoltServer, maxIdle int) (*backendPool, *Stats) {
+	t.Helper()
+	stats := &Stats{}
+	pool := newBackendPool(
+		func(ctx context.Context) (net.Conn, error) { return srv.Dial(ctx) },
+		"root", "", maxIdle, 0, stats,
+	)
+	t.Cleanup(pool.drain)
+	return pool, stats
+}
+
+func openThroughProxy(t *testing.T, addr, db string) *sql.DB {
+	t.Helper()
+	dsn := fmt.Sprintf("root@tcp(%s)/%s?parseTime=true&timeout=10s&readTimeout=10s&writeTimeout=10s", addr, db)
+	dbConn, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	dbConn.SetMaxOpenConns(1) // one client TCP conn at a time for deterministic pooling
+	return dbConn
+}
+
+func TestSpike_PooledQueryRoundTrip(t *testing.T) {
+	srv, _ := spikeDolt(t)
+	pool, stats := newSpikePool(t, srv, 4)
+	addr := servePooled(t, pool, stats)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Create the database via the proxy (no DB selected yet).
+	admin := openThroughProxy(t, addr, "")
+	defer func() { _ = admin.Close() }()
+	_, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS spikedb")
+	require.NoError(t, err)
+	_ = admin.Close()
+
+	// Now connect WITH the database (exercises CONNECT_WITH_DB handshake path).
+	conn := openThroughProxy(t, addr, "spikedb")
+	defer func() { _ = conn.Close() }()
+
+	var one int
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT 1").Scan(&one))
+	require.Equal(t, 1, one)
+
+	_, err = conn.ExecContext(ctx, "CREATE TABLE t (id INT PRIMARY KEY, v VARCHAR(32))")
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, "INSERT INTO t VALUES (1, 'hello'), (2, 'world')")
+	require.NoError(t, err)
+
+	var v string
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT v FROM t WHERE id=2").Scan(&v))
+	require.Equal(t, "world", v)
+
+	// Transaction + DOLT_COMMIT round-trip (bd's write pattern).
+	_, err = conn.ExecContext(ctx, "INSERT INTO t VALUES (3, 'tx')")
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'spike commit')")
+	require.NoError(t, err)
+
+	var cnt int
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM t").Scan(&cnt))
+	require.Equal(t, 3, cnt)
+
+	t.Logf("stats: %+v", stats.Snapshot())
+}
+
+func TestSpike_SessionIsolation(t *testing.T) {
+	srv, _ := spikeDolt(t)
+	pool, stats := newSpikePool(t, srv, 1) // force a single shared backend
+	addr := servePooled(t, pool, stats)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Create a database so temp tables have somewhere to live, then drain the
+	// admin backend so the isolation check below runs against a single shared
+	// pooled connection keyed by db="isodb".
+	admin := openThroughProxy(t, addr, "")
+	_, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS isodb")
+	require.NoError(t, err)
+	require.NoError(t, admin.Close())
+
+	// Borrower #1: set a session var and an autocommit override, then a temp
+	// table — all session-scoped state that must NOT survive to borrower #2.
+	c1 := openThroughProxy(t, addr, "isodb")
+	conn1, err := c1.Conn(ctx)
+	require.NoError(t, err)
+	_, err = conn1.ExecContext(ctx, "SET @leak = 42")
+	require.NoError(t, err)
+	_, err = conn1.ExecContext(ctx, "SET autocommit = 0")
+	require.NoError(t, err)
+	_, err = conn1.ExecContext(ctx, "CREATE TEMPORARY TABLE leaks (x INT)")
+	require.NoError(t, err)
+	var leak sql.NullInt64
+	require.NoError(t, conn1.QueryRowContext(ctx, "SELECT @leak").Scan(&leak))
+	require.True(t, leak.Valid && leak.Int64 == 42, "borrower #1 should see its own var")
+	require.NoError(t, conn1.Close())
+	require.NoError(t, c1.Close()) // returns backend to pool (reset)
+
+	// Give the pool a moment to reset+return the single backend.
+	require.Eventually(t, func() bool { return pool.idleCount() == 1 }, 5*time.Second, 20*time.Millisecond)
+
+	// Borrower #2: must reuse the SAME backend and see a clean session.
+	c2 := openThroughProxy(t, addr, "isodb")
+	defer func() { _ = c2.Close() }()
+	conn2, err := c2.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = conn2.Close() }()
+
+	var leak2 sql.NullInt64
+	require.NoError(t, conn2.QueryRowContext(ctx, "SELECT @leak").Scan(&leak2))
+	require.False(t, leak2.Valid, "session var @leak leaked across borrowers: %v", leak2)
+
+	var autocommit int
+	require.NoError(t, conn2.QueryRowContext(ctx, "SELECT @@autocommit").Scan(&autocommit))
+	require.Equal(t, 1, autocommit, "autocommit override leaked across borrowers")
+
+	// The temp table must be gone: querying it should error (unknown table).
+	var n int
+	err = conn2.QueryRowContext(ctx, "SELECT COUNT(*) FROM leaks").Scan(&n)
+	require.Error(t, err, "temp table 'leaks' leaked across borrowers")
+
+	snap := stats.Snapshot()
+	t.Logf("stats: %+v", snap)
+	require.GreaterOrEqual(t, snap.PoolResets, int64(1), "expected at least one COM_RESET_CONNECTION")
+	require.GreaterOrEqual(t, snap.PoolHits, int64(1), "borrower #2 should have reused the pooled backend")
+}
+
+func TestSpike_ConnectionCounterFlat(t *testing.T) {
+	srv, port := spikeDolt(t)
+	pool, stats := newSpikePool(t, srv, 2)
+	addr := servePooled(t, pool, stats)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// A persistent direct (non-proxied) connection to read the global counter
+	// with constant overhead.
+	directDSN := fmt.Sprintf("root@tcp(127.0.0.1:%d)/?timeout=10s", port)
+	direct, err := sql.Open("mysql", directDSN)
+	require.NoError(t, err)
+	direct.SetMaxOpenConns(1)
+	defer func() { _ = direct.Close() }()
+
+	readConnections := func() int64 {
+		var name string
+		var val int64
+		require.NoError(t, direct.QueryRowContext(ctx, "SHOW STATUS LIKE 'Connections'").Scan(&name, &val))
+		return val
+	}
+
+	// Warm the pool once.
+	warm := openThroughProxy(t, addr, "")
+	require.NoError(t, warm.PingContext(ctx))
+	_, _ = warm.ExecContext(ctx, "SELECT 1")
+	_ = warm.Close()
+	require.Eventually(t, func() bool { return pool.idleCount() >= 1 }, 5*time.Second, 20*time.Millisecond)
+
+	before := readConnections()
+
+	const N = 40
+	for i := 0; i < N; i++ {
+		c := openThroughProxy(t, addr, "")
+		var one int
+		require.NoError(t, c.QueryRowContext(ctx, "SELECT 1").Scan(&one))
+		require.NoError(t, c.Close())
+		require.Eventually(t, func() bool { return pool.idleCount() >= 1 }, 5*time.Second, 10*time.Millisecond)
+	}
+
+	after := readConnections()
+	delta := after - before
+	snap := stats.Snapshot()
+	t.Logf("Connections delta over %d sequential pooled sessions: %d (pool stats: %+v)", N, delta, snap)
+
+	// With pooling, the dolt-side Connections counter must stay essentially
+	// flat (well under N). Allow a small slack for incidental reconnects.
+	require.Less(t, delta, int64(N/2), "Connections grew ~1:1 with sessions — pooling not effective")
+	require.GreaterOrEqual(t, snap.PoolHits, int64(N-2), "most sessions should be pool hits")
+}

--- a/internal/storage/dbproxy/proxy/mysqlwire_test.go
+++ b/internal/storage/dbproxy/proxy/mysqlwire_test.go
@@ -1,0 +1,86 @@
+package proxy
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLenencIntRoundTrip(t *testing.T) {
+	for _, v := range []uint64{0, 1, 250, 251, 0xfb, 0xfc, 0xffff, 0x10000, 0xffffff, 0x1000000, 1 << 40} {
+		b := appendLenencInt(nil, v)
+		got, next, err := readLenencInt(b, 0)
+		require.NoError(t, err, "v=%d", v)
+		require.Equal(t, v, got, "v=%d", v)
+		require.Equal(t, len(b), next, "v=%d consumed all bytes", v)
+	}
+}
+
+func TestPacketFramingRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	payload := bytes.Repeat([]byte{0xab}, 100)
+	require.NoError(t, writePacket(&buf, 7, payload))
+	got, seq, err := readPacket(&buf)
+	require.NoError(t, err)
+	require.Equal(t, byte(7), seq)
+	require.Equal(t, payload, got)
+}
+
+func TestServerGreetingParsesBack(t *testing.T) {
+	// A greeting the proxy emits to clients must be parseable by our own
+	// backend-side parser (the two are symmetric on salt + plugin).
+	salt := makeSalt(42)
+	g := serverGreeting(42, salt)
+	parsedSalt, plugin, err := parseServerGreeting(g)
+	require.NoError(t, err)
+	require.Equal(t, mysqlNativePassword, plugin)
+	require.Equal(t, salt, parsedSalt, "round-tripped salt must match")
+}
+
+func TestParseClientHandshakeResponse(t *testing.T) {
+	// Build a HandshakeResponse41 the way a backend handshake would and parse
+	// it as the server side would.
+	caps := capProtocol41 | capSecureConnection | capPluginAuth | capConnectWithDB
+	resp := buildHandshakeResponse41(caps, "mydb", "root", nil, mysqlNativePassword)
+	h, err := parseClientHandshakeResponse(resp)
+	require.NoError(t, err)
+	require.Equal(t, "root", h.username)
+	require.Equal(t, "mydb", h.database)
+	require.NotZero(t, h.capabilities&capProtocol41)
+	require.NotZero(t, h.capabilities&capConnectWithDB)
+}
+
+func TestParseClientHandshakeResponse_NoDB(t *testing.T) {
+	caps := capProtocol41 | capSecureConnection | capPluginAuth
+	resp := buildHandshakeResponse41(caps, "", "someuser", []byte{1, 2, 3, 4}, mysqlNativePassword)
+	h, err := parseClientHandshakeResponse(resp)
+	require.NoError(t, err)
+	require.Equal(t, "someuser", h.username)
+	require.Equal(t, "", h.database)
+	require.Zero(t, h.capabilities&capConnectWithDB)
+}
+
+func TestNativeScrambleEmptyPassword(t *testing.T) {
+	require.Nil(t, scramble(mysqlNativePassword, "", makeSalt(1)))
+}
+
+func TestNativeScrambleDeterministic(t *testing.T) {
+	salt := makeSalt(99)
+	a := nativeScramble("hunter2", salt)
+	b := nativeScramble("hunter2", salt)
+	require.Equal(t, a, b)
+	require.Len(t, a, 20) // SHA1 digest length
+	require.NotEqual(t, nativeScramble("other", salt), a)
+}
+
+func TestOKPacketShapes(t *testing.T) {
+	// PROTOCOL_41 OK has status(2)+warnings(2) after the two lenenc ints.
+	ok41 := okPacket(capProtocol41)
+	require.Equal(t, byte(0x00), ok41[0])
+	require.Len(t, ok41, 1+1+1+2+2)
+
+	// No PROTOCOL_41, no TRANSACTIONS: just header + two lenenc ints.
+	okPlain := okPacket(0)
+	require.Len(t, okPlain, 1+1+1)
+}

--- a/internal/storage/dbproxy/proxy/pool.go
+++ b/internal/storage/dbproxy/proxy/pool.go
@@ -1,0 +1,201 @@
+package proxy
+
+// backendPool keeps a set of already-authenticated, live MySQL connections to
+// the dolt backend and lends them to clients at session granularity (one
+// backend per client TCP connection). This is the core of the connection-churn
+// fix: without it, every bd CLI invocation forks a process that opens a fresh
+// connection (TCP + auth handshake + session setup) and tears it down at exit,
+// which the dolt sql-server pays for as raw connection-setup CPU. Reusing warm
+// backends collapses that to ~zero new connections per second in steady state.
+//
+// Connections are keyed by (capabilities, database): byte-transparent
+// command-phase forwarding requires the client↔proxy and proxy↔backend
+// capability sets to match, and the initial database must be correct since the
+// proxy does not parse the command stream. All bd clients share one driver and
+// DSN, so they collapse onto a single key and reuse the same warm connections.
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"time"
+)
+
+// backendKey identifies an interchangeable class of pooled connections. Two
+// borrowers may share a connection only if their keys are equal.
+type backendKey struct {
+	caps uint32
+	db   string
+}
+
+// pooledConn is a live, authenticated backend connection plus the metadata the
+// pool needs to decide reuse.
+type pooledConn struct {
+	conn      net.Conn
+	key       backendKey
+	createdAt time.Time
+	transient bool // dialed past the idle cap; closed (not returned) on put
+}
+
+// poolDialer establishes a raw TCP connection to the backend. It is satisfied
+// by server.DatabaseServer.Dial.
+type poolDialer func(ctx context.Context) (net.Conn, error)
+
+type backendPool struct {
+	dial     poolDialer
+	user     string
+	password string
+	maxIdle  int           // max idle connections retained per key
+	lifetime time.Duration // 0 = unlimited; retire+reopen on exceed
+	stats    *Stats
+
+	mu     sync.Mutex
+	idle   map[backendKey][]*pooledConn
+	closed bool
+}
+
+func newBackendPool(dial poolDialer, user, password string, maxIdle int, lifetime time.Duration, stats *Stats) *backendPool {
+	if maxIdle < 1 {
+		maxIdle = 1
+	}
+	return &backendPool{
+		dial:     dial,
+		user:     user,
+		password: password,
+		maxIdle:  maxIdle,
+		lifetime: lifetime,
+		stats:    stats,
+		idle:     make(map[backendKey][]*pooledConn),
+	}
+}
+
+var errPoolClosed = errors.New("proxy: backend pool closed")
+
+// get returns a connection for key, reusing a live idle one when available or
+// dialing+authenticating a fresh one otherwise. The handshake against the
+// backend is performed with exactly key.caps so the session is wire-compatible
+// with the client the caller will forward.
+func (p *backendPool) get(ctx context.Context, key backendKey) (*pooledConn, error) {
+	for {
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			return nil, errPoolClosed
+		}
+		stack := p.idle[key]
+		if n := len(stack); n > 0 {
+			pc := stack[n-1]
+			p.idle[key] = stack[:n-1]
+			p.mu.Unlock()
+			if p.expired(pc) {
+				_ = pc.conn.Close()
+				p.stats.IncPoolRetire()
+				continue
+			}
+			// Liveness check: a backend may have dropped the conn while idle.
+			pingCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			err := pingBackend(pingCtx, pc.conn)
+			cancel()
+			if err != nil {
+				_ = pc.conn.Close()
+				p.stats.IncPoolDead()
+				continue
+			}
+			p.stats.IncPoolHit()
+			return pc, nil
+		}
+		p.mu.Unlock()
+		return p.dialNew(ctx, key, false)
+	}
+}
+
+// dialNew opens and authenticates a fresh backend connection for key.
+func (p *backendPool) dialNew(ctx context.Context, key backendKey, transient bool) (*pooledConn, error) {
+	conn, err := p.dial(ctx)
+	if err != nil {
+		p.stats.IncPoolDialError()
+		return nil, err
+	}
+	deadline, _ := ctx.Deadline()
+	if err := backendHandshake(conn, key.caps, key.db, p.user, p.password, deadline); err != nil {
+		_ = conn.Close()
+		p.stats.IncPoolDialError()
+		return nil, err
+	}
+	p.stats.IncPoolMiss()
+	return &pooledConn{
+		conn:      conn,
+		key:       key,
+		createdAt: time.Now(),
+		transient: transient,
+	}, nil
+}
+
+// put returns pc to the pool after resetting its session state. If the reset
+// fails, the connection is destroyed rather than risk leaking state to the
+// next borrower. Transient connections and connections returned after the pool
+// is closed are always destroyed.
+func (p *backendPool) put(pc *pooledConn) {
+	if pc == nil {
+		return
+	}
+	resetCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	err := resetBackend(resetCtx, pc.conn)
+	cancel()
+	if err != nil {
+		p.stats.IncPoolResetError()
+		_ = pc.conn.Close()
+		return
+	}
+	p.stats.IncPoolReset()
+
+	if pc.transient || p.expired(pc) {
+		_ = pc.conn.Close()
+		p.stats.IncPoolRetire()
+		return
+	}
+
+	p.mu.Lock()
+	if p.closed || len(p.idle[pc.key]) >= p.maxIdle {
+		p.mu.Unlock()
+		_ = pc.conn.Close()
+		return
+	}
+	p.idle[pc.key] = append(p.idle[pc.key], pc)
+	p.mu.Unlock()
+}
+
+func (p *backendPool) expired(pc *pooledConn) bool {
+	if p.lifetime <= 0 || pc.createdAt.IsZero() {
+		return false
+	}
+	return time.Since(pc.createdAt) >= p.lifetime
+}
+
+// drain closes every idle connection and marks the pool closed. In-flight
+// borrowed connections are closed by their handlers on put (which sees closed
+// and destroys them).
+func (p *backendPool) drain() {
+	p.mu.Lock()
+	idle := p.idle
+	p.idle = make(map[backendKey][]*pooledConn)
+	p.closed = true
+	p.mu.Unlock()
+	for _, stack := range idle {
+		for _, pc := range stack {
+			_ = pc.conn.Close()
+		}
+	}
+}
+
+// idleCount reports the total number of idle connections held (test helper).
+func (p *backendPool) idleCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	n := 0
+	for _, stack := range p.idle {
+		n += len(stack)
+	}
+	return n
+}

--- a/internal/storage/dbproxy/proxy/pool_test.go
+++ b/internal/storage/dbproxy/proxy/pool_test.go
@@ -1,0 +1,202 @@
+package proxy
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBackend is an in-memory MySQL-speaking stub: it completes the server side
+// of the handshake and answers COM_PING / COM_RESET_CONNECTION with OK. It lets
+// the pool be exercised without a real dolt sql-server. Counters are shared
+// across all connections a dialer produces.
+type fakeBackend struct {
+	dials  atomic.Int64
+	resets atomic.Int64
+	pings  atomic.Int64
+}
+
+// dialer returns a poolDialer that spins up a fresh stub connection per dial.
+func (f *fakeBackend) dialer() poolDialer {
+	return func(ctx context.Context) (net.Conn, error) {
+		f.dials.Add(1)
+		proxySide, backendSide := net.Pipe()
+		go f.serve(backendSide)
+		return proxySide, nil
+	}
+}
+
+func (f *fakeBackend) serve(c net.Conn) {
+	defer func() { _ = c.Close() }()
+	// Server greeting (seq 0).
+	if err := writePacket(c, 0, serverGreeting(1, makeSalt(1))); err != nil {
+		return
+	}
+	// Read client handshake response (seq 1); accept anything.
+	resp, _, err := readPacket(c)
+	if err != nil {
+		return
+	}
+	if _, perr := parseClientHandshakeResponse(resp); perr != nil {
+		_ = writePacket(c, 2, []byte{0xff, 0x15, 0x04}) // ERR
+		return
+	}
+	if err := writePacket(c, 2, okPacket(capProtocol41)); err != nil { // auth OK (seq 2)
+		return
+	}
+	// Command loop.
+	for {
+		pkt, seq, err := readPacket(c)
+		if err != nil {
+			return
+		}
+		if len(pkt) == 0 {
+			return
+		}
+		switch pkt[0] {
+		case comResetConnection:
+			f.resets.Add(1)
+			if err := writePacket(c, seq+1, okPacket(capProtocol41)); err != nil {
+				return
+			}
+		case comPing:
+			f.pings.Add(1)
+			if err := writePacket(c, seq+1, okPacket(capProtocol41)); err != nil {
+				return
+			}
+		case 0x01: // COM_QUIT
+			return
+		default:
+			_ = writePacket(c, seq+1, okPacket(capProtocol41))
+		}
+	}
+}
+
+func testKey() backendKey {
+	return backendKey{caps: capProtocol41 | capSecureConnection | capPluginAuth, db: "beads"}
+}
+
+func TestPool_GetDialsAndPutReturns(t *testing.T) {
+	fb := &fakeBackend{}
+	stats := &Stats{}
+	p := newBackendPool(fb.dialer(), "root", "", 4, 0, stats)
+	defer p.drain()
+
+	ctx := context.Background()
+	pc, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), fb.dials.Load(), "first get must dial")
+	require.Equal(t, 0, p.idleCount())
+
+	p.put(pc)
+	require.Equal(t, int64(1), fb.resets.Load(), "put must COM_RESET_CONNECTION")
+	require.Equal(t, 1, p.idleCount(), "reset conn returns to pool")
+
+	// Second get reuses the idle connection (no new dial).
+	pc2, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), fb.dials.Load(), "reuse must not dial")
+	require.GreaterOrEqual(t, fb.pings.Load(), int64(1), "reuse pings for liveness")
+	p.put(pc2)
+
+	snap := stats.Snapshot()
+	require.GreaterOrEqual(t, snap.PoolHits, int64(1))
+	require.GreaterOrEqual(t, snap.PoolMisses, int64(1))
+	require.GreaterOrEqual(t, snap.PoolResets, int64(2))
+}
+
+func TestPool_MaxIdleCap(t *testing.T) {
+	fb := &fakeBackend{}
+	p := newBackendPool(fb.dialer(), "root", "", 2, 0, &Stats{})
+	defer p.drain()
+	ctx := context.Background()
+
+	// Borrow three concurrently, then return all three. Only maxIdle=2 are kept.
+	a, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	b, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	c, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	require.Equal(t, int64(3), fb.dials.Load())
+
+	p.put(a)
+	p.put(b)
+	p.put(c)
+	require.Equal(t, 2, p.idleCount(), "idle retention capped at maxIdle")
+}
+
+func TestPool_KeyIsolation(t *testing.T) {
+	fb := &fakeBackend{}
+	p := newBackendPool(fb.dialer(), "root", "", 4, 0, &Stats{})
+	defer p.drain()
+	ctx := context.Background()
+
+	k1 := backendKey{caps: capProtocol41, db: "alpha"}
+	k2 := backendKey{caps: capProtocol41, db: "beta"}
+
+	pc1, err := p.get(ctx, k1)
+	require.NoError(t, err)
+	p.put(pc1)
+
+	// A get for a different key must NOT reuse k1's idle connection.
+	pc2, err := p.get(ctx, k2)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), fb.dials.Load(), "different key dials a fresh backend")
+	p.put(pc2)
+}
+
+func TestPool_DrainClosesIdle(t *testing.T) {
+	fb := &fakeBackend{}
+	p := newBackendPool(fb.dialer(), "root", "", 4, 0, &Stats{})
+	ctx := context.Background()
+	pc, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	p.put(pc)
+	require.Equal(t, 1, p.idleCount())
+
+	p.drain()
+	require.Equal(t, 0, p.idleCount())
+
+	// get after drain fails.
+	_, err = p.get(ctx, testKey())
+	require.ErrorIs(t, err, errPoolClosed)
+}
+
+func TestPool_DeadIdleConnDiscarded(t *testing.T) {
+	fb := &fakeBackend{}
+	p := newBackendPool(fb.dialer(), "root", "", 4, 0, &Stats{})
+	defer p.drain()
+	ctx := context.Background()
+
+	pc, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	p.put(pc)
+	require.Equal(t, 1, p.idleCount())
+
+	// Kill the idle connection out from under the pool.
+	pc.conn.Close()
+
+	// Next get must detect the dead conn (ping fails) and dial a fresh one.
+	pc2, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	require.Equal(t, int64(2), fb.dials.Load(), "dead idle conn replaced by a fresh dial")
+	p.put(pc2)
+}
+
+func TestPool_LifetimeRetire(t *testing.T) {
+	fb := &fakeBackend{}
+	p := newBackendPool(fb.dialer(), "root", "", 4, 10*time.Millisecond, &Stats{})
+	defer p.drain()
+	ctx := context.Background()
+
+	pc, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	time.Sleep(20 * time.Millisecond)
+	p.put(pc) // expired → destroyed, not returned
+	require.Equal(t, 0, p.idleCount(), "expired conn not retained")
+}

--- a/internal/storage/dbproxy/proxy/pooledconn.go
+++ b/internal/storage/dbproxy/proxy/pooledconn.go
@@ -22,7 +22,7 @@ const handshakeTimeout = 10 * time.Second
 
 // sessionResult reports what the pool should do with the backend afterward.
 type sessionResult struct {
-	backend *pooledConn
+	backend  *pooledConn
 	reusable bool // false → caller must destroy (don't return to pool)
 }
 

--- a/internal/storage/dbproxy/proxy/pooledconn.go
+++ b/internal/storage/dbproxy/proxy/pooledconn.go
@@ -1,0 +1,169 @@
+package proxy
+
+// handlePooledSession drives one client connection against a pooled backend:
+// it terminates the client handshake (skip-auth), borrows a wire-compatible
+// backend connection, forwards the command phase byte-transparently in both
+// directions, and returns the backend to the pool (reset) when the client
+// disconnects. This is the pooling counterpart to the transparent
+// dial+io.Copy+Close path in proxyServer.handleConn.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// handshakeTimeout bounds the client+backend handshake phase. The command
+// phase that follows is unbounded (long-lived bd sessions are normal).
+const handshakeTimeout = 10 * time.Second
+
+// sessionResult reports what the pool should do with the backend afterward.
+type sessionResult struct {
+	backend *pooledConn
+	reusable bool // false → caller must destroy (don't return to pool)
+}
+
+// runPooledSession performs the handshake handoff and bidirectional copy. It
+// returns the borrowed backend and whether it is safe to return to the pool.
+// The caller owns closing the client connection.
+func runPooledSession(ctx context.Context, stats *Stats, pool *backendPool, client net.Conn, connID uint32) (sessionResult, error) {
+	hsDeadline := time.Now().Add(handshakeTimeout)
+	ch, err := acceptClient(client, connID, hsDeadline)
+	if err != nil {
+		return sessionResult{}, err
+	}
+
+	key := backendKey{caps: ch.capabilities, db: ch.database}
+	getCtx, cancel := context.WithDeadline(ctx, hsDeadline)
+	pc, err := pool.get(getCtx, key)
+	cancel()
+	if err != nil {
+		return sessionResult{}, err
+	}
+
+	// Command phase. The backend→client direction is byte-transparent
+	// (io.Copy), exactly like handleConn. The client→backend direction is
+	// frame-aware so it can intercept COM_QUIT: go-sql-driver sends COM_QUIT
+	// when it closes a connection, and forwarding that to a pooled backend
+	// would terminate it — defeating pooling. We swallow COM_QUIT, end the
+	// session, reset the backend, and return it to the pool instead.
+	done := make(chan struct{})
+	var once sync.Once
+	finish := func() { once.Do(func() { close(done) }) }
+
+	var g sync.WaitGroup
+	var c2bErr error
+	var sawQuit bool
+
+	g.Add(1)
+	go func() {
+		defer g.Done()
+		defer finish()
+		var n int64
+		n, sawQuit, c2bErr = copyClientCommands(pc.conn, client)
+		stats.AddBytesClientToBackend(n)
+	}()
+
+	g.Add(1)
+	go func() {
+		defer g.Done()
+		n, _ := io.Copy(client, pc.conn)
+		stats.AddBytesBackendToClient(n)
+	}()
+
+	// When the client→backend direction finishes (client closed its write
+	// side / disconnected), unblock the backend→client copy by setting an
+	// immediate read deadline on the backend so io.Copy returns and we can
+	// reclaim the connection for the pool.
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-done:
+		}
+		_ = pc.conn.SetReadDeadline(time.Now())
+	}()
+
+	g.Wait()
+	_ = pc.conn.SetReadDeadline(time.Time{}) // clear for reuse
+
+	// Determine reusability. The safe case is a clean COM_QUIT from the client:
+	// the backend is then guaranteed to be at a command boundary. A plain EOF
+	// (client vanished without COM_QUIT) may have happened mid-command, so the
+	// backend stream could be misaligned — the reset's sequence-id check
+	// (resetBackend) is the backstop, but we conservatively destroy on
+	// non-quit endings and on context cancellation.
+	reusable := backendReusable(ctx, sawQuit, c2bErr)
+	return sessionResult{backend: pc, reusable: reusable}, nil
+}
+
+// copyClientCommands forwards client→backend bytes frame by frame, intercepting
+// a standalone COM_QUIT (which go-sql-driver emits on Close) so it is not
+// delivered to the pooled backend. It returns the byte count forwarded, whether
+// a COM_QUIT was seen, and any transport error.
+func copyClientCommands(backend, client net.Conn) (int64, bool, error) {
+	var total int64
+	var hdr [4]byte
+	atCommandStart := true
+	for {
+		if _, err := io.ReadFull(client, hdr[:]); err != nil {
+			if isExpectedClose(err) {
+				return total, false, nil
+			}
+			return total, false, err
+		}
+		n := int(hdr[0]) | int(hdr[1])<<8 | int(hdr[2])<<16
+		seq := hdr[3]
+		payload := make([]byte, n)
+		if n > 0 {
+			if _, err := io.ReadFull(client, payload); err != nil {
+				return total, false, err
+			}
+		}
+		// A new command begins at seq 0 when we are not mid-multiframe. A
+		// standalone COM_QUIT is exactly one byte (0x01).
+		if atCommandStart && seq == 0 && n == 1 && payload[0] == 0x01 {
+			return total, true, nil
+		}
+		if _, err := backend.Write(hdr[:]); err != nil {
+			return total, false, err
+		}
+		if n > 0 {
+			if _, err := backend.Write(payload); err != nil {
+				return total, false, err
+			}
+		}
+		total += int64(4 + n)
+		// The next frame starts a new command unless this was a max-size frame
+		// (0xffffff) that continues into another frame.
+		atCommandStart = n < 0xffffff
+	}
+}
+
+// backendReusable decides whether the backend connection can be safely reset
+// and returned to the pool after a session ends.
+func backendReusable(ctx context.Context, sawQuit bool, c2bErr error) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	if c2bErr != nil {
+		return false
+	}
+	return sawQuit
+}
+
+func isExpectedClose(err error) bool {
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	return false
+}

--- a/internal/storage/dbproxy/proxy/proxy_pool_integration_test.go
+++ b/internal/storage/dbproxy/proxy/proxy_pool_integration_test.go
@@ -1,0 +1,276 @@
+//go:build cgo
+
+package proxy
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
+)
+
+// These tests drive the REAL proxyServer (ListenAndServe → handleConn →
+// handlePooledConn) in pooling mode against a real dolt sql-server that the
+// proxy itself manages, validating the production path end to end. Gated on
+// dolt + cgo.
+
+// startManagedPooledProxy creates an unstarted DoltServer and a proxyServer
+// configured to pool, runs the proxy (which starts dolt) in the background, and
+// returns the proxy address, the dolt port (for direct counter reads), and the
+// stats. The proxy is stopped on test cleanup.
+func startManagedPooledProxy(t *testing.T, poolSize int) (proxyAddr string, doltPort int, stats *Stats) {
+	t.Helper()
+	bin, err := exec.LookPath("dolt")
+	if err != nil {
+		t.Skipf("dolt not on PATH: %v", err)
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	doltPort = freeTCPPort(t)
+	rootDir := t.TempDir()
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	body := fmt.Sprintf("log_level: warning\nlistener:\n  host: 127.0.0.1\n  port: %d\n", doltPort)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(body), 0o600))
+	logPath := filepath.Join(t.TempDir(), "server.log")
+
+	srv, err := server.NewDoltServer(bin, rootDir, cfgPath, logPath, 0)
+	require.NoError(t, err)
+
+	proxyPort := freeTCPPort(t)
+	proxyRoot := t.TempDir()
+	stats = &Stats{}
+	p := NewProxyServer(ProxyOpts{
+		RootDir:     proxyRoot,
+		Port:        proxyPort,
+		IdleTimeout: 0,
+		Server:      srv,
+		Stats:       stats,
+		PoolSize:    poolSize,
+		BackendUser: "root",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- p.ListenAndServe(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-errCh:
+		case <-time.After(30 * time.Second):
+			t.Log("proxy did not shut down within 30s")
+		}
+	})
+
+	// Wait for the proxy port to accept connections.
+	proxyAddr = fmt.Sprintf("127.0.0.1:%d", proxyPort)
+	require.Eventually(t, func() bool {
+		return probePort(Endpoint{Host: "127.0.0.1", Port: proxyPort}, 300*time.Millisecond)
+	}, 60*time.Second, 200*time.Millisecond, "proxy never became ready")
+	return proxyAddr, doltPort, stats
+}
+
+func TestIntegration_ManagedProxyPooling(t *testing.T) {
+	addr, _, stats := startManagedPooledProxy(t, 4)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	admin := openThroughProxy(t, addr, "")
+	_, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS itdb")
+	require.NoError(t, err)
+	require.NoError(t, admin.Close())
+
+	db := openThroughProxy(t, addr, "itdb")
+	defer func() { _ = db.Close() }()
+
+	_, err = db.ExecContext(ctx, "CREATE TABLE t (id INT PRIMARY KEY)")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "INSERT INTO t VALUES (1),(2),(3)")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'it')")
+	require.NoError(t, err)
+
+	var n int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM t").Scan(&n))
+	require.Equal(t, 3, n)
+	t.Logf("stats: %+v", stats.Snapshot())
+}
+
+func TestIntegration_TransactionRollback(t *testing.T) {
+	addr, _, _ := startManagedPooledProxy(t, 2)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	admin := openThroughProxy(t, addr, "")
+	_, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS rb")
+	require.NoError(t, err)
+	require.NoError(t, admin.Close())
+
+	db := openThroughProxy(t, addr, "rb")
+	defer func() { _ = db.Close() }()
+	_, err = db.ExecContext(ctx, "CREATE TABLE t (id INT PRIMARY KEY)")
+	require.NoError(t, err)
+
+	// Begin, insert, rollback — the row must not survive, and the backend must
+	// be reusable afterward (no leaked open transaction).
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(ctx, "INSERT INTO t VALUES (99)")
+	require.NoError(t, err)
+	require.NoError(t, tx.Rollback())
+
+	var n int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM t WHERE id=99").Scan(&n))
+	require.Equal(t, 0, n, "rolled-back row must not persist")
+}
+
+func TestIntegration_ConcurrentClientsDistinctBackends(t *testing.T) {
+	addr, _, stats := startManagedPooledProxy(t, 8)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	admin := openThroughProxy(t, addr, "")
+	_, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS conc")
+	require.NoError(t, err)
+	require.NoError(t, admin.Close())
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			db := openThroughProxy(t, addr, "conc")
+			defer func() { _ = db.Close() }()
+			// Hold a session var, sleep, then verify it is still ours — proves
+			// concurrent clients did NOT share one backend mid-session.
+			conn, err := db.Conn(ctx)
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer func() { _ = conn.Close() }()
+			if _, err := conn.ExecContext(ctx, fmt.Sprintf("SET @who = %d", id)); err != nil {
+				errs <- err
+				return
+			}
+			time.Sleep(150 * time.Millisecond)
+			var who int
+			if err := conn.QueryRowContext(ctx, "SELECT @who").Scan(&who); err != nil {
+				errs <- err
+				return
+			}
+			if who != id {
+				errs <- fmt.Errorf("worker %d saw @who=%d — backend shared mid-session", id, who)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	t.Logf("stats after %d concurrent workers: %+v", workers, stats.Snapshot())
+}
+
+// BenchmarkConnectionChurn measures the dolt-side Connections counter delta for
+// N sequential client sessions with pooling on vs off. Run with:
+//
+//	go test ./internal/storage/dbproxy/proxy -run NONE -bench ConnectionChurn -benchtime 1x
+func BenchmarkConnectionChurn(b *testing.B) {
+	for _, tc := range []struct {
+		name     string
+		poolSize int
+	}{
+		{"pooling_off", 0},
+		{"pooling_on", 4},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			benchChurn(b, tc.poolSize)
+		})
+	}
+}
+
+func benchChurn(b *testing.B, poolSize int) {
+	b.Helper()
+	bin, err := exec.LookPath("dolt")
+	if err != nil {
+		b.Skipf("dolt not on PATH: %v", err)
+	}
+	b.Setenv("HOME", b.TempDir())
+	doltPort := benchFreePort(b)
+	rootDir := b.TempDir()
+	cfgPath := filepath.Join(b.TempDir(), "config.yaml")
+	body := fmt.Sprintf("log_level: warning\nlistener:\n  host: 127.0.0.1\n  port: %d\n", doltPort)
+	require.NoError(b, os.WriteFile(cfgPath, []byte(body), 0o600))
+	srv, err := server.NewDoltServer(bin, rootDir, cfgPath, filepath.Join(b.TempDir(), "s.log"), 0)
+	require.NoError(b, err)
+
+	proxyPort := benchFreePort(b)
+	stats := &Stats{}
+	p := NewProxyServer(ProxyOpts{
+		RootDir: b.TempDir(), Port: proxyPort, Server: srv, Stats: stats,
+		PoolSize: poolSize, BackendUser: "root",
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = p.ListenAndServe(ctx) }()
+	addr := fmt.Sprintf("127.0.0.1:%d", proxyPort)
+	require.Eventually(b, func() bool {
+		return probePort(Endpoint{Host: "127.0.0.1", Port: proxyPort}, 300*time.Millisecond)
+	}, 60*time.Second, 200*time.Millisecond)
+
+	bctx := context.Background()
+	direct, err := sql.Open("mysql", fmt.Sprintf("root@tcp(127.0.0.1:%d)/?timeout=10s", doltPort))
+	require.NoError(b, err)
+	direct.SetMaxOpenConns(1)
+	defer func() { _ = direct.Close() }()
+	readConns := func() int64 {
+		var name string
+		var v int64
+		require.NoError(b, direct.QueryRowContext(bctx, "SHOW STATUS LIKE 'Connections'").Scan(&name, &v))
+		return v
+	}
+
+	const N = 50
+	// warm
+	warm, _ := sql.Open("mysql", fmt.Sprintf("root@tcp(%s)/?timeout=10s", addr))
+	_ = warm.PingContext(bctx)
+	_, _ = warm.ExecContext(bctx, "SELECT 1")
+	_ = warm.Close()
+	time.Sleep(200 * time.Millisecond)
+
+	before := readConns()
+	b.ResetTimer()
+	for i := 0; i < N; i++ {
+		c, _ := sql.Open("mysql", fmt.Sprintf("root@tcp(%s)/?timeout=10s", addr))
+		var one int
+		require.NoError(b, c.QueryRowContext(bctx, "SELECT 1").Scan(&one))
+		_ = c.Close()
+		time.Sleep(10 * time.Millisecond)
+	}
+	b.StopTimer()
+	after := readConns()
+	b.ReportMetric(float64(after-before), "dolt_conns/"+fmt.Sprint(N)+"sessions")
+	b.Logf("poolSize=%d Connections delta over %d sessions: %d (stats: %+v)", poolSize, N, after-before, stats.Snapshot())
+}
+
+func benchFreePort(b *testing.B) int {
+	b.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(b, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}

--- a/internal/storage/dbproxy/proxy/server.go
+++ b/internal/storage/dbproxy/proxy/server.go
@@ -33,17 +33,41 @@ type ProxyOpts struct {
 	// against it; tests use Snapshot() to assert. Production code should
 	// leave this nil.
 	Stats *Stats
+
+	// PoolSize enables connection pooling when > 0: instead of dialing a fresh
+	// backend per client and closing it on disconnect (the transparent path),
+	// the proxy terminates each client handshake itself and lends a backend
+	// from a pool of up to PoolSize warm, already-authenticated connections,
+	// resetting and returning them on client disconnect. This collapses the
+	// per-bd-invocation connection churn that dolt pays for as setup CPU.
+	// 0 (default) preserves the original transparent forwarding behavior.
+	PoolSize int
+	// BackendUser / BackendPassword are the credentials the proxy uses to
+	// authenticate pooled backend connections to dolt. Only consulted when
+	// PoolSize > 0. For the managed loopback server this is root / empty.
+	BackendUser     string
+	BackendPassword string
+	// PoolConnMaxLifetime optionally retires pooled connections after this
+	// duration. 0 (default) keeps them indefinitely — a short lifetime would
+	// re-create the very connection churn pooling exists to eliminate.
+	PoolConnMaxLifetime time.Duration
 }
 
 type proxyServer struct {
-	rootDir     string
-	port        int
-	idleTimeout time.Duration
-	server      server.DatabaseServer
-	stats       *Stats
+	rootDir         string
+	port            int
+	idleTimeout     time.Duration
+	server          server.DatabaseServer
+	stats           *Stats
+	poolSize        int
+	backendUser     string
+	backendPassword string
+	poolLifetime    time.Duration
 
 	logger      *log.Logger
 	listener    net.Listener
+	pool        *backendPool
+	connID      atomic.Uint32
 	activeConns atomic.Int64
 	conns       errgroup.Group
 }
@@ -79,11 +103,15 @@ var errIdleTimeout = errors.New("idle timeout reached")
 
 func NewProxyServer(opts ProxyOpts) *proxyServer {
 	return &proxyServer{
-		rootDir:     opts.RootDir,
-		port:        opts.Port,
-		idleTimeout: opts.IdleTimeout,
-		server:      opts.Server,
-		stats:       opts.Stats,
+		rootDir:         opts.RootDir,
+		port:            opts.Port,
+		idleTimeout:     opts.IdleTimeout,
+		server:          opts.Server,
+		stats:           opts.Stats,
+		poolSize:        opts.PoolSize,
+		backendUser:     opts.BackendUser,
+		backendPassword: opts.BackendPassword,
+		poolLifetime:    opts.PoolConnMaxLifetime,
 	}
 }
 
@@ -163,6 +191,19 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 		return fmt.Errorf("write pid file: %w", err)
 	}
 	defer func() { _ = pidfile.Remove(p.rootDir, PIDFileName) }()
+
+	if p.poolSize > 0 {
+		user := p.backendUser
+		if user == "" {
+			user = "root"
+		}
+		p.pool = newBackendPool(
+			func(dctx context.Context) (net.Conn, error) { return p.server.Dial(dctx) },
+			user, p.backendPassword, p.poolSize, p.poolLifetime, p.stats,
+		)
+		p.tracef("connection pooling enabled (maxIdle=%d, user=%q, lifetime=%s)", p.poolSize, user, p.poolLifetime)
+		defer p.pool.drain()
+	}
 
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
@@ -269,6 +310,10 @@ func (p *proxyServer) handleConn(ctx context.Context, client net.Conn) error {
 		p.tracef("handleConn(%s) end (active=%d)", addr, p.activeConns.Load())
 	}()
 
+	if p.pool != nil {
+		return p.handlePooledConn(ctx, client)
+	}
+
 	p.stats.IncBackendDialAttempt()
 	backend, err := p.server.Dial(ctx)
 	if err != nil {
@@ -315,6 +360,32 @@ func (p *proxyServer) handleConn(ctx context.Context, client net.Conn) error {
 		return err
 	})
 	return g.Wait()
+}
+
+// handlePooledConn serves one client connection in pooling mode: terminate the
+// client handshake, borrow a wire-compatible backend from the pool, forward the
+// command phase byte-transparently, and reset+return the backend on disconnect.
+func (p *proxyServer) handlePooledConn(ctx context.Context, client net.Conn) error {
+	defer func() { _ = client.Close() }()
+	p.stats.IncHandledConn()
+	res, err := runPooledSession(ctx, p.stats, p.pool, client, p.connID.Add(1))
+	if err != nil {
+		p.tracef("handlePooledConn(%s) session error: %v", client.RemoteAddr(), err)
+		if res.backend != nil {
+			_ = res.backend.conn.Close()
+		}
+		return err
+	}
+	if res.backend == nil {
+		return nil
+	}
+	if res.reusable {
+		p.pool.put(res.backend)
+	} else {
+		_ = res.backend.conn.Close()
+		p.stats.IncPoolRetire()
+	}
+	return nil
 }
 
 func waitForServerReady(ctx context.Context, s server.DatabaseServer, timeout time.Duration) error {

--- a/internal/storage/dbproxy/proxy/stats.go
+++ b/internal/storage/dbproxy/proxy/stats.go
@@ -16,6 +16,20 @@ type Counters struct {
 	HandledConns         int64
 	BytesClientToBackend int64
 	BytesBackendToClient int64
+
+	// Pool counters (session-pooling proxy). PoolHit: a borrow served by a
+	// warm idle connection. PoolMiss: a borrow that had to dial+authenticate
+	// a new backend. PoolDial​Errors: failed dial/handshake. PoolResets /
+	// PoolResetErrors: COM_RESET_CONNECTION outcomes on return. PoolDead:
+	// idle connection failed its liveness check and was discarded.
+	// PoolRetires: connection closed due to lifetime/idle-cap/transient.
+	PoolHits        int64
+	PoolMisses      int64
+	PoolDialErrors  int64
+	PoolResets      int64
+	PoolResetErrors int64
+	PoolDead        int64
+	PoolRetires     int64
 }
 
 type Stats struct {
@@ -58,3 +72,10 @@ func (s *Stats) AddBytesClientToBackend(n int64) {
 func (s *Stats) AddBytesBackendToClient(n int64) {
 	s.update(func(c *Counters) { c.BytesBackendToClient += n })
 }
+func (s *Stats) IncPoolHit()       { s.update(func(c *Counters) { c.PoolHits++ }) }
+func (s *Stats) IncPoolMiss()      { s.update(func(c *Counters) { c.PoolMisses++ }) }
+func (s *Stats) IncPoolDialError() { s.update(func(c *Counters) { c.PoolDialErrors++ }) }
+func (s *Stats) IncPoolReset()     { s.update(func(c *Counters) { c.PoolResets++ }) }
+func (s *Stats) IncPoolResetError() { s.update(func(c *Counters) { c.PoolResetErrors++ }) }
+func (s *Stats) IncPoolDead()      { s.update(func(c *Counters) { c.PoolDead++ }) }
+func (s *Stats) IncPoolRetire()    { s.update(func(c *Counters) { c.PoolRetires++ }) }

--- a/internal/storage/dbproxy/proxy/stats.go
+++ b/internal/storage/dbproxy/proxy/stats.go
@@ -72,10 +72,10 @@ func (s *Stats) AddBytesClientToBackend(n int64) {
 func (s *Stats) AddBytesBackendToClient(n int64) {
 	s.update(func(c *Counters) { c.BytesBackendToClient += n })
 }
-func (s *Stats) IncPoolHit()       { s.update(func(c *Counters) { c.PoolHits++ }) }
-func (s *Stats) IncPoolMiss()      { s.update(func(c *Counters) { c.PoolMisses++ }) }
-func (s *Stats) IncPoolDialError() { s.update(func(c *Counters) { c.PoolDialErrors++ }) }
-func (s *Stats) IncPoolReset()     { s.update(func(c *Counters) { c.PoolResets++ }) }
+func (s *Stats) IncPoolHit()        { s.update(func(c *Counters) { c.PoolHits++ }) }
+func (s *Stats) IncPoolMiss()       { s.update(func(c *Counters) { c.PoolMisses++ }) }
+func (s *Stats) IncPoolDialError()  { s.update(func(c *Counters) { c.PoolDialErrors++ }) }
+func (s *Stats) IncPoolReset()      { s.update(func(c *Counters) { c.PoolResets++ }) }
 func (s *Stats) IncPoolResetError() { s.update(func(c *Counters) { c.PoolResetErrors++ }) }
-func (s *Stats) IncPoolDead()      { s.update(func(c *Counters) { c.PoolDead++ }) }
-func (s *Stats) IncPoolRetire()    { s.update(func(c *Counters) { c.PoolRetires++ }) }
+func (s *Stats) IncPoolDead()       { s.update(func(c *Counters) { c.PoolDead++ }) }
+func (s *Stats) IncPoolRetire()     { s.update(func(c *Counters) { c.PoolRetires++ }) }

--- a/internal/storage/dolt/port_file_persist_test.go
+++ b/internal/storage/dolt/port_file_persist_test.go
@@ -1,0 +1,76 @@
+package dolt
+
+import (
+	"os"
+	"testing"
+)
+
+// TestShouldPersistPortFileForConfig guards the proxied-server port-file clobber
+// fix. A proxied routed store (RoutedThroughProxy) connects to an ephemeral
+// db-proxy listener; its port must never be persisted into
+// .beads/dolt-server.port, which is the canonical-server discovery hint. Before
+// the fix, newServerMode wrote the proxy's listener port there, so the file went
+// stale the moment the proxy respawned on a new port and any reader that trusted
+// it targeted a dead endpoint.
+func TestShouldPersistPortFileForConfig(t *testing.T) {
+	// The decision keys off BEADS_DOLT_SERVER_PORT / BEADS_DOLT_PORT; clear both
+	// so the env-override branch does not mask the RoutedThroughProxy logic.
+	for _, k := range []string{"BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT"} {
+		if orig, ok := os.LookupEnv(k); ok {
+			t.Cleanup(func() { _ = os.Setenv(k, orig) })
+			_ = os.Unsetenv(k)
+		}
+	}
+
+	tests := []struct {
+		name string
+		cfg  *Config
+		want bool
+	}{
+		{
+			name: "canonical local server persists",
+			cfg:  &Config{ServerHost: "127.0.0.1", ServerPort: 48770},
+			want: true,
+		},
+		{
+			name: "proxied routed store does not persist",
+			cfg:  &Config{ServerHost: "127.0.0.1", ServerPort: 50534, RoutedThroughProxy: true},
+			want: false,
+		},
+		{
+			name: "remote host never persists",
+			cfg:  &Config{ServerHost: "db.example.com", ServerPort: 3306},
+			want: false,
+		},
+		{
+			name: "nil config is safe",
+			cfg:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldPersistPortFileForConfig(tt.cfg); got != tt.want {
+				t.Fatalf("shouldPersistPortFileForConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestShouldPersistPortFileForConfig_EnvOverrideSuppresses confirms an explicit
+// port override still suppresses the persist even for a canonical local server,
+// preserving the pre-existing shouldPersistResolvedPortFile contract.
+func TestShouldPersistPortFileForConfig_EnvOverrideSuppresses(t *testing.T) {
+	if orig, ok := os.LookupEnv("BEADS_DOLT_PORT"); ok {
+		t.Cleanup(func() { _ = os.Setenv("BEADS_DOLT_PORT", orig) })
+	} else {
+		t.Cleanup(func() { _ = os.Unsetenv("BEADS_DOLT_PORT") })
+	}
+	_ = os.Setenv("BEADS_DOLT_PORT", "48770")
+
+	cfg := &Config{ServerHost: "127.0.0.1", ServerPort: 48770}
+	if shouldPersistPortFileForConfig(cfg) {
+		t.Fatal("expected env port override to suppress port-file persist")
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -252,6 +252,14 @@ type Config struct {
 	// defaults would enable it. Diagnostic paths use this to stay read-only.
 	DisableAutoStart bool
 
+	// RoutedThroughProxy indicates ServerHost/ServerPort point at a db-proxy
+	// listener (the proxied-server routed store), not the canonical dolt
+	// sql-server. The proxy port is ephemeral and reassigned on every respawn,
+	// so it must never be persisted into .beads/dolt-server.port — that file is
+	// the discovery hint for the real server and gets clobbered/stale if a
+	// forwarder port lands in it. Set by newProxiedServerRoutedStore.
+	RoutedThroughProxy bool
+
 	// MaxOpenConns overrides the connection pool size (0 = default 10).
 	// Set to 1 for branch isolation in tests (DOLT_CHECKOUT is session-level).
 	MaxOpenConns int
@@ -1136,7 +1144,11 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		}
 	}
 
-	if isLocalHost(cfg.ServerHost) && shouldPersistResolvedPortFile() {
+	// Persist the resolved port only when this store targets the canonical local
+	// dolt sql-server. A proxied routed store connects to an ephemeral db-proxy
+	// listener; persisting that port clobbers the real server's discovery hint
+	// and goes stale the moment the proxy respawns.
+	if shouldPersistPortFileForConfig(cfg) {
 		beadsDir := cfg.BeadsDir
 		if beadsDir == "" && cfg.Path != "" {
 			beadsDir = filepath.Dir(cfg.Path)
@@ -1157,6 +1169,21 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 
 func shouldPersistResolvedPortFile() bool {
 	return os.Getenv("BEADS_DOLT_SERVER_PORT") == "" && os.Getenv("BEADS_DOLT_PORT") == ""
+}
+
+// shouldPersistPortFileForConfig reports whether a freshly-opened server-mode
+// store should record its resolved port into .beads/dolt-server.port. Only the
+// canonical local dolt sql-server qualifies. A proxied routed store
+// (RoutedThroughProxy) targets an ephemeral db-proxy listener whose port must
+// never become the on-disk discovery hint: it is clobbered on the next
+// reconcile and goes stale when the proxy respawns on a new port, breaking
+// endpoint resolution for any reader that trusts the file. An explicit port
+// override (BEADS_DOLT_SERVER_PORT / BEADS_DOLT_PORT) also suppresses the write.
+func shouldPersistPortFileForConfig(cfg *Config) bool {
+	if cfg == nil {
+		return false
+	}
+	return isLocalHost(cfg.ServerHost) && shouldPersistResolvedPortFile() && !cfg.RoutedThroughProxy
 }
 
 // verifyProjectIdentity checks that the database belongs to the expected project.

--- a/internal/storage/uow/doltserver_provider.go
+++ b/internal/storage/uow/doltserver_provider.go
@@ -55,7 +55,7 @@ func NewDoltServerUOWProvider(
 		ConfigFilePath: serverConfigFilePath,
 		LogFilePath:    serverLogFilePath,
 		DoltBinPath:    absDoltBinExec,
-		IdleTimeout:    defaultProxyIdleTimeout,
+		IdleTimeout:    proxy.IdleTimeoutFromEnv(defaultProxyIdleTimeout),
 		PoolSize:       proxy.PoolSizeFromEnv(),
 		BackendUser:    rootUser,
 	})

--- a/internal/storage/uow/doltserver_provider.go
+++ b/internal/storage/uow/doltserver_provider.go
@@ -56,6 +56,8 @@ func NewDoltServerUOWProvider(
 		LogFilePath:    serverLogFilePath,
 		DoltBinPath:    absDoltBinExec,
 		IdleTimeout:    defaultProxyIdleTimeout,
+		PoolSize:       proxy.PoolSizeFromEnv(),
+		BackendUser:    rootUser,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("uow: get proxy endpoint: %w", err)

--- a/internal/storage/uow/external_doltserver_provider.go
+++ b/internal/storage/uow/external_doltserver_provider.go
@@ -46,6 +46,8 @@ func NewExternalDoltServerUOWProvider(
 		LogFilePath: serverLogFilePath,
 		External:    external,
 		IdleTimeout: defaultProxyIdleTimeout,
+		PoolSize:    proxy.PoolSizeFromEnv(),
+		BackendUser: rootUser,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("uow: get proxy endpoint: %w", err)

--- a/internal/storage/uow/external_doltserver_provider.go
+++ b/internal/storage/uow/external_doltserver_provider.go
@@ -45,7 +45,7 @@ func NewExternalDoltServerUOWProvider(
 		Backend:     proxy.BackendExternal,
 		LogFilePath: serverLogFilePath,
 		External:    external,
-		IdleTimeout: defaultProxyIdleTimeout,
+		IdleTimeout: proxy.IdleTimeoutFromEnv(defaultProxyIdleTimeout),
 		PoolSize:    proxy.PoolSizeFromEnv(),
 		BackendUser: rootUser,
 	})


### PR DESCRIPTION
**Note**: This fix builds on the connection-pooling work in PR #4303
(\`cstar:feat/connection-pooling\`). The first 8 commits in this diff come from
that PR; the single fix commit \`48118a1e5\` is the change being added. If
you prefer, merge #4303 first and I will rebase this PR onto main to show
only the one-commit fix.

## Problem

\`newProxiedServerRoutedStore\` (introduced in PR #4303) opens a \`ServerMode\`
DoltStore pointed at the db-proxy's ephemeral listener so legacy store-based
commands (\`list\`, \`ready\`, \`update\`, \`--claim\`, \`close\`) work through the proxy.
\`newServerMode\` then persists that listener port into \`.beads/dolt-server.port\`
via \`EnsurePortFile\`, because the connection looks like a localhost server.

That file is the **canonical-server discovery hint**. Writing the proxy's
ephemeral port there means:
- It is clobbered on the next reconcile cycle.
- It goes stale the moment the proxy idle-dies and respawns on a new port.
- Any reader that resolves the endpoint from the file then targets a dead
  listener — manifesting downstream as silent connection failures and a
  fleet-wide claim stall.

Observed in production: port-file churn, proxy-pool leak, and 0 claims
transitioning to \`in_progress\` across all rigs until a supervisor restart.

## Fix

Add \`Config.RoutedThroughProxy\` (bool). Set it in \`newProxiedServerRoutedStore\`.
Gate the port-file persist on it via \`shouldPersistPortFileForConfig\` so only
the canonical local \`dolt sql-server\` records its port — never an ephemeral
proxy listener.

The guard layers on top of the existing \`shouldPersistResolvedPortFile\` check:
a proxied store never persists regardless of host/port values, and an env-override
still suppresses the persist for a canonical server.

## Tests

New pure-Go unit test in \`internal/storage/dolt/port_file_persist_test.go\`:
- \`canonical local server persists\` — happy path unchanged
- \`proxied routed store does not persist\` — the fix
- \`remote host never persists\` — unchanged
- \`nil config is safe\` — defensive nil guard
- \`EnvOverrideSuppresses\` — env-override still wins

All 6 subtests pass. \`go test ./...\` + \`go build ./...\` + \`go vet ./...\` clean.