### PR TITLE
Feature/4051

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ named `origin` automatically. Cross-machine sync uses `bd dolt push` and
 for viewers and interchange, not the source of truth or a full database
 backup.
 
+Attachment metadata syncs with the Dolt database, but attachment bytes are
+plain local files under `.beads/attachments`. See
+[docs/ATTACHMENTS.md](docs/ATTACHMENTS.md) before relying on sync or backup for
+attached files.
+
 ### Server Mode
 
 ```bash
@@ -171,6 +176,8 @@ migration instructions.
 for review, migration, and interoperability, but they do not capture Dolt
 branches, commit history, working-set state, or non-issue tables. Use
 `bd backup` or a manual Dolt backup when you need a restorable database backup.
+Attachment bytes under `.beads/attachments` are outside the Dolt database and
+need a separate filesystem backup.
 
 ## 🌐 Community Tools
 

--- a/cmd/bd/attachment.go
+++ b/cmd/bd/attachment.go
@@ -1,0 +1,546 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	attachfs "github.com/steveyegge/beads/internal/attachments"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+type attachmentListItem struct {
+	ID               string    `json:"id"`
+	IssueID          string    `json:"issue_id"`
+	HashAlgorithm    string    `json:"hash_algorithm"`
+	ContentHash      string    `json:"content_hash"`
+	ShortHash        string    `json:"short_hash"`
+	OriginalFilename string    `json:"original_filename"`
+	MimeType         string    `json:"mime_type"`
+	ByteSize         int64     `json:"byte_size"`
+	Size             string    `json:"size"`
+	StorageRelPath   string    `json:"storage_relpath"`
+	Missing          bool      `json:"missing"`
+	CreatedBy        string    `json:"created_by"`
+	CreatedAt        time.Time `json:"created_at"`
+}
+
+type unreachableAttachmentFile struct {
+	StorageRelPath string `json:"storage_relpath"`
+	Path           string `json:"path"`
+	ByteSize       int64  `json:"byte_size"`
+	Size           string `json:"size"`
+}
+
+type attachmentMaintenanceResult struct {
+	Status      string                      `json:"status"`
+	Count       int                         `json:"count"`
+	Unreachable []unreachableAttachmentFile `json:"unreachable"`
+	DryRun      bool                        `json:"dry_run,omitempty"`
+}
+
+var attachmentCmd = &cobra.Command{
+	Use:     "attachment",
+	Aliases: []string{"attachments"},
+	GroupID: "issues",
+	Short:   "Manage issue file attachments",
+}
+
+var attachmentAddCmd = &cobra.Command{
+	Use:   "add [issue-id] [path]",
+	Short: "Attach a file to an issue",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		CheckReadonly("attachment add")
+		if err := ensureStoreActive(); err != nil {
+			FatalErrorRespectJSON("adding attachment: %v", err)
+		}
+
+		ctx := rootCtx
+		result, err := resolveAndGetIssueWithRouting(ctx, store, args[0])
+		if err != nil {
+			if result != nil {
+				result.Close()
+			}
+			FatalErrorRespectJSON("resolving %s: %v", args[0], err)
+		}
+		if result == nil || result.Issue == nil {
+			if result != nil {
+				result.Close()
+			}
+			FatalErrorRespectJSON("issue %s not found", args[0])
+		}
+		defer result.Close()
+		if err := validateIssueUpdatable(args[0], result.Issue); err != nil {
+			FatalErrorRespectJSON("%s", err)
+		}
+
+		stored, err := attachfs.Store(result.Store, result.ResolvedID, args[1])
+		if err != nil {
+			FatalErrorRespectJSON("storing attachment: %v", err)
+		}
+
+		attachment, err := result.Store.AddAttachment(ctx, &types.Attachment{
+			IssueID:          result.ResolvedID,
+			HashAlgorithm:    stored.HashAlgorithm,
+			ContentHash:      stored.ContentHash,
+			OriginalFilename: stored.OriginalFilename,
+			MimeType:         stored.MimeType,
+			ByteSize:         stored.ByteSize,
+			StorageRelPath:   stored.StorageRelPath,
+			CreatedBy:        getActorWithGit(),
+		})
+		if err != nil {
+			if !attachmentRelPathReferenced(ctx, result.Store, result.ResolvedID, stored.StorageRelPath, "") {
+				_ = attachfs.RemoveStoredFile(result.Store, &types.Attachment{StorageRelPath: stored.StorageRelPath})
+			}
+			FatalErrorRespectJSON("adding attachment metadata: %v", err)
+		}
+		if err := commitPendingIfEmbedded(ctx, result.Store, actor, doltAutoCommitParams{
+			Command:  "attachment add",
+			IssueIDs: []string{result.ResolvedID},
+		}); err != nil {
+			FatalErrorRespectJSON("failed to commit: %v", err)
+		}
+
+		commandDidWrite.Store(true)
+		SetLastTouchedID(result.ResolvedID)
+		if jsonOutput {
+			outputJSON(attachmentListEntry(result.Store, attachment))
+			return
+		}
+		fmt.Printf("%s Attached %s to %s (%s, %s)\n",
+			ui.RenderPass("✓"),
+			attachment.OriginalFilename,
+			formatFeedbackID(result.ResolvedID, result.Issue.Title),
+			shortAttachmentHash(attachment.ContentHash),
+			formatBytes(attachment.ByteSize))
+	},
+}
+
+var attachmentListCmd = &cobra.Command{
+	Use:   "list [issue-id]",
+	Short: "List attachments for an issue",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := ensureStoreActive(); err != nil {
+			FatalErrorRespectJSON("listing attachments: %v", err)
+		}
+
+		ctx := rootCtx
+		result, err := resolveAndGetIssueWithRouting(ctx, store, args[0])
+		if err != nil {
+			if result != nil {
+				result.Close()
+			}
+			FatalErrorRespectJSON("resolving %s: %v", args[0], err)
+		}
+		if result == nil || result.Issue == nil {
+			if result != nil {
+				result.Close()
+			}
+			FatalErrorRespectJSON("issue %s not found", args[0])
+		}
+		defer result.Close()
+
+		attachments, err := result.Store.ListAttachments(ctx, result.ResolvedID)
+		if err != nil {
+			FatalErrorRespectJSON("listing attachments: %v", err)
+		}
+		items := attachmentListEntries(result.Store, attachments)
+		if jsonOutput {
+			outputJSON(items)
+			return
+		}
+		if len(items) == 0 {
+			fmt.Printf("No attachments on %s\n", result.ResolvedID)
+			return
+		}
+
+		fmt.Printf("\nAttachments on %s:\n\n", result.ResolvedID)
+		for _, item := range items {
+			missing := ""
+			if item.Missing {
+				missing = " missing"
+			}
+			fmt.Printf("  %s  %s  %s  %s%s\n",
+				item.ShortHash,
+				item.OriginalFilename,
+				item.MimeType,
+				item.Size,
+				missing)
+		}
+	},
+}
+
+var attachmentCopyCmd = &cobra.Command{
+	Use:   "copy [issue-id] [filename-or-hash] [target]",
+	Short: "Copy an attachment out to a file or directory",
+	Args:  cobra.ExactArgs(3),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := ensureStoreActive(); err != nil {
+			FatalErrorRespectJSON("copying attachment: %v", err)
+		}
+		force, _ := cmd.Flags().GetBool("force")
+
+		ctx := rootCtx
+		result, err := resolveAndGetIssueWithRouting(ctx, store, args[0])
+		if err != nil {
+			if result != nil {
+				result.Close()
+			}
+			FatalErrorRespectJSON("resolving %s: %v", args[0], err)
+		}
+		if result == nil || result.Issue == nil {
+			if result != nil {
+				result.Close()
+			}
+			FatalErrorRespectJSON("issue %s not found", args[0])
+		}
+		defer result.Close()
+
+		attachment, err := result.Store.ResolveAttachment(ctx, result.ResolvedID, args[1])
+		if err != nil {
+			FatalErrorRespectJSON("resolving attachment: %v", err)
+		}
+		targetPath, err := attachfs.CopyOut(result.Store, attachment, args[2], force)
+		if err != nil {
+			FatalErrorRespectJSON("copying attachment: %v", err)
+		}
+		if jsonOutput {
+			outputJSON(map[string]interface{}{
+				"status":        "copied",
+				"issue_id":      result.ResolvedID,
+				"attachment_id": attachment.ID,
+				"target":        targetPath,
+			})
+			return
+		}
+		fmt.Printf("%s Copied %s to %s\n", ui.RenderPass("✓"), attachment.OriginalFilename, targetPath)
+	},
+}
+
+var attachmentRemoveCmd = &cobra.Command{
+	Use:     "remove [issue-id] [filename-or-hash]",
+	Aliases: []string{"rm"},
+	Short:   "Remove an attachment from an issue",
+	Args:    cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		CheckReadonly("attachment remove")
+		if err := ensureStoreActive(); err != nil {
+			FatalErrorRespectJSON("removing attachment: %v", err)
+		}
+
+		ctx := rootCtx
+		result, err := resolveAndGetIssueWithRouting(ctx, store, args[0])
+		if err != nil {
+			if result != nil {
+				result.Close()
+			}
+			FatalErrorRespectJSON("resolving %s: %v", args[0], err)
+		}
+		if result == nil || result.Issue == nil {
+			if result != nil {
+				result.Close()
+			}
+			FatalErrorRespectJSON("issue %s not found", args[0])
+		}
+		defer result.Close()
+		if err := validateIssueUpdatable(args[0], result.Issue); err != nil {
+			FatalErrorRespectJSON("%s", err)
+		}
+
+		attachment, err := result.Store.ResolveAttachment(ctx, result.ResolvedID, args[1])
+		if err != nil {
+			FatalErrorRespectJSON("resolving attachment: %v", err)
+		}
+		referencedByOther := attachmentRelPathReferenced(ctx, result.Store, result.ResolvedID, attachment.StorageRelPath, attachment.ID)
+		if err := result.Store.RemoveAttachment(ctx, result.ResolvedID, attachment.ID); err != nil {
+			FatalErrorRespectJSON("removing attachment metadata: %v", err)
+		}
+		commandDidWrite.Store(true)
+		if !referencedByOther {
+			if err := attachfs.RemoveStoredFile(result.Store, attachment); err != nil {
+				FatalErrorRespectJSON("removing attachment file: %v", err)
+			}
+		}
+		if err := commitPendingIfEmbedded(ctx, result.Store, actor, doltAutoCommitParams{
+			Command:  "attachment remove",
+			IssueIDs: []string{result.ResolvedID},
+		}); err != nil {
+			FatalErrorRespectJSON("failed to commit: %v", err)
+		}
+
+		SetLastTouchedID(result.ResolvedID)
+		if jsonOutput {
+			outputJSON(map[string]interface{}{
+				"status":        "removed",
+				"issue_id":      result.ResolvedID,
+				"attachment_id": attachment.ID,
+				"file_removed":  !referencedByOther,
+			})
+			return
+		}
+		fmt.Printf("%s Removed %s from %s\n",
+			ui.RenderPass("✓"),
+			attachment.OriginalFilename,
+			formatFeedbackID(result.ResolvedID, result.Issue.Title))
+	},
+}
+
+var attachmentFsckCmd = &cobra.Command{
+	Use:   "fsck",
+	Short: "Find unreachable attachment files",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := ensureStoreActive(); err != nil {
+			FatalErrorRespectJSON("checking attachments: %v", err)
+		}
+
+		unreachable, err := findUnreachableAttachmentFiles(rootCtx, store)
+		if err != nil {
+			FatalErrorRespectJSON("checking attachments: %v", err)
+		}
+		if jsonOutput {
+			outputJSON(attachmentMaintenanceResult{
+				Status:      "ok",
+				Count:       len(unreachable),
+				Unreachable: unreachable,
+			})
+			return
+		}
+		if len(unreachable) == 0 {
+			fmt.Println("No unreachable attachment files found")
+			return
+		}
+		fmt.Printf("Unreachable attachment files (%d):\n\n", len(unreachable))
+		for _, file := range unreachable {
+			fmt.Printf("  %s  %s\n", file.Size, file.StorageRelPath)
+		}
+	},
+}
+
+var attachmentPruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Remove unreachable attachment files",
+	Run: func(cmd *cobra.Command, args []string) {
+		CheckReadonly("attachment prune")
+		if err := ensureStoreActive(); err != nil {
+			FatalErrorRespectJSON("pruning attachments: %v", err)
+		}
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		unreachable, err := findUnreachableAttachmentFiles(rootCtx, store)
+		if err != nil {
+			FatalErrorRespectJSON("pruning attachments: %v", err)
+		}
+		if !dryRun {
+			for _, file := range unreachable {
+				if err := os.Remove(file.Path); err != nil && !os.IsNotExist(err) {
+					FatalErrorRespectJSON("removing %s: %v", file.StorageRelPath, err)
+				}
+			}
+		}
+		if jsonOutput {
+			status := "pruned"
+			if dryRun {
+				status = "would_prune"
+			}
+			outputJSON(attachmentMaintenanceResult{
+				Status:      status,
+				Count:       len(unreachable),
+				Unreachable: unreachable,
+				DryRun:      dryRun,
+			})
+			return
+		}
+		if len(unreachable) == 0 {
+			fmt.Println("No unreachable attachment files found")
+			return
+		}
+		verb := "Removed"
+		if dryRun {
+			verb = "Would remove"
+		}
+		for _, file := range unreachable {
+			fmt.Printf("%s %s %s\n", ui.RenderPass("✓"), verb, file.StorageRelPath)
+		}
+	},
+}
+
+func attachmentListEntries(st any, attachments []*types.Attachment) []attachmentListItem {
+	if attachments == nil {
+		return []attachmentListItem{}
+	}
+	items := make([]attachmentListItem, 0, len(attachments))
+	for _, attachment := range attachments {
+		items = append(items, attachmentListEntry(st, attachment))
+	}
+	return items
+}
+
+func attachmentListEntry(st any, attachment *types.Attachment) attachmentListItem {
+	if attachment == nil {
+		return attachmentListItem{}
+	}
+	return attachmentListItem{
+		ID:               attachment.ID,
+		IssueID:          attachment.IssueID,
+		HashAlgorithm:    attachment.HashAlgorithm,
+		ContentHash:      attachment.ContentHash,
+		ShortHash:        shortAttachmentHash(attachment.ContentHash),
+		OriginalFilename: attachment.OriginalFilename,
+		MimeType:         attachment.MimeType,
+		ByteSize:         attachment.ByteSize,
+		Size:             formatBytes(attachment.ByteSize),
+		StorageRelPath:   attachment.StorageRelPath,
+		Missing:          !attachfs.Exists(st, attachment),
+		CreatedBy:        attachment.CreatedBy,
+		CreatedAt:        attachment.CreatedAt,
+	}
+}
+
+func shortAttachmentHash(hash string) string {
+	hash = strings.TrimSpace(hash)
+	if len(hash) <= 12 {
+		return hash
+	}
+	return hash[:12]
+}
+
+func attachmentRelPathReferenced(ctx context.Context, st interface {
+	ListAttachments(context.Context, string) ([]*types.Attachment, error)
+}, issueID, relPath, exceptID string) bool {
+	attachments, err := st.ListAttachments(ctx, issueID)
+	if err != nil {
+		return true
+	}
+	for _, attachment := range attachments {
+		if attachment == nil || attachment.ID == exceptID {
+			continue
+		}
+		if attachment.StorageRelPath == relPath {
+			return true
+		}
+	}
+	return false
+}
+
+func findUnreachableAttachmentFiles(ctx context.Context, st interface {
+	SearchIssues(context.Context, string, types.IssueFilter) ([]*types.Issue, error)
+	ListAttachments(context.Context, string) ([]*types.Attachment, error)
+}) ([]unreachableAttachmentFile, error) {
+	referenced, err := referencedAttachmentPaths(ctx, st)
+	if err != nil {
+		return nil, err
+	}
+	return scanUnreachableAttachmentFiles(st, referenced)
+}
+
+func referencedAttachmentPaths(ctx context.Context, st interface {
+	SearchIssues(context.Context, string, types.IssueFilter) ([]*types.Issue, error)
+	ListAttachments(context.Context, string) ([]*types.Attachment, error)
+}) (map[string]struct{}, error) {
+	issues, err := st.SearchIssues(ctx, "", types.IssueFilter{Limit: 0})
+	if err != nil {
+		return nil, fmt.Errorf("list issues: %w", err)
+	}
+	referenced := make(map[string]struct{})
+	for _, issue := range issues {
+		if issue == nil {
+			continue
+		}
+		attachments, err := st.ListAttachments(ctx, issue.ID)
+		if err != nil {
+			return nil, fmt.Errorf("list attachments for %s: %w", issue.ID, err)
+		}
+		for _, attachment := range attachments {
+			if attachment == nil {
+				continue
+			}
+			relPath := filepath.ToSlash(filepath.Clean(filepath.FromSlash(strings.TrimSpace(attachment.StorageRelPath))))
+			if relPath != "." && relPath != "" {
+				referenced[relPath] = struct{}{}
+			}
+		}
+	}
+	return referenced, nil
+}
+
+func scanUnreachableAttachmentFiles(st any, referenced map[string]struct{}) ([]unreachableAttachmentFile, error) {
+	root, err := attachfs.Root(st)
+	if err != nil {
+		return nil, err
+	}
+	beadsDir, err := attachfs.BeadsDir(st)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		return []unreachableAttachmentFile{}, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("stat attachment root: %w", err)
+	}
+
+	var unreachable []unreachableAttachmentFile
+	err = filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(beadsDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if _, ok := referenced[rel]; ok {
+			return nil
+		}
+		unreachable = append(unreachable, unreachableAttachmentFile{
+			StorageRelPath: rel,
+			Path:           path,
+			ByteSize:       info.Size(),
+			Size:           formatBytes(info.Size()),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan attachment files: %w", err)
+	}
+	sort.Slice(unreachable, func(i, j int) bool {
+		return unreachable[i].StorageRelPath < unreachable[j].StorageRelPath
+	})
+	return unreachable, nil
+}
+
+func init() {
+	attachmentCopyCmd.Flags().BoolP("force", "f", false, "Overwrite the target file if it exists")
+	attachmentPruneCmd.Flags().BoolP("dry-run", "n", false, "Show unreachable files without removing them")
+
+	attachmentAddCmd.ValidArgsFunction = issueIDCompletion
+	attachmentListCmd.ValidArgsFunction = issueIDCompletion
+	attachmentCopyCmd.ValidArgsFunction = issueIDCompletion
+	attachmentRemoveCmd.ValidArgsFunction = issueIDCompletion
+
+	attachmentCmd.AddCommand(attachmentAddCmd)
+	attachmentCmd.AddCommand(attachmentListCmd)
+	attachmentCmd.AddCommand(attachmentCopyCmd)
+	attachmentCmd.AddCommand(attachmentRemoveCmd)
+	attachmentCmd.AddCommand(attachmentFsckCmd)
+	attachmentCmd.AddCommand(attachmentPruneCmd)
+	rootCmd.AddCommand(attachmentCmd)
+}

--- a/cmd/bd/attachment_embedded_test.go
+++ b/cmd/bd/attachment_embedded_test.go
@@ -1,0 +1,147 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func bdAttachment(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"attachment"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd attachment %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	return stdout.String()
+}
+
+func bdAttachmentFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"attachment"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected bd attachment %s to fail, but succeeded:\n%s", strings.Join(args, " "), out)
+	}
+	return string(out)
+}
+
+func TestEmbeddedAttachmentCommands(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+
+	bd := buildEmbeddedBD(t)
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "att")
+	issue := bdCreate(t, bd, dir, "Attachment issue", "--type", "task")
+
+	source := filepath.Join(dir, "body.md")
+	if err := os.WriteFile(source, []byte("# Attachment\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	addOut := bdAttachment(t, bd, dir, "add", issue.ID, source, "--json")
+	var added attachmentListItem
+	if err := json.Unmarshal([]byte(addOut), &added); err != nil {
+		t.Fatalf("parse attachment add JSON: %v\n%s", err, addOut)
+	}
+	if added.IssueID != issue.ID {
+		t.Fatalf("added issue_id = %q, want %q", added.IssueID, issue.ID)
+	}
+	if added.OriginalFilename != "body.md" {
+		t.Fatalf("original filename = %q", added.OriginalFilename)
+	}
+	if added.Missing {
+		t.Fatal("added attachment is unexpectedly missing")
+	}
+
+	storedPath := filepath.Join(beadsDir, filepath.FromSlash(added.StorageRelPath))
+	if _, err := os.Stat(storedPath); err != nil {
+		t.Fatalf("stored attachment not found at %s: %v", storedPath, err)
+	}
+
+	listOut := bdAttachment(t, bd, dir, "list", issue.ID, "--json")
+	var listed []attachmentListItem
+	if err := json.Unmarshal([]byte(listOut), &listed); err != nil {
+		t.Fatalf("parse attachment list JSON: %v\n%s", err, listOut)
+	}
+	if len(listed) != 1 || listed[0].ID != added.ID {
+		t.Fatalf("listed attachments = %+v, want one %s", listed, added.ID)
+	}
+
+	orphanPath := filepath.Join(beadsDir, "attachments", issue.ID, "orphan")
+	if err := os.WriteFile(orphanPath, []byte("orphan"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fsckOut := bdAttachment(t, bd, dir, "fsck", "--json")
+	var fsck attachmentMaintenanceResult
+	if err := json.Unmarshal([]byte(fsckOut), &fsck); err != nil {
+		t.Fatalf("parse attachment fsck JSON: %v\n%s", err, fsckOut)
+	}
+	if fsck.Count != 1 || fsck.Unreachable[0].StorageRelPath != filepath.ToSlash(filepath.Join("attachments", issue.ID, "orphan")) {
+		t.Fatalf("fsck result = %+v, want orphan", fsck)
+	}
+	bdAttachment(t, bd, dir, "prune", "--dry-run")
+	if _, err := os.Stat(orphanPath); err != nil {
+		t.Fatalf("dry-run prune removed orphan unexpectedly: %v", err)
+	}
+	bdAttachment(t, bd, dir, "prune")
+	if _, err := os.Stat(orphanPath); !os.IsNotExist(err) {
+		t.Fatalf("orphan still exists or stat failed unexpectedly: %v", err)
+	}
+
+	outDir := filepath.Join(dir, "out")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	copyOut := bdAttachment(t, bd, dir, "copy", issue.ID, added.ShortHash, outDir, "--json")
+	var copied map[string]interface{}
+	if err := json.Unmarshal([]byte(copyOut), &copied); err != nil {
+		t.Fatalf("parse attachment copy JSON: %v\n%s", err, copyOut)
+	}
+	copiedPath := filepath.Join(outDir, "body.md")
+	data, err := os.ReadFile(copiedPath)
+	if err != nil {
+		t.Fatalf("copy target missing: %v", err)
+	}
+	if string(data) != "# Attachment\n" {
+		t.Fatalf("copied data = %q", data)
+	}
+
+	failOut := bdAttachmentFail(t, bd, dir, "copy", issue.ID, "body.md", outDir)
+	if !strings.Contains(failOut, "already exists") {
+		t.Fatalf("overwrite failure = %q, want already exists", failOut)
+	}
+	bdAttachment(t, bd, dir, "copy", issue.ID, "body.md", outDir, "--force")
+
+	removeOut := bdAttachment(t, bd, dir, "remove", issue.ID, added.ContentHash, "--json")
+	var removed map[string]interface{}
+	if err := json.Unmarshal([]byte(removeOut), &removed); err != nil {
+		t.Fatalf("parse attachment remove JSON: %v\n%s", err, removeOut)
+	}
+	if removed["status"] != "removed" {
+		t.Fatalf("remove status = %v", removed["status"])
+	}
+	if _, err := os.Stat(storedPath); !os.IsNotExist(err) {
+		t.Fatalf("stored attachment still exists or stat failed unexpectedly: %v", err)
+	}
+
+	listOut = bdAttachment(t, bd, dir, "list", issue.ID, "--json")
+	if err := json.Unmarshal([]byte(listOut), &listed); err != nil {
+		t.Fatalf("parse final attachment list JSON: %v\n%s", err, listOut)
+	}
+	if len(listed) != 0 {
+		t.Fatalf("final listed attachments = %+v, want empty", listed)
+	}
+}

--- a/cmd/bd/attachment_policy_test.go
+++ b/cmd/bd/attachment_policy_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAttachmentSyncBackupPolicyIsDocumented(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "docs", "ATTACHMENTS.md"))
+	if err != nil {
+		t.Fatalf("ReadFile docs/ATTACHMENTS.md: %v", err)
+	}
+	doc := normalizedPolicyText(string(data))
+	for _, want := range []string{
+		"attachment metadata is stored in the dolt database",
+		"attachment files are local-only",
+		"dolt sync",
+		"dolt backups",
+		"do not copy the plain files in `.beads/attachments`",
+		"`bd show` and `bd attachment list` report those entries as",
+		"`bd export` and `.beads/issues.jsonl`",
+		"git lfs",
+		"bd attachment fsck",
+		"bd attachment prune",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("docs/ATTACHMENTS.md missing policy text %q", want)
+		}
+	}
+}
+
+func TestBackupSyncHelpMentionsAttachmentBytesAreNotBackedUp(t *testing.T) {
+	help := normalizedPolicyText(backupSyncCmd.Long)
+	for _, want := range []string{
+		"attachment metadata is part of the database",
+		"attachment bytes under .beads/attachments are local files",
+		"separate filesystem backup",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("backup sync help missing %q", want)
+		}
+	}
+}
+
+func normalizedPolicyText(s string) string {
+	return strings.Join(strings.Fields(strings.ToLower(s)), " ")
+}

--- a/cmd/bd/attachment_test.go
+++ b/cmd/bd/attachment_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+type attachmentTestStore struct {
+	path        string
+	cliDir      string
+	issues      []*types.Issue
+	attachments []*types.Attachment
+	err         error
+}
+
+func (s attachmentTestStore) Path() string   { return s.path }
+func (s attachmentTestStore) CLIDir() string { return s.cliDir }
+
+func (s attachmentTestStore) ListAttachments(context.Context, string) ([]*types.Attachment, error) {
+	return s.attachments, s.err
+}
+
+func (s attachmentTestStore) SearchIssues(context.Context, string, types.IssueFilter) ([]*types.Issue, error) {
+	return s.issues, s.err
+}
+
+func TestShortAttachmentHash(t *testing.T) {
+	t.Parallel()
+
+	if got := shortAttachmentHash("1234567890abcdef"); got != "1234567890ab" {
+		t.Fatalf("shortAttachmentHash() = %q", got)
+	}
+	if got := shortAttachmentHash("abc"); got != "abc" {
+		t.Fatalf("shortAttachmentHash(short) = %q", got)
+	}
+}
+
+func TestAttachmentListEntryMarksMissingFiles(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	st := attachmentTestStore{path: filepath.Join(tmp, ".beads", "dolt")}
+	attachment := &types.Attachment{
+		ID:               "att-1",
+		IssueID:          "bd-abc",
+		HashAlgorithm:    "sha256",
+		ContentHash:      "1234567890abcdef",
+		OriginalFilename: "body.md",
+		MimeType:         "text/markdown",
+		ByteSize:         1536,
+		StorageRelPath:   "attachments/bd-abc/1234567890abcdef",
+		CreatedBy:        "tester",
+		CreatedAt:        time.Unix(100, 0).UTC(),
+	}
+
+	missing := attachmentListEntry(st, attachment)
+	if !missing.Missing {
+		t.Fatal("Missing = false, want true")
+	}
+	if missing.ShortHash != "1234567890ab" {
+		t.Fatalf("ShortHash = %q", missing.ShortHash)
+	}
+	if missing.Size != "1.5 KB" {
+		t.Fatalf("Size = %q", missing.Size)
+	}
+
+	path := filepath.Join(tmp, ".beads", "attachments", "bd-abc", "1234567890abcdef")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	present := attachmentListEntry(st, attachment)
+	if present.Missing {
+		t.Fatal("Missing = true, want false")
+	}
+}
+
+func TestAttachmentRelPathReferenced(t *testing.T) {
+	t.Parallel()
+
+	st := attachmentTestStore{
+		attachments: []*types.Attachment{
+			{ID: "att-1", StorageRelPath: "attachments/bd-abc/hash"},
+			{ID: "att-2", StorageRelPath: "attachments/bd-abc/hash"},
+			{ID: "att-3", StorageRelPath: "attachments/bd-abc/other"},
+		},
+	}
+
+	if !attachmentRelPathReferenced(context.Background(), st, "bd-abc", "attachments/bd-abc/hash", "att-1") {
+		t.Fatal("referenced by another attachment = false, want true")
+	}
+	if attachmentRelPathReferenced(context.Background(), st, "bd-abc", "attachments/bd-abc/other", "att-3") {
+		t.Fatal("referenced by another attachment = true, want false")
+	}
+}
+
+func TestAttachmentListEntriesNil(t *testing.T) {
+	t.Parallel()
+
+	got := attachmentListEntries(attachmentTestStore{}, nil)
+	if got == nil {
+		t.Fatal("attachmentListEntries(nil) returned nil slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("len = %d, want 0", len(got))
+	}
+}
+
+func TestReferencedAttachmentPaths(t *testing.T) {
+	t.Parallel()
+
+	st := attachmentTestStore{
+		issues: []*types.Issue{{ID: "bd-abc"}},
+		attachments: []*types.Attachment{
+			{ID: "att-1", StorageRelPath: "attachments/bd-abc/hash"},
+			{ID: "att-2", StorageRelPath: ""},
+		},
+	}
+
+	got, err := referencedAttachmentPaths(context.Background(), st)
+	if err != nil {
+		t.Fatalf("referencedAttachmentPaths() error = %v", err)
+	}
+	if _, ok := got["attachments/bd-abc/hash"]; !ok {
+		t.Fatalf("referenced paths = %#v, want stored path", got)
+	}
+	if _, ok := got[""]; ok {
+		t.Fatalf("referenced paths included empty key: %#v", got)
+	}
+}
+
+func TestScanUnreachableAttachmentFiles(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	st := attachmentTestStore{path: filepath.Join(tmp, ".beads", "dolt")}
+	referencedPath := filepath.Join(tmp, ".beads", "attachments", "bd-abc", "referenced")
+	unreachablePath := filepath.Join(tmp, ".beads", "attachments", "bd-abc", "unreachable")
+	for _, path := range []string{referencedPath, unreachablePath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := scanUnreachableAttachmentFiles(st, map[string]struct{}{
+		"attachments/bd-abc/referenced": {},
+	})
+	if err != nil {
+		t.Fatalf("scanUnreachableAttachmentFiles() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1: %#v", len(got), got)
+	}
+	if got[0].StorageRelPath != "attachments/bd-abc/unreachable" {
+		t.Fatalf("StorageRelPath = %q", got[0].StorageRelPath)
+	}
+	if got[0].ByteSize != 4 || got[0].Size != "4 B" {
+		t.Fatalf("size = %d/%q", got[0].ByteSize, got[0].Size)
+	}
+}

--- a/cmd/bd/backup_dolt.go
+++ b/cmd/bd/backup_dolt.go
@@ -108,7 +108,9 @@ var backupSyncCmd = &cobra.Command{
 	Long: `Sync the current beads database to the configured Dolt backup destination.
 
 This pushes the entire database state (all branches, full history) to the
