### PR TITLE
fix(storage): normalize persisted audit timestamps to UTC

### DIFF
--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -425,6 +425,13 @@ func PrepareIssueForInsert(issue *types.Issue, customStatuses, customTypes []str
 	} else {
 		issue.UpdatedAt = issue.UpdatedAt.UTC()
 	}
+	normalizeTimePtrToUTC(issue.StartedAt)
+	normalizeTimePtrToUTC(issue.ClosedAt)
+	normalizeTimePtrToUTC(issue.LeaseExpiresAt)
+	normalizeTimePtrToUTC(issue.HeartbeatAt)
+	normalizeTimePtrToUTC(issue.DueAt)
+	normalizeTimePtrToUTC(issue.DeferUntil)
+	normalizeTimePtrToUTC(issue.CompactedAt)
 
 	// Ensure closed issues have a closed_at timestamp.
 	if issue.Status == types.StatusClosed && issue.ClosedAt == nil {
@@ -443,6 +450,12 @@ func PrepareIssueForInsert(issue *types.Issue, customStatuses, customTypes []str
 		issue.ContentHash = issue.ComputeContentHash()
 	}
 	return nil
+}
+
+func normalizeTimePtrToUTC(value *time.Time) {
+	if value != nil && !value.IsZero() {
+		*value = value.UTC()
+	}
 }
 
 // ValidateIssueIDPrefix validates that the issue ID matches the configured prefix
@@ -665,6 +678,8 @@ func PersistComments(ctx context.Context, tx *sql.Tx, issue *types.Issue) (Creat
 		createdAt := comment.CreatedAt
 		if createdAt.IsZero() {
 			createdAt = time.Now().UTC()
+		} else {
+			createdAt = createdAt.UTC()
 		}
 		// Check for existing identical comment to prevent duplicates on re-import.
 		// The UUID PK means ON DUPLICATE KEY UPDATE would never fire,
@@ -752,10 +767,7 @@ func PersistDependenciesWithOptionsResult(ctx context.Context, tx *sql.Tx, issue
 				return result, fmt.Errorf("invalid dependency %s -> %s: %w", dep.IssueID, dep.DependsOnID, err)
 			}
 
-			createdAt := dep.CreatedAt
-			if createdAt.IsZero() {
-				createdAt = time.Now().UTC()
-			}
+			createdAt := dependencyCreatedAt(dep)
 			// Deterministic id from (issue_id, target) keeps bulk-imported edges
 			// merge-safe across clones — two clones importing the same JSONL get the
 			// same primary key, not two random UUIDs that collide on uk_dep_* (#4259).
@@ -789,6 +801,13 @@ func dependencyCreatedBy(dep *types.Dependency, actor string) string {
 		return dep.CreatedBy
 	}
 	return actor
+}
+
+func dependencyCreatedAt(dep *types.Dependency) time.Time {
+	if dep == nil || dep.CreatedAt.IsZero() {
+		return time.Now().UTC()
+	}
+	return dep.CreatedAt.UTC()
 }
 
 func recordSkippedDependency(opts storage.BatchCreateOptions, dep *types.Dependency, reason string) {

--- a/internal/storage/issueops/create_test.go
+++ b/internal/storage/issueops/create_test.go
@@ -6,12 +6,86 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/depid"
 	"github.com/steveyegge/beads/internal/types"
 )
