### PR TITLE
Expose configured backend opener

### DIFF
--- a/beads.go
+++ b/beads.go
@@ -10,6 +10,7 @@ package beads
 import (
 	"context"
 
+	"github.com/steveyegge/beads/internal/backend"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
@@ -22,6 +23,33 @@ type Storage = beads.Storage
 // Transaction provides atomic multi-operation support within a database transaction.
 // Use Storage.RunInTransaction() to obtain a Transaction instance.
 type Transaction = beads.Transaction
+
+// BackendCapabilities describes optional backend behavior without exposing
+// concrete database drivers or connection handles.
+type BackendCapabilities struct {
+	Embedded          bool
+	Transactions      bool
+	RawSQL            bool
+	Leases            bool
+	Maintenance       bool
+	Versioning        bool
+	Branching         bool
+	DoltRemotes       bool
+	ConcurrentWriters bool
+}
+
+// BackendInfo identifies the backend selected by OpenConfigured.
+type BackendInfo struct {
+	Name         string
+	External     bool
+	Capabilities BackendCapabilities
+}
+
+// OpenConfiguredOptions controls behavior that cannot be inferred from the
+// workspace's metadata.json.
+type OpenConfiguredOptions struct {
+	ReadOnly bool
+}
 
 // RemoteStore provides dolt remote management and replication operations.
 // Use type assertion on a Storage value to access these methods:
@@ -62,6 +90,31 @@ type (
 // server mode settings from metadata.json.
 func Open(ctx context.Context, dbPath string) (Storage, error) {
 	return dolt.New(ctx, &dolt.Config{Path: dbPath, CreateIfMissing: true})
+}
+
+// OpenConfigured opens the built-in backend selected by metadata.json and
+// returns a backend-neutral descriptor. It supports Dolt, PostgreSQL, MySQL,
+// and SQLite. Unknown backend names fail closed.
+func OpenConfigured(ctx context.Context, beadsDir string, opts OpenConfiguredOptions) (Storage, BackendInfo, error) {
+	store, descriptor, err := backend.OpenConfigured(ctx, beadsDir, opts.ReadOnly)
+	if err != nil {
+		return nil, BackendInfo{}, err
+	}
+	return store, BackendInfo{
+		Name:     descriptor.Name,
+		External: descriptor.External,
+		Capabilities: BackendCapabilities{
+			Embedded:          descriptor.Capabilities.Embedded,
+			Transactions:      descriptor.Capabilities.Transactions,
+			RawSQL:            descriptor.Capabilities.RawSQL,
+			Leases:            descriptor.Capabilities.Leases,
+			Maintenance:       descriptor.Capabilities.Maintenance,
+			Versioning:        descriptor.Capabilities.Versioning,
+			Branching:         descriptor.Capabilities.Branching,
+			DoltRemotes:       descriptor.Capabilities.DoltRemotes,
+			ConcurrentWriters: descriptor.Capabilities.ConcurrentWriters,
+		},
+	}, nil
 }
 
 // OpenFromConfig opens a beads database using configuration from metadata.json.

--- a/internal/backend/configured.go
+++ b/internal/backend/configured.go
@@ -1,0 +1,92 @@
+// Package backend opens the built-in storage backend selected by a Beads
+// workspace's metadata. It deliberately contains no executable-plugin
+// discovery: callers of the public Go API must never execute a command named
+// in committed workspace metadata.
+package backend
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
+	beadsmysql "github.com/steveyegge/beads/internal/storage/mysql"
+	"github.com/steveyegge/beads/internal/storage/postgres"
+	beadssqlite "github.com/steveyegge/beads/internal/storage/sqlite"
+)
+
+// Capabilities describes optional backend behavior without exposing a concrete
+// database driver or connection handle.
+type Capabilities struct {
+	Embedded          bool
+	Transactions      bool
+	RawSQL            bool
+	Leases            bool
+	Maintenance       bool
+	Versioning        bool
+	Branching         bool
+	DoltRemotes       bool
+	ConcurrentWriters bool
+}
+
+// Descriptor identifies the built-in backend opened for a workspace.
+type Descriptor struct {
+	Name         string
+	External     bool
+	Capabilities Capabilities
+}
+
+// OpenConfigured opens the built-in backend selected by metadata.json. It
+// fails closed for unsupported names, rather than silently opening Dolt.
+func OpenConfigured(ctx context.Context, beadsDir string, readOnly bool) (storage.DoltStorage, Descriptor, error) {
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil {
+		return nil, Descriptor{}, fmt.Errorf("load %s: %w", configfile.ConfigPath(beadsDir), err)
+	}
+	if cfg == nil {
+		cfg = configfile.DefaultConfig()
+	}
+
+	name := strings.ToLower(strings.TrimSpace(cfg.Backend))
+	if name == "" {
+		name = configfile.BackendDolt
+	}
+	switch name {
+	case configfile.BackendDolt:
+		store, err := openDolt(ctx, beadsDir, cfg, readOnly)
+		if err != nil {
+			return nil, Descriptor{}, err
+		}
+		return store, Descriptor{Name: configfile.BackendDolt, Capabilities: doltCapabilities(cfg)}, nil
+	case configfile.BackendPostgres:
+		store, err := postgres.NewFromConfig(ctx, beadsDir)
+		return store, Descriptor{Name: configfile.BackendPostgres, Capabilities: sqlServerCapabilities()}, err
+	case configfile.BackendMySQL:
+		store, err := beadsmysql.NewFromConfig(ctx, beadsDir)
+		return store, Descriptor{Name: configfile.BackendMySQL, Capabilities: sqlServerCapabilities()}, err
+	case configfile.BackendSQLite:
+		store, err := beadssqlite.NewFromConfig(ctx, beadsDir)
+		return store, Descriptor{Name: configfile.BackendSQLite, Capabilities: Capabilities{Embedded: true, Transactions: true, Leases: true}}, err
+	default:
+		return nil, Descriptor{}, fmt.Errorf("unsupported configured backend %q", name)
+	}
+}
+
+func doltCapabilities(cfg *configfile.Config) Capabilities {
+	return Capabilities{
+		Embedded:          !cfg.IsDoltServerMode() && !cfg.IsDoltProxiedServerMode(),
+		Transactions:      true,
+		RawSQL:            true,
+		Leases:            true,
+		Maintenance:       true,
+		Versioning:        true,
+		Branching:         true,
+		DoltRemotes:       true,
+		ConcurrentWriters: cfg.IsDoltServerMode() || cfg.IsDoltProxiedServerMode(),
+	}
+}
+
+func sqlServerCapabilities() Capabilities {
+	return Capabilities{Transactions: true, Leases: true, ConcurrentWriters: true}
+}

--- a/internal/backend/dolt_cgo.go
+++ b/internal/backend/dolt_cgo.go
@@ -1,0 +1,22 @@
+//go:build cgo
+
+package backend
+
+import (
+	"context"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+)
+
+func openDolt(ctx context.Context, beadsDir string, cfg *configfile.Config, readOnly bool) (storage.DoltStorage, error) {
+	if cfg.IsDoltServerMode() {
+		return dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: readOnly})
+	}
+	if readOnly {
+		return embeddeddolt.OpenReadOnly(ctx, beadsDir, cfg.GetDoltDatabase(), "main")
+	}
+	return embeddeddolt.Open(ctx, beadsDir, cfg.GetDoltDatabase(), "main")
+}