-backup location configured with 'bd backup init'.
+backup location configured with 'bd backup init'. Attachment metadata is part
+of the database, but attachment bytes under .beads/attachments are local files
+and need a separate filesystem backup.
 
 The backup is atomic — if the sync fails, the previous backup state is preserved.
 

--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -156,6 +156,9 @@ var showCmd = &cobra.Command{
 				details.DependencyCount = &depnCount
 				cmtCount, _ := issueStore.CountIssueComments(ctx, issue.ID)
 				details.CommentCount = &cmtCount
+				attCount, _ := issueStore.CountAttachments(ctx, issue.ID)
+				details.AttachmentCount = &attCount
+				details.Attachments, _ = issueStore.ListAttachments(ctx, issue.ID)
 
 				// --include-dependents: stream via Iter, shallow-copy each item.
 				// May be slow on hub beads with many dependents.
@@ -268,6 +271,23 @@ var showCmd = &cobra.Command{
 			labels, _ := issueStore.GetLabels(ctx, issue.ID) // Best effort: show issue even if label fetch fails
 			if len(labels) > 0 {
 				fmt.Printf("\n%s %s\n", ui.RenderBold("LABELS:"), strings.Join(labels, ", "))
+			}
+
+			attachments, _ := issueStore.ListAttachments(ctx, issue.ID) // Best effort: show issue even if attachments unavailable
+			if len(attachments) > 0 {
+				fmt.Printf("\n%s\n", ui.RenderBold("ATTACHMENTS"))
+				for _, item := range attachmentListEntries(issueStore, attachments) {
+					missing := ""
+					if item.Missing {
+						missing = " " + ui.RenderMuted("(missing)")
+					}
+					fmt.Printf("  %s  %s  %s  %s%s\n",
+						item.ShortHash,
+						item.OriginalFilename,
+						item.MimeType,
+						item.Size,
+						missing)
+				}
 			}
 
 			// Show custom metadata (GH#1406)

--- a/cmd/bd/show_embedded_test.go
+++ b/cmd/bd/show_embedded_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -146,6 +147,48 @@ func TestEmbeddedShow(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("expected 'bug' in labels: %v", labels)
+		}
+	})
+
+	t.Run("show_includes_attachments", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Attachment show", "--type", "task")
+		source := filepath.Join(dir, "show-attachment.txt")
+		if err := os.WriteFile(source, []byte("show attachment"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		attachOut := bdAttachment(t, bd, dir, "add", issue.ID, source, "--json")
+		var added attachmentListItem
+		if err := json.Unmarshal([]byte(attachOut), &added); err != nil {
+			t.Fatalf("parse attachment add JSON: %v\n%s", err, attachOut)
+		}
+
+		out := bdShowRaw(t, bd, dir, issue.ID)
+		if !strings.Contains(out, "ATTACHMENTS") {
+			t.Fatalf("expected ATTACHMENTS section in show output:\n%s", out)
+		}
+		if !strings.Contains(out, "show-attachment.txt") {
+			t.Fatalf("expected attachment filename in show output:\n%s", out)
+		}
+		if !strings.Contains(out, added.ShortHash) {
+			t.Fatalf("expected attachment short hash %s in show output:\n%s", added.ShortHash, out)
+		}
+
+		m := bdShowDetails(t, bd, dir, issue.ID)
+		if got := m["attachment_count"]; got != float64(1) {
+			t.Fatalf("attachment_count = %v, want 1", got)
+		}
+		attachments, ok := m["attachments"].([]interface{})
+		if !ok || len(attachments) != 1 {
+			t.Fatalf("attachments = %#v, want one attachment", m["attachments"])
+		}
+
+		storedPath := filepath.Join(beadsDir, filepath.FromSlash(added.StorageRelPath))
+		if err := os.Remove(storedPath); err != nil {
+			t.Fatalf("remove stored attachment for missing marker: %v", err)
+		}
+		missingOut := bdShowRaw(t, bd, dir, issue.ID)
+		if !strings.Contains(missingOut, "(missing)") {
+			t.Fatalf("expected missing marker in show output:\n%s", missingOut)
 		}
 	})
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -288,6 +288,7 @@ orchestration, or team-specific data before adding new first-class fields; see
 ```
 .beads/
 ├── dolt/             # Dolt database, sql-server.pid, sql-server.log (gitignored)
+├── attachments/      # Local attachment bytes; metadata lives in Dolt
 ├── metadata.json     # Backend config (local, gitignored)
 └── config.yaml       # Project config (optional)
 ```

--- a/docs/ATTACHMENTS.md
+++ b/docs/ATTACHMENTS.md
@@ -1,0 +1,58 @@
+# Attachment Storage Policy
+
+Attachment support uses a split storage model:
+
+- Attachment metadata is stored in the Dolt database.
+- Attachment bytes are stored as plain files under `.beads/attachments/<BEADID>/<sha256>`.
+- Attachment files are local-only in the MVP. Dolt sync, Dolt backups, and JSONL exports do not copy the plain files in `.beads/attachments`.
+
+This keeps large binary payloads out of Dolt history while still making the
+relationship between a bead and its attachments versioned metadata.
+
+## What Syncs
+
+`bd dolt push`, `bd dolt pull`, and Dolt-native `bd backup` move the database
+state. For attachments, that means they carry attachment metadata rows such as
+the bead ID, content hash, original filename, MIME type, size, and storage path.
+
+They do not move the file bytes under `.beads/attachments`. After a metadata-only
+sync or restore on another machine, an attachment can be listed even when the
+local file is absent. `bd show` and `bd attachment list` report those entries as
+missing instead of hiding them or failing the whole command.
+
+`bd export` and `.beads/issues.jsonl` remain issue-table exports. They are not a
+restorable database backup and they do not include attachment bytes.
+
+## Backing Up Bytes
+
+If attachment bytes matter, back up `.beads/attachments` with your repository or
+machine backup tooling in addition to using `bd dolt push` or `bd backup sync`
+for the Dolt database.
+
+For example, a complete project backup needs both:
+
+```sh
+bd backup sync
+rsync -a .beads/attachments/ /backup/beads-attachments/
+```
+
+Restore the Dolt database first, then restore `.beads/attachments` into the
+same `.beads` directory. Run `bd attachment fsck` afterward to find files that
+are present on disk but no longer referenced by any bead, and `bd attachment
+prune` to remove those unreachable files when the report looks correct.
+
+## Git and Git LFS
+
+Git does not automatically track `.beads/attachments`. Many repositories ignore
+`.beads/*`, including this repository. If a team wants attachment bytes in git,
+that must be an explicit project policy.
+
+For Git LFS, opt in by tracking the attachment path deliberately:
+
+```gitattributes
+.beads/attachments/** filter=lfs diff=lfs merge=lfs -text
+```
+
+The repository also needs matching `.gitignore` exceptions for `.beads/attachments`
+before git can see those files. This is intentionally not enabled by `bd init`
+because it changes repository size, clone behavior, and LFS hosting requirements.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -7,6 +7,13 @@ Reference for bd Latest. Generated from `bd help --all`.
 ### Working With Issues:
 
 - [bd assign](#bd-assign) — Assign an issue to someone
+- [bd attachment](#bd-attachment) — Manage issue file attachments
+  - [bd attachment add](#bd-attachment-add) — Attach a file to an issue
+  - [bd attachment copy](#bd-attachment-copy) — Copy an attachment out to a file or directory
+  - [bd attachment fsck](#bd-attachment-fsck) — Find unreachable attachment files
+  - [bd attachment list](#bd-attachment-list) — List attachments for an issue
+  - [bd attachment prune](#bd-attachment-prune) — Remove unreachable attachment files
+  - [bd attachment remove](#bd-attachment-remove) — Remove an attachment from an issue
 - [bd children](#bd-children) — List child beads of a parent
 - [bd close](#bd-close) — Close one or more issues
 - [bd comment](#bd-comment) — Add a comment to an issue
@@ -322,6 +329,78 @@ Examples:
 ```
 bd assign <id> <name>
 ```
+
+### bd attachment
+
+Manage issue file attachments
+
+```
+bd attachment
+```
+
+**Aliases:** attachments
+
+#### bd attachment add
+
+Attach a file to an issue
+
+```
+bd attachment add [issue-id] [path]
+```
+
+#### bd attachment copy
+
+Copy an attachment out to a file or directory
+
+```
+bd attachment copy [issue-id] [filename-or-hash] [target] [flags]
+```
+
+**Flags:**
+
+```
+  -f, --force   Overwrite the target file if it exists
+```
+
+#### bd attachment fsck
+
+Find unreachable attachment files
+
+```
+bd attachment fsck
+```
+
+#### bd attachment list
+
+List attachments for an issue
+
+```
+bd attachment list [issue-id]
+```
+
+#### bd attachment prune
+
+Remove unreachable attachment files
+
+```
+bd attachment prune [flags]
+```
+
+**Flags:**
+
+```
+  -n, --dry-run   Show unreachable files without removing them
+```
+
+#### bd attachment remove
+
+Remove an attachment from an issue
+
+```
+bd attachment remove [issue-id] [filename-or-hash]
+```
+
+**Aliases:** rm
 
 ### bd children
 
@@ -2306,7 +2385,9 @@ bd backup status
 Sync the current beads database to the configured Dolt backup destination.
 
 This pushes the entire database state (all branches, full history) to the
-backup location configured with 'bd backup init'.
+backup location configured with 'bd backup init'. Attachment metadata is part
+of the database, but attachment bytes under .beads/attachments are local files
+and need a separate filesystem backup.
 
 The backup is atomic — if the sync fails, the previous backup state is preserved.
 

--- a/docs/DOC_INVENTORY.md
+++ b/docs/DOC_INVENTORY.md
@@ -18,7 +18,7 @@ freshness source.
 |---|---|---|
 | Architecture | `ARCHITECTURE.md`, `INTERNALS.md`, `DOLT.md`, `adr/`, `design/` | Durable structure, package boundaries, storage model, and invariants live here. |
 | Behaviour/reference | `CLI_REFERENCE.md`, `CONFIG.md`, `SETUP.md`, `JSON_SCHEMA.md`, `RECOVERY.md`, `ERROR_HANDLING.md`, `TROUBLESHOOTING.md` | CLI/config/runtime contracts live here and need generation or freshness review. |
-| User-facing workflow | `INSTALLING.md`, `QUICKSTART.md`, `FAQ.md`, `SYNC_SETUP.md`, integration guides, `WORKTREES.md`, `UNINSTALLING.md` | Task-oriented user docs live here; avoid duplicating implementation tables unless linked to reference docs. |
+| User-facing workflow | `INSTALLING.md`, `QUICKSTART.md`, `FAQ.md`, `SYNC_SETUP.md`, `ATTACHMENTS.md`, integration guides, `WORKTREES.md`, `UNINSTALLING.md` | Task-oriented user docs live here; avoid duplicating implementation tables unless linked to reference docs. |
 | Maintainer/operator | root `RELEASING.md`, `RELEASE-STABILITY-GATE.md`, `LINTING.md`, `SECURITY-DEPENDENCY-EXCEPTIONS.md`, `PERFORMANCE_TESTING.md`, `CI_TEST_SURFACE_AUDIT.md`, `CI_CLEANUP_PLAN.md` | Maintainer process docs stay active only when tied to current scripts/checks. |
 | Historical/staged | `staged-for-removal/` | Resolved audits, stale duplicates, and unsupported snapshots are preserved here until deleted or rescued. |
 
@@ -32,6 +32,7 @@ freshness source.
 | `SETUP.md` | `Last reviewed:` marker tied to `cmd/bd/setup*.go` and `internal/recipes/`. |
 | `ADO_CONFIG.md` | `Last reviewed:` marker tied to `cmd/bd/ado*.go` and `internal/ado/`. |
 | `JSON_SCHEMA.md` | `Last reviewed:` marker tied to `cmd/bd/output.go`, `cmd/bd/errors.go`, and protocol tests. |
+| `ATTACHMENTS.md` | Policy assertions covered by `cmd/bd/attachment_policy_test.go`. |
 | `RECOVERY.md` | `Last reviewed:` marker tied to `cmd/bd/init*.go` safety code and tests. |
 | `ERROR_HANDLING.md` | `Last reviewed:` marker tied to current command error exits and JSON error helpers. |
 | `LINTING.md` | `Last reviewed:` marker tied to `.golangci.yml` and current lint output. |
@@ -53,6 +54,7 @@ Follow-up automation should replace marker-only checks with generated or
 | `AIDER_INTEGRATION.md` | Keep | User-facing integration guide; evidence is setup/integration behaviour. |
 | `ANTIVIRUS.md` | Keep | User-facing operational note; review vendor/version claims when touched. |
 | `ARCHITECTURE.md` | Keep | Primary architecture overview; evidence is current package layout and Dolt-only storage path. |
+| `ATTACHMENTS.md` | Keep with freshness | User-facing attachment storage/sync/backup policy; key claims are guarded by `cmd/bd/attachment_policy_test.go`. |
 | `ATTRIBUTION.md` | Keep | Attribution record for removed merge engine. |
 | `CLAUDE_INTEGRATION.md` | Keep | Design/user guide for Claude setup; paired with `SETUP.md`. |
 | `CLAUDE.md` | Revise | Kept as architecture orientation only; command/workflow duplication was reduced in favour of root `AGENTS.md` and `AGENT_INSTRUCTIONS.md`. |

--- a/docs/SYNC_SETUP.md
+++ b/docs/SYNC_SETUP.md
@@ -221,6 +221,7 @@ bd list                            # sees the closed task
 - **Commit before pulling** — if you have uncommitted working set changes, `bd dolt pull` will fail with "cannot merge with uncommitted changes". Run `bd dolt commit` first.
 - **Push before switching machines** — unpushed changes only exist locally.
 - **Do not use JSONL as sync** — `.beads/issues.jsonl` is an export for viewers and interchange. It is not the source of truth, not a full database backup, and cannot safely reconcile deletes or pruning.
+- **Back up attachment bytes separately** — attachment metadata syncs through Dolt, but plain files under `.beads/attachments` are local-only. After metadata-only sync, `bd show` and `bd attachment list` report absent files as missing. See [ATTACHMENTS.md](ATTACHMENTS.md).
 
 ## Troubleshooting
 

--- a/docs/UNINSTALLING.md
+++ b/docs/UNINSTALLING.md
@@ -22,6 +22,8 @@ bd export -o ~/beads-issues-$(date +%Y%m%d).jsonl
 
 `bd export` is not a complete restorable database backup. It does not preserve
 Dolt branches, commit history, working-set state, or non-issue tables.
+Attachment bytes are also outside the Dolt database and JSONL export; copy
+`.beads/attachments` separately if you need to keep attached files.
 
 ## Repository Reset
 

--- a/internal/attachments/files.go
+++ b/internal/attachments/files.go
@@ -1,0 +1,359 @@
+// Package attachments stores and retrieves attachment bytes on disk.
+//
+// Attachment metadata lives in Dolt SQL. The bytes stay outside the database
+// under .beads/attachments so large files do not bloat Dolt history.
+package attachments
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/atomicfile"
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+const (
+	// DirName is the directory under .beads where attachment bytes are stored.
+	DirName = "attachments"
+	// HashAlgorithm is the initial content-addressing algorithm.
+	HashAlgorithm = "sha256"
+)
+
+// StoredFile describes bytes copied into the attachment store.
+type StoredFile struct {
+	IssueID          string
+	OriginalFilename string
+	HashAlgorithm    string
+	ContentHash      string
+	MimeType         string
+	ByteSize         int64
+	StorageRelPath   string
+	StorageAbsPath   string
+}
+
+// BeadsDir returns the .beads root for a store.
+func BeadsDir(st any) (string, error) {
+	loc, ok := st.(storage.StoreLocator)
+	if !ok {
+		return "", fmt.Errorf("store does not expose filesystem location")
+	}
+	path := filepath.Clean(loc.Path())
+	if path == "." || path == "" {
+		return "", fmt.Errorf("store path is empty")
+	}
+	base := filepath.Base(path)
+	switch base {
+	case ".beads":
+		return path, nil
+	case "dolt", "embeddeddolt":
+		return filepath.Dir(path), nil
+	}
+
+	cliDir := filepath.Clean(loc.CLIDir())
+	if cliDir != "." && cliDir != "" {
+		parent := filepath.Dir(cliDir)
+		switch filepath.Base(parent) {
+		case "dolt", "embeddeddolt":
+			return filepath.Dir(parent), nil
+		}
+	}
+
+	return "", fmt.Errorf("cannot derive .beads directory from store path %q", path)
+}
+
+// Root returns the directory that stores attachment bytes for the store.
+func Root(st any) (string, error) {
+	beadsDir, err := BeadsDir(st)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(beadsDir, DirName), nil
+}
+
+// Store copies sourcePath into .beads/attachments/<issueID>/<sha256>.
+// The copy is streamed through SHA-256 and lands via same-directory rename so
+// callers never record metadata for a partially written stored object.
+func Store(st any, issueID, sourcePath string) (*StoredFile, error) {
+	issueID = strings.TrimSpace(issueID)
+	if issueID == "" {
+		return nil, fmt.Errorf("issue ID is empty")
+	}
+
+	filename, err := SafeFilename(filepath.Base(sourcePath))
+	if err != nil {
+		return nil, err
+	}
+
+	source, err := os.Open(sourcePath) //nolint:gosec // user-provided attachment source path
+	if err != nil {
+		return nil, fmt.Errorf("open attachment source: %w", err)
+	}
+	defer source.Close()
+
+	info, err := source.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat attachment source: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("attachment source is not a regular file")
+	}
+
+	root, err := Root(st)
+	if err != nil {
+		return nil, err
+	}
+	issueDir := filepath.Join(root, issueID)
+	if err := os.MkdirAll(issueDir, config.BeadsDirPerm); err != nil {
+		return nil, fmt.Errorf("create attachment directory: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(issueDir, ".~attach-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temporary attachment: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	hasher := sha256.New()
+	sniffer := &sniffWriter{limit: 512}
+	w := io.MultiWriter(tmp, hasher, sniffer)
+	n, err := io.Copy(w, source)
+	if err != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("copy attachment source: %w", err)
+	}
+	if err := tmp.Chmod(config.BeadsFilePerm); err != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("chmod temporary attachment: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("sync temporary attachment: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return nil, fmt.Errorf("close temporary attachment: %w", err)
+	}
+
+	contentHash := hex.EncodeToString(hasher.Sum(nil))
+	relPath := filepath.ToSlash(filepath.Join(DirName, issueID, contentHash))
+	targetPath := filepath.Join(issueDir, contentHash)
+	if _, err := os.Stat(targetPath); err == nil {
+		cleanup = true
+	} else if os.IsNotExist(err) {
+		if err := os.Rename(tmpPath, targetPath); err != nil {
+			return nil, fmt.Errorf("store attachment: %w", err)
+		}
+		cleanup = false
+	} else {
+		return nil, fmt.Errorf("stat stored attachment: %w", err)
+	}
+
+	return &StoredFile{
+		IssueID:          issueID,
+		OriginalFilename: filename,
+		HashAlgorithm:    HashAlgorithm,
+		ContentHash:      contentHash,
+		MimeType:         DetectMimeType(filename, sniffer.Bytes()),
+		ByteSize:         n,
+		StorageRelPath:   relPath,
+		StorageAbsPath:   targetPath,
+	}, nil
+}
+
+// SafeFilename validates a display filename before it is written to metadata
+// or used as the default copy-out filename.
+func SafeFilename(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" || name == "." || name == ".." {
+		return "", fmt.Errorf("attachment filename is empty")
+	}
+	if filepath.Base(name) != name || strings.ContainsAny(name, `/\`) {
+		return "", fmt.Errorf("attachment filename %q must not contain path separators", name)
+	}
+	return name, nil
+}
+
+// DetectMimeType returns a MIME type from file contents with an extension
+// fallback for formats that content sniffing reports only as generic text.
+func DetectMimeType(filename string, sample []byte) string {
+	detected := http.DetectContentType(sample)
+	byExt := mime.TypeByExtension(filepath.Ext(filename))
+	if byExt == "" {
+		switch strings.ToLower(filepath.Ext(filename)) {
+		case ".md", ".markdown":
+			byExt = "text/markdown; charset=utf-8"
+		}
+	}
+	if byExt == "" {
+		return detected
+	}
+	if detected == "application/octet-stream" || strings.HasPrefix(detected, "text/plain") {
+		return byExt
+	}
+	return detected
+}
+
+// StoredPath resolves attachment metadata's storage_relpath safely under
+// the store's .beads directory.
+func StoredPath(st any, relPath string) (string, error) {
+	beadsDir, err := BeadsDir(st)
+	if err != nil {
+		return "", err
+	}
+	clean, err := cleanRelPath(relPath)
+	if err != nil {
+		return "", err
+	}
+	abs := filepath.Join(beadsDir, clean)
+	if err := ensureWithin(beadsDir, abs); err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+
+// Exists reports whether the attachment bytes referenced by metadata exist.
+func Exists(st any, attachment *types.Attachment) bool {
+	if attachment == nil {
+		return false
+	}
+	path, err := StoredPath(st, attachment.StorageRelPath)
+	if err != nil {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+// CopyOut copies attachment bytes to target. If target is an existing
+// directory, the attachment's original filename is used inside that directory.
+// Existing files are rejected unless force is true.
+func CopyOut(st any, attachment *types.Attachment, target string, force bool) (string, error) {
+	if attachment == nil {
+		return "", fmt.Errorf("attachment is nil")
+	}
+	sourcePath, err := StoredPath(st, attachment.StorageRelPath)
+	if err != nil {
+		return "", err
+	}
+	filename, err := SafeFilename(attachment.OriginalFilename)
+	if err != nil {
+		return "", err
+	}
+
+	dest := target
+	if info, err := os.Stat(target); err == nil && info.IsDir() {
+		dest = filepath.Join(target, filename)
+	} else if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("stat copy target: %w", err)
+	}
+	if !force {
+		if _, err := os.Stat(dest); err == nil {
+			return "", fmt.Errorf("copy target %s already exists", dest)
+		} else if err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("stat copy target: %w", err)
+		}
+	}
+
+	source, err := os.Open(sourcePath) //nolint:gosec // path is resolved under .beads above
+	if err != nil {
+		return "", fmt.Errorf("open stored attachment: %w", err)
+	}
+	defer source.Close()
+
+	writer, err := atomicfile.Create(dest, 0o644)
+	if err != nil {
+		return "", err
+	}
+	if _, err := io.Copy(writer, source); err != nil {
+		_ = writer.Abort()
+		return "", fmt.Errorf("copy attachment out: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return "", err
+	}
+	return dest, nil
+}
+
+// RemoveStoredFile removes attachment bytes. Missing files are treated as
+// already removed so metadata cleanup can stay idempotent.
+func RemoveStoredFile(st any, attachment *types.Attachment) error {
+	if attachment == nil {
+		return fmt.Errorf("attachment is nil")
+	}
+	path, err := StoredPath(st, attachment.StorageRelPath)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stored attachment: %w", err)
+	}
+	return nil
+}
+
+type sniffWriter struct {
+	limit int
+	buf   []byte
+}
+
+func (w *sniffWriter) Write(p []byte) (int, error) {
+	remaining := w.limit - len(w.buf)
+	if remaining > 0 {
+		if len(p) < remaining {
+			remaining = len(p)
+		}
+		w.buf = append(w.buf, p[:remaining]...)
+	}
+	return len(p), nil
+}
+
+func (w *sniffWriter) Bytes() []byte {
+	return w.buf
+}
+
+func cleanRelPath(relPath string) (string, error) {
+	relPath = strings.TrimSpace(relPath)
+	if relPath == "" {
+		return "", fmt.Errorf("attachment storage path is empty")
+	}
+	if filepath.IsAbs(relPath) {
+		return "", fmt.Errorf("attachment storage path must be relative")
+	}
+	parts := strings.FieldsFunc(relPath, func(r rune) bool {
+		return r == '/' || r == '\\'
+	})
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return "", fmt.Errorf("attachment storage path %q is unsafe", relPath)
+		}
+	}
+	clean := filepath.Clean(filepath.FromSlash(relPath))
+	if clean == "." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || clean == ".." {
+		return "", fmt.Errorf("attachment storage path %q is unsafe", relPath)
+	}
+	return clean, nil
+}
+
+func ensureWithin(root, path string) error {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return fmt.Errorf("resolve attachment path: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return fmt.Errorf("attachment path escapes .beads")
+	}
+	return nil
+}

--- a/internal/attachments/files_test.go
+++ b/internal/attachments/files_test.go
@@ -1,0 +1,169 @@
+package attachments
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+type fakeStore struct {
+	path   string
+	cliDir string
+}
+
+func (s fakeStore) Path() string   { return s.path }
+func (s fakeStore) CLIDir() string { return s.cliDir }
+
+func TestRootFromStoreLocator(t *testing.T) {
+	tmp := t.TempDir()
+	beadsDir := filepath.Join(tmp, ".beads")
+
+	tests := []struct {
+		name string
+		st   fakeStore
+	}{
+		{
+			name: "dolt",
+			st:   fakeStore{path: filepath.Join(beadsDir, "dolt"), cliDir: filepath.Join(beadsDir, "dolt", "beads")},
+		},
+		{
+			name: "embedded",
+			st:   fakeStore{path: filepath.Join(beadsDir, "embeddeddolt"), cliDir: filepath.Join(beadsDir, "embeddeddolt", "beads")},
+		},
+		{
+			name: ".beads",
+			st:   fakeStore{path: beadsDir},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Root(tt.st)
+			if err != nil {
+				t.Fatalf("Root() error = %v", err)
+			}
+			want := filepath.Join(beadsDir, DirName)
+			if got != want {
+				t.Fatalf("Root() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestStoreCopiesAndHashesAttachment(t *testing.T) {
+	tmp := t.TempDir()
+	st := fakeStore{path: filepath.Join(tmp, ".beads", "embeddeddolt")}
+	source := filepath.Join(tmp, "body.md")
+	if err := os.WriteFile(source, []byte("# Hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Store(st, "bd-abc", source)
+	if err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+	if got.OriginalFilename != "body.md" {
+		t.Fatalf("OriginalFilename = %q", got.OriginalFilename)
+	}
+	if got.HashAlgorithm != HashAlgorithm {
+		t.Fatalf("HashAlgorithm = %q", got.HashAlgorithm)
+	}
+	if got.ByteSize != int64(len("# Hello\n")) {
+		t.Fatalf("ByteSize = %d", got.ByteSize)
+	}
+	if !strings.HasPrefix(got.MimeType, "text/markdown") {
+		t.Fatalf("MimeType = %q, want text/markdown", got.MimeType)
+	}
+	wantRel := filepath.ToSlash(filepath.Join(DirName, "bd-abc", got.ContentHash))
+	if got.StorageRelPath != wantRel {
+		t.Fatalf("StorageRelPath = %q, want %q", got.StorageRelPath, wantRel)
+	}
+	data, err := os.ReadFile(got.StorageAbsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(stored) error = %v", err)
+	}
+	if string(data) != "# Hello\n" {
+		t.Fatalf("stored data = %q", data)
+	}
+}
+
+func TestStoredPathRejectsTraversal(t *testing.T) {
+	tmp := t.TempDir()
+	st := fakeStore{path: filepath.Join(tmp, ".beads", "dolt")}
+
+	for _, rel := range []string{
+		"../outside",
+		"attachments/../outside",
+		"attachments/bd-abc/../outside",
+	} {
+		t.Run(rel, func(t *testing.T) {
+			if _, err := StoredPath(st, rel); err == nil {
+				t.Fatalf("StoredPath(%q) succeeded, want error", rel)
+			}
+		})
+	}
+}
+
+func TestCopyOutRefusesOverwriteUnlessForced(t *testing.T) {
+	tmp := t.TempDir()
+	st := fakeStore{path: filepath.Join(tmp, ".beads", "embeddeddolt")}
+	source := filepath.Join(tmp, "note.txt")
+	if err := os.WriteFile(source, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := Store(st, "bd-abc", source)
+	if err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+	attachment := &types.Attachment{
+		OriginalFilename: stored.OriginalFilename,
+		StorageRelPath:   stored.StorageRelPath,
+	}
+
+	targetDir := filepath.Join(tmp, "out")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	targetPath, err := CopyOut(st, attachment, targetDir, false)
+	if err != nil {
+		t.Fatalf("CopyOut() error = %v", err)
+	}
+	if targetPath != filepath.Join(targetDir, "note.txt") {
+		t.Fatalf("CopyOut() path = %q", targetPath)
+	}
+	if _, err := CopyOut(st, attachment, targetDir, false); err == nil {
+		t.Fatal("CopyOut() overwrite succeeded, want error")
+	}
+	if _, err := CopyOut(st, attachment, targetDir, true); err != nil {
+		t.Fatalf("CopyOut(force) error = %v", err)
+	}
+}
+
+func TestRemoveStoredFile(t *testing.T) {
+	tmp := t.TempDir()
+	st := fakeStore{path: filepath.Join(tmp, ".beads", "dolt")}
+	source := filepath.Join(tmp, "note.txt")
+	if err := os.WriteFile(source, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := Store(st, "bd-abc", source)
+	if err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+	attachment := &types.Attachment{StorageRelPath: stored.StorageRelPath}
+	if !Exists(st, attachment) {
+		t.Fatal("Exists() = false, want true")
+	}
+	if err := RemoveStoredFile(st, attachment); err != nil {
+		t.Fatalf("RemoveStoredFile() error = %v", err)
+	}
+	if Exists(st, attachment) {
+		t.Fatal("Exists() = true, want false")
+	}
+	if err := RemoveStoredFile(st, attachment); err != nil {
+		t.Fatalf("RemoveStoredFile() second call error = %v", err)
+	}
+}

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -705,6 +705,16 @@ func (s *configStore) AddIssueComment(_ context.Context, _, _, _ string) (*types
 func (s *configStore) GetIssueComments(_ context.Context, _ string) ([]*types.Comment, error) {
 	return nil, nil
 }
+func (s *configStore) AddAttachment(_ context.Context, _ *types.Attachment) (*types.Attachment, error) {
+	return nil, nil
+}
+func (s *configStore) ListAttachments(_ context.Context, _ string) ([]*types.Attachment, error) {
+	return nil, nil
+}
+func (s *configStore) ResolveAttachment(_ context.Context, _, _ string) (*types.Attachment, error) {
+	return nil, nil
+}
+func (s *configStore) RemoveAttachment(_ context.Context, _, _ string) error { return nil }
 func (s *configStore) GetEvents(_ context.Context, _ string, _ int) ([]*types.Event, error) {
 	return nil, nil
 }
@@ -745,6 +755,9 @@ func (s *configStore) CountDependencies(_ context.Context, _ string) (int64, err
 func (s *configStore) CountIssueComments(_ context.Context, _ string) (int64, error) {
 	return 0, nil
 }
+func (s *configStore) CountAttachments(_ context.Context, _ string) (int64, error) {
+	return 0, nil
+}
 func (s *configStore) CountEvents(_ context.Context, _ string, _ int) (int64, error) {
 	return 0, nil
 }
@@ -760,6 +773,9 @@ func (s *configStore) IterDependenciesWithMetadata(_ context.Context, _ string) 
 }
 func (s *configStore) IterIssueComments(_ context.Context, _ string) (storage.Iter[types.Comment], error) {
 	return storage.NewSliceIter[types.Comment](nil), nil
+}
+func (s *configStore) IterAttachments(_ context.Context, _ string) (storage.Iter[types.Attachment], error) {
+	return storage.NewSliceIter[types.Attachment](nil), nil
 }
 func (s *configStore) IterEvents(_ context.Context, _ string, _ int) (storage.Iter[types.Event], error) {
 	return storage.NewSliceIter[types.Event](nil), nil

--- a/internal/storage/dolt/attachments.go
+++ b/internal/storage/dolt/attachments.go
@@ -1,0 +1,59 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// AddAttachment inserts attachment metadata for a persistent issue.
+func (s *DoltStore) AddAttachment(ctx context.Context, attachment *types.Attachment) (*types.Attachment, error) {
+	var result *types.Attachment
+	err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.AddAttachmentInTx(ctx, tx, attachment)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := s.doltAddAndCommit(ctx, []string{"attachments"}, fmt.Sprintf("bd: attach %s", result.IssueID)); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// ListAttachments lists attachment metadata for an issue.
+func (s *DoltStore) ListAttachments(ctx context.Context, issueID string) ([]*types.Attachment, error) {
+	var result []*types.Attachment
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.ListAttachmentsInTx(ctx, tx, issueID)
+		return err
+	})
+	return result, err
+}
+
+// ResolveAttachment resolves an attachment ID, content-hash prefix, or filename.
+func (s *DoltStore) ResolveAttachment(ctx context.Context, issueID, selector string) (*types.Attachment, error) {
+	var result *types.Attachment
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.ResolveAttachmentInTx(ctx, tx, issueID, selector)
+		return err
+	})
+	return result, err
+}
+
+// RemoveAttachment deletes one attachment metadata row.
+func (s *DoltStore) RemoveAttachment(ctx context.Context, issueID, attachmentID string) error {
+	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		return issueops.RemoveAttachmentInTx(ctx, tx, issueID, attachmentID)
+	}); err != nil {
+		return err
+	}
+	return s.doltAddAndCommit(ctx, []string{"attachments"}, fmt.Sprintf("bd: detach %s", issueID))
+}

--- a/internal/storage/dolt/counts.go
+++ b/internal/storage/dolt/counts.go
@@ -113,6 +113,16 @@ func (s *DoltStore) CountIssueComments(ctx context.Context, issueID string) (int
 	return n, err
 }
 
+// CountAttachments returns the number of file attachments on an issue.
+func (s *DoltStore) CountAttachments(ctx context.Context, issueID string) (int64, error) {
+	var n int64
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			`SELECT count(*) FROM attachments WHERE issue_id = ?`, issueID).Scan(&n)
+	})
+	return n, err
+}
+
 // CountEvents returns the number of audit events for an issue, capped at limit
 // (or unbounded if limit == 0).
 func (s *DoltStore) CountEvents(ctx context.Context, issueID string, limit int) (int64, error) {

--- a/internal/storage/dolt/iter_stubs.go
+++ b/internal/storage/dolt/iter_stubs.go
@@ -27,6 +27,18 @@ func (s *DoltStore) IterIssueComments(ctx context.Context, issueID string) (stor
 	return storage.NewSliceIter(cs), nil
 }
 
+// IterAttachments streams attachment metadata on an issue.
+//
+// TODO(be-yinl4d-iter): replace slice-then-walk with a fully streaming
+// implementation.
+func (s *DoltStore) IterAttachments(ctx context.Context, issueID string) (storage.Iter[types.Attachment], error) {
+	as, err := s.ListAttachments(ctx, issueID)
+	if err != nil {
+		return nil, err
+	}
+	return storage.NewSliceIter(as), nil
+}
+
 // IterEvents streams the audit-trail events for an issue.
 //
 // TODO(be-yinl4d-iter): replace with a fully streaming implementation.

--- a/internal/storage/embeddeddolt/attachments.go
+++ b/internal/storage/embeddeddolt/attachments.go
@@ -1,0 +1,51 @@
+//go:build cgo
+
+package embeddeddolt
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// AddAttachment inserts attachment metadata for a persistent issue.
+func (s *EmbeddedDoltStore) AddAttachment(ctx context.Context, attachment *types.Attachment) (*types.Attachment, error) {
+	var result *types.Attachment
+	err := s.withConn(ctx, true, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.AddAttachmentInTx(ctx, tx, attachment)
+		return err
+	})
+	return result, err
+}
+
+// ListAttachments lists attachment metadata for an issue.
+func (s *EmbeddedDoltStore) ListAttachments(ctx context.Context, issueID string) ([]*types.Attachment, error) {
+	var result []*types.Attachment
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.ListAttachmentsInTx(ctx, tx, issueID)
+		return err
+	})
+	return result, err
+}
+
+// ResolveAttachment resolves an attachment ID, content-hash prefix, or filename.
+func (s *EmbeddedDoltStore) ResolveAttachment(ctx context.Context, issueID, selector string) (*types.Attachment, error) {
+	var result *types.Attachment
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.ResolveAttachmentInTx(ctx, tx, issueID, selector)
+		return err
+	})
+	return result, err
+}
+
+// RemoveAttachment deletes one attachment metadata row.
+func (s *EmbeddedDoltStore) RemoveAttachment(ctx context.Context, issueID, attachmentID string) error {
+	return s.withConn(ctx, true, func(tx *sql.Tx) error {
+		return issueops.RemoveAttachmentInTx(ctx, tx, issueID, attachmentID)
+	})
+}

--- a/internal/storage/embeddeddolt/counts.go
+++ b/internal/storage/embeddeddolt/counts.go
@@ -112,6 +112,15 @@ func (s *EmbeddedDoltStore) CountIssueComments(ctx context.Context, issueID stri
 	return n, err
 }
 
+func (s *EmbeddedDoltStore) CountAttachments(ctx context.Context, issueID string) (int64, error) {
+	var n int64
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			`SELECT count(*) FROM attachments WHERE issue_id = ?`, issueID).Scan(&n)
+	})
+	return n, err
+}
+
 func (s *EmbeddedDoltStore) CountEvents(ctx context.Context, issueID string, limit int) (int64, error) {
 	var n int64
 	err := s.withConn(ctx, false, func(tx *sql.Tx) error {

--- a/internal/storage/embeddeddolt/iter_stubs.go
+++ b/internal/storage/embeddeddolt/iter_stubs.go
@@ -64,6 +64,17 @@ func (s *EmbeddedDoltStore) IterIssueComments(ctx context.Context, issueID strin
 	return storage.NewSliceIter(cs), nil
 }
 
+// IterAttachments streams attachment metadata on an issue (slice-then-walk).
+//
+// TODO(be-yinl4d-iter): replace with a fully streaming implementation.
+func (s *EmbeddedDoltStore) IterAttachments(ctx context.Context, issueID string) (storage.Iter[types.Attachment], error) {
+	as, err := s.ListAttachments(ctx, issueID)
+	if err != nil {
+		return nil, err
+	}
+	return storage.NewSliceIter(as), nil
+}
+
 // IterEvents streams audit-trail events for an issue (slice-then-walk).
 //
 // TODO(be-yinl4d-iter): replace with a fully streaming implementation.

--- a/internal/storage/hook_decorator.go
+++ b/internal/storage/hook_decorator.go
@@ -185,6 +185,27 @@ func (h *HookFiringStore) AddIssueComment(ctx context.Context, issueID, author, 
 	return comment, nil
 }
 
+// AddAttachment adds attachment metadata and fires on_update.
+func (h *HookFiringStore) AddAttachment(ctx context.Context, attachment *types.Attachment) (*types.Attachment, error) {
+	result, err := h.inner.AddAttachment(ctx, attachment)
+	if err != nil {
+		return nil, err
+	}
+	if result != nil {
+		h.fireHookByID(ctx, hooks.EventUpdate, result.IssueID)
+	}
+	return result, nil
+}
+
+// RemoveAttachment removes attachment metadata and fires on_update.
+func (h *HookFiringStore) RemoveAttachment(ctx context.Context, issueID, attachmentID string) error {
+	if err := h.inner.RemoveAttachment(ctx, issueID, attachmentID); err != nil {
+		return err
+	}
+	h.fireHookByID(ctx, hooks.EventUpdate, issueID)
+	return nil
+}
+
 // ── Transaction support ─────────────────────────────────────────────
 
 // RunInTransaction wraps the callback's transaction with hook tracking.
@@ -556,6 +577,12 @@ var (
 	} = (*HookFiringStore)(nil)
 	_ interface {
 		AddIssueComment(context.Context, string, string, string) (*types.Comment, error)
+	} = (*HookFiringStore)(nil)
+	_ interface {
+		AddAttachment(context.Context, *types.Attachment) (*types.Attachment, error)
+	} = (*HookFiringStore)(nil)
+	_ interface {
+		RemoveAttachment(context.Context, string, string) error
 	} = (*HookFiringStore)(nil)
 	_ interface {
 		ReopenIssue(context.Context, string, string, string) error

--- a/internal/storage/issueops/attachments.go
+++ b/internal/storage/issueops/attachments.go
@@ -1,0 +1,169 @@
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// AddAttachmentInTx inserts attachment metadata for a persistent issue.
+// Attachment bytes live outside SQL storage; this only records where the
+// byte-store layer placed the object.
+func AddAttachmentInTx(ctx context.Context, tx *sql.Tx, attachment *types.Attachment) (*types.Attachment, error) {
+	if attachment == nil {
+		return nil, fmt.Errorf("attachment is nil")
+	}
+
+	var exists bool
+	if err := tx.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM issues WHERE id = ?)`, attachment.IssueID).Scan(&exists); err != nil {
+		return nil, fmt.Errorf("check issue existence: %w", err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("issue %s: %w", attachment.IssueID, storage.ErrNotFound)
+	}
+
+	result := *attachment
+	if result.ID == "" {
+		result.ID = uuid.Must(uuid.NewV7()).String()
+	}
+	if result.HashAlgorithm == "" {
+		result.HashAlgorithm = "sha256"
+	}
+	if result.CreatedAt.IsZero() {
+		result.CreatedAt = time.Now().UTC()
+	} else {
+		result.CreatedAt = result.CreatedAt.UTC()
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO attachments (
+			id, issue_id, hash_algorithm, content_hash, original_filename,
+			mime_type, byte_size, storage_relpath, created_by, created_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, result.ID, result.IssueID, result.HashAlgorithm, result.ContentHash, result.OriginalFilename,
+		result.MimeType, result.ByteSize, result.StorageRelPath, result.CreatedBy, result.CreatedAt); err != nil {
+		return nil, fmt.Errorf("add attachment metadata: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ListAttachmentsInTx lists attachment metadata for an issue.
+func ListAttachmentsInTx(ctx context.Context, tx *sql.Tx, issueID string) ([]*types.Attachment, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, issue_id, hash_algorithm, content_hash, original_filename,
+		       mime_type, byte_size, storage_relpath, created_by, created_at
+		FROM attachments
+		WHERE issue_id = ?
+		ORDER BY created_at ASC, id ASC
+	`, issueID)
+	if err != nil {
+		return nil, fmt.Errorf("list attachments: %w", err)
+	}
+	defer rows.Close()
+	return scanAttachments(rows)
+}
+
+// ResolveAttachmentInTx resolves a user-facing selector to one attachment row.
+// It accepts an attachment ID, content-hash prefix, or original filename.
+func ResolveAttachmentInTx(ctx context.Context, tx *sql.Tx, issueID, selector string) (*types.Attachment, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return nil, fmt.Errorf("attachment selector is empty")
+	}
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, issue_id, hash_algorithm, content_hash, original_filename,
+		       mime_type, byte_size, storage_relpath, created_by, created_at
+		FROM attachments
+		WHERE issue_id = ?
+		  AND (id = ? OR content_hash LIKE ? OR original_filename = ?)
+		ORDER BY created_at ASC, id ASC
+	`, issueID, selector, selector+"%", selector)
+	if err != nil {
+		return nil, fmt.Errorf("resolve attachment: %w", err)
+	}
+	defer rows.Close()
+
+	matches, err := scanAttachments(rows)
+	if err != nil {
+		return nil, err
+	}
+	matches = dedupeAttachments(matches)
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("attachment %q on issue %s: %w", selector, issueID, storage.ErrNotFound)
+	case 1:
+		return matches[0], nil
+	default:
+		return nil, fmt.Errorf("attachment selector %q on issue %s: %w", selector, issueID, storage.ErrAmbiguous)
+	}
+}
+
+// RemoveAttachmentInTx deletes one attachment metadata row.
+func RemoveAttachmentInTx(ctx context.Context, tx *sql.Tx, issueID, attachmentID string) error {
+	res, err := tx.ExecContext(ctx,
+		`DELETE FROM attachments WHERE issue_id = ? AND id = ?`, issueID, attachmentID)
+	if err != nil {
+		return fmt.Errorf("remove attachment metadata: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("remove attachment metadata rows affected: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("attachment %s on issue %s: %w", attachmentID, issueID, storage.ErrNotFound)
+	}
+	return nil
+}
+
+// CountAttachmentsInTx counts attachment metadata rows for an issue.
+func CountAttachmentsInTx(ctx context.Context, tx *sql.Tx, issueID string) (int64, error) {
+	var n int64
+	if err := tx.QueryRowContext(ctx,
+		`SELECT count(*) FROM attachments WHERE issue_id = ?`, issueID).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count attachments: %w", err)
+	}
+	return n, nil
+}
+
+func scanAttachments(rows *sql.Rows) ([]*types.Attachment, error) {
+	var attachments []*types.Attachment
+	for rows.Next() {
+		var a types.Attachment
+		if err := rows.Scan(&a.ID, &a.IssueID, &a.HashAlgorithm, &a.ContentHash, &a.OriginalFilename,
+			&a.MimeType, &a.ByteSize, &a.StorageRelPath, &a.CreatedBy, &a.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan attachment: %w", err)
+		}
+		attachments = append(attachments, &a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("scan attachments: %w", err)
+	}
+	return attachments, nil
+}
+
+func dedupeAttachments(in []*types.Attachment) []*types.Attachment {
+	out := make([]*types.Attachment, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, a := range in {
+		if a == nil {
+			continue
+		}
+		if _, ok := seen[a.ID]; ok {
+			continue
+		}
+		seen[a.ID] = struct{}{}
+		out = append(out, a)
+	}
+	return out
+}

--- a/internal/storage/issueops/attachments_test.go
+++ b/internal/storage/issueops/attachments_test.go
@@ -1,0 +1,235 @@
+package issueops
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestAddAttachmentInTx(t *testing.T) {
+	ctx := context.Background()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer tx.Rollback()
+
+	createdAt := time.Date(2026, 6, 7, 11, 0, 0, 0, time.UTC)
+	attachment := &types.Attachment{
+		IssueID:          "bd-abc",
+		ContentHash:      "abc123",
+		OriginalFilename: "body.md",
+		MimeType:         "text/markdown",
+		ByteSize:         1234,
+		StorageRelPath:   "attachments/bd-abc/abc123",
+		CreatedBy:        "tester",
+		CreatedAt:        createdAt,
+	}
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS(SELECT 1 FROM issues WHERE id = ?)`)).
+		WithArgs("bd-abc").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectExec(regexp.QuoteMeta(`
+		INSERT INTO attachments (
+			id, issue_id, hash_algorithm, content_hash, original_filename,
+			mime_type, byte_size, storage_relpath, created_by, created_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`)).
+		WithArgs(sqlmock.AnyArg(), "bd-abc", "sha256", "abc123", "body.md", "text/markdown", int64(1234), "attachments/bd-abc/abc123", "tester", createdAt).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	got, err := AddAttachmentInTx(ctx, tx, attachment)
+	if err != nil {
+		t.Fatalf("AddAttachmentInTx: %v", err)
+	}
+	if got.ID == "" {
+		t.Fatal("AddAttachmentInTx generated empty ID")
+	}
+	if got.HashAlgorithm != "sha256" {
+		t.Fatalf("HashAlgorithm = %q, want sha256", got.HashAlgorithm)
+	}
+	if got.CreatedAt != createdAt {
+		t.Fatalf("CreatedAt = %s, want %s", got.CreatedAt, createdAt)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestAddAttachmentInTxMissingIssue(t *testing.T) {
+	ctx := context.Background()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer tx.Rollback()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS(SELECT 1 FROM issues WHERE id = ?)`)).
+		WithArgs("bd-missing").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	_, err = AddAttachmentInTx(ctx, tx, &types.Attachment{IssueID: "bd-missing"})
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("AddAttachmentInTx error = %v, want ErrNotFound", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListAndCountAttachmentsInTx(t *testing.T) {
+	ctx := context.Background()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer tx.Rollback()
+
+	createdAt := time.Date(2026, 6, 7, 11, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, issue_id, hash_algorithm, content_hash, original_filename,
+		       mime_type, byte_size, storage_relpath, created_by, created_at
+		FROM attachments
+		WHERE issue_id = ?
+		ORDER BY created_at ASC, id ASC
+	`)).
+		WithArgs("bd-abc").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "issue_id", "hash_algorithm", "content_hash", "original_filename", "mime_type", "byte_size", "storage_relpath", "created_by", "created_at"}).
+			AddRow("att-1", "bd-abc", "sha256", "abc123", "body.md", "text/markdown", int64(1234), "attachments/bd-abc/abc123", "tester", createdAt))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM attachments WHERE issue_id = ?`)).
+		WithArgs("bd-abc").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
+
+	list, err := ListAttachmentsInTx(ctx, tx, "bd-abc")
+	if err != nil {
+		t.Fatalf("ListAttachmentsInTx: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != "att-1" || list[0].ByteSize != 1234 {
+		t.Fatalf("ListAttachmentsInTx = %+v, want att-1", list)
+	}
+	count, err := CountAttachmentsInTx(ctx, tx, "bd-abc")
+	if err != nil {
+		t.Fatalf("CountAttachmentsInTx: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("CountAttachmentsInTx = %d, want 1", count)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestResolveAttachmentInTx(t *testing.T) {
+	ctx := context.Background()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer tx.Rollback()
+
+	createdAt := time.Date(2026, 6, 7, 11, 0, 0, 0, time.UTC)
+	expectResolveQuery(mock, "bd-abc", "abc").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "issue_id", "hash_algorithm", "content_hash", "original_filename", "mime_type", "byte_size", "storage_relpath", "created_by", "created_at"}).
+			AddRow("att-1", "bd-abc", "sha256", "abc123", "body.md", "text/markdown", int64(1234), "attachments/bd-abc/abc123", "tester", createdAt))
+	expectResolveQuery(mock, "bd-abc", "body.md").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "issue_id", "hash_algorithm", "content_hash", "original_filename", "mime_type", "byte_size", "storage_relpath", "created_by", "created_at"}).
+			AddRow("att-1", "bd-abc", "sha256", "abc123", "body.md", "text/markdown", int64(1234), "attachments/bd-abc/abc123", "tester", createdAt).
+			AddRow("att-2", "bd-abc", "sha256", "def456", "body.md", "text/markdown", int64(4321), "attachments/bd-abc/def456", "tester", createdAt))
+
+	got, err := ResolveAttachmentInTx(ctx, tx, "bd-abc", "abc")
+	if err != nil {
+		t.Fatalf("ResolveAttachmentInTx: %v", err)
+	}
+	if got.ID != "att-1" {
+		t.Fatalf("ResolveAttachmentInTx ID = %q, want att-1", got.ID)
+	}
+	_, err = ResolveAttachmentInTx(ctx, tx, "bd-abc", "body.md")
+	if !errors.Is(err, storage.ErrAmbiguous) {
+		t.Fatalf("ResolveAttachmentInTx ambiguous error = %v, want ErrAmbiguous", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestRemoveAttachmentInTx(t *testing.T) {
+	ctx := context.Background()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer tx.Rollback()
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM attachments WHERE issue_id = ? AND id = ?`)).
+		WithArgs("bd-abc", "att-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM attachments WHERE issue_id = ? AND id = ?`)).
+		WithArgs("bd-abc", "missing").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	if err := RemoveAttachmentInTx(ctx, tx, "bd-abc", "att-1"); err != nil {
+		t.Fatalf("RemoveAttachmentInTx: %v", err)
+	}
+	err = RemoveAttachmentInTx(ctx, tx, "bd-abc", "missing")
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("RemoveAttachmentInTx error = %v, want ErrNotFound", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func expectResolveQuery(mock sqlmock.Sqlmock, issueID, selector string) *sqlmock.ExpectedQuery {
+	return mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, issue_id, hash_algorithm, content_hash, original_filename,
+		       mime_type, byte_size, storage_relpath, created_by, created_at
+		FROM attachments
+		WHERE issue_id = ?
+		  AND (id = ? OR content_hash LIKE ? OR original_filename = ?)
+		ORDER BY created_at ASC, id ASC
+	`)).
+		WithArgs(issueID, selector, selector+"%", selector)
+}

--- a/internal/storage/schema/migrations/0050_create_attachments.down.sql
+++ b/internal/storage/schema/migrations/0050_create_attachments.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS attachments;

--- a/internal/storage/schema/migrations/0050_create_attachments.up.sql
+++ b/internal/storage/schema/migrations/0050_create_attachments.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS attachments (
+    id CHAR(36) NOT NULL PRIMARY KEY DEFAULT (UUID()),
+    issue_id VARCHAR(255) NOT NULL,
+    hash_algorithm VARCHAR(32) NOT NULL,
+    content_hash VARCHAR(128) NOT NULL,
+    original_filename VARCHAR(1024) NOT NULL,
+    mime_type VARCHAR(255) NOT NULL,
+    byte_size BIGINT NOT NULL,
+    storage_relpath VARCHAR(2048) NOT NULL,
+    created_by VARCHAR(255) NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_attachments_issue (issue_id),
+    INDEX idx_attachments_issue_filename (issue_id, original_filename),
+    INDEX idx_attachments_hash (content_hash),
+    UNIQUE KEY uniq_attachments_issue_hash (issue_id, hash_algorithm, content_hash),
+    CONSTRAINT fk_attachments_issue FOREIGN KEY (issue_id) REFERENCES issues(id) ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -26,6 +26,9 @@ var ErrNotClaimable = errors.New("issue not claimable")
 // ErrNotFound is returned when a requested entity does not exist in the database.
 var ErrNotFound = errors.New("not found")
 
+// ErrAmbiguous is returned when a selector matches multiple entities.
+var ErrAmbiguous = errors.New("ambiguous selector")
+
 // ErrNotInitialized is returned when the database has not been initialized
 // (e.g., issue_prefix config is missing).
 var ErrNotInitialized = errors.New("database not initialized")
@@ -83,6 +86,12 @@ type Storage interface {
 	GetEvents(ctx context.Context, issueID string, limit int) ([]*types.Event, error)
 	GetAllEventsSince(ctx context.Context, since time.Time) ([]*types.Event, error)
 
+	// Attachments
+	AddAttachment(ctx context.Context, attachment *types.Attachment) (*types.Attachment, error)
+	ListAttachments(ctx context.Context, issueID string) ([]*types.Attachment, error)
+	ResolveAttachment(ctx context.Context, issueID, selector string) (*types.Attachment, error)
+	RemoveAttachment(ctx context.Context, issueID, attachmentID string) error
+
 	// Aggregate counts — cheaper than materializing rows when only cardinality is needed.
 	// Filter.Limit and Filter.Offset are ignored by CountIssues; all others apply.
 
@@ -97,6 +106,8 @@ type Storage interface {
 	CountDependencies(ctx context.Context, issueID string) (int64, error)
 	// CountIssueComments returns the number of comments on an issue.
 	CountIssueComments(ctx context.Context, issueID string) (int64, error)
+	// CountAttachments returns the number of file attachments on an issue.
+	CountAttachments(ctx context.Context, issueID string) (int64, error)
 	// CountEvents returns the number of audit events for an issue, capped at limit
 	// (or unbounded if limit == 0).
 	CountEvents(ctx context.Context, issueID string, limit int) (int64, error)
@@ -117,6 +128,8 @@ type Storage interface {
 	IterDependenciesWithMetadata(ctx context.Context, issueID string) (Iter[types.IssueWithDependencyMetadata], error)
 	// IterIssueComments streams comments on an issue, ordered by created_at.
 	IterIssueComments(ctx context.Context, issueID string) (Iter[types.Comment], error)
+	// IterAttachments streams file attachment metadata on an issue.
+	IterAttachments(ctx context.Context, issueID string) (Iter[types.Attachment], error)
 	// IterEvents streams the audit-trail events for an issue, ordered by
 	// created_at descending. limit==0 means unbounded.
 	IterEvents(ctx context.Context, issueID string, limit int) (Iter[types.Event], error)

--- a/internal/telemetry/storage.go
+++ b/internal/telemetry/storage.go
@@ -372,6 +372,42 @@ func (s *InstrumentedStorage) GetIssueComments(ctx context.Context, issueID stri
 	return v, err
 }
 
+func (s *InstrumentedStorage) AddAttachment(ctx context.Context, attachment *types.Attachment) (*types.Attachment, error) {
+	issueID := ""
+	if attachment != nil {
+		issueID = attachment.IssueID
+	}
+	attrs := []attribute.KeyValue{attribute.String("bd.issue.id", issueID)}
+	ctx, span, t := s.op(ctx, "AddAttachment", attrs...)
+	v, err := s.inner.AddAttachment(ctx, attachment)
+	s.done(ctx, span, t, err, attrs...)
+	return v, err
+}
+
+func (s *InstrumentedStorage) ListAttachments(ctx context.Context, issueID string) ([]*types.Attachment, error) {
+	attrs := []attribute.KeyValue{attribute.String("bd.issue.id", issueID)}
+	ctx, span, t := s.op(ctx, "ListAttachments", attrs...)
+	v, err := s.inner.ListAttachments(ctx, issueID)
+	s.done(ctx, span, t, err, attrs...)
+	return v, err
+}
+
+func (s *InstrumentedStorage) ResolveAttachment(ctx context.Context, issueID, selector string) (*types.Attachment, error) {
+	attrs := []attribute.KeyValue{attribute.String("bd.issue.id", issueID)}
+	ctx, span, t := s.op(ctx, "ResolveAttachment", attrs...)
+	v, err := s.inner.ResolveAttachment(ctx, issueID, selector)
+	s.done(ctx, span, t, err, attrs...)
+	return v, err
+}
+
+func (s *InstrumentedStorage) RemoveAttachment(ctx context.Context, issueID, attachmentID string) error {
+	attrs := []attribute.KeyValue{attribute.String("bd.issue.id", issueID)}
+	ctx, span, t := s.op(ctx, "RemoveAttachment", attrs...)
+	err := s.inner.RemoveAttachment(ctx, issueID, attachmentID)
+	s.done(ctx, span, t, err, attrs...)
+	return err
+}
+
 func (s *InstrumentedStorage) GetEvents(ctx context.Context, issueID string, limit int) ([]*types.Event, error) {
 	attrs := []attribute.KeyValue{attribute.String("bd.issue.id", issueID)}
 	ctx, span, t := s.op(ctx, "GetEvents", attrs...)
@@ -505,6 +541,14 @@ func (s *InstrumentedStorage) IterIssueComments(ctx context.Context, issueID str
 	return it, err
 }
 
+func (s *InstrumentedStorage) IterAttachments(ctx context.Context, issueID string) (storage.Iter[types.Attachment], error) {
+	attrs := []attribute.KeyValue{attribute.String("bd.issue.id", issueID)}
+	ctx, span, t := s.op(ctx, "IterAttachments", attrs...)
+	it, err := s.inner.IterAttachments(ctx, issueID)
+	s.done(ctx, span, t, err, attrs...)
+	return it, err
+}
+
 func (s *InstrumentedStorage) IterEvents(ctx context.Context, issueID string, limit int) (storage.Iter[types.Event], error) {
 	attrs := []attribute.KeyValue{attribute.String("bd.issue.id", issueID)}
 	ctx, span, t := s.op(ctx, "IterEvents", attrs...)
@@ -575,6 +619,13 @@ func (s *InstrumentedStorage) CountDependencies(ctx context.Context, issueID str
 func (s *InstrumentedStorage) CountIssueComments(ctx context.Context, issueID string) (int64, error) {
 	ctx, span, t := s.op(ctx, "CountIssueComments", attribute.String("issue.id", issueID))
 	v, err := s.inner.CountIssueComments(ctx, issueID)
+	s.done(ctx, span, t, err)
+	return v, err
+}
+
+func (s *InstrumentedStorage) CountAttachments(ctx context.Context, issueID string) (int64, error) {
+	ctx, span, t := s.op(ctx, "CountAttachments", attribute.String("issue.id", issueID))
+	v, err := s.inner.CountAttachments(ctx, issueID)
 	s.done(ctx, span, t, err)
 	return v, err
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -951,6 +951,24 @@ type Comment struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// Attachment describes a file associated with an issue.
+//
+// The bytes are stored outside this metadata row. StorageRelPath records the
+// path relative to the bead store root so filesystem code can locate the
+// object without coupling SQL storage to the byte-store implementation.
+type Attachment struct {
+	ID               string    `json:"id"`
+	IssueID          string    `json:"issue_id"`
+	HashAlgorithm    string    `json:"hash_algorithm"`
+	ContentHash      string    `json:"content_hash"`
+	OriginalFilename string    `json:"original_filename"`
+	MimeType         string    `json:"mime_type"`
+	ByteSize         int64     `json:"byte_size"`
+	StorageRelPath   string    `json:"storage_relpath"`
+	CreatedBy        string    `json:"created_by"`
+	CreatedAt        time.Time `json:"created_at"`
+}
+
 // UnmarshalJSON handles backward compatibility for Comment.
 // Pre-v1.0 exported Comment.ID as int64; current schema uses string.
 func (c *Comment) UnmarshalJSON(data []byte) error {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -757,6 +757,7 @@ type IssueDetails struct {
 	Dependencies []*IssueWithDependencyMetadata `json:"dependencies,omitempty"`
 	Dependents   []*IssueWithDependencyMetadata `json:"dependents,omitempty"`
 	Comments     []*Comment                     `json:"comments,omitempty"`
+	Attachments  []*Attachment                  `json:"attachments,omitempty"`
 	Parent       *string                        `json:"parent,omitempty"`
 
 	// Cardinality fields — emitted by default (count-only mode).
@@ -765,6 +766,7 @@ type IssueDetails struct {
 	DependentCount  *int64 `json:"dependent_count,omitempty"`
 	DependencyCount *int64 `json:"dependency_count,omitempty"`
 	CommentCount    *int64 `json:"comment_count,omitempty"`
+	AttachmentCount *int64 `json:"attachment_count,omitempty"`
 
 	// Epic progress fields (populated only for issue_type=epic with children)
 	EpicTotalChildren  *int  `json:"epic_total_children,omitempty"`

--- a/website/docs/cli-reference/attachment.md
+++ b/website/docs/cli-reference/attachment.md
@@ -1,0 +1,81 @@
+---
+id: attachment
+title: bd attachment
+slug: /cli-reference/attachment
+sidebar_position: 999
+---
+
+<!-- AUTO-GENERATED: do not edit manually -->
+Generated from `bd help --doc attachment`
+
+## bd attachment
+
+Manage issue file attachments
+
+```
+bd attachment
+```
+
+**Aliases:** attachments
+
+### bd attachment add
+
+Attach a file to an issue
+
+```
+bd attachment add [issue-id] [path]
+```
+
+### bd attachment copy
+
+Copy an attachment out to a file or directory
+
+```
+bd attachment copy [issue-id] [filename-or-hash] [target] [flags]
+```
+
+**Flags:**
+
+```
+  -f, --force   Overwrite the target file if it exists
+```
+
+### bd attachment fsck
+
+Find unreachable attachment files
+
+```
+bd attachment fsck
+```
+
+### bd attachment list
+
+List attachments for an issue
+
+```
+bd attachment list [issue-id]
+```
+
+### bd attachment prune
+
+Remove unreachable attachment files
+
+```
+bd attachment prune [flags]
+```
+
+**Flags:**
+
+```
+  -n, --dry-run   Show unreachable files without removing them
+```
+
+### bd attachment remove
+
+Remove an attachment from an issue
+
+```
+bd attachment remove [issue-id] [filename-or-hash]
+```
+
+**Aliases:** rm

--- a/website/docs/cli-reference/backup.md
+++ b/website/docs/cli-reference/backup.md
@@ -107,7 +107,9 @@ bd backup status
 Sync the current beads database to the configured Dolt backup destination.
 
 This pushes the entire database state (all branches, full history) to the
-backup location configured with 'bd backup init'.
+backup location configured with 'bd backup init'. Attachment metadata is part
+of the database, but attachment bytes under .beads/attachments are local files
+and need a separate filesystem backup.
 
 The backup is atomic — if the sync fails, the previous backup state is preserved.
 

--- a/website/docs/cli-reference/index.md
+++ b/website/docs/cli-reference/index.md
@@ -9,7 +9,7 @@ sidebar_position: 0
 <!-- AUTO-GENERATED: do not edit manually -->
 Reference for bd Latest. Generated from `bd help --list` and `bd help --doc <command>`.
 
-This reference covers all 106 live top-level `bd` commands. Regenerate it with:
+This reference covers all 107 live top-level `bd` commands. Regenerate it with:
 
 ```bash
 ./scripts/generate-cli-docs.sh
@@ -20,6 +20,7 @@ This reference covers all 106 live top-level `bd` commands. Regenerate it with:
 - [`bd admin`](./admin.md)
 - [`bd ado`](./ado.md)
 - [`bd assign`](./assign.md)
+- [`bd attachment`](./attachment.md)
 - [`bd audit`](./audit.md)
 - [`bd backup`](./backup.md)
 - [`bd batch`](./batch.md)

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -8,6 +8,12 @@
 
 <document path="docs/intro.md">
 
+---
+id: intro
+title: Introduction
+sidebar_position: 1
+slug: /
+---
 
 # Beads Documentation
 
@@ -96,6 +102,11 @@ The magic is automatic synchronization via Dolt's version-controlled database wi
 
 <document path="docs/getting-started/ide-setup.md">
 
+---
+id: ide-setup
+title: IDE Setup
+sidebar_position: 3
+---
 
 # IDE Setup for AI Agents
 
@@ -309,6 +320,11 @@ bd setup claude --check   # or cursor, aider
 
 <document path="docs/getting-started/installation.md">
 
+---
+id: installation
+title: Installation
+sidebar_position: 1
+---
 
 # Installing bd
 
@@ -584,6 +600,11 @@ After installation:
 
 <document path="docs/getting-started/quickstart.md">
 
+---
+id: quickstart
+title: Quick Start
+sidebar_position: 2
+---
 
 # Beads Quick Start
 
@@ -955,6 +976,11 @@ See the [repository README](https://github.com/gastownhall/beads/blob/main/READM
 
 <document path="docs/getting-started/upgrading.md">
 
+---
+id: upgrading
+title: Upgrading
+sidebar_position: 4
+---
 
 # Upgrading bd
 
@@ -1196,6 +1222,11 @@ bd dolt pull
 
 <document path="docs/core-concepts/index.md">
 
+---
+id: index
+title: Core Concepts
+sidebar_position: 1
+---
 
 # Core Concepts
 
@@ -1272,6 +1303,11 @@ Declarative workflow templates:
 
 <document path="docs/core-concepts/hash-ids.md">
 
+---
+id: hash-ids
+title: Hash-based IDs
+sidebar_position: 5
+---
 
 # Hash-based IDs
 
@@ -1401,6 +1437,11 @@ bd show bd-new --json | jq '.original_id'
 
 <document path="docs/core-concepts/issues.md">
 
+---
+id: issues
+title: Issues & Dependencies
+sidebar_position: 2
+---
 
 # Issues & Dependencies
 
@@ -1584,6 +1625,11 @@ bd list --status open --priority 1 --type bug --json
 
 <document path="docs/core-concepts/labels.md">
 
+---
+id: labels
+title: Labels
+slug: /core-concepts/labels
+---
 
 # Labels in Beads
 
@@ -2373,6 +2419,11 @@ bd doctor
 
 <document path="docs/core-concepts/metadata.md">
 
+---
+id: metadata
+title: Issue Metadata
+slug: /core-concepts/metadata
+---
 
 # Issue Metadata
 
@@ -2458,6 +2509,11 @@ Avoid these prefixes in user-defined keys to prevent conflicts with future Beads
 
 <document path="docs/core-concepts/sync-concepts.md">
 
+---
+id: sync-concepts
+title: Sync Concepts
+slug: /core-concepts/sync-concepts
+---
 
 # Sync Concepts
 
@@ -2531,6 +2587,11 @@ bd bootstrap
 
 <document path="docs/architecture/index.md">
 
+---
+sidebar_position: 1
+title: Architecture Overview
+description: Understanding Beads' three-layer data model
+---
 
 # Architecture Overview
 
@@ -2750,7 +2811,7 @@ For these use cases, consider GitHub Issues, Linear, or Jira.
 <!-- AUTO-GENERATED: do not edit manually -->
 Reference for bd Latest. Generated from `bd help --list` and `bd help --doc <command>`.
 
-This reference covers all 106 live top-level `bd` commands. Regenerate it with:
+This reference covers all 107 live top-level `bd` commands. Regenerate it with:
 
 ```bash
 ./scripts/generate-cli-docs.sh
@@ -2761,6 +2822,7 @@ This reference covers all 106 live top-level `bd` commands. Regenerate it with:
 - [`bd admin`](./admin.md)
 - [`bd ado`](./ado.md)
 - [`bd assign`](./assign.md)
+- [`bd attachment`](./attachment.md)
 - [`bd audit`](./audit.md)
 - [`bd backup`](./backup.md)
 - [`bd batch`](./batch.md)
@@ -3166,6 +3228,86 @@ bd assign <id> <name>
 
 </document>
 
+<document path="docs/cli-reference/attachment.md">
+
+
+<!-- AUTO-GENERATED: do not edit manually -->
+Generated from `bd help --doc attachment`
+
+## bd attachment
+
+Manage issue file attachments
+
+```
+bd attachment
+```
+
+**Aliases:** attachments
+
+### bd attachment add
+
+Attach a file to an issue
+
+```
+bd attachment add [issue-id] [path]
+```
+
+### bd attachment copy
+
+Copy an attachment out to a file or directory
+
+```
+bd attachment copy [issue-id] [filename-or-hash] [target] [flags]
+```
+
+**Flags:**
+
+```
+  -f, --force   Overwrite the target file if it exists
+```
+
+### bd attachment fsck
+
+Find unreachable attachment files
+
+```
+bd attachment fsck
+```
+
+### bd attachment list
+
+List attachments for an issue
+
+```
+bd attachment list [issue-id]
+```
+
+### bd attachment prune
+
+Remove unreachable attachment files
+
+```
+bd attachment prune [flags]
+```
+
+**Flags:**
+
+```
+  -n, --dry-run   Show unreachable files without removing them
+```
+
+### bd attachment remove
+
+Remove an attachment from an issue
+
+```
+bd attachment remove [issue-id] [filename-or-hash]
+```
+
+**Aliases:** rm
+
+</document>
+
 <document path="docs/cli-reference/audit.md">
 
 
@@ -3330,7 +3472,9 @@ bd backup status
 Sync the current beads database to the configured Dolt backup destination.
 
 This pushes the entire database state (all branches, full history) to the
-backup location configured with 'bd backup init'.
+backup location configured with 'bd backup init'. Attachment metadata is part
+of the database, but attachment bytes under .beads/attachments are local files
+and need a separate filesystem backup.
 
 The backup is atomic — if the sync fails, the previous backup state is preserved.
 
@@ -10138,6 +10282,11 @@ bd worktree remove <name> [flags]
 
 <document path="docs/workflows/index.md">
 
+---
+id: index
+title: Workflows
+sidebar_position: 1
+---
 
 # Workflows
 
@@ -10232,6 +10381,11 @@ bd close release-1.0.0.1
 
 <document path="docs/workflows/formulas.md">
 
+---
+id: formulas
+title: Formulas
+sidebar_position: 3
+---
 
 # Formulas
 
@@ -10484,6 +10638,11 @@ type = "human"
 
 <document path="docs/workflows/gates.md">
 
+---
+id: gates
+title: Gates
+sidebar_position: 4
+---
 
 # Gates
 
@@ -10700,6 +10859,11 @@ waits_for = ["test-a", "test-b"]  # Fan-in: waits for all
 
 <document path="docs/workflows/molecules.md">
 
+---
+id: molecules
+title: Molecules
+sidebar_position: 2
+---
 
 # Molecules
 
@@ -10866,6 +11030,11 @@ bd ready  # Shows next steps
 
 <document path="docs/workflows/wisps.md">
 
+---
+id: wisps
+title: Wisps
+sidebar_position: 5
+---
 
 # Wisps
 
@@ -10995,6 +11164,11 @@ bd wisp cleanup --completed  # Remove only completed
 
 <document path="docs/multi-agent/index.md">
 
+---
+id: index
+title: Multi-Agent
+sidebar_position: 1
+---
 
 # Multi-Agent Coordination
 
@@ -11067,6 +11241,11 @@ bd dep add bd-42 external:other-repo/bd-100
 
 <document path="docs/multi-agent/coordination.md">
 
+---
+id: coordination
+title: Agent Coordination
+sidebar_position: 3
+---
 
 # Agent Coordination
 
@@ -11224,6 +11403,11 @@ bd list --label-any needs-review
 
 <document path="docs/multi-agent/routing.md">
 
+---
+id: routing
+title: Routing
+sidebar_position: 2
+---
 
 # Multi-Repo Routing
 
@@ -11340,6 +11524,11 @@ bd hydrate --from backend-repo
 
 <document path="docs/integrations/index.md">
 
+---
+id: index
+title: Integrations
+slug: /integrations
+---
 
 # Integrations
 
@@ -11382,6 +11571,11 @@ These integrations use the Beads MCP server rather than a dedicated `bd setup` r
 
 <document path="docs/integrations/aider.md">
 
+---
+id: aider
+title: Aider
+sidebar_position: 3
+---
 
 # Aider Integration
 
@@ -11498,6 +11692,11 @@ bd doctor
 
 <document path="docs/integrations/claude-code.md">
 
+---
+id: claude-code
+title: Claude Code
+sidebar_position: 1
+---
 
 # Claude Code Integration
 
@@ -11683,6 +11882,11 @@ bd init --quiet
 
 <document path="docs/integrations/codex.md">
 
+---
+id: codex
+title: Codex
+sidebar_position: 2
+---
 
 # Codex Integration
 
@@ -11710,6 +11914,10 @@ The Beads Codex plugin stores hooks at `plugins/beads/.codex-plugin/hooks/hooks.
 
 <document path="docs/integrations/cody.md">
 
+---
+id: cody
+title: Sourcegraph Cody
+---
 
 # Sourcegraph Cody Integration
 
@@ -11732,6 +11940,10 @@ bd setup cody --remove
 
 <document path="docs/integrations/cursor.md">
 
+---
+id: cursor
+title: Cursor
+---
 
 # Cursor Integration
 
@@ -11754,6 +11966,10 @@ bd setup cursor --remove
 
 <document path="docs/integrations/factory.md">
 
+---
+id: factory
+title: Factory.ai Droid
+---
 
 # Factory.ai Droid Integration
 
@@ -11776,6 +11992,10 @@ bd setup factory --remove
 
 <document path="docs/integrations/gemini.md">
 
+---
+id: gemini
+title: Gemini CLI
+---
 
 # Gemini CLI Integration
 
@@ -11814,6 +12034,11 @@ bd setup gemini --project --remove
 
 <document path="docs/integrations/github-copilot.md">
 
+---
+id: github-copilot
+title: GitHub Copilot
+sidebar_position: 4
+---
 
 # GitHub Copilot Integration
 
@@ -11959,6 +12184,11 @@ Git hooks are optional. They refresh exports and legacy fallback checks, while i
 
 <document path="docs/integrations/junie.md">
 
+---
+id: junie
+title: Junie
+sidebar_position: 4
+---
 
 # Junie Integration
 
@@ -12178,6 +12408,10 @@ This removes:
 
 <document path="docs/integrations/kilocode.md">
 
+---
+id: kilocode
+title: Kilo Code
+---
 
 # Kilo Code Integration
 
@@ -12200,6 +12434,11 @@ bd setup kilocode --remove
 
 <document path="docs/integrations/mcp-server.md">
 
+---
+id: mcp-server
+title: MCP Server
+sidebar_position: 2
+---
 
 # MCP Server
 
@@ -12386,6 +12625,10 @@ bd init --quiet
 
 <document path="docs/integrations/mux.md">
 
+---
+id: mux
+title: Mux
+---
 
 # Mux Integration
 
@@ -12428,6 +12671,10 @@ bd setup mux --global --remove
 
 <document path="docs/integrations/opencode.md">
 
+---
+id: opencode
+title: OpenCode
+---
 
 # OpenCode Integration
 
@@ -12450,6 +12697,10 @@ bd setup opencode --remove
 
 <document path="docs/integrations/windsurf.md">
 
+---
+id: windsurf
+title: Windsurf
+---
 
 # Windsurf Integration
 
@@ -12472,6 +12723,11 @@ bd setup windsurf --remove
 
 <document path="docs/community-tools.md">
 
+---
+id: community-tools
+title: Community Tools
+slug: /community-tools
+---
 
 # Beads Community Tools
 
@@ -12596,6 +12852,11 @@ Found or built a tool? Open a PR to add it to this list or comment on discussion
 
 <document path="docs/recovery/index.md">
 
+---
+sidebar_position: 1
+title: Recovery Overview
+description: Diagnose and resolve common Beads issues
+---
 
 # Recovery Overview
 
@@ -12641,6 +12902,11 @@ If these runbooks don't resolve your issue:
 
 <document path="docs/recovery/circular-dependencies.md">
 
+---
+sidebar_position: 4
+title: Circular Dependencies
+description: Detect and break dependency cycles
+---
 
 # Circular Dependencies Recovery
 
@@ -12703,6 +12969,11 @@ bd ready
 
 <document path="docs/recovery/database-corruption.md">
 
+---
+sidebar_position: 2
+title: Database Corruption
+description: Recover from Dolt database corruption
+---
 
 # Database Corruption Recovery
 
@@ -12768,6 +13039,11 @@ dolt sql-server
 
 <document path="docs/recovery/merge-conflicts.md">
 
+---
+sidebar_position: 3
+title: Merge Conflicts
+description: Resolve Dolt merge conflicts
+---
 
 # Merge Conflicts Recovery
 
@@ -12825,6 +13101,11 @@ bd dolt push
 
 <document path="docs/recovery/sync-failures.md">
 
+---
+sidebar_position: 5
+title: Sync Failures
+description: Recover from Dolt sync failures
+---
 
 # Sync Failures Recovery
 
@@ -12903,6 +13184,11 @@ bd doctor
 
 <document path="docs/recovery/uninstalling.md">
 
+---
+id: uninstalling
+title: Uninstalling
+slug: /recovery/uninstalling
+---
 
 # Uninstalling Beads
 
@@ -13035,6 +13321,11 @@ bd init
 
 <document path="docs/reference/advanced.md">
 
+---
+id: advanced
+title: Advanced Features
+sidebar_position: 3
+---
 
 # Advanced Features
 
@@ -13217,6 +13508,11 @@ bd list
 
 <document path="docs/reference/antivirus.md">
 
+---
+id: antivirus
+title: Antivirus False Positives
+slug: /reference/antivirus
+---
 
 # Antivirus False Positives
 
@@ -13428,6 +13724,11 @@ This helps us track and address false positives across different antivirus vendo
 
 <document path="docs/reference/configuration.md">
 
+---
+id: configuration
+title: Configuration
+sidebar_position: 1
+---
 
 # Configuration
 
@@ -13706,6 +14007,11 @@ bd info --json | jq '.config' # Quick snapshot
 
 <document path="docs/reference/faq.md">
 
+---
+id: faq
+title: FAQ
+sidebar_position: 5
+---
 
 # Frequently Asked Questions
 
@@ -13864,6 +14170,11 @@ bd hooks status
 
 <document path="docs/reference/git-integration.md">
 
+---
+id: git-integration
+title: Git Integration
+sidebar_position: 2
+---
 
 # Git Integration
 
@@ -13985,6 +14296,11 @@ bd duplicates --auto-merge
 
 <document path="docs/reference/troubleshooting.md">
 
+---
+id: troubleshooting
+title: Troubleshooting
+sidebar_position: 4
+---
 
 # Troubleshooting
 

--- a/website/versioned_docs/version-1.0.0/cli-reference/attachment.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/attachment.md
@@ -1,0 +1,81 @@
+---
+id: attachment
+title: bd attachment
+slug: /cli-reference/attachment
+sidebar_position: 999
+---
+
+<!-- AUTO-GENERATED: do not edit manually -->
+Generated from `bd help --doc attachment`
+
+## bd attachment
+
+Manage issue file attachments
+
+```
+bd attachment
+```
+
+**Aliases:** attachments
+
+### bd attachment add
+
+Attach a file to an issue
+
+```
+bd attachment add [issue-id] [path]
+```
+
+### bd attachment copy
+
+Copy an attachment out to a file or directory
+
+```
+bd attachment copy [issue-id] [filename-or-hash] [target] [flags]
+```
+
+**Flags:**
+
+```
+  -f, --force   Overwrite the target file if it exists
+```
+
+### bd attachment fsck
+
+Find unreachable attachment files
+
+```
+bd attachment fsck
+```
+
+### bd attachment list
+
+List attachments for an issue
+
+```
+bd attachment list [issue-id]
+```
+
+### bd attachment prune
+
+Remove unreachable attachment files
+
+```
+bd attachment prune [flags]
+```
+
+**Flags:**
+
+```
+  -n, --dry-run   Show unreachable files without removing them
+```
+
+### bd attachment remove
+
+Remove an attachment from an issue
+
+```
+bd attachment remove [issue-id] [filename-or-hash]
+```
+
+**Aliases:** rm

--- a/website/versioned_docs/version-1.0.0/cli-reference/backup.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/backup.md
@@ -107,7 +107,9 @@ bd backup status
 Sync the current beads database to the configured Dolt backup destination.
 
 This pushes the entire database state (all branches, full history) to the
-backup location configured with 'bd backup init'.
+backup location configured with 'bd backup init'. Attachment metadata is part
+of the database, but attachment bytes under .beads/attachments are local files
+and need a separate filesystem backup.
 
 The backup is atomic — if the sync fails, the previous backup state is preserved.
 

--- a/website/versioned_docs/version-1.0.0/cli-reference/index.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/index.md
@@ -9,7 +9,7 @@ sidebar_position: 0
 <!-- AUTO-GENERATED: do not edit manually -->
 Reference for bd v1.0.0. Generated from `bd help --list` and `bd help --doc <command>`.
 
-This reference covers all 106 live top-level `bd` commands. Regenerate it with:
+This reference covers all 107 live top-level `bd` commands. Regenerate it with:
 
 ```bash
 ./scripts/generate-cli-docs.sh
@@ -20,6 +20,7 @@ This reference covers all 106 live top-level `bd` commands. Regenerate it with:
 - [`bd admin`](./admin.md)
 - [`bd ado`](./ado.md)
 - [`bd assign`](./assign.md)
+- [`bd attachment`](./attachment.md)
 - [`bd audit`](./audit.md)
 - [`bd backup`](./backup.md)
 - [`bd batch`](./batch.md)

--- a/website/versioned_docs/version-1.0.4/cli-reference/attachment.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/attachment.md
@@ -1,0 +1,81 @@
+---
+id: attachment
+title: bd attachment
+slug: /cli-reference/attachment
+sidebar_position: 999
+---
+
+<!-- AUTO-GENERATED: do not edit manually -->
+Generated from `bd help --doc attachment`
+
+## bd attachment
+
+Manage issue file attachments
+
+```
+bd attachment
+```
+
+**Aliases:** attachments
+
+### bd attachment add
+
+Attach a file to an issue
+
+```
+bd attachment add [issue-id] [path]
+```
+
+### bd attachment copy
+
+Copy an attachment out to a file or directory
+
+```
+bd attachment copy [issue-id] [filename-or-hash] [target] [flags]
+```
+
+**Flags:**
+
+```
+  -f, --force   Overwrite the target file if it exists
+```
+
+### bd attachment fsck
+
+Find unreachable attachment files
+
+```
+bd attachment fsck
+```
+
+### bd attachment list
+
+List attachments for an issue
+
+```
+bd attachment list [issue-id]
+```
+
+### bd attachment prune
+
+Remove unreachable attachment files
+
+```
+bd attachment prune [flags]
+```
+
+**Flags:**
+
+```
+  -n, --dry-run   Show unreachable files without removing them
+```
+
+### bd attachment remove
+
+Remove an attachment from an issue
+
+```
+bd attachment remove [issue-id] [filename-or-hash]
+```
+
+**Aliases:** rm

--- a/website/versioned_docs/version-1.0.4/cli-reference/backup.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/backup.md
@@ -107,7 +107,9 @@ bd backup status
 Sync the current beads database to the configured Dolt backup destination.
 
 This pushes the entire database state (all branches, full history) to the
-backup location configured with 'bd backup init'.
+backup location configured with 'bd backup init'. Attachment metadata is part
+of the database, but attachment bytes under .beads/attachments are local files
+and need a separate filesystem backup.
 
 The backup is atomic — if the sync fails, the previous backup state is preserved.
 

--- a/website/versioned_docs/version-1.0.4/cli-reference/index.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/index.md
@@ -9,7 +9,7 @@ sidebar_position: 0
 <!-- AUTO-GENERATED: do not edit manually -->
 Reference for bd v1.0.4. Generated from `bd help --list` and `bd help --doc <command>`.
 
-This reference covers all 106 live top-level `bd` commands. Regenerate it with:
+This reference covers all 107 live top-level `bd` commands. Regenerate it with:
 
 ```bash
 ./scripts/generate-cli-docs.sh
@@ -20,6 +20,7 @@ This reference covers all 106 live top-level `bd` commands. Regenerate it with:
 - [`bd admin`](./admin.md)
 - [`bd ado`](./ado.md)
 - [`bd assign`](./assign.md)
+- [`bd attachment`](./attachment.md)
 - [`bd audit`](./audit.md)
 - [`bd backup`](./backup.md)
 - [`bd batch`](./batch.md)

--- a/website/versioned_docs/version-1.0.5/cli-reference/attachment.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/attachment.md
@@ -1,0 +1,81 @@
+---
+id: attachment
+title: bd attachment
+slug: /cli-reference/attachment
+sidebar_position: 999
+---
+
+<!-- AUTO-GENERATED: do not edit manually -->
+Generated from `bd help --doc attachment`
+
+## bd attachment
+
+Manage issue file attachments
+
+```
+bd attachment
+```
+
+**Aliases:** attachments
+
+### bd attachment add
+
+Attach a file to an issue
+
+```
+bd attachment add [issue-id] [path]
+```
+
+### bd attachment copy
+
+Copy an attachment out to a file or directory
+
+```
+bd attachment copy [issue-id] [filename-or-hash] [target] [flags]
+```
+
+**Flags:**
+
+```
+  -f, --force   Overwrite the target file if it exists
+```
+
+### bd attachment fsck
+
+Find unreachable attachment files
+
+```
+bd attachment fsck
+```
+
+### bd attachment list
+
+List attachments for an issue
+
+```
+bd attachment list [issue-id]
+```
+
+### bd attachment prune
+
+Remove unreachable attachment files
+
+```
+bd attachment prune [flags]
+```
+
+**Flags:**
+
+```
+  -n, --dry-run   Show unreachable files without removing them
+```
+
+### bd attachment remove
+
+Remove an attachment from an issue
+
+```
+bd attachment remove [issue-id] [filename-or-hash]
+```
+
+**Aliases:** rm

--- a/website/versioned_docs/version-1.0.5/cli-reference/backup.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/backup.md
@@ -107,7 +107,9 @@ bd backup status
 Sync the current beads database to the configured Dolt backup destination.
 
 This pushes the entire database state (all branches, full history) to the
-backup location configured with 'bd backup init'.
+backup location configured with 'bd backup init'. Attachment metadata is part
+of the database, but attachment bytes under .beads/attachments are local files
+and need a separate filesystem backup.
 
 The backup is atomic — if the sync fails, the previous backup state is preserved.
 

--- a/website/versioned_docs/version-1.0.5/cli-reference/index.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/index.md
@@ -9,7 +9,7 @@ sidebar_position: 0
 <!-- AUTO-GENERATED: do not edit manually -->
 Reference for bd v1.0.5. Generated from `bd help --list` and `bd help --doc <command>`.
 
-This reference covers all 106 live top-level `bd` commands. Regenerate it with:
+This reference covers all 107 live top-level `bd` commands. Regenerate it with:
 
 ```bash
 ./scripts/generate-cli-docs.sh
@@ -20,6 +20,7 @@ This reference covers all 106 live top-level `bd` commands. Regenerate it with:
 - [`bd admin`](./admin.md)
 - [`bd ado`](./ado.md)
 - [`bd assign`](./assign.md)
+- [`bd attachment`](./attachment.md)
 - [`bd audit`](./audit.md)
 - [`bd backup`](./backup.md)
 - [`bd batch`](./batch.md)


### PR DESCRIPTION
## What

Adding minimum-viable support for handling file attachements for beads.

## Why

Users usually want to attach files to beads that are useful for reproducing bugs and errors or provide additional context for a featuture or task.

## Verification

Tested the functionality, but review & feedback would be nice.

## Not in scope

Support for file attachement sync for Jira/Linear is not implemented yet.