### PR TITLE
fix: commit config-table writes in server mode + truthful explicit commits (GH#4078)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Server-mode config writes commit again — `bd dolt pull` no longer needs a
+  manual flush.** `bd remember`, `bd forget`, and `bd config set|unset|set-many`
+  in server mode left the `config` table dirty forever: `maybeAutoCommit` skips
+  SQL-server modes entirely, and generic `Commit()` excludes config
+  ([#2455](https://github.com/gastownhall/beads/issues/2455)), so the next
+  `bd dolt pull` failed with `cannot merge with uncommitted changes` until the
+  operator ran raw `DOLT_ADD('config')`/`DOLT_COMMIT` SQL. Config writes now
+  commit immediately via the new scoped `CommitConfigOnly` (stages ONLY the
+  config table — concurrent operations' dirty tables are never swept),
+  restoring the v1.0.1 behavior from
+  [#3052](https://github.com/gastownhall/beads/pull/3052)
+  ([#4078](https://github.com/gastownhall/beads/issues/4078)).
+- **`bd dolt commit` and `bd vc commit` are truthful and include config.** On a
+  config-only working set both commands printed success (`Committed.` /
+  `Created commit <hash>` — the hash being the unchanged HEAD) while committing
+  nothing. Explicit commits are intentional flush points: they now include the
+  config table and honestly report `Nothing to commit` when the working set is
+  clean ([#4078](https://github.com/gastownhall/beads/issues/4078)).
 - **Cross-clone issue-delete vs child-row-insert merges now converge.** The
   synced child tables (`dependencies`, `labels`, `comments`, `events`,
   snapshots) carry `FOREIGN KEY ... ON DELETE CASCADE` to `issues` (migrations

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -208,6 +208,10 @@ var configSetCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		commandDidWrite.Store(true)
+		if err := commitConfigWrite(ctx, store, "config set"); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 
 		if jsonOutput {
 			outputJSON(map[string]string{
@@ -479,6 +483,10 @@ var configUnsetCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		commandDidWrite.Store(true)
+		if err := commitConfigWrite(ctx, store, "config unset"); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 
 		if jsonOutput {
 			outputJSON(map[string]string{
@@ -743,6 +751,11 @@ Examples:
 				}
 			}
 			commandDidWrite.Store(true)
+			// One scoped commit for the whole batch, not one per key.
+			if err := commitConfigWrite(ctx, store, "config set-many"); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
 		}
 
 		// Phase 7: Output results

--- a/cmd/bd/config_commit_write_test.go
+++ b/cmd/bd/config_commit_write_test.go
@@ -1,0 +1,114 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+type fakeConfigCommitStore struct {
+	storage.DoltStorage
+	configOnlyCalls int
+	messages        []string
+	err             error
+}
+
+func (f *fakeConfigCommitStore) CommitConfigOnly(_ context.Context, message string) error {
+	f.configOnlyCalls++
+	f.messages = append(f.messages, message)
+	return f.err
+}
+
+// GH#4078: server-mode config writes (bd remember, bd config set) must be
+// committed immediately and scoped — maybeAutoCommit skips server mode
+// entirely and generic Commit() excludes config, so nothing else ever
+// commits them.
+func TestCommitConfigWriteServerModeCommitsScoped(t *testing.T) {
+	saveStorageMode(t)
+	serverMode = true
+
+	fake := &fakeConfigCommitStore{}
+	if err := commitConfigWrite(context.Background(), fake, "remember"); err != nil {
+		t.Fatalf("commitConfigWrite: %v", err)
+	}
+	if fake.configOnlyCalls != 1 {
+		t.Fatalf("CommitConfigOnly calls = %d, want 1 in server mode", fake.configOnlyCalls)
+	}
+	if !strings.HasPrefix(fake.messages[0], "bd: remember (auto-commit) by ") {
+		t.Fatalf("commit message = %q, want prefix %q", fake.messages[0], "bd: remember (auto-commit) by ")
+	}
+}
+
+func TestCommitConfigWriteProxiedServerModeCommitsScoped(t *testing.T) {
+	saveStorageMode(t)
+	proxiedServerMode = true
+
+	fake := &fakeConfigCommitStore{}
+	if err := commitConfigWrite(context.Background(), fake, "config set"); err != nil {
+		t.Fatalf("commitConfigWrite: %v", err)
+	}
+	if fake.configOnlyCalls != 1 {
+		t.Fatalf("CommitConfigOnly calls = %d, want 1 in proxied server mode", fake.configOnlyCalls)
+	}
+}
+
+// Embedded mode already commits config via the '-Am' auto-commit and the
+// unflagged-writes sweep — the helper must not double-commit there.
+func TestCommitConfigWriteEmbeddedModeIsNoOp(t *testing.T) {
+	saveStorageMode(t)
+	serverMode = false
+	proxiedServerMode = false
+
+	fake := &fakeConfigCommitStore{}
+	if err := commitConfigWrite(context.Background(), fake, "remember"); err != nil {
+		t.Fatalf("commitConfigWrite: %v", err)
+	}
+	if fake.configOnlyCalls != 0 {
+		t.Fatalf("CommitConfigOnly calls = %d, want 0 in embedded mode", fake.configOnlyCalls)
+	}
+}
+
+// A real commit failure must surface — silently losing the commit is the
+// exact bug class this helper exists to fix (GH#4078's silent no-op half).
+func TestCommitConfigWriteSurfacesCommitError(t *testing.T) {
+	saveStorageMode(t)
+	serverMode = true
+
+	fake := &fakeConfigCommitStore{err: errors.New("connection refused")}
+	err := commitConfigWrite(context.Background(), fake, "remember")
+	if err == nil {
+		t.Fatal("commitConfigWrite returned nil, want the commit error surfaced")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("error = %q, want it to wrap %q", err.Error(), "connection refused")
+	}
+}
+
+// "Nothing to commit" is a benign race (e.g. the same key re-written to an
+// identical value) and must not fail the user's write.
+func TestCommitConfigWriteSwallowsNothingToCommit(t *testing.T) {
+	saveStorageMode(t)
+	serverMode = true
+
+	fake := &fakeConfigCommitStore{err: errors.New("nothing to commit")}
+	if err := commitConfigWrite(context.Background(), fake, "remember"); err != nil {
+		t.Fatalf("commitConfigWrite: %v, want nothing-to-commit swallowed", err)
+	}
+	if fake.configOnlyCalls != 1 {
+		t.Fatalf("CommitConfigOnly calls = %d, want 1", fake.configOnlyCalls)
+	}
+}
+
+func TestCommitConfigWriteNilStoreIsNoOp(t *testing.T) {
+	saveStorageMode(t)
+	serverMode = true
+
+	if err := commitConfigWrite(context.Background(), nil, "remember"); err != nil {
+		t.Fatalf("commitConfigWrite with nil store: %v, want no-op", err)
+	}
+}

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -473,16 +473,16 @@ For more options (--stdin, custom messages), see: bd vc commit`,
 			os.Exit(1)
 		}
 		msg, _ := cmd.Flags().GetString("message")
-		if msg == "" {
-			msg = fmt.Sprintf("bd: dolt commit (auto-commit) by %s", getActor())
-		}
-		if err := st.Commit(ctx, msg); err != nil {
-			if isDoltNothingToCommit(err) {
-				fmt.Println("Nothing to commit.")
-				return
-			}
+		// GH#4078: explicit commits include config and report truthfully.
+		// Without -m, CommitPending builds a descriptive summary message.
+		committed, err := explicitDoltCommit(ctx, st, msg)
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
+		}
+		if !committed {
+			fmt.Println("Nothing to commit.")
+			return
 		}
 		commandDidExplicitDoltCommit = true
 		fmt.Println("Committed.")

--- a/cmd/bd/dolt_autocommit.go
+++ b/cmd/bd/dolt_autocommit.go
@@ -83,6 +83,31 @@ func commitPendingIfEmbedded(ctx context.Context, st storage.DoltStorage, actor 
 	return maybeAutoCommitStore(ctx, st, p)
 }
 
+// commitConfigWrite commits the config table immediately after an
+// intentional config write (bd remember/forget, bd config set/unset).
+// Server modes only: maybeAutoCommit skips SQL-server modes entirely, and
+// generic Commit() excludes config (GH#2455) — so without this the write
+// strands the working set dirty and the next 'bd dolt pull' fails until a
+// manual flush (GH#4078). The commit is SCOPED to the config table, so a
+// concurrent operation's dirty tables are never swept. Embedded mode is a
+// no-op: its '-Am' auto-commit and the unflagged-writes sweep already
+// include config. Runs regardless of dolt.auto-commit mode — leaving the
+// config write uncommitted is the bug, not a batching feature (this
+// restores the v1.0.1 behavior from PR #3052).
+func commitConfigWrite(ctx context.Context, st storage.DoltStorage, command string) error {
+	if isEmbeddedMode() || st == nil {
+		return nil
+	}
+	if lm, ok := storage.UnwrapStore(st).(storage.LifecycleManager); ok && lm.IsClosed() {
+		return nil
+	}
+	msg := formatDoltAutoCommitMessage(command, getActor(), nil)
+	if err := st.CommitConfigOnly(ctx, msg); err != nil && !isDoltNothingToCommit(err) {
+		return fmt.Errorf("committing config write: %w", err)
+	}
+	return nil
+}
+
 func maybeAutoCommitStore(ctx context.Context, st storage.DoltStorage, p doltAutoCommitParams) error {
 	mode, err := getDoltAutoCommitMode()
 	if err != nil {

--- a/cmd/bd/explicit_commit.go
+++ b/cmd/bd/explicit_commit.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// explicitDoltCommit performs an intentional, user-initiated commit — the
+// shared logic behind 'bd dolt commit' and 'bd vc commit'.
+//
+// Explicit commits are flush points and include the config table, the same
+// rationale CommitPending documents for GH#2455. The old path called
+// Commit(), which excludes config and returns nil early on a config-only
+// working set — both commands then printed success while committing
+// nothing, and the next 'bd dolt pull' failed on the still-dirty config
+// table (GH#4078).
+//
+// Returns whether a commit was actually created so callers can report
+// truthfully ("Committed." vs "Nothing to commit").
+func explicitDoltCommit(ctx context.Context, st storage.DoltStorage, message string) (bool, error) {
+	// No custom message: CommitPending already does exactly this job —
+	// config-inclusive (CommitWithConfig), truthful committed bool, and a
+	// descriptive summary message built from the working set.
+	if strings.TrimSpace(message) == "" {
+		return st.CommitPending(ctx, getActor())
+	}
+
+	// Custom message: check for committable changes first so a clean
+	// working set reports "nothing to commit" instead of a fake success.
+	// Same optional-capability assertion as workingSetHasUnflaggedWrites.
+	if checker, ok := storage.UnwrapStore(st).(interface {
+		HasPendingChanges(ctx context.Context) (bool, error)
+	}); ok {
+		pending, err := checker.HasPendingChanges(ctx)
+		if err != nil {
+			return false, fmt.Errorf("checking pending changes: %w", err)
+		}
+		if !pending {
+			return false, nil
+		}
+	}
+
+	if err := st.CommitWithConfig(ctx, message); err != nil {
+		// Embedded CommitWithConfig surfaces dolt's raw "nothing to
+		// commit" error (the server store swallows it) — either way it is
+		// the truthful not-committed outcome, not a failure.
+		if isDoltNothingToCommit(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/cmd/bd/explicit_commit_test.go
+++ b/cmd/bd/explicit_commit_test.go
@@ -1,0 +1,134 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+type fakeExplicitCommitStore struct {
+	storage.DoltStorage
+	pending           bool
+	pendingErr        error
+	withConfigCalls   int
+	withConfigMessage string
+	withConfigErr     error
+	pendingCalls      int
+	pendingCommitted  bool
+	pendingCommitErr  error
+}
+
+func (f *fakeExplicitCommitStore) HasPendingChanges(_ context.Context) (bool, error) {
+	return f.pending, f.pendingErr
+}
+
+func (f *fakeExplicitCommitStore) CommitWithConfig(_ context.Context, message string) error {
+	f.withConfigCalls++
+	f.withConfigMessage = message
+	return f.withConfigErr
+}
+
+func (f *fakeExplicitCommitStore) CommitPending(_ context.Context, _ string) (bool, error) {
+	f.pendingCalls++
+	return f.pendingCommitted, f.pendingCommitErr
+}
+
+// GH#4078: explicit user commits (bd dolt commit / bd vc commit) are
+// intentional flush points — they must include the config table and report
+// truthfully. The old path called Commit(), which excludes config and
+// returns nil early on a config-only working set, printing success while
+// committing nothing.
+
+func TestExplicitCommitNoMessageUsesCommitPending(t *testing.T) {
+	fake := &fakeExplicitCommitStore{pendingCommitted: true}
+
+	committed, err := explicitDoltCommit(context.Background(), fake, "")
+	if err != nil {
+		t.Fatalf("explicitDoltCommit: %v", err)
+	}
+	if !committed {
+		t.Fatal("committed = false, want true from CommitPending")
+	}
+	if fake.pendingCalls != 1 {
+		t.Fatalf("CommitPending calls = %d, want 1", fake.pendingCalls)
+	}
+	if fake.withConfigCalls != 0 {
+		t.Fatalf("CommitWithConfig calls = %d, want 0 on the no-message path", fake.withConfigCalls)
+	}
+}
+
+func TestExplicitCommitWithMessageCommitsConfigInclusive(t *testing.T) {
+	fake := &fakeExplicitCommitStore{pending: true}
+
+	committed, err := explicitDoltCommit(context.Background(), fake, "checkpoint: my message")
+	if err != nil {
+		t.Fatalf("explicitDoltCommit: %v", err)
+	}
+	if !committed {
+		t.Fatal("committed = false, want true when changes are pending")
+	}
+	if fake.withConfigCalls != 1 {
+		t.Fatalf("CommitWithConfig calls = %d, want 1", fake.withConfigCalls)
+	}
+	if fake.withConfigMessage != "checkpoint: my message" {
+		t.Fatalf("commit message = %q, want the user's message verbatim", fake.withConfigMessage)
+	}
+}
+
+// The truthfulness half: a clean working set must report committed=false
+// (the command prints "Nothing to commit"), never a fake success.
+func TestExplicitCommitWithMessageNothingPendingIsTruthful(t *testing.T) {
+	fake := &fakeExplicitCommitStore{pending: false}
+
+	committed, err := explicitDoltCommit(context.Background(), fake, "checkpoint: my message")
+	if err != nil {
+		t.Fatalf("explicitDoltCommit: %v", err)
+	}
+	if committed {
+		t.Fatal("committed = true with nothing pending — the GH#4078 silent-success lie")
+	}
+	if fake.withConfigCalls != 0 {
+		t.Fatalf("CommitWithConfig calls = %d, want 0 with nothing pending", fake.withConfigCalls)
+	}
+}
+
+// Embedded CommitWithConfig surfaces dolt's raw "nothing to commit" error
+// (it does not swallow it like the server store) — treat it as the
+// truthful not-committed outcome, not a failure.
+func TestExplicitCommitNothingToCommitRaceReportsNotCommitted(t *testing.T) {
+	fake := &fakeExplicitCommitStore{pending: true, withConfigErr: errors.New("nothing to commit")}
+
+	committed, err := explicitDoltCommit(context.Background(), fake, "checkpoint: my message")
+	if err != nil {
+		t.Fatalf("explicitDoltCommit: %v, want nothing-to-commit treated as not-committed", err)
+	}
+	if committed {
+		t.Fatal("committed = true on a nothing-to-commit result")
+	}
+}
+
+func TestExplicitCommitSurfacesCommitError(t *testing.T) {
+	fake := &fakeExplicitCommitStore{pending: true, withConfigErr: errors.New("connection refused")}
+
+	committed, err := explicitDoltCommit(context.Background(), fake, "checkpoint: my message")
+	if err == nil || !strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("err = %v, want the commit error surfaced", err)
+	}
+	if committed {
+		t.Fatal("committed = true on a failed commit")
+	}
+}
+
+func TestExplicitCommitSurfacesPendingCheckError(t *testing.T) {
+	fake := &fakeExplicitCommitStore{pendingErr: errors.New("dolt_status query failed")}
+
+	_, err := explicitDoltCommit(context.Background(), fake, "checkpoint: my message")
+	if err == nil || !strings.Contains(err.Error(), "dolt_status query failed") {
+		t.Fatalf("err = %v, want the pending-check error surfaced", err)
+	}
+}

--- a/cmd/bd/memory.go
+++ b/cmd/bd/memory.go
@@ -92,6 +92,9 @@ Examples:
 			FatalErrorRespectJSON("storing memory: %v", err)
 		}
 		commandDidWrite.Store(true)
+		if err := commitConfigWrite(ctx, store, "remember"); err != nil {
+			FatalErrorRespectJSON("%v", err)
+		}
 
 		if jsonOutput {
 			outputJSON(map[string]string{
@@ -232,6 +235,9 @@ Examples:
 			FatalErrorRespectJSON("forgetting memory: %v", err)
 		}
 		commandDidWrite.Store(true)
+		if err := commitConfigWrite(ctx, store, "forget"); err != nil {
+			FatalErrorRespectJSON("%v", err)
+		}
 
 		if jsonOutput {
 			outputJSON(map[string]string{

--- a/cmd/bd/vc.go
+++ b/cmd/bd/vc.go
@@ -153,16 +153,20 @@ Examples:
 
 		// We are explicitly creating a Dolt commit; avoid redundant auto-commit in PersistentPostRun.
 		commandDidExplicitDoltCommit = true
-		if err := store.Commit(ctx, vcCommitMessage); err != nil {
-			if isDoltNothingToCommit(err) {
-				if jsonOutput {
-					outputJSON(map[string]interface{}{"committed": false, "message": "nothing to commit"})
-				} else {
-					fmt.Println("Nothing to commit")
-				}
-				return
-			}
+		// GH#4078: include config and report truthfully — the old Commit()
+		// path silently no-opped on config-only working sets while still
+		// printing "Created commit".
+		committed, err := explicitDoltCommit(ctx, store, vcCommitMessage)
+		if err != nil {
 			FatalErrorRespectJSON("failed to commit: %v", err)
+		}
+		if !committed {
+			if jsonOutput {
+				outputJSON(map[string]interface{}{"committed": false, "message": "nothing to commit"})
+			} else {
+				fmt.Println("Nothing to commit")
+			}
+			return
 		}
 
 		// Get the new commit hash

--- a/internal/storage/dolt/commit_config_test.go
+++ b/internal/storage/dolt/commit_config_test.go
@@ -1,0 +1,156 @@
+package dolt
+
+import (
+	"testing"
+)
+
+// dirtyTables returns the set of table names currently in dolt_status.
+func dirtyTables(t *testing.T, store *DoltStore) map[string]bool {
+	t.Helper()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	rows, err := store.db.QueryContext(ctx, "SELECT table_name FROM dolt_status")
+	if err != nil {
+		t.Fatalf("query dolt_status: %v", err)
+	}
+	defer rows.Close()
+
+	tables := make(map[string]bool)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan dolt_status: %v", err)
+		}
+		tables[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate dolt_status: %v", err)
+	}
+	return tables
+}
+
+// GH#4078: a config-only working set must be committable. Generic Commit()
+// excludes config by design (GH#2455), so intentional config writes
+// (bd remember, bd config set) need a scoped commit that stages ONLY the
+// config table and creates a real Dolt commit.
+func TestCommitConfigCommitsConfigOnlyWorkingSet(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Start from a clean working set so the only dirty table is config.
+	if err := store.CommitWithConfig(ctx, "test: baseline"); err != nil {
+		t.Fatalf("baseline commit: %v", err)
+	}
+	before, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("get baseline commit: %v", err)
+	}
+
+	if err := store.SetConfig(ctx, "test_gh4078_marker", "config-only write"); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	if !dirtyTables(t, store)["config"] {
+		t.Fatal("precondition failed: SetConfig did not leave config dirty")
+	}
+
+	if err := store.CommitConfigOnly(ctx, "test: scoped config commit"); err != nil {
+		t.Fatalf("CommitConfigOnly: %v", err)
+	}
+
+	after, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("get commit after CommitConfigOnly: %v", err)
+	}
+	if after == before {
+		t.Fatalf("CommitConfigOnly created no commit: HEAD still %s", before)
+	}
+	if dirtyTables(t, store)["config"] {
+		t.Fatal("config table still dirty after CommitConfigOnly")
+	}
+}
+
+// GH#2455 must survive GH#4078: the scoped commit stages ONLY config.
+// Dirty rows in other tables (e.g. a concurrent operation's half-written
+// issue) must remain in the working set, not get swept into the commit.
+func TestCommitConfigDoesNotSweepOtherDirtyTables(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.CommitWithConfig(ctx, "test: baseline"); err != nil {
+		t.Fatalf("baseline commit: %v", err)
+	}
+
+	// Dirty the issues table directly, bypassing any commit machinery —
+	// simulates a concurrent operation's uncommitted write.
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type)"+
+			" VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		"testdb-gh4078", "concurrent dirty row", "", "", "", "", "open", 2, "task"); err != nil {
+		t.Fatalf("dirty issues table: %v", err)
+	}
+	if err := store.SetConfig(ctx, "test_gh4078_scoped", "scoped"); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	pre := dirtyTables(t, store)
+	if !pre["config"] || !pre["issues"] {
+		t.Fatalf("precondition failed: want config+issues dirty, got %v", pre)
+	}
+
+	if err := store.CommitConfigOnly(ctx, "test: scoped config commit"); err != nil {
+		t.Fatalf("CommitConfigOnly: %v", err)
+	}
+
+	post := dirtyTables(t, store)
+	if post["config"] {
+		t.Fatal("config table still dirty after CommitConfigOnly")
+	}
+	if !post["issues"] {
+		t.Fatal("CommitConfigOnly swept the dirty issues table — GH#2455 regression")
+	}
+}
+
+// Pin the GH#2455 contract that motivates CommitConfigOnly's existence: the
+// generic Commit() must keep EXCLUDING config. If this ever changes, the
+// scoped-commit call sites should be revisited.
+func TestCommitExcludesConfigOnlyWorkingSet(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.CommitWithConfig(ctx, "test: baseline"); err != nil {
+		t.Fatalf("baseline commit: %v", err)
+	}
+	before, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("get baseline commit: %v", err)
+	}
+
+	if err := store.SetConfig(ctx, "test_gh2455_excluded", "stays dirty"); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	if err := store.Commit(ctx, "test: generic commit must skip config"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	after, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("get commit after Commit: %v", err)
+	}
+	if after != before {
+		t.Fatal("generic Commit() committed a config-only working set — GH#2455 regression")
+	}
+	if !dirtyTables(t, store)["config"] {
+		t.Fatal("config table no longer dirty after generic Commit()")
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1793,6 +1793,15 @@ func (s *DoltStore) CommitWithConfig(ctx context.Context, message string) error 
 	return nil
 }
 
+// CommitConfigOnly commits ONLY the config table (GH#4078). Use after
+// intentional config writes (bd remember, bd config set) in server mode,
+// where generic Commit() excludes config (GH#2455) and nothing else ever
+// commits it. Scoped staging means a concurrent operation's dirty tables
+// are never swept — the same guarantee that motivated GH#2455.
+func (s *DoltStore) CommitConfigOnly(ctx context.Context, message string) error {
+	return s.doltAddAndCommit(ctx, []string{"config"}, message)
+}
+
 // doltAddAndCommit stages the specified tables and commits on a pinned
 // connection. This prevents DOLT_COMMIT('-Am') from sweeping up stale
 // working set changes from concurrent operations (GH#2455).

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -113,6 +113,15 @@ func (s *EmbeddedDoltStore) CommitWithConfig(ctx context.Context, message string
 	return s.Commit(ctx, message)
 }
 
+// CommitConfigOnly commits the config table (GH#4078). Embedded mode is
+// single-process, so the '-Am' Commit cannot sweep a concurrent operation's
+// working set — the scoped-staging concern that exists in server mode
+// (GH#2455) does not apply here, and this aliases Commit for the same
+// reason CommitWithConfig does.
+func (s *EmbeddedDoltStore) CommitConfigOnly(ctx context.Context, message string) error {
+	return s.Commit(ctx, message)
+}
+
 func (s *EmbeddedDoltStore) AddRemote(ctx context.Context, name, url string) error {
 	return s.withMutatingDBConn(ctx, func(db versioncontrolops.DBConn) error {
 		_, err := db.ExecContext(ctx, "CALL DOLT_REMOTE('add', ?, ?)", name, url)

--- a/internal/storage/version_control.go
+++ b/internal/storage/version_control.go
@@ -38,6 +38,13 @@ type VersionControl interface {
 	// Use after intentional config writes (bd init, bd config set, bd rename-prefix).
 	// GH#3216: bootstrap paths must use this to commit issue_prefix.
 	CommitWithConfig(ctx context.Context, message string) error
+	// CommitConfigOnly commits ONLY the config table — the scoped commit for
+	// intentional config writes (bd remember, bd config set) in server mode.
+	// Unlike CommitWithConfig ('-Am'), it never stages other tables, so a
+	// concurrent operation's dirty working set is not swept (GH#2455).
+	// GH#4078: without this, server-mode config writes strand the working
+	// set dirty — generic Commit() excludes config and silently no-ops.
+	CommitConfigOnly(ctx context.Context, message string) error
 	CommitPending(ctx context.Context, actor string) (bool, error)
 	CommitExists(ctx context.Context, commitHash string) (bool, error)
 	GetCurrentCommit(ctx context.Context) (string, error)


### PR DESCRIPTION
> **Updated 2026-06-13:** rebased onto current `main` and narrowed. Two things this PR originally bundled are now resolved upstream by #4389, so they've been dropped and this PR is purely the #4078 config-commit fix:
> - the **routed-sibling read-only fix** — #4389's `routed.go` change fixes the same `store is read-only` bug;
> - the **CLI doc regeneration** — #4389 regenerated the docs, so the doc-flags jobs are green on `main` (companion PR #4385 closed as superseded).
>
> CI now runs against today's green `main`.

## What

Makes server-mode config-table writes actually commit, and makes the explicit
commit commands (`bd dolt commit` / `bd vc commit`) config-inclusive and
truthful.

## Why

Fixes #4078. In server mode, `bd remember` / `bd forget` /
`bd config set|unset|set-many` strand the working set dirty forever:
`maybeAutoCommit` skips SQL-server modes entirely, and generic `Commit()`
excludes `config` by design (#2455) — so the explicit flush commands silently
no-op on a config-only working set while still printing success. Every
subsequent `bd dolt pull` fails with `cannot merge with uncommitted changes`
until the operator runs raw `DOLT_ADD('config')`/`DOLT_COMMIT` SQL (we hit
this daily on a shared-server deployment).

Approach is per the claim comment on #4078 (option (b), modernized to current
`main`):

1. **`CommitConfigOnly`** (new `VersionControl` method): stages ONLY the
   config table via the existing `doltAddAndCommit` helper. Unlike
   `CommitWithConfig` (`-Am`), it cannot sweep a concurrent operation's dirty
   tables — the same guarantee that motivated #2455. Embedded aliases
   `Commit` for the same reason its `CommitWithConfig` does.
2. **Config writes commit immediately in server mode** (`commitConfigWrite`
   helper wired into the five write sites; `set-many` commits once per
   batch). Embedded mode is untouched — its `-Am` auto-commit and the
   unflagged-writes sweep already cover config. This restores the v1.0.1
   behavior from #3052 that the unified-PostRun refactor regressed.
3. **Truthful explicit commits**: `bd dolt commit` / `bd vc commit` share
   `explicitDoltCommit` — config-inclusive (`CommitPending` /
   `HasPendingChanges`+`CommitWithConfig`) and honest about
   `Nothing to commit` vs `Committed.` (previously `bd vc commit` printed
   `Created commit <hash>` where the hash was the unchanged HEAD).
   `--json` keeps its exact `{committed, hash, message}` shape.

`Commit()`'s #2455 config exclusion is intentionally unchanged — its ~60
callers keep their semantics.

## Verification

- New tests: 3 storage tests against a real `dolt-sql-server` container
  (scoped commit lands; concurrent dirty `issues` row survives — #2455
  pinned; generic `Commit()` exclusion pinned), 6 unit tests for
  `commitConfigWrite` (server/proxied/embedded modes, error surfacing,
  nothing-to-commit), 6 for `explicitDoltCommit` (truthfulness matrix).
- Full embedded group (memory, config, dep/link + direct-commit head
  invariants, VC, dolt) passes against current `main`.
- Live end-to-end on a disposable `dolthub/dolt-sql-server:2.1.0` container
  with a `file://` remote: `bd remember` → `dolt_status` clean → `bd dolt
  pull` → `Pull complete.` with zero manual SQL; truthful-output matrix for
  both explicit commit commands verified against `dolt_status`/`dolt_log`
  after each step.
- `go build` (default tags + `gms_pure_go` + `CGO_ENABLED=0`), `go vet`, and
  `./scripts/test.sh` clean.

Possible follow-ups (not in this PR, one issue per PR):

- `migrate.go` and `rename_prefix.go` have `SetConfig` sites with the same
  stranded-config shape.
- The v49→v51 `events` rekey migration panics with
  `invalid hash length: 19` on a database carrying 0.62-era event rows
  (clean databases migrate fine) — can file separately with the repro.
- macOS dev nit: `TestExpandPath/tilde_only` fails under `scripts/test.sh`
  because `test-env.sh` builds `HOME` from `$TMPDIR`, which carries a
  trailing slash on macOS. Passes bare; Linux CI unaffected.

---

## 📍 PR series map

Coordinated series from the same contributor fixing the config-commit bug
family and (next) proposing a centralized mode-policy architecture. Each item
is independently reviewable.

| # | PR / item | What | Status |
|---|-----------|------|--------|
| — | #4389 (merged) | `count --include-infra`; also regenerated the CLI docs and fixed routed-sibling writes + the bulk `--no-cycle-check` test | **merged** — resolved the doc-staleness and routed-sibling pieces this series originally carried |
| — | #4385 | standalone CLI doc regeneration | **closed** — superseded by #4389 |
| 1 | **this PR (#4383)** | GH#4078 config-commit core — server-mode config commits + truthful explicit commits | ready; CI green against current `main` |
| 2 | *(planned)* | RFC + Phase 1–5: centralize deployment-mode policy so the bug family becomes structurally impossible (each phase small, independently shippable, stacked on this PR) | after this PR, in phase order |

*"Stacked on" is a CI/merge-order relationship only — the diffs don't overlap.*