+
+func offsetTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		t.Fatalf("time.Parse(%q): %v", value, err)
+	}
+	return parsed
+}
+
+func TestPrepareIssueForInsertNormalizesTimestampsToUTC(t *testing.T) {
+	createdAt := offsetTime(t, "2026-07-11T18:40:00+10:00")
+	startedAt := offsetTime(t, "2026-07-11T18:41:00+10:00")
+	closedAt := offsetTime(t, "2026-07-11T18:42:00+10:00")
+	leaseExpiresAt := offsetTime(t, "2026-07-11T18:43:00+10:00")
+	heartbeatAt := offsetTime(t, "2026-07-11T18:44:00+10:00")
+	dueAt := offsetTime(t, "2026-07-11T18:45:00+10:00")
+	deferUntil := offsetTime(t, "2026-07-11T18:46:00+10:00")
+	compactedAt := offsetTime(t, "2026-07-11T18:47:00+10:00")
+	issue := &types.Issue{
+		ID: "test-utc", Title: "UTC", Status: types.StatusClosed, IssueType: types.TypeTask,
+		CreatedAt: createdAt, UpdatedAt: createdAt, StartedAt: &startedAt, ClosedAt: &closedAt,
+		LeaseExpiresAt: &leaseExpiresAt, HeartbeatAt: &heartbeatAt, DueAt: &dueAt,
+		DeferUntil: &deferUntil, CompactedAt: &compactedAt,
+	}
+
+	if err := PrepareIssueForInsert(issue, nil, nil); err != nil {
+		t.Fatalf("PrepareIssueForInsert: %v", err)
+	}
+	values := []time.Time{issue.CreatedAt, issue.UpdatedAt, *issue.StartedAt, *issue.ClosedAt,
+		*issue.LeaseExpiresAt, *issue.HeartbeatAt, *issue.DueAt, *issue.DeferUntil, *issue.CompactedAt}
+	for _, value := range values {
+		if value.Location() != time.UTC {
+			t.Errorf("timestamp location = %v, want UTC", value.Location())
+		}
+	}
+	if got, want := issue.ClosedAt.Format(time.RFC3339), "2026-07-11T08:42:00Z"; got != want {
+		t.Errorf("ClosedAt = %s, want %s", got, want)
+	}
+}
+
+func TestPersistCommentsNormalizesImportedTimestampToUTC(t *testing.T) {
+	ctx := context.Background()
+	db, mock, tx := beginMockTx(t)
+	defer db.Close()
+	createdAt := offsetTime(t, "2026-07-11T18:42:00+10:00")
+	wantUTC := createdAt.UTC()
+	issue := &types.Issue{ID: "source", Comments: []*types.Comment{{
+		ID: "comment-id", Author: "original-author", Text: "kept", CreatedAt: createdAt,
+	}}}
+
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM comments").
+		WithArgs("source", "original-author", wantUTC, "kept").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec("INSERT INTO comments").
+		WithArgs("comment-id", "source", "original-author", "kept", wantUTC).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	result, err := PersistComments(ctx, tx, issue)
+	if err != nil {
+		t.Fatalf("PersistComments: %v", err)
+	}
+	if !result.ChangedTables["comments"] {
+		t.Fatalf("ChangedTables = %#v, want comments changed", result.ChangedTables)
+	}
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
 
 func TestValidateCreateIssuesMixedBucketDependenciesRejectsCrossBucketEdges(t *testing.T) {
 	regularA := &types.Issue{ID: "test-regular-a", IssueType: types.TypeTask}
@@ -156,6 +230,7 @@ func TestPersistDependenciesHonorsImportedCreatedBy(t *testing.T) {
 	db, mock, tx := beginMockTx(t)
 	defer db.Close()
 
+	createdAt := offsetTime(t, "2026-07-11T18:41:00+10:00")
 	target := &types.Issue{ID: "target", IssueType: types.TypeTask}
 	source := &types.Issue{
 		ID:        "source",
@@ -164,6 +239,7 @@ func TestPersistDependenciesHonorsImportedCreatedBy(t *testing.T) {
 			DependsOnID: "target",
 			Type:        types.DepRelated,
 			CreatedBy:   "someone.else",
+			CreatedAt:   createdAt,
 		}},
 	}
 
@@ -174,7 +250,7 @@ func TestPersistDependenciesHonorsImportedCreatedBy(t *testing.T) {
 		WithArgs("target").
 		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 	mock.ExpectExec("INSERT INTO dependencies").
-		WithArgs(depid.New("source", "target"), "source", "target", types.DepRelated, "someone.else", sqlmock.AnyArg()).
+		WithArgs(depid.New("source", "target"), "source", "target", types.DepRelated, "someone.else", createdAt.UTC()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	result, err := PersistDependenciesWithOptionsResult(ctx, tx, []*types.Issue{target, source}, "current.user", storage.BatchCreateOptions{})
@@ -230,6 +306,24 @@ func TestPersistDependenciesDefaultsCreatedByToActor(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestDependencyCreatedAtNormalizesToUTC(t *testing.T) {
+	createdAt := offsetTime(t, "2026-07-11T18:41:00+10:00")
+	got := dependencyCreatedAt(&types.Dependency{CreatedAt: createdAt})
+	if got.Location() != time.UTC {
+		t.Fatalf("Location = %v, want UTC", got.Location())
+	}
+	if want := "2026-07-11T08:41:00Z"; got.Format(time.RFC3339) != want {
+		t.Fatalf("dependencyCreatedAt = %s, want %s", got.Format(time.RFC3339), want)
+	}
+
+	before := time.Now().UTC().Add(-time.Second)
+	defaulted := dependencyCreatedAt(&types.Dependency{})
+	after := time.Now().UTC().Add(time.Second)
+	if defaulted.Before(before) || defaulted.After(after) || defaulted.Location() != time.UTC {
+		t.Fatalf("default dependency time = %v, want current UTC instant", defaulted)
 	}
 }
 

--- a/internal/storage/issueops/create_test.go
+++ b/internal/storage/issueops/create_test.go
@@ -3,6 +3,7 @@ package issueops
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"strings"
 	"testing"
@@ -13,6 +14,16 @@ import (
 	"github.com/steveyegge/beads/internal/storage/depid"
 	"github.com/steveyegge/beads/internal/types"
 )
+
+type utcTimeBetween struct {
+	before time.Time
+	after  time.Time
+}
+
+func (m utcTimeBetween) Match(value driver.Value) bool {
+	timestamp, ok := value.(time.Time)
+	return ok && timestamp.Location() == time.UTC && !timestamp.Before(m.before) && !timestamp.After(m.after)
+}
 
 func offsetTime(t *testing.T, value string) time.Time {
 	t.Helper()
@@ -324,6 +335,74 @@ func TestDependencyCreatedAtNormalizesToUTC(t *testing.T) {
 	after := time.Now().UTC().Add(time.Second)
 	if defaulted.Before(before) || defaulted.After(after) || defaulted.Location() != time.UTC {
 		t.Fatalf("default dependency time = %v, want current UTC instant", defaulted)
+	}
+}
+
+func TestAddDependencyInTxBindsCreatedAtUTC(t *testing.T) {
+	ctx := context.Background()
+	kind := DepTargetIssue
+	opts := AddDependencyOpts{
+		SourceTable:    "issues",
+		TargetTable:    "issues",
+		WriteTable:     "dependencies",
+		SkipCycleCheck: true,
+		TargetKind:     &kind,
+	}
+
+	t.Run("preserves supplied instant", func(t *testing.T) {
+		db, mock, tx := beginMockTx(t)
+		defer db.Close()
+		createdAt := offsetTime(t, "2026-07-11T18:41:00+10:00")
+		dep := &types.Dependency{
+			IssueID: "source", DependsOnID: "target", Type: types.DepRelated, CreatedAt: createdAt,
+		}
+
+		expectAddDependencyInsert(mock, dep, createdAt.UTC())
+		if err := AddDependencyInTx(ctx, tx, dep, "current.user", opts); err != nil {
+			t.Fatalf("AddDependencyInTx: %v", err)
+		}
+		finishMockTx(t, mock, tx)
+	})
+
+	t.Run("defaults zero time to current UTC", func(t *testing.T) {
+		db, mock, tx := beginMockTx(t)
+		defer db.Close()
+		dep := &types.Dependency{IssueID: "source", DependsOnID: "target", Type: types.DepRelated}
+		before := time.Now().UTC()
+		createdAt := utcTimeBetween{before: before, after: before.Add(5 * time.Second)}
+
+		expectAddDependencyInsert(mock, dep, createdAt)
+		if err := AddDependencyInTx(ctx, tx, dep, "current.user", opts); err != nil {
+			t.Fatalf("AddDependencyInTx: %v", err)
+		}
+		finishMockTx(t, mock, tx)
+	})
+}
+
+func expectAddDependencyInsert(mock sqlmock.Sqlmock, dep *types.Dependency, createdAt driver.Value) {
+	mock.ExpectQuery("SELECT issue_type FROM issues WHERE id = \\?").
+		WithArgs(dep.IssueID).
+		WillReturnRows(sqlmock.NewRows([]string{"issue_type"}).AddRow(types.TypeTask))
+	mock.ExpectQuery("SELECT issue_type FROM issues WHERE id = \\?").
+		WithArgs(dep.DependsOnID).
+		WillReturnRows(sqlmock.NewRows([]string{"issue_type"}).AddRow(types.TypeTask))
+	mock.ExpectQuery("SELECT type FROM dependencies").
+		WithArgs(dep.IssueID, dep.DependsOnID).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectExec("INSERT INTO dependencies").
+		WithArgs(depid.New(dep.IssueID, dep.DependsOnID), dep.IssueID, dep.DependsOnID, dep.Type,
+			createdAt, "current.user", "{}", "").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+func finishMockTx(t *testing.T, mock sqlmock.Sqlmock, tx *sql.Tx) {
+	t.Helper()
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
 	}
 }
 

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -208,6 +208,8 @@ func AddDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 		return fmt.Errorf("failed to check existing dependency: %w", err)
 	}
 
+	createdAt := dependencyCreatedAt(dep)
+
 	// id is derived deterministically from the natural edge key (issue_id,
 	// target) so the same edge gets the same primary key on every clone and the
 	// dependencies table merges cleanly across Dolt clones (#4259). DependsOnID
@@ -215,8 +217,8 @@ func AddDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 	//nolint:gosec // G201: writeTable from WispTableRouting; targetCol from DepTargetKind.Column()
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		INSERT INTO %s (id, issue_id, %s, type, created_at, created_by, metadata, thread_id)
-		VALUES (?, ?, ?, ?, NOW(), ?, ?, ?)
-	`, writeTable, targetCol), depid.New(dep.IssueID, dep.DependsOnID), dep.IssueID, dep.DependsOnID, dep.Type, actor, metadata, dep.ThreadID); err != nil {
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, writeTable, targetCol), depid.New(dep.IssueID, dep.DependsOnID), dep.IssueID, dep.DependsOnID, dep.Type, createdAt, actor, metadata, dep.ThreadID); err != nil {
 		return fmt.Errorf("failed to add dependency: %w", err)
 	}
 


### PR DESCRIPTION
## What

Normalize imported issue, comment, and dependency timestamps to UTC before persistence. Fresh dependency inserts now bind the same explicit UTC `created_at` value instead of relying on database-side `NOW()`.

## Why

Serialized timestamps can carry a non-UTC offset even when they represent the correct instant. Persisting those values unchanged makes audit fields backend/session dependent and can break byte-stable export and cross-clone comparisons.

This keeps imported dependency attribution from #4432 intact: a serialized `created_by` is preserved, while dependencies without one still fall back to the current actor. It also keeps the deterministic dependency identity introduced in #4266 unchanged.

This is separate from #4298 / #4346, which concern implicit `updated_at` changes during blocked-state recomputation.

## Verification

- `go test ./internal/storage/issueops` passes.
- Direct `AddDependencyInTx` sqlmock coverage asserts that an offset timestamp is bound as the exact equivalent UTC instant in the fifth INSERT argument, and that a zero timestamp falls back to a current `time.Time` with `Location() == time.UTC`.
- `go test ./internal/storage/...` passed the changed package plus `internal/storage/embeddeddolt`, SQLite, schema, and most storage packages. The aggregate Windows run remains red on existing platform/external-tool assumptions: Unix absolute-path fixtures, `printf`, missing external `dolt`, and generated-file newline drift.
- `git diff --check` passes.

The required PR wrappers were also attempted on Windows with the repository-pinned Go 1.26.2 toolchain:

- `make ci-pr-core`, `make ci-pr-policy`, and `make ci-pr-lint` cannot start directly because GNU Make is not installed.
- Direct `./scripts/ci/pr-core.sh` reaches `go test` but cannot build `runtime/cgo` because `gcc` is unavailable.
- Direct `./scripts/ci/pr-policy.sh` passes build-tag policy and Go-install guidance, then cannot read JSON version files because `jq` is unavailable.
- Direct `./scripts/ci/pr-lint.sh` stops when its formatting step invokes missing GNU Make; `golangci-lint` is also unavailable. A direct Windows `gofmt -l .` reports the repository-wide CRLF checkout, while the changed files were formatted with `gofmt` and the focused package test passes.

Linux CI should establish the complete required wrapper results.
