### PR TITLE
fix(mol): route bond operand resolution like show/update/close (closes #4714)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,7 +242,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   message before any mutation is attempted. Two operands that live in the same
   routed rig share one store handle and bond normally; only a bond whose
   operands resolve to genuinely different databases is rejected rather than
-  written to the wrong one. Same routing-parity fix as
+  written to the wrong one. As part of this change, maintainer/default
+  auto-routed stores now open writable for any validated write-intent resolver
+  (`bd update`/`bd close` target resolution included, not just `mol bond`);
+  contributor auto-routes remain read-only and mutation-forbidden. Same
+  routing-parity fix as
   [#3608](https://github.com/gastownhall/beads/issues/3608) for `bd close`.
   Fixes [#4714](https://github.com/gastownhall/beads/issues/4714).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,9 +236,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   against the local store only, so `gt sling <bead> <rig>` — which cooks the
   default formula and bonds it to a rig-routed bead — died at `bd mol bond` even
   though `bd show <bead>` resolved the same ID. Resolution is write-intent: a
-  prefix-routed target opens writable and the bond commits where the bead lives.
-  A bond whose two operands resolve to different stores is rejected rather than
-  written to the wrong database. Same routing-parity fix as
+  prefix-routed target opens writable and the bond commits where the bead lives,
+  while a bond pinned to the contributor auto-routed store — which always opens
+  read-only because it hydrates a foreign project — fails fast with a clear
+  message before any mutation is attempted. Two operands that live in the same
+  routed rig share one store handle and bond normally; only a bond whose
+  operands resolve to genuinely different databases is rejected rather than
+  written to the wrong one. Same routing-parity fix as
   [#3608](https://github.com/gastownhall/beads/issues/3608) for `bd close`.
   Fixes [#4714](https://github.com/gastownhall/beads/issues/4714).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   emphasis (`**bold**`, `*italic*`), `SELECT * FROM t`, code spans and fenced
   blocks all render exactly as before.
 
+- **`bd mol bond <A> <B>` ignored prefix routing** — operand resolution now uses
+  the same routing fallback as `bd show`/`bd update`/`bd close`, so a bead that
+  lives in a routed store (a prefix-routed rig via `routes.jsonl`, or the
+  contributor planning store) resolves instead of failing with `'<id>' not found
+  as issue or formula`. Previously `bd mol bond` resolved operands
+  against the local store only, so `gt sling <bead> <rig>` — which cooks the
+  default formula and bonds it to a rig-routed bead — died at `bd mol bond` even
+  though `bd show <bead>` resolved the same ID. Resolution is write-intent: a
+  prefix-routed target opens writable and the bond commits where the bead lives.
+  A bond whose two operands resolve to different stores is rejected rather than
+  written to the wrong database. Same routing-parity fix as
+  [#3608](https://github.com/gastownhall/beads/issues/3608) for `bd close`.
+  Fixes [#4714](https://github.com/gastownhall/beads/issues/4714).
+
 ### Documentation
 
 - **The heartbeat/re-home invariant and the two states it can strand are now

--- a/cmd/bd/mol_bond.go
+++ b/cmd/bd/mol_bond.go
@@ -12,7 +12,6 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
-	"github.com/steveyegge/beads/internal/utils"
 )
 
 var molBondCmd = &cobra.Command{
@@ -110,11 +109,11 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 	}
 
 	if in.dryRun {
-		issueA, formulaA, err := resolveOrDescribe(ctx, store, in.argA, in.vars)
+		issueA, formulaA, err := resolveOrDescribeWithRouting(ctx, store, in.argA, in.vars)
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
 		}
-		issueB, formulaB, err := resolveOrDescribe(ctx, store, in.argB, in.vars)
+		issueB, formulaB, err := resolveOrDescribeWithRouting(ctx, store, in.argB, in.vars)
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
 		}
@@ -122,38 +121,56 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	subgraphA, cookedA, err := resolveOrCookToSubgraph(ctx, store, in.argA, in.vars)
+	opA, err := resolveMolBondOperand(ctx, store, in.argA, in.vars)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
-	subgraphB, cookedB, err := resolveOrCookToSubgraph(ctx, store, in.argB, in.vars)
+	defer opA.Close()
+	opB, err := resolveMolBondOperand(ctx, store, in.argB, in.vars)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	defer opB.Close()
+
+	// The bond mutation runs against the store that owns the operands. When an
+	// operand was resolved via routing (e.g. a prefix-routed rig bead), that is
+	// the routed store, not the local one — otherwise the bond would write to
+	// the wrong database or fail on a cross-store reference (mirrors #3609).
+	activeStore, err := pickBondStore(store, opA, opB)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
 
+	// No cleanup needed - in-memory subgraphs don't pollute the DB
+	subgraphA, cookedA := opA.subgraph, opA.cooked
+	subgraphB, cookedB := opB.subgraph, opB.cooked
 	issueA := subgraphA.Root
 	issueB := subgraphB.Root
 	aIsProto := issueA.IsTemplate || cookedA
 	bIsProto := issueB.IsTemplate || cookedB
 
+	// Dispatch based on operand types
+	// All operations use activeStore; phase flags determine ephemeral vs persistent.
 	var result *BondResult
 	switch {
 	case aIsProto && bIsProto:
-		result, err = bondProtoProto(ctx, store, issueA, issueB, in.bondType, in.customTitle, actor)
+		// Compound protos are templates - always persistent
+		// Note: Proto+proto bonding from formulas is a DB operation, not in-memory
+		result, err = bondProtoProto(ctx, activeStore, issueA, issueB, in.bondType, in.customTitle, actor)
 	case aIsProto && !bIsProto:
 		if cookedA {
-			result, err = bondProtoMolWithSubgraph(ctx, store, subgraphA, issueA, issueB, in.bondType, in.vars, in.childRef, actor, in.ephemeral, in.pour)
+			result, err = bondProtoMolWithSubgraph(ctx, activeStore, subgraphA, issueA, issueB, in.bondType, in.vars, in.childRef, actor, in.ephemeral, in.pour)
 		} else {
-			result, err = bondProtoMol(ctx, store, issueA, issueB, in.bondType, in.vars, in.childRef, actor, in.ephemeral, in.pour)
+			result, err = bondProtoMol(ctx, activeStore, issueA, issueB, in.bondType, in.vars, in.childRef, actor, in.ephemeral, in.pour)
 		}
 	case !aIsProto && bIsProto:
 		if cookedB {
-			result, err = bondProtoMolWithSubgraph(ctx, store, subgraphB, issueB, issueA, in.bondType, in.vars, in.childRef, actor, in.ephemeral, in.pour)
+			result, err = bondProtoMolWithSubgraph(ctx, activeStore, subgraphB, issueB, issueA, in.bondType, in.vars, in.childRef, actor, in.ephemeral, in.pour)
 		} else {
-			result, err = bondMolProto(ctx, store, issueA, issueB, in.bondType, in.vars, in.childRef, actor, in.ephemeral, in.pour)
+			result, err = bondMolProto(ctx, activeStore, issueA, issueB, in.bondType, in.vars, in.childRef, actor, in.ephemeral, in.pour)
 		}
 	default:
-		result, err = bondMolMol(ctx, store, issueA, issueB, in.bondType, actor)
+		result, err = bondMolMol(ctx, activeStore, issueA, issueB, in.bondType, actor)
 	}
 	if err != nil {
 		return HandleErrorRespectJSON("bonding: %v", err)
@@ -604,11 +621,155 @@ func minPriority(a, b int) int {
 	return b
 }
 
+// molBondOperand is a resolved mol-bond operand together with the store that
+// owns it. For an existing issue, store is whichever store resolution found the
+// issue in (local or routed) and cooked is false. For a formula cooked inline,
+// store is nil (the cooked protos are in-memory until the bond writes them) and
+// cooked is true.
+type molBondOperand struct {
+	subgraph *TemplateSubgraph
+	cooked   bool                // cooked inline from a formula (no owning store yet)
+	store    storage.DoltStorage // store that owns the issue; nil for cooked formulas
+	routed   bool                // issue was found via routing, not the local store
+	closeFn  func()              // releases any routed store handle
+}
+
+// Close releases any routed store handle held by the operand. Safe on nil.
+func (o *molBondOperand) Close() {
+	if o != nil && o.closeFn != nil {
+		o.closeFn()
+	}
+}
+
+// operandFromIssue wraps a resolved issue as a molBondOperand, loading the full
+// proto subgraph when the issue is a proto and wrapping a plain molecule as a
+// single-issue subgraph otherwise.
+func operandFromIssue(ctx context.Context, s storage.DoltStorage, issue *types.Issue, routed bool, closeFn func()) (*molBondOperand, error) {
+	if isProto(issue) {
+		subgraph, err := loadTemplateSubgraph(ctx, s, issue.ID)
+		if err != nil {
+			if closeFn != nil {
+				closeFn()
+			}
+			return nil, fmt.Errorf("loading proto subgraph '%s': %w", issue.ID, err)
+		}
+		return &molBondOperand{subgraph: subgraph, store: s, routed: routed, closeFn: closeFn}, nil
+	}
+	return &molBondOperand{
+		subgraph: &TemplateSubgraph{
+			Root:     issue,
+			Issues:   []*types.Issue{issue},
+			IssueMap: map[string]*types.Issue{issue.ID: issue},
+		},
+		store:   s,
+		routed:  routed,
+		closeFn: closeFn,
+	}, nil
+}
+
+// resolveMolBondOperand resolves a single mol-bond operand as an existing issue
+// or, failing that, an inline formula.
+//
+// Issue resolution uses the same routing fallback as bd show/update/close
+// (local store, then prefix-routed rig via routes.jsonl, then contributor
+// auto-routing) so an operand that lives only in a routed store resolves
+// instead of failing with "not found". Resolution is write-intent: a
+// prefix-routed target opens writable so the bond commits where the issue
+// lives, mirroring the bd close fix in #3608/#3609. The returned operand
+// carries the owning store; the caller runs the bond mutation against it and
+// must call Close() to release any routed handle.
+//
+// The vars parameter is used for step condition filtering (bd-7zka.1).
+// Formulas are cooked to in-memory subgraphs (gt-4v1eo, no DB storage).
+func resolveMolBondOperand(ctx context.Context, localStore storage.DoltStorage, operand string, vars map[string]string) (*molBondOperand, error) {
+	rr, err := resolveAndGetIssueForMutation(ctx, localStore, operand)
+	if err == nil {
+		return operandFromIssue(ctx, rr.Store, rr.Issue, rr.Routed, rr.Close)
+	}
+	if !isNotFoundErr(err) {
+		return nil, err
+	}
+
+	// Not found as issue in any store — fall through to the formula registry.
+	// resolveAndCookFormulaWithVars lets parser.LoadByName decide (it returns
+	// "formula %q not found in search paths" for genuinely unknown names, which
+	// is the right error). This matches the resolution behavior of
+	// bd formula show / bd mol seed / bd mol pour / bd cook (#3874).
+	subgraph, cookErr := resolveAndCookFormulaWithVars(operand, nil, vars)
+	if cookErr != nil {
+		return nil, fmt.Errorf("'%s' not found as issue or formula: %w", operand, cookErr)
+	}
+	return &molBondOperand{subgraph: subgraph, cooked: true}, nil
+}
+
+// pickBondStore returns the store the bond mutation must run against.
+//
+// Cooked-formula operands are in-memory and store-agnostic, so they impose no
+// constraint. Each existing-issue operand pins the bond to the store that owns
+// it. When both operands are existing issues owned by different stores the bond
+// is a cross-store operation with no well-defined home, so it is rejected rather
+// than silently written to the wrong database. When nothing pins a store (both
+// operands are cooked formulas) the bond stays on the local store.
+func pickBondStore(localStore storage.DoltStorage, a, b *molBondOperand) (storage.DoltStorage, error) {
+	active := localStore
+	pinned := false
+	for _, op := range []*molBondOperand{a, b} {
+		if op.cooked || op.store == nil {
+			continue
+		}
+		if !pinned {
+			active = op.store
+			pinned = true
+			continue
+		}
+		if op.store != active {
+			return nil, fmt.Errorf("cannot bond operands that live in different stores/rigs; run the bond from the rig that owns them")
+		}
+	}
+	return active, nil
+}
+
+// resolveOrDescribeWithRouting checks if an operand is an issue or formula
+// without cooking. It is the embedded/server-store dry-run resolver; the
+// proxied-server path retains resolveOrDescribe over its transaction reader.
+//
+// Issue resolution uses the read-only routing fallback (local, then prefix-routed
+// rig, then contributor auto-routing) so a dry run previews routed operands the
+// same way the real bond resolves them.
+func resolveOrDescribeWithRouting(ctx context.Context, localStore storage.DoltStorage, operand string, vars map[string]string) (*types.Issue, string, error) {
+	rr, err := resolveAndGetIssueWithRouting(ctx, localStore, operand)
+	if err == nil {
+		issue := rr.Issue
+		rr.Close()
+		return issue, "", nil
+	}
+	if !isNotFoundErr(err) {
+		return nil, "", err
+	}
+
+	// Not found as issue — fall through to the formula registry. parser.LoadByName
+	// returns "formula %q not found in search paths" for genuinely unknown names,
+	// which is the right error. This matches the resolution behavior of
+	// bd formula show / bd mol seed / bd mol pour / bd cook.
+	parser := formula.NewParser()
+	f, err := parser.LoadByName(operand)
+	if err != nil {
+		return nil, "", fmt.Errorf("'%s' not found as issue or formula: %w", operand, err)
+	}
+
+	// A dry-run must fail the same way the real bond would: an enum/pattern/
+	// provided-empty violation in --var values fails resolveOrCookToSubgraph,
+	// so reporting "will be cooked" here would be a false preview.
+	if err := formula.ValidateProvidedVars(f, vars); err != nil {
+		return nil, "", err
+	}
+
+	return nil, f.Formula, nil
+}
+
 // resolveOrDescribe checks if an operand is an issue or formula without cooking.
-// Used for dry-run mode. Returns (issue, formulaName, error).
-// If it's an issue, issue is set. If it's a formula, formulaName is set.
+// Used by proxied-server dry-run mode. Returns (issue, formulaName, error).
 func resolveOrDescribe(ctx context.Context, s molReader, operand string, vars map[string]string) (*types.Issue, string, error) {
-	// First, try to resolve as an existing issue
 	id, err := utils.ResolvePartialID(ctx, s, operand)
 	if err == nil {
 		issue, err := s.GetIssue(ctx, id)
@@ -617,10 +778,6 @@ func resolveOrDescribe(ctx context.Context, s molReader, operand string, vars ma
 		}
 	}
 
-	// Not found as issue — fall through to the formula registry. parser.LoadByName
-	// returns "formula %q not found in search paths" for genuinely unknown names,
-	// which is the right error. This matches the resolution behavior of
-	// bd formula show / bd mol seed / bd mol pour / bd cook.
 	parser := formula.NewParser()
 	f, err := parser.LoadByName(operand)
 	if err != nil {

--- a/cmd/bd/mol_bond.go
+++ b/cmd/bd/mol_bond.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/formula"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/utils"
 )
 
 var molBondCmd = &cobra.Command{
@@ -108,36 +110,60 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 		return HandleErrorRespectJSON("no database connection")
 	}
 
+	discA, err := discoverMolBondOperand(ctx, store, in.argA)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	defer discA.Close()
+	discB, err := discoverMolBondOperand(ctx, store, in.argB)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	defer discB.Close()
+
+	targetID, targetStoreKey, err := validateMolBondHomes(store, discA, discB)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+
+	// Dry-run uses the exact same read-only discovery and store-policy
+	// validation as execution. It stops before writable reopen or formula cook.
 	if in.dryRun {
-		issueA, formulaA, err := resolveOrDescribeWithRouting(ctx, store, in.argA, in.vars)
-		if err != nil {
-			return HandleErrorRespectJSON("%v", err)
-		}
-		issueB, formulaB, err := resolveOrDescribeWithRouting(ctx, store, in.argB, in.vars)
-		if err != nil {
-			return HandleErrorRespectJSON("%v", err)
-		}
-		renderMolBondDryRun(in, issueA, formulaA, issueB, formulaB)
+		renderMolBondDryRun(in, discA.issue, discA.formula, discB.issue, discB.formula)
 		return nil
 	}
 
-	ops, cleanup, err := resolveMolBondOperands(ctx, store, [2]string{in.argA, in.argB}, in.vars)
+	// Close foreign read handles before opening the one accepted target home
+	// writable. Rejected cross-store bonds therefore never writable-open a
+	// foreign rig (and cannot trigger its open-time migrations).
+	discA.Close()
+	discB.Close()
+
+	activeStore := store
+	closeActiveStore := func() {}
+	if targetID != "" && targetStoreKey != dependencyStoreKey(store) {
+		rr, routeErr := resolveAndGetIssueForMutation(ctx, store, targetID)
+		if routeErr != nil {
+			return HandleErrorRespectJSON("%v", routeErr)
+		}
+		if routeErr := verifyMolBondWritableHome(rr, targetStoreKey); routeErr != nil {
+			rr.Close()
+			return HandleErrorRespectJSON("%v", routeErr)
+		}
+		activeStore = wireStorageDecorators(rr.Store, hookRunner, config.GetBool("no-hooks"))
+		closeActiveStore = rr.Close
+	}
+	defer closeActiveStore()
+
+	opA, err := materializeMolBondOperand(ctx, activeStore, discA, in.vars)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
-	defer cleanup()
-	opA, opB := ops[0], ops[1]
-
-	// The bond mutation runs against the store that owns the operands. When an
-	// operand was resolved via routing (e.g. a prefix-routed rig bead), that is
-	// the routed store, not the local one — otherwise the bond would write to
-	// the wrong database or fail on a cross-store reference (mirrors #3609).
-	activeStore, err := pickBondStore(store, opA, opB)
+	opB, err := materializeMolBondOperand(ctx, activeStore, discB, in.vars)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
 
-	// No cleanup needed - in-memory subgraphs don't pollute the DB
 	subgraphA, cookedA := opA.subgraph, opA.cooked
 	subgraphB, cookedB := opB.subgraph, opB.cooked
 	issueA := subgraphA.Root
@@ -617,30 +643,136 @@ func minPriority(a, b int) int {
 	return b
 }
 
-// molBondOperand is a resolved mol-bond operand together with the store that
-// owns it. For an existing issue, store is whichever store resolution found the
-// issue in (local or routed) and cooked is false. For a formula cooked inline,
-// store is nil (the cooked protos are in-memory until the bond writes them) and
-// cooked is true. Routed store handles are owned by the cleanup function
-// returned from resolveMolBondOperands, not by the operand.
 type molBondOperand struct {
 	subgraph *TemplateSubgraph
-	cooked   bool                // cooked inline from a formula (no owning store yet)
-	store    storage.DoltStorage // store that owns the issue; nil for cooked formulas
-	routed   bool                // issue was found via routing, not the local store
-	writable bool                // false only for contributor auto-routed stores, which open read-only
+	cooked   bool
 }
 
-// operandFromIssue wraps a resolved issue as a molBondOperand, loading the full
-// proto subgraph when the issue is a proto and wrapping a plain molecule as a
-// single-issue subgraph otherwise.
-func operandFromIssue(ctx context.Context, s storage.DoltStorage, issue *types.Issue, routed, writable bool) (*molBondOperand, error) {
+// molBondDiscovery is the read-only phase of operand resolution. Existing
+// issues retain their logical store home; formulas remain storeless.
+type molBondDiscovery struct {
+	operand           string
+	issue             *types.Issue
+	formula           string
+	store             storage.DoltStorage
+	storeKey          string
+	mutationForbidden bool
+	closeFn           func()
+}
+
+func (d *molBondDiscovery) Close() {
+	if d != nil && d.closeFn != nil {
+		d.closeFn()
+		d.closeFn = nil
+	}
+}
+
+// discoverMolBondOperand resolves issue-first through read-only routing. This
+// lets store-policy validation finish before any foreign database is opened
+// writable. Formula fallback remains unconditional: the parser decides whether
+// an operand names a formula (#3874).
+func discoverMolBondOperand(ctx context.Context, localStore storage.DoltStorage, operand string) (*molBondDiscovery, error) {
+	rr, err := resolveAndGetIssueWithRouting(ctx, localStore, operand)
+	if err == nil {
+		return &molBondDiscovery{
+			operand:           operand,
+			issue:             rr.Issue,
+			store:             rr.Store,
+			storeKey:          dependencyStoreKey(rr.Store),
+			mutationForbidden: rr.MutationForbidden,
+			closeFn:           rr.Close,
+		}, nil
+	}
+	parser := formula.NewParser()
+	f, loadErr := parser.LoadByName(operand)
+	if loadErr == nil {
+		return &molBondDiscovery{operand: operand, formula: f.Formula}, nil
+	}
+	if !isNotFoundErr(err) {
+		return nil, err
+	}
+	return nil, fmt.Errorf("'%s' not found as issue or formula: %w", operand, loadErr)
+}
+
+// validateMolBondHomes returns the issue and logical store that pin the
+// mutation. Formula-only bonds stay local. All checks use read-only handles.
+func validateMolBondHomes(localStore storage.DoltStorage, discoveries ...*molBondDiscovery) (string, string, error) {
+	var targetID, targetKey string
+	var targetStore storage.DoltStorage
+	for _, d := range discoveries {
+		if d == nil || d.issue == nil {
+			continue
+		}
+		if d.mutationForbidden {
+			return "", "", fmt.Errorf("cannot bond issue %s: contributor auto-routing forbids mutation; run the bond from the project that owns the issue", d.issue.ID)
+		}
+		if targetStore == nil {
+			targetID, targetKey, targetStore = d.issue.ID, d.storeKey, d.store
+			continue
+		}
+		if !sameBondStore(targetStore, d.store) {
+			return "", "", fmt.Errorf("cannot bond %s and %s: they live in different stores/rigs; run the bond from the rig that owns them", targetID, d.issue.ID)
+		}
+	}
+	if targetStore == nil {
+		return "", dependencyStoreKey(localStore), nil
+	}
+	return targetID, targetKey, nil
+}
+
+// verifyMolBondWritableHome closes the TOCTOU gap between read-only discovery
+// and writable reopen. Routing or local contents may change between phases; a
+// bond must never mutate a logical store that was not the validated home.
+func verifyMolBondWritableHome(rr *RoutedResult, expectedStoreKey string) error {
+	if rr == nil || rr.Store == nil {
+		return fmt.Errorf("routed bond target reopened without a store")
+	}
+	if rr.MutationForbidden {
+		return fmt.Errorf("cannot bond issue %s: contributor auto-routing forbids mutation; run the bond from the project that owns the issue", rr.ResolvedID)
+	}
+	if actual := dependencyStoreKey(rr.Store); actual != expectedStoreKey {
+		return fmt.Errorf("routed bond target changed between discovery and writable reopen (expected %s, got %s); retry the command", expectedStoreKey, actual)
+	}
+	return nil
+}
+
+// sameBondStore reports whether two store handles refer to the same underlying
+// database. dependencyStoreKey unwraps decorators before consulting
+// StoreLocator, so a HookFiringStore and a separately opened raw route handle
+// onto the same database compare equal.
+func sameBondStore(a, b storage.DoltStorage) bool {
+	if a == b {
+		return true
+	}
+	return dependencyStoreKey(a) == dependencyStoreKey(b)
+}
+
+// materializeMolBondOperand is the writable phase. After validation selects one
+// store home, existing issues are re-read there and formulas are cooked in
+// memory for the bond operation.
+func materializeMolBondOperand(ctx context.Context, activeStore storage.DoltStorage, d *molBondDiscovery, vars map[string]string) (*molBondOperand, error) {
+	if d == nil {
+		return nil, fmt.Errorf("missing mol bond operand")
+	}
+	if d.issue == nil {
+		subgraph, err := resolveAndCookFormulaWithVars(d.operand, nil, vars)
+		if err != nil {
+			return nil, fmt.Errorf("'%s' not found as issue or formula: %w", d.operand, err)
+		}
+		return &molBondOperand{subgraph: subgraph, cooked: true}, nil
+	}
+
+	rr, err := resolveAndGetFromStore(ctx, activeStore, d.issue.ID, false)
+	if err != nil {
+		return nil, err
+	}
+	issue := rr.Issue
 	if isProto(issue) {
-		subgraph, err := loadTemplateSubgraph(ctx, s, issue.ID)
+		subgraph, err := loadTemplateSubgraph(ctx, activeStore, issue.ID)
 		if err != nil {
 			return nil, fmt.Errorf("loading proto subgraph '%s': %w", issue.ID, err)
 		}
-		return &molBondOperand{subgraph: subgraph, store: s, routed: routed, writable: writable}, nil
+		return &molBondOperand{subgraph: subgraph}, nil
 	}
 	return &molBondOperand{
 		subgraph: &TemplateSubgraph{
@@ -648,209 +780,7 @@ func operandFromIssue(ctx context.Context, s storage.DoltStorage, issue *types.I
 			Issues:   []*types.Issue{issue},
 			IssueMap: map[string]*types.Issue{issue.ID: issue},
 		},
-		store:    s,
-		routed:   routed,
-		writable: writable,
 	}, nil
-}
-
-// resolveMolBondOperands resolves both mol-bond operands as existing issues or,
-// failing that, inline formulas. It mirrors resolveCloseTargets: per operand the
-// fallback order is the local store, then a routed store already opened for the
-// other operand of this bond, then a prefix-routed rig via routes.jsonl (opened
-// write-intent so the bond commits where the issue lives, #4141), then the
-// shared contributor auto-routed store. Contributor auto-routed stores open
-// read-only — they hydrate foreign projects that must never be mutated — so
-// their operands are marked non-writable and pickBondStore rejects the bond
-// before any mutation is attempted.
-//
-// Reusing an already-opened routed handle means two operands that live in the
-// same routed rig share one store handle instead of opening the same database
-// twice (and pickBondStore sees one identity, not a spurious cross-store pair).
-//
-// The caller must invoke cleanup() once when done; it releases every routed
-// handle opened for this bond.
-//
-// The vars parameter is used for step condition filtering (bd-7zka.1).
-// Formulas are cooked to in-memory subgraphs (gt-4v1eo, no DB storage).
-func resolveMolBondOperands(ctx context.Context, localStore storage.DoltStorage, operands [2]string, vars map[string]string) ([2]*molBondOperand, func(), error) {
-	type routedHandle struct {
-		store    storage.DoltStorage
-		writable bool
-	}
-	var handles []routedHandle
-	var closers []func()
-	cleanup := func() {
-		for _, c := range closers {
-			c()
-		}
-	}
-
-	var sharedAuto storage.DoltStorage
-	sharedAutoTried := false
-	ensureSharedAuto := func() (storage.DoltStorage, error) {
-		if sharedAuto != nil {
-			return sharedAuto, nil
-		}
-		if sharedAutoTried {
-			return nil, fmt.Errorf("no auto-routed store available")
-		}
-		sharedAutoTried = true
-		rs, routed, err := openRoutedReadStore(ctx, localStore)
-		if err != nil {
-			return nil, err
-		}
-		if !routed {
-			return nil, fmt.Errorf("no auto-routed store available")
-		}
-		sharedAuto = rs
-		closers = append(closers, func() { _ = rs.Close() })
-		return rs, nil
-	}
-
-	resolveOne := func(operand string) (*molBondOperand, error) {
-		// Local first.
-		if rr, err := resolveAndGetFromStore(ctx, localStore, operand, false); err == nil {
-			return operandFromIssue(ctx, localStore, rr.Issue, false, true)
-		} else if !isNotFoundErr(err) {
-			return nil, err
-		}
-		// A routed store already opened for the other operand of this bond.
-		for _, h := range handles {
-			if rr, err := resolveAndGetFromStore(ctx, h.store, operand, true); err == nil {
-				return operandFromIssue(ctx, h.store, rr.Issue, true, h.writable)
-			}
-		}
-		// Write-intent prefix routing: the routed target opens writable so the
-		// bond commits on the target head, like bd close (#4141, #3608/#3609).
-		if rr, err := resolveViaPrefixRoutingWithAccess(ctx, operand, true); err == nil {
-			handles = append(handles, routedHandle{store: rr.Store, writable: true})
-			closers = append(closers, rr.Close)
-			return operandFromIssue(ctx, rr.Store, rr.Issue, true, true)
-		}
-		// Contributor auto-routing uses one shared read-only store (GH#2345).
-		if rs, rerr := ensureSharedAuto(); rerr == nil {
-			if rr, err := resolveAndGetFromStore(ctx, rs, operand, true); err == nil {
-				return operandFromIssue(ctx, rs, rr.Issue, true, false)
-			}
-		}
-		// Not found as issue in any store — fall through to the formula registry.
-		// resolveAndCookFormulaWithVars lets parser.LoadByName decide (it returns
-		// "formula %q not found in search paths" for genuinely unknown names,
-		// which is the right error). This matches the resolution behavior of
-		// bd formula show / bd mol seed / bd mol pour / bd cook (#3874).
-		subgraph, cookErr := resolveAndCookFormulaWithVars(operand, nil, vars)
-		if cookErr != nil {
-			return nil, fmt.Errorf("'%s' not found as issue or formula: %w", operand, cookErr)
-		}
-		return &molBondOperand{subgraph: subgraph, cooked: true, writable: true}, nil
-	}
-
-	opA, err := resolveOne(operands[0])
-	if err != nil {
-		cleanup()
-		return [2]*molBondOperand{}, func() {}, err
-	}
-	opB, err := resolveOne(operands[1])
-	if err != nil {
-		cleanup()
-		return [2]*molBondOperand{}, func() {}, err
-	}
-	return [2]*molBondOperand{opA, opB}, cleanup, nil
-}
-
-// pickBondStore returns the store the bond mutation must run against.
-//
-// Cooked-formula operands are in-memory and store-agnostic, so they impose no
-// constraint. Each existing-issue operand pins the bond to the store that owns
-// it. When both operands are existing issues owned by different stores the bond
-// is a cross-store operation with no well-defined home, so it is rejected rather
-// than silently written to the wrong database. When nothing pins a store (both
-// operands are cooked formulas) the bond stays on the local store.
-//
-// A pinned store that opened read-only (a contributor auto-routed store) is
-// rejected here, before any mutation is attempted, instead of surfacing a
-// store-layer write refusal halfway through the bond.
-func pickBondStore(localStore storage.DoltStorage, a, b *molBondOperand) (storage.DoltStorage, error) {
-	active := localStore
-	var pinnedBy *molBondOperand
-	for _, op := range []*molBondOperand{a, b} {
-		if op.cooked || op.store == nil {
-			continue
-		}
-		if pinnedBy == nil {
-			active = op.store
-			pinnedBy = op
-			continue
-		}
-		if !sameBondStore(op.store, active) {
-			return nil, fmt.Errorf("cannot bond %s and %s: they live in different stores/rigs; run the bond from the rig that owns them",
-				pinnedBy.subgraph.Root.ID, op.subgraph.Root.ID)
-		}
-	}
-	if pinnedBy != nil && !pinnedBy.writable {
-		return nil, fmt.Errorf("%s lives in the contributor auto-routed store, which opens read-only; bd mol bond cannot write there — run the bond from the project that owns it",
-			pinnedBy.subgraph.Root.ID)
-	}
-	return active, nil
-}
-
-// sameBondStore reports whether two store handles refer to the same underlying
-// database. Handle identity covers shared handles; the StoreLocator comparison
-// covers separately-opened handles onto the same database (each route-open
-// constructs a fresh store in server mode), which must not be rejected as a
-// cross-store bond.
-func sameBondStore(a, b storage.DoltStorage) bool {
-	if a == b {
-		return true
-	}
-	la, aok := a.(storage.StoreLocator)
-	lb, bok := b.(storage.StoreLocator)
-	if !aok || !bok {
-		return false
-	}
-	// CLIDir pins the concrete database (path + database name); Path alone can
-	// collide across databases sharing a server root.
-	dirA, dirB := la.CLIDir(), lb.CLIDir()
-	return dirA != "" && dirA == dirB
-}
-
-// resolveOrDescribeWithRouting checks if an operand is an issue or formula
-// without cooking. It is the embedded/server-store dry-run resolver; the
-// proxied-server path retains resolveOrDescribe over its transaction reader.
-//
-// Issue resolution uses the read-only routing fallback (local, then prefix-routed
-// rig, then contributor auto-routing) so a dry run previews routed operands the
-// same way the real bond resolves them.
-func resolveOrDescribeWithRouting(ctx context.Context, localStore storage.DoltStorage, operand string, vars map[string]string) (*types.Issue, string, error) {
-	rr, err := resolveAndGetIssueWithRouting(ctx, localStore, operand)
-	if err == nil {
-		issue := rr.Issue
-		rr.Close()
-		return issue, "", nil
-	}
-	if !isNotFoundErr(err) {
-		return nil, "", err
-	}
-
-	// Not found as issue — fall through to the formula registry. parser.LoadByName
-	// returns "formula %q not found in search paths" for genuinely unknown names,
-	// which is the right error. This matches the resolution behavior of
-	// bd formula show / bd mol seed / bd mol pour / bd cook.
-	parser := formula.NewParser()
-	f, err := parser.LoadByName(operand)
-	if err != nil {
-		return nil, "", fmt.Errorf("'%s' not found as issue or formula: %w", operand, err)
-	}
-
-	// A dry-run must fail the same way the real bond would: an enum/pattern/
-	// provided-empty violation in --var values fails resolveOrCookToSubgraph,
-	// so reporting "will be cooked" here would be a false preview.
-	if err := formula.ValidateProvidedVars(f, vars); err != nil {
-		return nil, "", err
-	}
-
-	return nil, f.Formula, nil
 }
 
 // resolveOrDescribe checks if an operand is an issue or formula without cooking.

--- a/cmd/bd/mol_bond.go
+++ b/cmd/bd/mol_bond.go
@@ -121,16 +121,12 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	opA, err := resolveMolBondOperand(ctx, store, in.argA, in.vars)
+	ops, cleanup, err := resolveMolBondOperands(ctx, store, [2]string{in.argA, in.argB}, in.vars)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
-	defer opA.Close()
-	opB, err := resolveMolBondOperand(ctx, store, in.argB, in.vars)
-	if err != nil {
-		return HandleErrorRespectJSON("%v", err)
-	}
-	defer opB.Close()
+	defer cleanup()
+	opA, opB := ops[0], ops[1]
 
 	// The bond mutation runs against the store that owns the operands. When an
 	// operand was resolved via routing (e.g. a prefix-routed rig bead), that is
@@ -625,35 +621,26 @@ func minPriority(a, b int) int {
 // owns it. For an existing issue, store is whichever store resolution found the
 // issue in (local or routed) and cooked is false. For a formula cooked inline,
 // store is nil (the cooked protos are in-memory until the bond writes them) and
-// cooked is true.
+// cooked is true. Routed store handles are owned by the cleanup function
+// returned from resolveMolBondOperands, not by the operand.
 type molBondOperand struct {
 	subgraph *TemplateSubgraph
 	cooked   bool                // cooked inline from a formula (no owning store yet)
 	store    storage.DoltStorage // store that owns the issue; nil for cooked formulas
 	routed   bool                // issue was found via routing, not the local store
-	closeFn  func()              // releases any routed store handle
-}
-
-// Close releases any routed store handle held by the operand. Safe on nil.
-func (o *molBondOperand) Close() {
-	if o != nil && o.closeFn != nil {
-		o.closeFn()
-	}
+	writable bool                // false only for contributor auto-routed stores, which open read-only
 }
 
 // operandFromIssue wraps a resolved issue as a molBondOperand, loading the full
 // proto subgraph when the issue is a proto and wrapping a plain molecule as a
 // single-issue subgraph otherwise.
-func operandFromIssue(ctx context.Context, s storage.DoltStorage, issue *types.Issue, routed bool, closeFn func()) (*molBondOperand, error) {
+func operandFromIssue(ctx context.Context, s storage.DoltStorage, issue *types.Issue, routed, writable bool) (*molBondOperand, error) {
 	if isProto(issue) {
 		subgraph, err := loadTemplateSubgraph(ctx, s, issue.ID)
 		if err != nil {
-			if closeFn != nil {
-				closeFn()
-			}
 			return nil, fmt.Errorf("loading proto subgraph '%s': %w", issue.ID, err)
 		}
-		return &molBondOperand{subgraph: subgraph, store: s, routed: routed, closeFn: closeFn}, nil
+		return &molBondOperand{subgraph: subgraph, store: s, routed: routed, writable: writable}, nil
 	}
 	return &molBondOperand{
 		subgraph: &TemplateSubgraph{
@@ -661,45 +648,115 @@ func operandFromIssue(ctx context.Context, s storage.DoltStorage, issue *types.I
 			Issues:   []*types.Issue{issue},
 			IssueMap: map[string]*types.Issue{issue.ID: issue},
 		},
-		store:   s,
-		routed:  routed,
-		closeFn: closeFn,
+		store:    s,
+		routed:   routed,
+		writable: writable,
 	}, nil
 }
 
-// resolveMolBondOperand resolves a single mol-bond operand as an existing issue
-// or, failing that, an inline formula.
+// resolveMolBondOperands resolves both mol-bond operands as existing issues or,
+// failing that, inline formulas. It mirrors resolveCloseTargets: per operand the
+// fallback order is the local store, then a routed store already opened for the
+// other operand of this bond, then a prefix-routed rig via routes.jsonl (opened
+// write-intent so the bond commits where the issue lives, #4141), then the
+// shared contributor auto-routed store. Contributor auto-routed stores open
+// read-only — they hydrate foreign projects that must never be mutated — so
+// their operands are marked non-writable and pickBondStore rejects the bond
+// before any mutation is attempted.
 //
-// Issue resolution uses the same routing fallback as bd show/update/close
-// (local store, then prefix-routed rig via routes.jsonl, then contributor
-// auto-routing) so an operand that lives only in a routed store resolves
-// instead of failing with "not found". Resolution is write-intent: a
-// prefix-routed target opens writable so the bond commits where the issue
-// lives, mirroring the bd close fix in #3608/#3609. The returned operand
-// carries the owning store; the caller runs the bond mutation against it and
-// must call Close() to release any routed handle.
+// Reusing an already-opened routed handle means two operands that live in the
+// same routed rig share one store handle instead of opening the same database
+// twice (and pickBondStore sees one identity, not a spurious cross-store pair).
+//
+// The caller must invoke cleanup() once when done; it releases every routed
+// handle opened for this bond.
 //
 // The vars parameter is used for step condition filtering (bd-7zka.1).
 // Formulas are cooked to in-memory subgraphs (gt-4v1eo, no DB storage).
-func resolveMolBondOperand(ctx context.Context, localStore storage.DoltStorage, operand string, vars map[string]string) (*molBondOperand, error) {
-	rr, err := resolveAndGetIssueForMutation(ctx, localStore, operand)
-	if err == nil {
-		return operandFromIssue(ctx, rr.Store, rr.Issue, rr.Routed, rr.Close)
+func resolveMolBondOperands(ctx context.Context, localStore storage.DoltStorage, operands [2]string, vars map[string]string) ([2]*molBondOperand, func(), error) {
+	type routedHandle struct {
+		store    storage.DoltStorage
+		writable bool
 	}
-	if !isNotFoundErr(err) {
-		return nil, err
+	var handles []routedHandle
+	var closers []func()
+	cleanup := func() {
+		for _, c := range closers {
+			c()
+		}
 	}
 
-	// Not found as issue in any store — fall through to the formula registry.
-	// resolveAndCookFormulaWithVars lets parser.LoadByName decide (it returns
-	// "formula %q not found in search paths" for genuinely unknown names, which
-	// is the right error). This matches the resolution behavior of
-	// bd formula show / bd mol seed / bd mol pour / bd cook (#3874).
-	subgraph, cookErr := resolveAndCookFormulaWithVars(operand, nil, vars)
-	if cookErr != nil {
-		return nil, fmt.Errorf("'%s' not found as issue or formula: %w", operand, cookErr)
+	var sharedAuto storage.DoltStorage
+	sharedAutoTried := false
+	ensureSharedAuto := func() (storage.DoltStorage, error) {
+		if sharedAuto != nil {
+			return sharedAuto, nil
+		}
+		if sharedAutoTried {
+			return nil, fmt.Errorf("no auto-routed store available")
+		}
+		sharedAutoTried = true
+		rs, routed, err := openRoutedReadStore(ctx, localStore)
+		if err != nil {
+			return nil, err
+		}
+		if !routed {
+			return nil, fmt.Errorf("no auto-routed store available")
+		}
+		sharedAuto = rs
+		closers = append(closers, func() { _ = rs.Close() })
+		return rs, nil
 	}
-	return &molBondOperand{subgraph: subgraph, cooked: true}, nil
+
+	resolveOne := func(operand string) (*molBondOperand, error) {
+		// Local first.
+		if rr, err := resolveAndGetFromStore(ctx, localStore, operand, false); err == nil {
+			return operandFromIssue(ctx, localStore, rr.Issue, false, true)
+		} else if !isNotFoundErr(err) {
+			return nil, err
+		}
+		// A routed store already opened for the other operand of this bond.
+		for _, h := range handles {
+			if rr, err := resolveAndGetFromStore(ctx, h.store, operand, true); err == nil {
+				return operandFromIssue(ctx, h.store, rr.Issue, true, h.writable)
+			}
+		}
+		// Write-intent prefix routing: the routed target opens writable so the
+		// bond commits on the target head, like bd close (#4141, #3608/#3609).
+		if rr, err := resolveViaPrefixRoutingWithAccess(ctx, operand, true); err == nil {
+			handles = append(handles, routedHandle{store: rr.Store, writable: true})
+			closers = append(closers, rr.Close)
+			return operandFromIssue(ctx, rr.Store, rr.Issue, true, true)
+		}
+		// Contributor auto-routing uses one shared read-only store (GH#2345).
+		if rs, rerr := ensureSharedAuto(); rerr == nil {
+			if rr, err := resolveAndGetFromStore(ctx, rs, operand, true); err == nil {
+				return operandFromIssue(ctx, rs, rr.Issue, true, false)
+			}
+		}
+		// Not found as issue in any store — fall through to the formula registry.
+		// resolveAndCookFormulaWithVars lets parser.LoadByName decide (it returns
+		// "formula %q not found in search paths" for genuinely unknown names,
+		// which is the right error). This matches the resolution behavior of
+		// bd formula show / bd mol seed / bd mol pour / bd cook (#3874).
+		subgraph, cookErr := resolveAndCookFormulaWithVars(operand, nil, vars)
+		if cookErr != nil {
+			return nil, fmt.Errorf("'%s' not found as issue or formula: %w", operand, cookErr)
+		}
+		return &molBondOperand{subgraph: subgraph, cooked: true, writable: true}, nil
+	}
+
+	opA, err := resolveOne(operands[0])
+	if err != nil {
+		cleanup()
+		return [2]*molBondOperand{}, func() {}, err
+	}
+	opB, err := resolveOne(operands[1])
+	if err != nil {
+		cleanup()
+		return [2]*molBondOperand{}, func() {}, err
+	}
+	return [2]*molBondOperand{opA, opB}, cleanup, nil
 }
 
 // pickBondStore returns the store the bond mutation must run against.
@@ -710,23 +767,52 @@ func resolveMolBondOperand(ctx context.Context, localStore storage.DoltStorage, 
 // is a cross-store operation with no well-defined home, so it is rejected rather
 // than silently written to the wrong database. When nothing pins a store (both
 // operands are cooked formulas) the bond stays on the local store.
+//
+// A pinned store that opened read-only (a contributor auto-routed store) is
+// rejected here, before any mutation is attempted, instead of surfacing a
+// store-layer write refusal halfway through the bond.
 func pickBondStore(localStore storage.DoltStorage, a, b *molBondOperand) (storage.DoltStorage, error) {
 	active := localStore
-	pinned := false
+	var pinnedBy *molBondOperand
 	for _, op := range []*molBondOperand{a, b} {
 		if op.cooked || op.store == nil {
 			continue
 		}
-		if !pinned {
+		if pinnedBy == nil {
 			active = op.store
-			pinned = true
+			pinnedBy = op
 			continue
 		}
-		if op.store != active {
-			return nil, fmt.Errorf("cannot bond operands that live in different stores/rigs; run the bond from the rig that owns them")
+		if !sameBondStore(op.store, active) {
+			return nil, fmt.Errorf("cannot bond %s and %s: they live in different stores/rigs; run the bond from the rig that owns them",
+				pinnedBy.subgraph.Root.ID, op.subgraph.Root.ID)
 		}
 	}
+	if pinnedBy != nil && !pinnedBy.writable {
+		return nil, fmt.Errorf("%s lives in the contributor auto-routed store, which opens read-only; bd mol bond cannot write there — run the bond from the project that owns it",
+			pinnedBy.subgraph.Root.ID)
+	}
 	return active, nil
+}
+
+// sameBondStore reports whether two store handles refer to the same underlying
+// database. Handle identity covers shared handles; the StoreLocator comparison
+// covers separately-opened handles onto the same database (each route-open
+// constructs a fresh store in server mode), which must not be rejected as a
+// cross-store bond.
+func sameBondStore(a, b storage.DoltStorage) bool {
+	if a == b {
+		return true
+	}
+	la, aok := a.(storage.StoreLocator)
+	lb, bok := b.(storage.StoreLocator)
+	if !aok || !bok {
+		return false
+	}
+	// CLIDir pins the concrete database (path + database name); Path alone can
+	// collide across databases sharing a server root.
+	dirA, dirB := la.CLIDir(), lb.CLIDir()
+	return dirA != "" && dirA == dirB
 }
 
 // resolveOrDescribeWithRouting checks if an operand is an issue or formula

--- a/cmd/bd/mol_bond.go
+++ b/cmd/bd/mol_bond.go
@@ -110,12 +110,12 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 		return HandleErrorRespectJSON("no database connection")
 	}
 
-	discA, err := discoverMolBondOperand(ctx, store, in.argA)
+	discA, err := discoverMolBondOperand(ctx, store, in.argA, in.vars)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
 	defer discA.Close()
-	discB, err := discoverMolBondOperand(ctx, store, in.argB)
+	discB, err := discoverMolBondOperand(ctx, store, in.argB, in.vars)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
@@ -671,7 +671,7 @@ func (d *molBondDiscovery) Close() {
 // lets store-policy validation finish before any foreign database is opened
 // writable. Formula fallback remains unconditional: the parser decides whether
 // an operand names a formula (#3874).
-func discoverMolBondOperand(ctx context.Context, localStore storage.DoltStorage, operand string) (*molBondDiscovery, error) {
+func discoverMolBondOperand(ctx context.Context, localStore storage.DoltStorage, operand string, vars map[string]string) (*molBondDiscovery, error) {
 	rr, err := resolveAndGetIssueWithRouting(ctx, localStore, operand)
 	if err == nil {
 		return &molBondDiscovery{
@@ -686,6 +686,13 @@ func discoverMolBondOperand(ctx context.Context, localStore storage.DoltStorage,
 	parser := formula.NewParser()
 	f, loadErr := parser.LoadByName(operand)
 	if loadErr == nil {
+		// Discovery must fail the same way materialization would: an
+		// enum/pattern/provided-empty violation in --var values fails the
+		// cook, so surfacing it here makes --dry-run and execution reject
+		// the bond identically, before any writable reopen (#5253).
+		if err := formula.ValidateProvidedVars(f, vars); err != nil {
+			return nil, err
+		}
 		return &molBondDiscovery{operand: operand, formula: f.Formula}, nil
 	}
 	if !isNotFoundErr(err) {
@@ -757,6 +764,12 @@ func materializeMolBondOperand(ctx context.Context, activeStore storage.DoltStor
 	if d.issue == nil {
 		subgraph, err := resolveAndCookFormulaWithVars(d.operand, nil, vars)
 		if err != nil {
+			if errors.Is(err, formula.ErrVarValidation) {
+				// Don't double-wrap: the operand IS a formula, and the --var
+				// values it was given fail enum/pattern/required-empty
+				// constraints, which is a distinct condition from "not found".
+				return nil, err
+			}
 			return nil, fmt.Errorf("'%s' not found as issue or formula: %w", d.operand, err)
 		}
 		return &molBondOperand{subgraph: subgraph, cooked: true}, nil

--- a/cmd/bd/mol_bond_routing_test.go
+++ b/cmd/bd/mol_bond_routing_test.go
@@ -9,10 +9,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// TestResolveMolBondOperandsRouting is the regression test for the mol-bond
+// TestDiscoverMolBondOperandRouting is the regression test for the mol-bond
 // routing bug (#4714): `bd mol bond <formula> <bead>` failed with
 // "'<bead>' not found as issue or formula" whenever <bead> lived in a routed
 // store (a prefix-routed rig, or the contributor planning store), even though
@@ -20,43 +21,62 @@ import (
 // store only and never fell through to the routing fallback that
 // show/update/close use.
 //
-// resolveMolBondOperands now mirrors resolveCloseTargets (local store, then
-// prefix routing, then the shared contributor auto-routed store), so an
-// operand that exists only in a routed store resolves and reports the routed
-// store as its owner.
+// discoverMolBondOperand resolves through the same local, prefix-route, and
+// contributor auto-route order, read-only, before the accepted home is reopened
+// writable.
 //
 // The cases mirror TestResolveCloseTargets:
 //   - maintainer-mode local resolution (no routing involved)
-//   - contributor-mode operands that live only in the routed planning store;
-//     both operands must share one routed handle, and the planning store opens
-//     read-only so the operands are marked non-writable
-func TestResolveMolBondOperandsRouting(t *testing.T) {
+//   - contributor-mode operand that lives only in the routed planning store
+func TestDiscoverMolBondOperandRouting(t *testing.T) {
 	cases := []struct {
 		name          string
-		role          string   // git config beads.role value
-		enableRouting bool     // set routing.mode=auto + routing.contributor=<planningDir>
-		localSeed     []string // issue IDs to create in the primary (local) store
-		planningSeed  []string // issue IDs to create in the routed planning store
-		operands      [2]string
-		wantRouted    bool // expected molBondOperand.routed for both operands
-		wantWritable  bool // expected molBondOperand.writable for both operands
+		role          string
+		enableRouting bool
+		routingKey    string
+		localSeed     string
+		planningSeed  string
+		operand       string
+		wantForbidden bool
+		wantWritable  bool
+		wantStore     string
 	}{
 		{
-			name:         "maintainer_local_issues",
-			role:         "maintainer",
-			localSeed:    []string{"shared-local1", "shared-local2"},
-			operands:     [2]string{"shared-local1", "shared-local2"},
-			wantRouted:   false,
-			wantWritable: true,
+			name:      "maintainer_local_issue",
+			role:      "maintainer",
+			localSeed: "shared-local",
+			operand:   "shared-local",
+			wantStore: "local",
 		},
 		{
-			name:          "contributor_routed_issues_share_one_readonly_handle",
+			name:          "contributor_routed_issue",
 			role:          "contributor",
 			enableRouting: true,
-			planningSeed:  []string{"shared-r1", "shared-r2"},
-			operands:      [2]string{"shared-r1", "shared-r2"},
-			wantRouted:    true,
-			wantWritable:  false,
+			routingKey:    "routing.contributor",
+			planningSeed:  "shared-routed",
+			operand:       "shared-routed",
+			wantForbidden: true,
+			wantStore:     "planning",
+		},
+		{
+			name:          "maintainer_routed_issue",
+			role:          "maintainer",
+			enableRouting: true,
+			routingKey:    "routing.maintainer",
+			planningSeed:  "shared-maintainer",
+			operand:       "shared-maintainer",
+			wantWritable:  true,
+			wantStore:     "planning",
+		},
+		{
+			name:          "default_routed_issue",
+			role:          "maintainer",
+			enableRouting: true,
+			routingKey:    "routing.default",
+			planningSeed:  "shared-default",
+			operand:       "shared-default",
+			wantWritable:  true,
+			wantStore:     "planning",
 		},
 	}
 
@@ -78,21 +98,17 @@ func TestResolveMolBondOperandsRouting(t *testing.T) {
 				if err := primaryStore.SetConfig(ctx, "routing.mode", "auto"); err != nil {
 					t.Fatalf("set routing.mode: %v", err)
 				}
-				if err := primaryStore.SetConfig(ctx, "routing.contributor", planningDir); err != nil {
-					t.Fatalf("set routing.contributor: %v", err)
+				if err := primaryStore.SetConfig(ctx, tc.routingKey, planningDir); err != nil {
+					t.Fatalf("set %s: %v", tc.routingKey, err)
 				}
 			}
 
-			for _, id := range tc.localSeed {
-				seedIssue(t, ctx, primaryStore, id)
+			if tc.localSeed != "" {
+				seedIssue(t, ctx, primaryStore, tc.localSeed)
 			}
-			if len(tc.planningSeed) > 0 {
+			if tc.planningSeed != "" {
 				planningStore := newTestStoreIsolatedDB(t, filepath.Join(planningDir, ".beads", "beads.db"), "shared")
-				for _, id := range tc.planningSeed {
-					seedIssue(t, ctx, planningStore, id)
-				}
-				// Release the planning store so resolveMolBondOperands can open
-				// the routed store through the normal command path.
+				seedIssue(t, ctx, planningStore, tc.planningSeed)
 				if err := planningStore.Close(); err != nil {
 					t.Fatalf("close planning store: %v", err)
 				}
@@ -107,52 +123,107 @@ func TestResolveMolBondOperandsRouting(t *testing.T) {
 				t.Fatalf("chdir repoDir: %v", err)
 			}
 
-			ops, cleanup, err := resolveMolBondOperands(ctx, primaryStore, tc.operands, nil)
+			disc, err := discoverMolBondOperand(ctx, primaryStore, tc.operand)
 			if err != nil {
-				t.Fatalf("resolveMolBondOperands(%v): %v", tc.operands, err)
+				t.Fatalf("discoverMolBondOperand(%q): %v", tc.operand, err)
 			}
-			defer cleanup()
-
-			for i, op := range ops {
-				operand := tc.operands[i]
-				if op.subgraph == nil || op.subgraph.Root == nil {
-					t.Fatalf("operand %q: missing resolved subgraph", operand)
-				}
-				if op.subgraph.Root.ID != operand {
-					t.Errorf("operand %q: Root.ID = %q, want %q", operand, op.subgraph.Root.ID, operand)
-				}
-				if op.cooked {
-					t.Errorf("operand %q: cooked = true, want false (it is an existing issue)", operand)
-				}
-				if op.routed != tc.wantRouted {
-					t.Errorf("operand %q: routed = %v, want %v", operand, op.routed, tc.wantRouted)
-				}
-				if op.writable != tc.wantWritable {
-					t.Errorf("operand %q: writable = %v, want %v", operand, op.writable, tc.wantWritable)
-				}
-				if !tc.wantRouted && op.store != primaryStore {
-					t.Errorf("operand %q: store should be the local primary store", operand)
-				}
-				if tc.wantRouted && op.store == primaryStore {
-					t.Errorf("operand %q: store should be the routed planning store, not the local one", operand)
+			defer disc.Close()
+			if disc.issue == nil || disc.issue.ID != tc.operand || disc.formula != "" {
+				t.Fatalf("operand %q discovery = %#v", tc.operand, disc)
+			}
+			if disc.mutationForbidden != tc.wantForbidden {
+				t.Errorf("operand %q: mutationForbidden = %v, want %v", tc.operand, disc.mutationForbidden, tc.wantForbidden)
+			}
+			if disc.mutationForbidden {
+				formula := &molBondDiscovery{operand: "mol-test", formula: "mol-test"}
+				if _, _, err := validateMolBondHomes(primaryStore, formula, disc); err == nil || !strings.Contains(err.Error(), "auto-routing") {
+					t.Errorf("forbidden auto-routed operand error = %v, want clear refusal", err)
 				}
 			}
-
-			// Both routed operands must share one routed handle: identity is
-			// what pickBondStore checks first, and a second open of the same
-			// database would be wasted work.
-			if tc.wantRouted && ops[0].store != ops[1].store {
-				t.Errorf("routed operands should share one routed store handle")
+			localKey := dependencyStoreKey(primaryStore)
+			if tc.wantStore == "local" && disc.storeKey != localKey {
+				t.Errorf("operand %q storeKey = %q, want local %q", tc.operand, disc.storeKey, localKey)
+			}
+			if tc.wantStore == "planning" && disc.storeKey == localKey {
+				t.Errorf("operand %q unexpectedly resolved to local store", tc.operand)
+			}
+			if tc.wantWritable {
+				disc.Close()
+				rr, err := resolveAndGetIssueForMutation(ctx, primaryStore, tc.operand)
+				if err != nil {
+					t.Fatalf("resolveAndGetIssueForMutation(%q): %v", tc.operand, err)
+				}
+				defer rr.Close()
+				if rr.MutationForbidden {
+					t.Fatalf("operand %q: maintainer/default route unexpectedly forbids mutation", tc.operand)
+				}
+				routedStore, ok := storage.UnwrapStore(rr.Store).(interface{ IsReadOnly() bool })
+				if !ok {
+					t.Fatalf("operand %q: routed store %T does not expose read-only state", tc.operand, rr.Store)
+				}
+				if routedStore.IsReadOnly() {
+					t.Fatalf("operand %q: maintainer/default mutation route reopened read-only", tc.operand)
+				}
 			}
 		})
 	}
 }
 
+// TestDiscoverMolBondOperandFormulaWinsAmbiguousIssuePrefix preserves the
+// issue-first contract without making an ambiguous issue prefix shadow a valid
+// formula of the same name. The issue lookup error is actionable only when the
+// formula parser also rejects the operand.
+func TestDiscoverMolBondOperandFormulaWinsAmbiguousIssuePrefix(t *testing.T) {
+	initConfigForTest(t)
+	ctx := context.Background()
+
+	repoDir := t.TempDir()
+	beadsDir := filepath.Join(repoDir, ".beads")
+	localStore := newTestStoreIsolatedDB(t, filepath.Join(beadsDir, "beads.db"), "amb")
+	seedIssue(t, ctx, localStore, "ambiguous-formula-one")
+	seedIssue(t, ctx, localStore, "ambiguous-formula-two")
+
+	formulaDir := filepath.Join(beadsDir, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatalf("create formula directory: %v", err)
+	}
+	const name = "ambiguous-formula"
+	formula := []byte(`formula = "ambiguous-formula"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "step"
+title = "Step"
+type = "task"
+`)
+	if err := os.WriteFile(filepath.Join(formulaDir, name+".formula.toml"), formula, 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("chdir repoDir: %v", err)
+	}
+
+	disc, err := discoverMolBondOperand(ctx, localStore, name)
+	if err != nil {
+		t.Fatalf("discoverMolBondOperand(%q): %v", name, err)
+	}
+	defer disc.Close()
+	if disc.issue != nil || disc.formula != name {
+		t.Fatalf("ambiguous issue prefix should fall back to formula: %#v", disc)
+	}
+}
+
 // TestMolBondPrefixRoutedWriteThrough verifies the bond MUTATION against a
 // prefix-routed rig store, not just operand resolution: both operands live in
-// a routed rig, pickBondStore selects the routed store (a same-rig pair must
-// not be rejected as cross-store), the bond dependency write succeeds because
-// the prefix-routed store opened write-intent, and the dependency is visible
+// a routed rig, read-only validation accepts the same-rig pair, the selected
+// store reopens writable, and the dependency is visible
 // afterward through a fresh routed read — proving the write committed in the
 // routed database rather than the local one.
 //
@@ -181,8 +252,17 @@ func TestMolBondPrefixRoutedWriteThrough(t *testing.T) {
 	// Release the rig store before routing reopens it.
 	rigStore.Close()
 
+	otherRigBeadsDir := filepath.Join(tmpDir, "other-rig", ".beads")
+	if err := os.MkdirAll(otherRigBeadsDir, 0755); err != nil {
+		t.Fatalf("create other rig beads dir: %v", err)
+	}
+	otherStore := newTestStoreIsolatedDB(t, filepath.Join(otherRigBeadsDir, "dolt"), "zz")
+	seedIssue(t, ctx, otherStore, "zz-other")
+	otherStore.Close()
+
 	routesPath := filepath.Join(townBeadsDir, "routes.jsonl")
-	if err := os.WriteFile(routesPath, []byte(`{"prefix":"gt-","path":"rig"}`), 0644); err != nil {
+	routes := []byte("{\"prefix\":\"gt-\",\"path\":\"rig\"}\n{\"prefix\":\"zz-\",\"path\":\"other-rig\"}\n")
+	if err := os.WriteFile(routesPath, routes, 0644); err != nil {
 		t.Fatalf("write routes.jsonl: %v", err)
 	}
 
@@ -199,43 +279,43 @@ func TestMolBondPrefixRoutedWriteThrough(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
-	ops, cleanup, err := resolveMolBondOperands(ctx, townStore, [2]string{"gt-mol1", "gt-mol2"}, nil)
+	discA, err := discoverMolBondOperand(ctx, townStore, "gt-mol1")
 	if err != nil {
-		t.Fatalf("resolveMolBondOperands: %v", err)
+		t.Fatalf("discover first routed operand: %v", err)
 	}
-	for i, operand := range []string{"gt-mol1", "gt-mol2"} {
-		if !ops[i].routed {
-			cleanup()
-			t.Fatalf("operand %q: routed = false, want true", operand)
-		}
-		if !ops[i].writable {
-			cleanup()
-			t.Fatalf("operand %q: writable = false, want true (prefix routing is write-intent)", operand)
-		}
-	}
-	if ops[0].store != ops[1].store {
-		cleanup()
-		t.Fatal("same-rig operands should share one routed store handle")
-	}
-
-	// A same-rig pair must not be rejected as a cross-store bond.
-	activeStore, err := pickBondStore(townStore, ops[0], ops[1])
+	defer discA.Close()
+	discB, err := discoverMolBondOperand(ctx, townStore, "gt-mol2")
 	if err != nil {
-		cleanup()
-		t.Fatalf("pickBondStore rejected a same-rig pair: %v", err)
+		t.Fatalf("discover second routed operand: %v", err)
 	}
-	if activeStore != ops[0].store {
-		cleanup()
-		t.Fatal("pickBondStore should select the routed store that owns the operands")
+	defer discB.Close()
+	targetID, targetKey, err := validateMolBondHomes(townStore, discA, discB)
+	if err != nil {
+		t.Fatalf("validate same-rig operands: %v", err)
 	}
+	discA.Close()
+	discB.Close()
 
-	// The actual mutation: this is what a resolution-only test misses. The
-	// routed store opened write-intent, so the dependency write must succeed.
-	if _, err := bondMolMol(ctx, activeStore, ops[0].subgraph.Root, ops[1].subgraph.Root, types.BondTypeSequential, "test"); err != nil {
-		cleanup()
+	routed, err := resolveAndGetIssueForMutation(ctx, townStore, targetID)
+	if err != nil {
+		t.Fatalf("open accepted target writable: %v", err)
+	}
+	defer routed.Close()
+	if got := dependencyStoreKey(routed.Store); got != targetKey {
+		t.Fatalf("writable reopen changed store: got %q, want %q", got, targetKey)
+	}
+	opA, err := materializeMolBondOperand(ctx, routed.Store, discA, nil)
+	if err != nil {
+		t.Fatalf("materialize first operand: %v", err)
+	}
+	opB, err := materializeMolBondOperand(ctx, routed.Store, discB, nil)
+	if err != nil {
+		t.Fatalf("materialize second operand: %v", err)
+	}
+	if _, err := bondMolMol(ctx, routed.Store, opA.subgraph.Root, opB.subgraph.Root, types.BondTypeSequential, "test"); err != nil {
 		t.Fatalf("bondMolMol against the routed store: %v", err)
 	}
-	cleanup()
+	routed.Close()
 
 	// Verify through a fresh routed read that the bond committed in the rig
 	// database: gt-mol2 (B) now depends on gt-mol1 (A).
@@ -256,6 +336,50 @@ func TestMolBondPrefixRoutedWriteThrough(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("bond did not commit in the routed store: gt-mol2 dependencies = %+v", deps)
+	}
+	rr.Close()
+
+	crossA, err := discoverMolBondOperand(ctx, townStore, "gt-mol1")
+	if err != nil {
+		t.Fatalf("discover cross-store operand A: %v", err)
+	}
+	defer crossA.Close()
+	crossB, err := discoverMolBondOperand(ctx, townStore, "zz-other")
+	if err != nil {
+		t.Fatalf("discover cross-store operand B: %v", err)
+	}
+	defer crossB.Close()
+	if _, _, err := validateMolBondHomes(townStore, crossA, crossB); err == nil || !strings.Contains(err.Error(), "different stores/rigs") {
+		t.Fatalf("cross-store pair error = %v, want explicit rejection", err)
+	}
+	crossA.Close()
+	crossB.Close()
+
+	routes = append(routes, []byte("{\"prefix\":\"bad-\",\"path\":\"missing-rig\"}\n")...)
+	if err := os.WriteFile(routesPath, routes, 0644); err != nil {
+		t.Fatalf("write matched failure route: %v", err)
+	}
+	if _, err := discoverMolBondOperand(ctx, townStore, "bad-target"); err == nil || !strings.Contains(err.Error(), "no dolt_database") {
+		t.Fatalf("matched-route failure = %v, want actionable target metadata error", err)
+	}
+
+	drift, err := discoverMolBondOperand(ctx, townStore, "zz-other")
+	if err != nil {
+		t.Fatalf("discover drift fixture: %v", err)
+	}
+	_, driftKey, err := validateMolBondHomes(townStore, drift)
+	if err != nil {
+		t.Fatalf("validate drift fixture: %v", err)
+	}
+	drift.Close()
+	seedIssue(t, ctx, townStore, "zz-other")
+	reopened, err := resolveAndGetIssueForMutation(ctx, townStore, "zz-other")
+	if err != nil {
+		t.Fatalf("reopen drift fixture: %v", err)
+	}
+	defer reopened.Close()
+	if err := verifyMolBondWritableHome(reopened, driftKey); err == nil || !strings.Contains(err.Error(), "changed between discovery") {
+		t.Fatalf("reopen identity mismatch = %v, want retryable safety error", err)
 	}
 }
 
@@ -324,17 +448,22 @@ func TestSameBondStoreSeparateHandles(t *testing.T) {
 	}
 
 	// The negative case matters just as much: genuinely different databases
-	// must NOT compare as the same store, or pickBondStore would silently
+	// must NOT compare as the same store, or validation would silently
 	// allow the cross-store bonds it exists to reject.
 	if sameBondStore(townStore, rrA.Store) {
 		t.Fatal("sameBondStore: handles onto different databases must not compare as the same store")
+	}
+
+	wrapped := storage.NewHookFiringStore(rrA.Store, nil)
+	if !sameBondStore(wrapped, rrB.Store) {
+		t.Fatal("sameBondStore: decorator-wrapped and raw handles onto the same database must compare equal")
 	}
 }
 
 // TestMolBondAutoRoutedReadOnlyFailsFast verifies the write-path guard for
 // contributor auto-routing: the planning store deliberately opens read-only
 // (it hydrates a foreign project that must never be mutated), so a bond pinned
-// to it must fail fast with a clear message from pickBondStore — before any
+// to it must fail fast during read-only validation — before any
 // mutation is attempted — rather than surface a store-layer write refusal
 // halfway through the bond.
 func TestMolBondAutoRoutedReadOnlyFailsFast(t *testing.T) {
@@ -372,17 +501,22 @@ func TestMolBondAutoRoutedReadOnlyFailsFast(t *testing.T) {
 		t.Fatalf("chdir repoDir: %v", err)
 	}
 
-	ops, cleanup, err := resolveMolBondOperands(ctx, primaryStore, [2]string{"shared-ro1", "shared-ro2"}, nil)
+	discA, err := discoverMolBondOperand(ctx, primaryStore, "shared-ro1")
 	if err != nil {
-		t.Fatalf("resolveMolBondOperands: %v", err)
+		t.Fatalf("discover first auto-routed operand: %v", err)
 	}
-	defer cleanup()
+	defer discA.Close()
+	discB, err := discoverMolBondOperand(ctx, primaryStore, "shared-ro2")
+	if err != nil {
+		t.Fatalf("discover second auto-routed operand: %v", err)
+	}
+	defer discB.Close()
 
-	_, err = pickBondStore(primaryStore, ops[0], ops[1])
+	_, _, err = validateMolBondHomes(primaryStore, discA, discB)
 	if err == nil {
-		t.Fatal("pickBondStore should reject a bond pinned to the read-only auto-routed store")
+		t.Fatal("validateMolBondHomes should reject a bond pinned to the contributor auto-routed store")
 	}
-	if !strings.Contains(err.Error(), "read-only") || !strings.Contains(err.Error(), "auto-routed") {
-		t.Errorf("fail-fast error should explain the read-only auto-routed store, got: %v", err)
+	if !strings.Contains(err.Error(), "auto-routing") || !strings.Contains(err.Error(), "forbids mutation") {
+		t.Errorf("fail-fast error should explain the forbidden contributor auto-route, got: %v", err)
 	}
 }

--- a/cmd/bd/mol_bond_routing_test.go
+++ b/cmd/bd/mol_bond_routing_test.go
@@ -1,0 +1,146 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// TestResolveMolBondOperandRouting is the regression test for the mol-bond
+// routing bug: `bd mol bond <formula> <bead>` failed with
+// "'<bead>' not found (not an issue ID or formula name)" whenever <bead> lived
+// in a routed store (a prefix-routed rig, or the contributor planning store),
+// even though `bd show <bead>` resolved it. mol bond resolved operands with
+// utils.ResolvePartialID against the local store only and never fell through to
+// the routing fallback that show/update/close use.
+//
+// resolveMolBondOperand now routes operand resolution through
+// resolveAndGetIssueForMutation, so an operand that exists only in a routed
+// store resolves and reports the routed store as its owner. The bond mutation
+// then runs against that store instead of the local one.
+//
+// The cases mirror TestResolveCloseTargets:
+//   - maintainer-mode local resolution (no routing involved)
+//   - contributor-mode operand that lives only in the routed planning store
+func TestResolveMolBondOperandRouting(t *testing.T) {
+	cases := []struct {
+		name          string
+		role          string // git config beads.role value
+		enableRouting bool   // set routing.mode=auto + routing.contributor=<planningDir>
+		localSeed     string // issue ID to create in the primary (local) store, if non-empty
+		planningSeed  string // issue ID to create in the routed planning store, if non-empty
+		operand       string // argument to resolveMolBondOperand
+		wantRouted    bool   // expected molBondOperand.routed
+		wantStore     string // "local" (== primaryStore) or "planning" (routed handle)
+	}{
+		{
+			name:       "maintainer_local_issue",
+			role:       "maintainer",
+			localSeed:  "shared-local",
+			operand:    "shared-local",
+			wantRouted: false,
+			wantStore:  "local",
+		},
+		{
+			name:          "contributor_routed_issue",
+			role:          "contributor",
+			enableRouting: true,
+			planningSeed:  "shared-routed",
+			operand:       "shared-routed",
+			wantRouted:    true,
+			wantStore:     "planning",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			initConfigForTest(t)
+
+			tmpDir := t.TempDir()
+			repoDir := filepath.Join(tmpDir, "repo")
+			planningDir := filepath.Join(tmpDir, "planning")
+
+			runCmd(t, tmpDir, "git", "init", repoDir)
+			runCmd(t, repoDir, "git", "config", "beads.role", tc.role)
+
+			primaryStore := newTestStoreIsolatedDB(t, filepath.Join(repoDir, ".beads", "beads.db"), "shared")
+			ctx := context.Background()
+
+			if tc.enableRouting {
+				if err := primaryStore.SetConfig(ctx, "routing.mode", "auto"); err != nil {
+					t.Fatalf("set routing.mode: %v", err)
+				}
+				if err := primaryStore.SetConfig(ctx, "routing.contributor", planningDir); err != nil {
+					t.Fatalf("set routing.contributor: %v", err)
+				}
+			}
+
+			if tc.localSeed != "" {
+				seedIssue(t, ctx, primaryStore, tc.localSeed)
+			}
+			if tc.planningSeed != "" {
+				planningStore := newTestStoreIsolatedDB(t, filepath.Join(planningDir, ".beads", "beads.db"), "shared")
+				seedIssue(t, ctx, planningStore, tc.planningSeed)
+				// Release the planning store so resolveMolBondOperand can open the
+				// routed store through the normal command path.
+				if err := planningStore.Close(); err != nil {
+					t.Fatalf("close planning store: %v", err)
+				}
+			}
+
+			oldWD, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("getwd: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(oldWD) })
+			if err := os.Chdir(repoDir); err != nil {
+				t.Fatalf("chdir repoDir: %v", err)
+			}
+
+			op, err := resolveMolBondOperand(ctx, primaryStore, tc.operand, nil)
+			if err != nil {
+				t.Fatalf("resolveMolBondOperand(%q): %v", tc.operand, err)
+			}
+			defer op.Close()
+
+			if op.subgraph == nil || op.subgraph.Root == nil {
+				t.Fatalf("operand %q: missing resolved subgraph", tc.operand)
+			}
+			if op.subgraph.Root.ID != tc.operand {
+				t.Errorf("operand %q: Root.ID = %q, want %q", tc.operand, op.subgraph.Root.ID, tc.operand)
+			}
+			if op.cooked {
+				t.Errorf("operand %q: cooked = true, want false (it is an existing issue)", tc.operand)
+			}
+			if op.routed != tc.wantRouted {
+				t.Errorf("operand %q: routed = %v, want %v", tc.operand, op.routed, tc.wantRouted)
+			}
+
+			assertStoreOrigin(t, tc.operand, tc.wantStore, op.store, primaryStore)
+		})
+	}
+}
+
+func assertStoreOrigin(t *testing.T, operand, want string, got, local storage.DoltStorage) {
+	t.Helper()
+	switch want {
+	case "local":
+		if got != local {
+			t.Errorf("operand %q: store should be the local primary store", operand)
+		}
+	case "planning":
+		if got == nil {
+			t.Errorf("operand %q: store is nil", operand)
+		}
+		if got == local {
+			t.Errorf("operand %q: store should be the routed planning store, not the local one", operand)
+		}
+	default:
+		t.Fatalf("operand %q: unknown wantStore %q", operand, want)
+	}
+}

--- a/cmd/bd/mol_bond_routing_test.go
+++ b/cmd/bd/mol_bond_routing_test.go
@@ -89,6 +89,8 @@ func TestDiscoverMolBondOperandRouting(t *testing.T) {
 			planningDir := filepath.Join(tmpDir, "planning")
 
 			runCmd(t, tmpDir, "git", "init", repoDir)
+			// Force repo-local hooks so tests ignore any global hooksPath override.
+			runCmd(t, repoDir, "git", "config", "core.hooksPath", ".git/hooks")
 			runCmd(t, repoDir, "git", "config", "beads.role", tc.role)
 
 			primaryStore := newTestStoreIsolatedDB(t, filepath.Join(repoDir, ".beads", "beads.db"), "shared")
@@ -475,6 +477,8 @@ func TestMolBondAutoRoutedReadOnlyFailsFast(t *testing.T) {
 	planningDir := filepath.Join(tmpDir, "planning")
 
 	runCmd(t, tmpDir, "git", "init", repoDir)
+	// Force repo-local hooks so tests ignore any global hooksPath override.
+	runCmd(t, repoDir, "git", "config", "core.hooksPath", ".git/hooks")
 	runCmd(t, repoDir, "git", "config", "beads.role", "contributor")
 
 	primaryStore := newTestStoreIsolatedDB(t, filepath.Join(repoDir, ".beads", "beads.db"), "shared")

--- a/cmd/bd/mol_bond_routing_test.go
+++ b/cmd/bd/mol_bond_routing_test.go
@@ -123,7 +123,7 @@ func TestDiscoverMolBondOperandRouting(t *testing.T) {
 				t.Fatalf("chdir repoDir: %v", err)
 			}
 
-			disc, err := discoverMolBondOperand(ctx, primaryStore, tc.operand)
+			disc, err := discoverMolBondOperand(ctx, primaryStore, tc.operand, nil)
 			if err != nil {
 				t.Fatalf("discoverMolBondOperand(%q): %v", tc.operand, err)
 			}
@@ -210,7 +210,7 @@ type = "task"
 		t.Fatalf("chdir repoDir: %v", err)
 	}
 
-	disc, err := discoverMolBondOperand(ctx, localStore, name)
+	disc, err := discoverMolBondOperand(ctx, localStore, name, nil)
 	if err != nil {
 		t.Fatalf("discoverMolBondOperand(%q): %v", name, err)
 	}
@@ -279,12 +279,12 @@ func TestMolBondPrefixRoutedWriteThrough(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
-	discA, err := discoverMolBondOperand(ctx, townStore, "gt-mol1")
+	discA, err := discoverMolBondOperand(ctx, townStore, "gt-mol1", nil)
 	if err != nil {
 		t.Fatalf("discover first routed operand: %v", err)
 	}
 	defer discA.Close()
-	discB, err := discoverMolBondOperand(ctx, townStore, "gt-mol2")
+	discB, err := discoverMolBondOperand(ctx, townStore, "gt-mol2", nil)
 	if err != nil {
 		t.Fatalf("discover second routed operand: %v", err)
 	}
@@ -339,12 +339,12 @@ func TestMolBondPrefixRoutedWriteThrough(t *testing.T) {
 	}
 	rr.Close()
 
-	crossA, err := discoverMolBondOperand(ctx, townStore, "gt-mol1")
+	crossA, err := discoverMolBondOperand(ctx, townStore, "gt-mol1", nil)
 	if err != nil {
 		t.Fatalf("discover cross-store operand A: %v", err)
 	}
 	defer crossA.Close()
-	crossB, err := discoverMolBondOperand(ctx, townStore, "zz-other")
+	crossB, err := discoverMolBondOperand(ctx, townStore, "zz-other", nil)
 	if err != nil {
 		t.Fatalf("discover cross-store operand B: %v", err)
 	}
@@ -359,11 +359,11 @@ func TestMolBondPrefixRoutedWriteThrough(t *testing.T) {
 	if err := os.WriteFile(routesPath, routes, 0644); err != nil {
 		t.Fatalf("write matched failure route: %v", err)
 	}
-	if _, err := discoverMolBondOperand(ctx, townStore, "bad-target"); err == nil || !strings.Contains(err.Error(), "no dolt_database") {
+	if _, err := discoverMolBondOperand(ctx, townStore, "bad-target", nil); err == nil || !strings.Contains(err.Error(), "no dolt_database") {
 		t.Fatalf("matched-route failure = %v, want actionable target metadata error", err)
 	}
 
-	drift, err := discoverMolBondOperand(ctx, townStore, "zz-other")
+	drift, err := discoverMolBondOperand(ctx, townStore, "zz-other", nil)
 	if err != nil {
 		t.Fatalf("discover drift fixture: %v", err)
 	}
@@ -501,12 +501,12 @@ func TestMolBondAutoRoutedReadOnlyFailsFast(t *testing.T) {
 		t.Fatalf("chdir repoDir: %v", err)
 	}
 
-	discA, err := discoverMolBondOperand(ctx, primaryStore, "shared-ro1")
+	discA, err := discoverMolBondOperand(ctx, primaryStore, "shared-ro1", nil)
 	if err != nil {
 		t.Fatalf("discover first auto-routed operand: %v", err)
 	}
 	defer discA.Close()
-	discB, err := discoverMolBondOperand(ctx, primaryStore, "shared-ro2")
+	discB, err := discoverMolBondOperand(ctx, primaryStore, "shared-ro2", nil)
 	if err != nil {
 		t.Fatalf("discover second auto-routed operand: %v", err)
 	}

--- a/cmd/bd/mol_bond_routing_test.go
+++ b/cmd/bd/mol_bond_routing_test.go
@@ -6,54 +6,57 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
-	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
 )
 
-// TestResolveMolBondOperandRouting is the regression test for the mol-bond
-// routing bug: `bd mol bond <formula> <bead>` failed with
-// "'<bead>' not found (not an issue ID or formula name)" whenever <bead> lived
-// in a routed store (a prefix-routed rig, or the contributor planning store),
-// even though `bd show <bead>` resolved it. mol bond resolved operands with
-// utils.ResolvePartialID against the local store only and never fell through to
-// the routing fallback that show/update/close use.
+// TestResolveMolBondOperandsRouting is the regression test for the mol-bond
+// routing bug (#4714): `bd mol bond <formula> <bead>` failed with
+// "'<bead>' not found as issue or formula" whenever <bead> lived in a routed
+// store (a prefix-routed rig, or the contributor planning store), even though
+// `bd show <bead>` resolved it. mol bond resolved operands against the local
+// store only and never fell through to the routing fallback that
+// show/update/close use.
 //
-// resolveMolBondOperand now routes operand resolution through
-// resolveAndGetIssueForMutation, so an operand that exists only in a routed
-// store resolves and reports the routed store as its owner. The bond mutation
-// then runs against that store instead of the local one.
+// resolveMolBondOperands now mirrors resolveCloseTargets (local store, then
+// prefix routing, then the shared contributor auto-routed store), so an
+// operand that exists only in a routed store resolves and reports the routed
+// store as its owner.
 //
 // The cases mirror TestResolveCloseTargets:
 //   - maintainer-mode local resolution (no routing involved)
-//   - contributor-mode operand that lives only in the routed planning store
-func TestResolveMolBondOperandRouting(t *testing.T) {
+//   - contributor-mode operands that live only in the routed planning store;
+//     both operands must share one routed handle, and the planning store opens
+//     read-only so the operands are marked non-writable
+func TestResolveMolBondOperandsRouting(t *testing.T) {
 	cases := []struct {
 		name          string
-		role          string // git config beads.role value
-		enableRouting bool   // set routing.mode=auto + routing.contributor=<planningDir>
-		localSeed     string // issue ID to create in the primary (local) store, if non-empty
-		planningSeed  string // issue ID to create in the routed planning store, if non-empty
-		operand       string // argument to resolveMolBondOperand
-		wantRouted    bool   // expected molBondOperand.routed
-		wantStore     string // "local" (== primaryStore) or "planning" (routed handle)
+		role          string   // git config beads.role value
+		enableRouting bool     // set routing.mode=auto + routing.contributor=<planningDir>
+		localSeed     []string // issue IDs to create in the primary (local) store
+		planningSeed  []string // issue IDs to create in the routed planning store
+		operands      [2]string
+		wantRouted    bool // expected molBondOperand.routed for both operands
+		wantWritable  bool // expected molBondOperand.writable for both operands
 	}{
 		{
-			name:       "maintainer_local_issue",
-			role:       "maintainer",
-			localSeed:  "shared-local",
-			operand:    "shared-local",
-			wantRouted: false,
-			wantStore:  "local",
+			name:         "maintainer_local_issues",
+			role:         "maintainer",
+			localSeed:    []string{"shared-local1", "shared-local2"},
+			operands:     [2]string{"shared-local1", "shared-local2"},
+			wantRouted:   false,
+			wantWritable: true,
 		},
 		{
-			name:          "contributor_routed_issue",
+			name:          "contributor_routed_issues_share_one_readonly_handle",
 			role:          "contributor",
 			enableRouting: true,
-			planningSeed:  "shared-routed",
-			operand:       "shared-routed",
+			planningSeed:  []string{"shared-r1", "shared-r2"},
+			operands:      [2]string{"shared-r1", "shared-r2"},
 			wantRouted:    true,
-			wantStore:     "planning",
+			wantWritable:  false,
 		},
 	}
 
@@ -80,14 +83,16 @@ func TestResolveMolBondOperandRouting(t *testing.T) {
 				}
 			}
 
-			if tc.localSeed != "" {
-				seedIssue(t, ctx, primaryStore, tc.localSeed)
+			for _, id := range tc.localSeed {
+				seedIssue(t, ctx, primaryStore, id)
 			}
-			if tc.planningSeed != "" {
+			if len(tc.planningSeed) > 0 {
 				planningStore := newTestStoreIsolatedDB(t, filepath.Join(planningDir, ".beads", "beads.db"), "shared")
-				seedIssue(t, ctx, planningStore, tc.planningSeed)
-				// Release the planning store so resolveMolBondOperand can open the
-				// routed store through the normal command path.
+				for _, id := range tc.planningSeed {
+					seedIssue(t, ctx, planningStore, id)
+				}
+				// Release the planning store so resolveMolBondOperands can open
+				// the routed store through the normal command path.
 				if err := planningStore.Close(); err != nil {
 					t.Fatalf("close planning store: %v", err)
 				}
@@ -102,45 +107,282 @@ func TestResolveMolBondOperandRouting(t *testing.T) {
 				t.Fatalf("chdir repoDir: %v", err)
 			}
 
-			op, err := resolveMolBondOperand(ctx, primaryStore, tc.operand, nil)
+			ops, cleanup, err := resolveMolBondOperands(ctx, primaryStore, tc.operands, nil)
 			if err != nil {
-				t.Fatalf("resolveMolBondOperand(%q): %v", tc.operand, err)
+				t.Fatalf("resolveMolBondOperands(%v): %v", tc.operands, err)
 			}
-			defer op.Close()
+			defer cleanup()
 
-			if op.subgraph == nil || op.subgraph.Root == nil {
-				t.Fatalf("operand %q: missing resolved subgraph", tc.operand)
-			}
-			if op.subgraph.Root.ID != tc.operand {
-				t.Errorf("operand %q: Root.ID = %q, want %q", tc.operand, op.subgraph.Root.ID, tc.operand)
-			}
-			if op.cooked {
-				t.Errorf("operand %q: cooked = true, want false (it is an existing issue)", tc.operand)
-			}
-			if op.routed != tc.wantRouted {
-				t.Errorf("operand %q: routed = %v, want %v", tc.operand, op.routed, tc.wantRouted)
+			for i, op := range ops {
+				operand := tc.operands[i]
+				if op.subgraph == nil || op.subgraph.Root == nil {
+					t.Fatalf("operand %q: missing resolved subgraph", operand)
+				}
+				if op.subgraph.Root.ID != operand {
+					t.Errorf("operand %q: Root.ID = %q, want %q", operand, op.subgraph.Root.ID, operand)
+				}
+				if op.cooked {
+					t.Errorf("operand %q: cooked = true, want false (it is an existing issue)", operand)
+				}
+				if op.routed != tc.wantRouted {
+					t.Errorf("operand %q: routed = %v, want %v", operand, op.routed, tc.wantRouted)
+				}
+				if op.writable != tc.wantWritable {
+					t.Errorf("operand %q: writable = %v, want %v", operand, op.writable, tc.wantWritable)
+				}
+				if !tc.wantRouted && op.store != primaryStore {
+					t.Errorf("operand %q: store should be the local primary store", operand)
+				}
+				if tc.wantRouted && op.store == primaryStore {
+					t.Errorf("operand %q: store should be the routed planning store, not the local one", operand)
+				}
 			}
 
-			assertStoreOrigin(t, tc.operand, tc.wantStore, op.store, primaryStore)
+			// Both routed operands must share one routed handle: identity is
+			// what pickBondStore checks first, and a second open of the same
+			// database would be wasted work.
+			if tc.wantRouted && ops[0].store != ops[1].store {
+				t.Errorf("routed operands should share one routed store handle")
+			}
 		})
 	}
 }
 
-func assertStoreOrigin(t *testing.T, operand, want string, got, local storage.DoltStorage) {
-	t.Helper()
-	switch want {
-	case "local":
-		if got != local {
-			t.Errorf("operand %q: store should be the local primary store", operand)
+// TestMolBondPrefixRoutedWriteThrough verifies the bond MUTATION against a
+// prefix-routed rig store, not just operand resolution: both operands live in
+// a routed rig, pickBondStore selects the routed store (a same-rig pair must
+// not be rejected as cross-store), the bond dependency write succeeds because
+// the prefix-routed store opened write-intent, and the dependency is visible
+// afterward through a fresh routed read — proving the write committed in the
+// routed database rather than the local one.
+//
+// NOTE: This test uses os.Chdir and cannot run in parallel with other tests.
+func TestMolBondPrefixRoutedWriteThrough(t *testing.T) {
+	initConfigForTest(t)
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	townBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatalf("create town beads dir: %v", err)
+	}
+	rigBeadsDir := filepath.Join(tmpDir, "rig", ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatalf("create rig beads dir: %v", err)
+	}
+
+	townDBPath := filepath.Join(townBeadsDir, "dolt")
+	townStore := newTestStoreIsolatedDB(t, townDBPath, "hq")
+
+	rigDBPath := filepath.Join(rigBeadsDir, "dolt")
+	rigStore := newTestStoreIsolatedDB(t, rigDBPath, "gt")
+	seedIssue(t, ctx, rigStore, "gt-mol1")
+	seedIssue(t, ctx, rigStore, "gt-mol2")
+	// Release the rig store before routing reopens it.
+	rigStore.Close()
+
+	routesPath := filepath.Join(townBeadsDir, "routes.jsonl")
+	if err := os.WriteFile(routesPath, []byte(`{"prefix":"gt-","path":"rig"}`), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	oldDbPath := dbPath
+	dbPath = townDBPath
+	t.Cleanup(func() { dbPath = oldDbPath })
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	ops, cleanup, err := resolveMolBondOperands(ctx, townStore, [2]string{"gt-mol1", "gt-mol2"}, nil)
+	if err != nil {
+		t.Fatalf("resolveMolBondOperands: %v", err)
+	}
+	for i, operand := range []string{"gt-mol1", "gt-mol2"} {
+		if !ops[i].routed {
+			cleanup()
+			t.Fatalf("operand %q: routed = false, want true", operand)
 		}
-	case "planning":
-		if got == nil {
-			t.Errorf("operand %q: store is nil", operand)
+		if !ops[i].writable {
+			cleanup()
+			t.Fatalf("operand %q: writable = false, want true (prefix routing is write-intent)", operand)
 		}
-		if got == local {
-			t.Errorf("operand %q: store should be the routed planning store, not the local one", operand)
+	}
+	if ops[0].store != ops[1].store {
+		cleanup()
+		t.Fatal("same-rig operands should share one routed store handle")
+	}
+
+	// A same-rig pair must not be rejected as a cross-store bond.
+	activeStore, err := pickBondStore(townStore, ops[0], ops[1])
+	if err != nil {
+		cleanup()
+		t.Fatalf("pickBondStore rejected a same-rig pair: %v", err)
+	}
+	if activeStore != ops[0].store {
+		cleanup()
+		t.Fatal("pickBondStore should select the routed store that owns the operands")
+	}
+
+	// The actual mutation: this is what a resolution-only test misses. The
+	// routed store opened write-intent, so the dependency write must succeed.
+	if _, err := bondMolMol(ctx, activeStore, ops[0].subgraph.Root, ops[1].subgraph.Root, types.BondTypeSequential, "test"); err != nil {
+		cleanup()
+		t.Fatalf("bondMolMol against the routed store: %v", err)
+	}
+	cleanup()
+
+	// Verify through a fresh routed read that the bond committed in the rig
+	// database: gt-mol2 (B) now depends on gt-mol1 (A).
+	rr, err := resolveViaPrefixRoutingWithAccess(ctx, "gt-mol2", false)
+	if err != nil {
+		t.Fatalf("reopening routed store to verify the write: %v", err)
+	}
+	defer rr.Close()
+	deps, err := rr.Store.GetDependenciesWithMetadata(ctx, "gt-mol2")
+	if err != nil {
+		t.Fatalf("reading dependencies from the routed store: %v", err)
+	}
+	found := false
+	for _, dep := range deps {
+		if dep.ID == "gt-mol1" && dep.DependencyType == types.DepBlocks {
+			found = true
 		}
-	default:
-		t.Fatalf("operand %q: unknown wantStore %q", operand, want)
+	}
+	if !found {
+		t.Fatalf("bond did not commit in the routed store: gt-mol2 dependencies = %+v", deps)
+	}
+}
+
+// TestSameBondStoreSeparateHandles is the regression test for the store
+// identity check: two separately-opened handles onto the same routed database
+// (each route-open constructs a fresh store in server mode) must compare as
+// the same store, not be rejected as a cross-store bond.
+//
+// NOTE: This test uses os.Chdir and cannot run in parallel with other tests.
+func TestSameBondStoreSeparateHandles(t *testing.T) {
+	initConfigForTest(t)
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	townBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatalf("create town beads dir: %v", err)
+	}
+	rigBeadsDir := filepath.Join(tmpDir, "rig", ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatalf("create rig beads dir: %v", err)
+	}
+
+	townDBPath := filepath.Join(townBeadsDir, "dolt")
+	townStore := newTestStoreIsolatedDB(t, townDBPath, "hq")
+
+	rigDBPath := filepath.Join(rigBeadsDir, "dolt")
+	rigStore := newTestStoreIsolatedDB(t, rigDBPath, "gt")
+	seedIssue(t, ctx, rigStore, "gt-idn1")
+	rigStore.Close()
+
+	routesPath := filepath.Join(townBeadsDir, "routes.jsonl")
+	if err := os.WriteFile(routesPath, []byte(`{"prefix":"gt-","path":"rig"}`), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	oldDbPath := dbPath
+	dbPath = townDBPath
+	t.Cleanup(func() { dbPath = oldDbPath })
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	rrA, err := resolveViaPrefixRoutingWithAccess(ctx, "gt-idn1", true)
+	if err != nil {
+		t.Fatalf("first route-open: %v", err)
+	}
+	defer rrA.Close()
+	rrB, err := resolveViaPrefixRoutingWithAccess(ctx, "gt-idn1", true)
+	if err != nil {
+		t.Fatalf("second route-open: %v", err)
+	}
+	defer rrB.Close()
+
+	if rrA.Store == rrB.Store {
+		t.Fatal("test precondition: expected two distinct store handles from separate route-opens")
+	}
+	if !sameBondStore(rrA.Store, rrB.Store) {
+		t.Fatal("sameBondStore: two handles onto the same routed database must compare as the same store")
+	}
+
+	// The negative case matters just as much: genuinely different databases
+	// must NOT compare as the same store, or pickBondStore would silently
+	// allow the cross-store bonds it exists to reject.
+	if sameBondStore(townStore, rrA.Store) {
+		t.Fatal("sameBondStore: handles onto different databases must not compare as the same store")
+	}
+}
+
+// TestMolBondAutoRoutedReadOnlyFailsFast verifies the write-path guard for
+// contributor auto-routing: the planning store deliberately opens read-only
+// (it hydrates a foreign project that must never be mutated), so a bond pinned
+// to it must fail fast with a clear message from pickBondStore — before any
+// mutation is attempted — rather than surface a store-layer write refusal
+// halfway through the bond.
+func TestMolBondAutoRoutedReadOnlyFailsFast(t *testing.T) {
+	initConfigForTest(t)
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+	planningDir := filepath.Join(tmpDir, "planning")
+
+	runCmd(t, tmpDir, "git", "init", repoDir)
+	runCmd(t, repoDir, "git", "config", "beads.role", "contributor")
+
+	primaryStore := newTestStoreIsolatedDB(t, filepath.Join(repoDir, ".beads", "beads.db"), "shared")
+	if err := primaryStore.SetConfig(ctx, "routing.mode", "auto"); err != nil {
+		t.Fatalf("set routing.mode: %v", err)
+	}
+	if err := primaryStore.SetConfig(ctx, "routing.contributor", planningDir); err != nil {
+		t.Fatalf("set routing.contributor: %v", err)
+	}
+
+	planningStore := newTestStoreIsolatedDB(t, filepath.Join(planningDir, ".beads", "beads.db"), "shared")
+	seedIssue(t, ctx, planningStore, "shared-ro1")
+	seedIssue(t, ctx, planningStore, "shared-ro2")
+	if err := planningStore.Close(); err != nil {
+		t.Fatalf("close planning store: %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("chdir repoDir: %v", err)
+	}
+
+	ops, cleanup, err := resolveMolBondOperands(ctx, primaryStore, [2]string{"shared-ro1", "shared-ro2"}, nil)
+	if err != nil {
+		t.Fatalf("resolveMolBondOperands: %v", err)
+	}
+	defer cleanup()
+
+	_, err = pickBondStore(primaryStore, ops[0], ops[1])
+	if err == nil {
+		t.Fatal("pickBondStore should reject a bond pinned to the read-only auto-routed store")
+	}
+	if !strings.Contains(err.Error(), "read-only") || !strings.Contains(err.Error(), "auto-routed") {
+		t.Errorf("fail-fast error should explain the read-only auto-routed store, got: %v", err)
 	}
 }

--- a/cmd/bd/mol_bond_var_validation_test.go
+++ b/cmd/bd/mol_bond_var_validation_test.go
@@ -1,0 +1,102 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/formula"
+)
+
+// Regression coverage for the #5253 guarantees on the routed bond path:
+// bd mol bond resolves operands through discoverMolBondOperand (read-only
+// routing discovery) rather than resolveOrDescribe, so the discovery fallback
+// must enforce the same --var enum/pattern/provided-empty validation — for
+// --dry-run and execution alike — and a var-validation failure on a real
+// formula must surface directly instead of being masked as
+// "'X' not found as issue or formula".
+
+func makeMolBondVarTestCmd(dryRun bool, varFlags []string) *cobra.Command {
+	c := &cobra.Command{Use: "bond"}
+	c.Flags().String("type", "sequential", "")
+	c.Flags().String("as", "", "")
+	c.Flags().Bool("dry-run", dryRun, "")
+	c.Flags().Bool("ephemeral", false, "")
+	c.Flags().Bool("pour", false, "")
+	c.Flags().String("ref", "", "")
+	c.Flags().StringArray("var", varFlags, "")
+	return c
+}
+
+func runMolBondVarViolation(t *testing.T, dryRun bool) (error, string) {
+	t.Helper()
+	writeVarValidationFormula(t)
+	s := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	withWispTestGlobals(t, s, context.Background())
+
+	var runErr error
+	stderr := captureStderr(t, func() {
+		runErr = runMolBond(makeMolBondVarTestCmd(dryRun, []string{"policy=bogus", "slug=abc"}),
+			[]string{"pour-wisp-var-validation-test", "pour-wisp-var-validation-test"})
+	})
+	return runErr, stderr
+}
+
+// TestMolBondDryRunRejectsEnumViolatingVar pins #4714's framing: the dry-run
+// must fail the same way the real bond would, not preview success for a bond
+// execution refuses.
+func TestMolBondDryRunRejectsEnumViolatingVar(t *testing.T) {
+	runErr, stderr := runMolBondVarViolation(t, true)
+
+	if runErr == nil {
+		t.Fatal("mol bond --dry-run accepted a --var value outside the declared enum")
+	}
+	if !strings.Contains(stderr, "not in allowed values") {
+		t.Fatalf("stderr = %q, want an enum-violation message", stderr)
+	}
+	if strings.Contains(stderr, "not found as issue or formula") {
+		t.Fatalf("stderr = %q: the var-validation failure was masked as not-found", stderr)
+	}
+}
+
+func TestMolBondExecutionRejectsEnumViolatingVar(t *testing.T) {
+	runErr, stderr := runMolBondVarViolation(t, false)
+
+	if runErr == nil {
+		t.Fatal("mol bond accepted a --var value outside the declared enum")
+	}
+	if !strings.Contains(stderr, "not in allowed values") {
+		t.Fatalf("stderr = %q, want an enum-violation message", stderr)
+	}
+	if strings.Contains(stderr, "not found as issue or formula") {
+		t.Fatalf("stderr = %q: the var-validation failure was masked as not-found", stderr)
+	}
+}
+
+// TestMaterializeMolBondOperandPassesVarValidationThrough covers the writable
+// phase directly: even if a violating value reaches the cook (discovery only
+// checks vars that are provided against the formula it loaded), the sentinel
+// must pass through unwrapped so callers and users see the constraint
+// violation, not a bogus not-found.
+func TestMaterializeMolBondOperandPassesVarValidationThrough(t *testing.T) {
+	writeVarValidationFormula(t)
+	s := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+
+	_, err := materializeMolBondOperand(context.Background(), s,
+		&molBondDiscovery{operand: "pour-wisp-var-validation-test"},
+		map[string]string{"policy": "bogus", "slug": "abc"})
+	if err == nil {
+		t.Fatal("materializeMolBondOperand cooked a formula whose --var values violate its enum")
+	}
+	if !errors.Is(err, formula.ErrVarValidation) {
+		t.Fatalf("err = %v, want errors.Is(err, formula.ErrVarValidation)", err)
+	}
+	if strings.Contains(err.Error(), "not found as issue or formula") {
+		t.Fatalf("err = %q: the var-validation failure was double-wrapped as not-found", err)
+	}
+}

--- a/cmd/bd/routed.go
+++ b/cmd/bd/routed.go
@@ -12,10 +12,13 @@ import (
 
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/debug"
+	"github.com/steveyegge/beads/internal/routing"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/utils"
 )
+
+var errRoutingUnavailable = errors.New("routing unavailable")
 
 // isNotFoundErr returns true if the error indicates the issue was not found.
 // This covers both storage.ErrNotFound (from GetIssue) and the plain error
@@ -32,17 +35,19 @@ func isNotFoundErr(err error) bool {
 
 // RoutedResult contains the result of a routed issue lookup
 type RoutedResult struct {
-	Issue      *types.Issue
-	Store      storage.DoltStorage // The store that contains this issue (may be routed)
-	Routed     bool                // true if the issue was found via routing
-	ResolvedID string              // The resolved (full) issue ID
-	closeFn    func()              // Function to close routed storage (if any)
+	Issue             *types.Issue
+	Store             storage.DoltStorage // The store that contains this issue (may be routed)
+	Routed            bool                // true if the issue was found via routing
+	MutationForbidden bool                // true when routing policy forbids mutation
+	ResolvedID        string              // The resolved (full) issue ID
+	closeFn           func()              // Function to close routed storage (if any)
 }
 
 // Close closes any routed storage. Safe to call if Routed is false.
 func (r *RoutedResult) Close() {
 	if r.closeFn != nil {
 		r.closeFn()
+		r.closeFn = nil
 	}
 }
 
@@ -80,15 +85,19 @@ func resolveAndGetIssueWithRoutingAccess(ctx context.Context, localStore storage
 	if isNotFoundErr(err) {
 		if prefixResult, prefixErr := resolveViaPrefixRoutingWithAccess(ctx, id, writablePrefixRoute); prefixErr == nil {
 			return prefixResult, nil
+		} else if !errors.Is(prefixErr, errRoutingUnavailable) && !isNotFoundErr(prefixErr) {
+			return nil, prefixErr
 		}
 	}
 
-	// If not found via prefix routing, try contributor auto-routing as fallback (GH#2345).
-	// Auto-routed stores stay read-only even for write-intent callers (writablePrefixRoute):
-	// this path hydrates foreign contributor projects, which must never be mutated.
+	// If not found via prefix routing, try auto-routing as fallback (GH#2345).
+	// Contributor targets stay read-only; maintainer/default targets may reopen
+	// writable when the caller has write intent.
 	if isNotFoundErr(err) {
-		if autoResult, autoErr := resolveViaAutoRouting(ctx, localStore, id); autoErr == nil {
+		if autoResult, autoErr := resolveViaAutoRoutingWithAccess(ctx, localStore, id, writablePrefixRoute); autoErr == nil {
 			return autoResult, nil
+		} else if !errors.Is(autoErr, errRoutingUnavailable) && !isNotFoundErr(autoErr) {
+			return nil, autoErr
 		}
 	}
 
@@ -121,9 +130,16 @@ func resolveAndGetFromStore(ctx context.Context, s storage.DoltStorage, id strin
 // This is the fallback when the local store doesn't have the issue (GH#2345).
 // Returns a RoutedResult if the issue is found in the auto-routed store.
 func resolveViaAutoRouting(ctx context.Context, localStore storage.DoltStorage, id string) (*RoutedResult, error) {
-	routedStore, routed, _, err := openRoutedReadStore(ctx, localStore)
-	if err != nil || !routed {
-		return nil, fmt.Errorf("no auto-routed store available")
+	return resolveViaAutoRoutingWithAccess(ctx, localStore, id, false)
+}
+
+func resolveViaAutoRoutingWithAccess(ctx context.Context, localStore storage.DoltStorage, id string, writable bool) (*RoutedResult, error) {
+	routedStore, routed, rule, err := openAutoRoutedStore(ctx, localStore, writable)
+	if err != nil {
+		return nil, err
+	}
+	if !routed {
+		return nil, fmt.Errorf("%w: no auto-routed store available", errRoutingUnavailable)
 	}
 
 	result, err := resolveAndGetFromStore(ctx, routedStore, id, true)
@@ -131,6 +147,7 @@ func resolveViaAutoRouting(ctx context.Context, localStore storage.DoltStorage, 
 		_ = routedStore.Close()
 		return nil, err
 	}
+	result.MutationForbidden = rule == routing.RuleContributor
 	result.closeFn = func() { _ = routedStore.Close() }
 	return result, nil
 }
@@ -163,19 +180,25 @@ func resolveViaPrefixRoutingWithAccess(ctx context.Context, id string, writable 
 	// Extract prefix from the bead ID (e.g., "hr-" from "hr-8wn.1")
 	prefix := extractBeadPrefix(id)
 	if prefix == "" {
-		return nil, fmt.Errorf("no prefix in ID %q", id)
+		return nil, fmt.Errorf("%w: no prefix in ID %q", errRoutingUnavailable, id)
 	}
 
 	// Find the resolved beads directory (where routes.jsonl lives)
 	currentBeadsDir := resolveCommandBeadsDir(dbPath)
 	if currentBeadsDir == "" {
-		return nil, fmt.Errorf("no beads directory available")
+		return nil, fmt.Errorf("%w: no beads directory available", errRoutingUnavailable)
 	}
 
 	// Load routes from routes.jsonl
 	routes, err := loadPrefixRoutes(currentBeadsDir)
-	if err != nil || len(routes) == 0 {
-		return nil, fmt.Errorf("no routes available")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: no routes available", errRoutingUnavailable)
+		}
+		return nil, fmt.Errorf("loading routes: %w", err)
+	}
+	if len(routes) == 0 {
+		return nil, fmt.Errorf("%w: no routes available", errRoutingUnavailable)
 	}
 
 	// Find matching route for this prefix
@@ -187,12 +210,12 @@ func resolveViaPrefixRoutingWithAccess(ctx context.Context, id string, writable 
 		}
 	}
 	if matchedRoute == nil {
-		return nil, fmt.Errorf("no route for prefix %q", prefix)
+		return nil, fmt.Errorf("%w: no route for prefix %q", errRoutingUnavailable, prefix)
 	}
 
 	// Skip if the route points to current directory (town-level, already checked)
 	if matchedRoute.Path == "." {
-		return nil, fmt.Errorf("route points to current database")
+		return nil, fmt.Errorf("%w: route points to current database", errRoutingUnavailable)
 	}
 
 	// Derive the town root from the current beads dir.
@@ -323,6 +346,8 @@ func getIssueWithRouting(ctx context.Context, localStore storage.DoltStorage, id
 	if isNotFoundErr(err) {
 		if prefixResult, prefixErr := resolveViaPrefixRouting(ctx, id); prefixErr == nil {
 			return prefixResult, nil
+		} else if !errors.Is(prefixErr, errRoutingUnavailable) && !isNotFoundErr(prefixErr) {
+			return nil, prefixErr
 		}
 	}
 
@@ -330,6 +355,8 @@ func getIssueWithRouting(ctx context.Context, localStore storage.DoltStorage, id
 	if isNotFoundErr(err) {
 		if autoResult, autoErr := resolveViaAutoRouting(ctx, localStore, id); autoErr == nil {
 			return autoResult, nil
+		} else if !errors.Is(autoErr, errRoutingUnavailable) && !isNotFoundErr(autoErr) {
+			return nil, autoErr
 		}
 	}
 

--- a/cmd/bd/routed.go
+++ b/cmd/bd/routed.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -192,7 +193,7 @@ func resolveViaPrefixRoutingWithAccess(ctx context.Context, id string, writable 
 	// Load routes from routes.jsonl
 	routes, err := loadPrefixRoutes(currentBeadsDir)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil, fmt.Errorf("%w: no routes available", errRoutingUnavailable)
 		}
 		return nil, fmt.Errorf("loading routes: %w", err)

--- a/cmd/bd/routed_mutation_test.go
+++ b/cmd/bd/routed_mutation_test.go
@@ -1,0 +1,79 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMaintainerAutoRouteMutationWritesThrough covers the widened
+// openAutoRoutedStore behavior for write-intent callers beyond mol bond:
+// resolveAndGetIssueForMutation is the resolver bd update uses, and a
+// maintainer auto-routed store must open writable so the mutation actually
+// commits in the routed database. (Contributor auto-routes stay read-only and
+// mutation-forbidden; that side is covered by
+// TestMolBondAutoRoutedReadOnlyFailsFast.)
+func TestMaintainerAutoRouteMutationWritesThrough(t *testing.T) {
+	initConfigForTest(t)
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+	planningDir := filepath.Join(tmpDir, "planning")
+
+	runCmd(t, tmpDir, "git", "init", repoDir)
+	// Force repo-local hooks so tests ignore any global hooksPath override.
+	runCmd(t, repoDir, "git", "config", "core.hooksPath", ".git/hooks")
+	runCmd(t, repoDir, "git", "config", "beads.role", "maintainer")
+
+	primaryStore := newTestStoreIsolatedDB(t, filepath.Join(repoDir, ".beads", "beads.db"), "shared")
+	if err := primaryStore.SetConfig(ctx, "routing.mode", "auto"); err != nil {
+		t.Fatalf("set routing.mode: %v", err)
+	}
+	if err := primaryStore.SetConfig(ctx, "routing.maintainer", planningDir); err != nil {
+		t.Fatalf("set routing.maintainer: %v", err)
+	}
+
+	planningStore := newTestStoreIsolatedDB(t, filepath.Join(planningDir, ".beads", "beads.db"), "shared")
+	seedIssue(t, ctx, planningStore, "shared-hub")
+	if err := planningStore.Close(); err != nil {
+		t.Fatalf("close planning store: %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("chdir repoDir: %v", err)
+	}
+
+	rr, err := resolveAndGetIssueForMutation(ctx, primaryStore, "shared-hub")
+	if err != nil {
+		t.Fatalf("resolveAndGetIssueForMutation: %v", err)
+	}
+	if !rr.Routed || rr.MutationForbidden {
+		rr.Close()
+		t.Fatalf("routed = %v, mutationForbidden = %v; want a permitted maintainer auto-route", rr.Routed, rr.MutationForbidden)
+	}
+	if err := rr.Store.UpdateIssue(ctx, rr.ResolvedID, map[string]interface{}{"priority": 0}, "test"); err != nil {
+		rr.Close()
+		t.Fatalf("update through the maintainer auto-route: %v", err)
+	}
+	rr.Close()
+
+	// Verify through a fresh routed read that the update committed in the
+	// planning database, not in a doomed in-memory handle.
+	reread, err := resolveAndGetIssueWithRouting(ctx, primaryStore, "shared-hub")
+	if err != nil {
+		t.Fatalf("re-reading the routed issue: %v", err)
+	}
+	defer reread.Close()
+	if reread.Issue.Priority != 0 {
+		t.Fatalf("priority = %d after routed update, want 0", reread.Issue.Priority)
+	}
+}

--- a/cmd/bd/routing_read.go
+++ b/cmd/bd/routing_read.go
@@ -160,6 +160,14 @@ func printContributorRoutingNotice(ctx context.Context, localStore storage.DoltS
 // returned routing.RoutingRule identifies which rule matched, for callers
 // that print a routing notice.
 func openRoutedReadStore(ctx context.Context, store storage.DoltStorage) (storage.DoltStorage, bool, routing.RoutingRule, error) {
+	return openAutoRoutedStore(ctx, store, false)
+}
+
+// openAutoRoutedStore opens the target selected by auto-routing. Contributor
+// routing always stays read-only because it hydrates a foreign planning
+// project. Maintainer/default routes may be opened writable for commands whose
+// mutation home has already been validated.
+func openAutoRoutedStore(ctx context.Context, store storage.DoltStorage, writable bool) (storage.DoltStorage, bool, routing.RoutingRule, error) {
 	repoPath, rule := determineAutoRoutedRepoPath(ctx, store)
 	if repoPath == "" || repoPath == "." {
 		return nil, false, routing.RuleNone, nil
@@ -167,7 +175,13 @@ func openRoutedReadStore(ctx context.Context, store storage.DoltStorage) (storag
 
 	targetRepoPath := routing.ExpandPath(repoPath)
 	targetBeadsDir := filepath.Join(targetRepoPath, ".beads")
-	targetStore, err := newReadOnlyStoreFromConfig(ctx, targetBeadsDir)
+	var targetStore storage.DoltStorage
+	var err error
+	if writable && rule != routing.RuleContributor {
+		targetStore, err = newDoltStoreFromConfig(ctx, targetBeadsDir)
+	} else {
+		targetStore, err = newReadOnlyStoreFromConfig(ctx, targetBeadsDir)
+	}
 	if err != nil {
 		return nil, false, rule, fmt.Errorf("failed to open routed store at %s: %w", targetRepoPath, err)
 	}


### PR DESCRIPTION
## What

`bd mol bond <A> <B>` now resolves operands through the same local → prefix route → auto-route fallback used by other issue commands. Bonds run in the validated owning store, while unsupported cross-store and contributor-planning-store mutations fail before any writable foreign-store open.

## Why

Fixes #4714. `mol bond` previously resolved only against the local store, so `bd show <id>` could find a routed issue that `bd mol bond <formula> <id>` rejected. This breaks the default `gt sling` path.

The final design also incorporates the two applicable safety ideas from the older #4350 implementation: discover routed homes read-only before reopening one writable, and preserve actionable failures after a prefix route matches. Johan Snyman is credited as co-author on the maintainer integration commit.

## How

- Discover both operands read-only, with unconditional formula fallback so valid plain formulas and formulas colliding with ambiguous issue prefixes still work.
- Apply the same discovery and store-policy validation to `--dry-run` and execution.
- Compare logical stores using the existing `dependencyStoreKey`, which unwraps hook/telemetry decorators before consulting `StoreLocator`.
- Reject genuinely cross-store bonds and contributor auto-routed mutations before opening a foreign store writable.
- After validation, close read handles, reopen the accepted prefix/maintainer/default route writable, and verify its logical identity has not changed.
- Run routed mutations through the normal storage decorator chain so hooks and telemetry remain active.
- Distinguish “no matching route” from a matched route whose metadata or store open failed; the latter error is returned instead of being collapsed into “not found.”

The proxied-server `mol bond` path remains local-only and is intentionally outside this PR’s direct-store routing change.

## Verification

Focused cgo routing tests pass:

- `TestDiscoverMolBondOperandRouting`
- `TestDiscoverMolBondOperandFormulaWinsAmbiguousIssuePrefix`
- `TestMolBondPrefixRoutedWriteThrough`
- `TestSameBondStoreSeparateHandles`
- `TestMolBondAutoRoutedReadOnlyFailsFast`

Existing routing compatibility tests also pass:

- `TestResolveCloseTargets`
- `TestDepRoutedTargetOpensReadOnly`
- `TestDepListCrossRigRouting`

The affected package compiles under the pure-Go `gms_pure_go` configuration. A fresh cross-vendor review found no remaining code issues; the full local suite is queued through the repository verifier.

---

Original implementation and tests by Rody Vilchez; maintainer integration with Johan Snyman attribution.

_codex-gpt-5.6-sol-high on behalf of maphew_