--- a/internal/backend/dolt_nocgo.go
+++ b/internal/backend/dolt_nocgo.go
@@ -1,0 +1,19 @@
+//go:build !cgo
+
+package backend
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+)
+
+func openDolt(ctx context.Context, beadsDir string, cfg *configfile.Config, readOnly bool) (storage.DoltStorage, error) {
+	if !cfg.IsDoltServerMode() {
+		return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --server)")
+	}
+	return dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: readOnly})
+}

--- a/open_configured_test.go
+++ b/open_configured_test.go
@@ -1,0 +1,43 @@
+package beads
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+func TestOpenConfiguredSelectsSQLite(t *testing.T) {
+	beadsDir := t.TempDir()
+	cfg := &configfile.Config{Backend: configfile.BackendSQLite, SQLitePath: "configured.sqlite"}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	store, info, err := OpenConfigured(t.Context(), beadsDir, OpenConfiguredOptions{})
+	if err != nil {
+		t.Fatalf("OpenConfigured: %v", err)
+	}
+	defer store.Close()
+	if info.Name != configfile.BackendSQLite {
+		t.Fatalf("backend name = %q, want sqlite", info.Name)
+	}
+	if info.External {
+		t.Fatal("SQLite descriptor reports an external provider")
+	}
+	if !info.Capabilities.Embedded || !info.Capabilities.Transactions {
+		t.Fatalf("SQLite capabilities = %+v, want embedded transactions", info.Capabilities)
+	}
+}
+
+func TestOpenConfiguredUnknownBackendFailsClosed(t *testing.T) {
+	beadsDir := t.TempDir()
+	if err := (&configfile.Config{Backend: "mystery"}).Save(beadsDir); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	_, _, err := OpenConfigured(t.Context(), beadsDir, OpenConfiguredOptions{})
+	if err == nil || !strings.Contains(err.Error(), `unsupported configured backend "mystery"`) {
+		t.Fatalf("error = %v, want unsupported-backend diagnostic", err)
+	}
+}


### PR DESCRIPTION
## Summary

Expose a public `beads.OpenConfigured` API that opens the built-in backend selected by `.beads/metadata.json` and returns backend capabilities.

This supports the upstream-native Dolt, PostgreSQL, MySQL, and SQLite backends. Unknown backend names fail closed. It intentionally does **not** introduce external backend-plugin discovery or executable trust/configuration.

## Consumer

Gas City uses this API to open its native store against the configured Beads backend; see gastownhall/gascity#4154.

## Validation

- `go test . ./internal/backend`
- `CGO_ENABLED=0 go test . ./internal/backend`
- `go build ./cmd/bd`