### PR TITLE
feat(create): add status.default config for default initial status

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -72,6 +72,23 @@ Custom Status States:
   This enables issues to use statuses like 'awaiting_review' in addition to
   the built-in statuses (open, in_progress, blocked, deferred, closed).
 
+  Default Initial Status:
+    Set status.default to change the status new issues receive from a
+    single-issue 'bd create' when no explicit --status flag is given.
+    Precedence: an explicit --status flag wins, then a --defer-derived
+    'deferred', then status.default, then the built-in 'open'. The configured
+    value must be a built-in status or a configured custom status; it is
+    validated when 'bd create' runs.
+
+    Scope: this applies only to single-issue 'bd create'. Batch create
+    (--file / --graph), cross-repo routing (--repo and contributor/maintainer
+    auto-routing), and the sibling commands 'bd q', 'bd create-form',
+    'bd batch create', and 'bd todo add' intentionally still start issues in
+    'open' and do not consult status.default.
+
+    Example:
+      bd config set status.default backlog
+
 Suppressing Doctor Warnings:
   Suppress specific bd doctor warnings by check name slug:
     bd config set doctor.suppress.pending-migrations true

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -165,17 +165,27 @@ var createCmd = &cobra.Command{
 		issueType, _ := cmd.Flags().GetString("type")
 		assignee, _ := cmd.Flags().GetString("assignee")
 		statusFlag, _ := cmd.Flags().GetString("status")
-		if statusFlag != "" {
+		// store is nil for `create --repo=<remote URL>` with no local
+		// .beads/; fall back to built-in statuses only.
+		var defaultStatus string
+		if store != nil {
+			if ds, err := store.GetConfig(rootCtx, "status.default"); err == nil {
+				defaultStatus = strings.TrimSpace(ds)
+			}
+		}
+		if statusFlag != "" || defaultStatus != "" {
 			var customStatuses []string
-			// store is nil for `create --repo=<remote URL>` with no local
-			// .beads/; fall back to built-in statuses only.
 			if store != nil {
 				if cs, err := store.GetCustomStatuses(rootCtx); err == nil {
 					customStatuses = cs
 				}
 			}
-			if !types.Status(statusFlag).IsValidWithCustom(customStatuses) {
-				return HandleErrorRespectJSON("invalid status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", statusFlag)
+			if statusFlag != "" {
+				if !types.Status(statusFlag).IsValidWithCustom(customStatuses) {
+					return HandleErrorRespectJSON("invalid status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", statusFlag)
+				}
+			} else if !types.Status(defaultStatus).IsValidWithCustom(customStatuses) {
+				return HandleErrorRespectJSON("invalid status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", defaultStatus)
 			}
 		}
 
@@ -361,6 +371,7 @@ var createCmd = &cobra.Command{
 				MolType:            molType,
 				WispType:           wispType,
 				InitialStatus:      statusFlag,
+				DefaultStatus:      defaultStatus,
 				DueAt:              dueAt,
 				DeferUntil:         deferUntil,
 				Metadata:           metadata,
@@ -521,6 +532,7 @@ var createCmd = &cobra.Command{
 			Target:             eventTarget,
 			Payload:            eventPayload,
 			InitialStatus:      statusFlag,
+			DefaultStatus:      defaultStatus,
 			DueAt:              dueAt,
 			DeferUntil:         deferUntil,
 			Metadata:           metadata,
@@ -746,6 +758,7 @@ type createIssueParams struct {
 	Target             string
 	Payload            string
 	InitialStatus      string
+	DefaultStatus      string
 	DueAt              *time.Time
 	DeferUntil         *time.Time
 	Metadata           json.RawMessage
@@ -758,6 +771,9 @@ func buildCreateIssue(params createIssueParams) *types.Issue {
 	}
 
 	status := types.StatusOpen
+	if params.DefaultStatus != "" {
+		status = types.Status(params.DefaultStatus)
+	}
 	if params.InitialStatus != "" {
 		status = types.Status(params.InitialStatus)
 	} else if params.DeferUntil != nil && params.DeferUntil.After(time.Now()) {

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -481,6 +481,43 @@ func TestEmbeddedCreate(t *testing.T) {
 		}
 	})
 
+	t.Run("default_status_config_applies", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "dfb")
+		bdConfig(t, bd, dir, "set", "status.default", "blocked")
+		issue := bdCreate(t, bd, dir, "Default-status issue")
+		if issue.Status != types.StatusBlocked {
+			t.Errorf("status: got %q, want %q", issue.Status, types.StatusBlocked)
+		}
+	})
+
+	t.Run("default_status_flag_wins", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "dfw")
+		bdConfig(t, bd, dir, "set", "status.default", "blocked")
+		// Use in_progress (not the built-in 'open' fallback) so this proves the
+		// flag beats the default rather than passing on the fallback path.
+		issue := bdCreate(t, bd, dir, "Flag beats default", "--status", "in_progress")
+		if issue.Status != types.StatusInProgress {
+			t.Errorf("status: got %q, want %q", issue.Status, types.StatusInProgress)
+		}
+	})
+
+	t.Run("default_status_unset_falls_back_to_open", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "dfu")
+		issue := bdCreate(t, bd, dir, "No default configured")
+		if issue.Status != types.StatusOpen {
+			t.Errorf("status: got %q, want %q", issue.Status, types.StatusOpen)
+		}
+	})
+
+	t.Run("default_status_invalid", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "dfi")
+		bdConfig(t, bd, dir, "set", "status.default", "not_a_status")
+		out := bdCreateFail(t, bd, dir, "Invalid default status issue")
+		if !strings.Contains(out, `invalid status "not_a_status"`) {
+			t.Fatalf("expected invalid status error, got:\n%s", out)
+		}
+	})
+
 	t.Run("ephemeral", func(t *testing.T) {
 		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "ep")
 		issue := bdCreate(t, bd, dir, "Ephemeral issue", "--ephemeral")

--- a/cmd/bd/create_input.go
+++ b/cmd/bd/create_input.go
@@ -24,6 +24,7 @@ type createInput struct {
 	parentID           string
 	issueType          string
 	status             string
+	defaultStatus      string
 	priority           int
 	assignee           string
 	externalRef        string

--- a/cmd/bd/create_proxied_integration_test.go
+++ b/cmd/bd/create_proxied_integration_test.go
@@ -645,3 +645,63 @@ A new feature
 		}
 	})
 }
+
+// TestProxiedServerCreate_DefaultStatus exercises the proxied create path's
+// status.default wiring end-to-end (config read -> validate -> build in
+// runCreateProxiedSingle), which the builder-only unit tests do not cover. It
+// mirrors the embedded TestEmbeddedCreate/default_status_* coverage.
+func TestProxiedServerCreate_DefaultStatus(t *testing.T) {
+	requireProxiedServerEnv(t)
+
+	bd := buildEmbeddedBD(t)
+
+	t.Run("config_applies", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pds")
+		bdProxiedConfig(t, bd, p.dir, "set", "status.default", "blocked")
+		issue := bdProxiedCreate(t, bd, p.dir, "Default-status issue")
+		if issue.Status != types.StatusBlocked {
+			t.Errorf("status: got %q, want %q", issue.Status, types.StatusBlocked)
+		}
+	})
+
+	t.Run("flag_wins", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pdw")
+		bdProxiedConfig(t, bd, p.dir, "set", "status.default", "blocked")
+		// Use in_progress (not the built-in 'open' fallback) so this proves the
+		// flag beats the default rather than passing on the fallback path.
+		issue := bdProxiedCreate(t, bd, p.dir, "Flag beats default", "--status", "in_progress")
+		if issue.Status != types.StatusInProgress {
+			t.Errorf("status: got %q, want %q", issue.Status, types.StatusInProgress)
+		}
+	})
+
+	t.Run("invalid_default", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pdi")
+		bdProxiedConfig(t, bd, p.dir, "set", "status.default", "not_a_status")
+		out := bdProxiedCreateFail(t, bd, p.dir, "Invalid default status issue")
+		if !strings.Contains(out, `invalid status "not_a_status"`) {
+			t.Fatalf("expected invalid status error, got:\n%s", out)
+		}
+	})
+
+	t.Run("dry_run_reflects_default", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pdd")
+		bdProxiedConfig(t, bd, p.dir, "set", "status.default", "blocked")
+		out, err := bdProxiedRun(t, bd, p.dir, "create", "--dry-run", "Dry run default", "--json")
+		if err != nil {
+			t.Fatalf("bd create --dry-run failed: %v\n%s", err, out)
+		}
+		preview := parseIssueJSON(t, out)
+		if preview.Status != types.StatusBlocked {
+			t.Errorf("dry-run preview status: got %q, want %q (preview must reflect status.default)", preview.Status, types.StatusBlocked)
+		}
+		db := openProxiedDB(t, p)
+		var count int
+		if err := db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM issues").Scan(&count); err != nil {
+			t.Fatalf("query issues: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("expected dry-run to persist nothing, found %d issues", count)
+		}
+	})
+}

--- a/cmd/bd/create_proxied_server.go
+++ b/cmd/bd/create_proxied_server.go
@@ -73,41 +73,6 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 		return HandleError("%v", err)
 	}
 
-	if in.dryRun {
-		previewLabels := in.labels
-		if in.parentID != "" {
-			if uowProvider == nil {
-				return HandleError("proxied-server UOW provider not initialized")
-			}
-			dryUW, err := uowProvider.NewUOW(ctx)
-			if err != nil {
-				return HandleError("open unit of work: %v", err)
-			}
-			if _, err := dryUW.IssueUseCase().GetIssue(ctx, in.parentID); err != nil {
-				dryUW.Close(ctx)
-				return HandleError("parent issue %s not found: %v", in.parentID, err)
-			}
-			if !in.noInheritLabels {
-				inherited, lerr := dryUW.LabelUseCase().GetLabels(ctx, in.parentID)
-				if lerr != nil {
-					dryUW.Close(ctx)
-					return HandleError("dry-run inherit labels: %v", lerr)
-				}
-				previewLabels = mergeCreateLabels(in.labels, inherited)
-			}
-			dryUW.Close(ctx)
-		}
-		previewIssue := buildCreateIssueFromInput(in)
-		if in.jsonOutput {
-			if err := outputJSON(previewIssue); err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			}
-		} else {
-			renderCreateDryRunPreview(previewIssue, previewLabels, in.deps)
-		}
-		return nil
-	}
-
 	uw, cctx, err := proxiedOpenUOW(ctx)
 	if err != nil {
 		return err
@@ -121,15 +86,55 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 			return HandleError("invalid type %q (allowed: built-ins plus configured custom types)", in.issueType)
 		}
 	}
-	if in.status != "" {
+	// Resolve and validate status.default before the dry-run preview so the
+	// preview reflects the same initial status the real create would apply and
+	// an invalid status.default is caught in --dry-run too. This mirrors the
+	// embedded path, which resolves the default before its own dry-run render.
+	defaultStatus, err := uw.ConfigUseCase().GetConfig(ctx, "status.default")
+	if err != nil {
+		return HandleError("failed to get status.default config: %v", err)
+	}
+	in.defaultStatus = strings.TrimSpace(defaultStatus)
+	if in.status != "" || in.defaultStatus != "" {
 		customStatuses, err := uw.ConfigUseCase().GetCustomStatuses(ctx)
 		if err != nil {
 			return HandleError("failed to get custom statuses: %v", err)
 		}
-		if !types.Status(in.status).IsValidWithCustom(types.CustomStatusNames(customStatuses)) {
-			return HandleErrorRespectJSON("invalid status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", in.status)
+		names := types.CustomStatusNames(customStatuses)
+		if in.status != "" {
+			if !types.Status(in.status).IsValidWithCustom(names) {
+				return HandleErrorRespectJSON("invalid status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", in.status)
+			}
+		} else if !types.Status(in.defaultStatus).IsValidWithCustom(names) {
+			return HandleErrorRespectJSON("invalid status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", in.defaultStatus)
 		}
 	}
+
+	if in.dryRun {
+		previewLabels := in.labels
+		if in.parentID != "" {
+			if _, err := uw.IssueUseCase().GetIssue(ctx, in.parentID); err != nil {
+				return HandleError("parent issue %s not found: %v", in.parentID, err)
+			}
+			if !in.noInheritLabels {
+				inherited, lerr := uw.LabelUseCase().GetLabels(ctx, in.parentID)
+				if lerr != nil {
+					return HandleError("dry-run inherit labels: %v", lerr)
+				}
+				previewLabels = mergeCreateLabels(in.labels, inherited)
+			}
+		}
+		previewIssue := buildCreateIssueFromInput(in)
+		if in.jsonOutput {
+			if err := outputJSON(previewIssue); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
+		} else {
+			renderCreateDryRunPreview(previewIssue, previewLabels, in.deps)
+		}
+		return nil
+	}
+
 	if in.explicitID != "" {
 		effectivePrefix := overlayYAMLPrefix(cctx.IssuePrefix)
 		if err := validation.ValidateIDPrefixAllowed(in.explicitID, effectivePrefix, cctx.AllowedPrefixes, in.force); err != nil {
@@ -222,6 +227,7 @@ func buildCreateIssueFromInput(in createInput) *types.Issue {
 		Target:             in.eventTarget,
 		Payload:            in.eventPayload,
 		InitialStatus:      in.status,
+		DefaultStatus:      in.defaultStatus,
 		DueAt:              in.dueAt,
 		DeferUntil:         in.deferUntil,
 		Metadata:           in.metadata,

--- a/cmd/bd/create_proxied_server_test.go
+++ b/cmd/bd/create_proxied_server_test.go
@@ -117,6 +117,94 @@ func TestBuildCreateIssueFromInput_ExplicitStatusWinsOverDefer(t *testing.T) {
 	}
 }
 
+func TestBuildCreateIssueFromInput_DefaultStatusPrecedence(t *testing.T) {
+	t.Run("config_default_applies_without_flag_or_defer", func(t *testing.T) {
+		got := buildCreateIssueFromInput(createInput{
+			title:         "T",
+			priority:      2,
+			issueType:     "task",
+			defaultStatus: "blocked",
+		})
+		if got.Status != types.StatusBlocked {
+			t.Errorf("Status = %q, want %q", got.Status, types.StatusBlocked)
+		}
+	})
+
+	t.Run("defer_beats_config_default", func(t *testing.T) {
+		deferUntil := time.Now().UTC().Add(24 * time.Hour)
+		got := buildCreateIssueFromInput(createInput{
+			title:         "T",
+			priority:      2,
+			issueType:     "task",
+			defaultStatus: "blocked",
+			deferUntil:    &deferUntil,
+		})
+		if got.Status != types.StatusDeferred {
+			t.Errorf("Status = %q, want %q", got.Status, types.StatusDeferred)
+		}
+	})
+
+	t.Run("explicit_status_beats_config_default_and_defer", func(t *testing.T) {
+		deferUntil := time.Now().UTC().Add(24 * time.Hour)
+		got := buildCreateIssueFromInput(createInput{
+			title:         "T",
+			priority:      2,
+			issueType:     "task",
+			status:        "in_progress",
+			defaultStatus: "blocked",
+			deferUntil:    &deferUntil,
+		})
+		if got.Status != types.StatusInProgress {
+			t.Errorf("Status = %q, want %q", got.Status, types.StatusInProgress)
+		}
+	})
+}
+
+// TestBuildCreateIssue_DefaultStatusPrecedence covers the embedded/direct create
+// path's builder, mirroring the proxied buildCreateIssueFromInput coverage above.
+func TestBuildCreateIssue_DefaultStatusPrecedence(t *testing.T) {
+	t.Run("config_default_applies_without_flag_or_defer", func(t *testing.T) {
+		got := buildCreateIssue(createIssueParams{
+			Title:         "T",
+			Priority:      2,
+			IssueType:     types.TypeTask,
+			DefaultStatus: "blocked",
+		})
+		if got.Status != types.StatusBlocked {
+			t.Errorf("Status = %q, want %q", got.Status, types.StatusBlocked)
+		}
+	})
+
+	t.Run("defer_beats_config_default", func(t *testing.T) {
+		deferUntil := time.Now().UTC().Add(24 * time.Hour)
+		got := buildCreateIssue(createIssueParams{
+			Title:         "T",
+			Priority:      2,
+			IssueType:     types.TypeTask,
+			DefaultStatus: "blocked",
+			DeferUntil:    &deferUntil,
+		})
+		if got.Status != types.StatusDeferred {
+			t.Errorf("Status = %q, want %q", got.Status, types.StatusDeferred)
+		}
+	})
+
+	t.Run("explicit_status_beats_config_default_and_defer", func(t *testing.T) {
+		deferUntil := time.Now().UTC().Add(24 * time.Hour)
+		got := buildCreateIssue(createIssueParams{
+			Title:         "T",
+			Priority:      2,
+			IssueType:     types.TypeTask,
+			InitialStatus: "in_progress",
+			DefaultStatus: "blocked",
+			DeferUntil:    &deferUntil,
+		})
+		if got.Status != types.StatusInProgress {
+			t.Errorf("Status = %q, want %q", got.Status, types.StatusInProgress)
+		}
+	})
+}
+
 func TestMaterializeGraphNodeIssue_DefaultsAndOpts(t *testing.T) {
 	t.Run("type and priority defaults", func(t *testing.T) {
 		issue, err := materializeGraphNodeIssue(GraphApplyNode{Key: "n", Title: "N"}, createInput{createdBy: "t"})

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2763,6 +2763,23 @@ Custom Status States:
   This enables issues to use statuses like 'awaiting_review' in addition to
   the built-in statuses (open, in_progress, blocked, deferred, closed).
 
+  Default Initial Status:
+    Set status.default to change the status new issues receive from a
+    single-issue 'bd create' when no explicit --status flag is given.
+    Precedence: an explicit --status flag wins, then a --defer-derived
+    'deferred', then status.default, then the built-in 'open'. The configured
+    value must be a built-in status or a configured custom status; it is
+    validated when 'bd create' runs.
+
+    Scope: this applies only to single-issue 'bd create'. Batch create
+    (--file / --graph), cross-repo routing (--repo and contributor/maintainer
+    auto-routing), and the sibling commands 'bd q', 'bd create-form',
+    'bd batch create', and 'bd todo add' intentionally still start issues in
+    'open' and do not consult status.default.
+
+    Example:
+      bd config set status.default backlog
+
 Suppressing Doctor Warnings:
   Suppress specific bd doctor warnings by check name slug:
     bd config set doctor.suppress.pending-migrations true

--- a/website/docs/cli-reference/config.md
+++ b/website/docs/cli-reference/config.md
@@ -58,6 +58,23 @@ Custom Status States:
   This enables issues to use statuses like 'awaiting_review' in addition to
   the built-in statuses (open, in_progress, blocked, deferred, closed).
 
+  Default Initial Status:
+    Set status.default to change the status new issues receive from a
+    single-issue 'bd create' when no explicit --status flag is given.
+    Precedence: an explicit --status flag wins, then a --defer-derived
+    'deferred', then status.default, then the built-in 'open'. The configured
+    value must be a built-in status or a configured custom status; it is
+    validated when 'bd create' runs.
+
+    Scope: this applies only to single-issue 'bd create'. Batch create
+    (--file / --graph), cross-repo routing (--repo and contributor/maintainer
+    auto-routing), and the sibling commands 'bd q', 'bd create-form',
+    'bd batch create', and 'bd todo add' intentionally still start issues in
+    'open' and do not consult status.default.
+
+    Example:
+      bd config set status.default backlog
+
 Suppressing Doctor Warnings:
   Suppress specific bd doctor warnings by check name slug:
     bd config set doctor.suppress.pending-migrations true


### PR DESCRIPTION
## Summary

Adds a `status.default` config key that sets the initial status of **single-issue `bd create`** when no explicit `--status` flag is given, instead of the built-in `open`. Complements the per-call `--status` flag (#4536) with an opt-out tenant default.

Precedence (highest → lowest): explicit `--status` flag → `--defer`-derived `deferred` → `status.default` → built-in `open`.

The configured value must be a built-in status or a configured custom status; it is validated at create time (matching the `--status` flag's `IsValidWithCustom` check), not at `bd config set` time. An empty/unset value falls through to `open` unchanged. Both create paths — embedded/direct and proxied/sql-server — read and validate it identically, **including the `--dry-run` preview**.

## Scope (intentional — narrow by design)

This deliberately covers **single-issue `bd create` only**, which is the path the requesting consumer (livespec's ledger-status-conformance track) uses. The following intentionally continue to start issues in `open` and do **not** consult `status.default`:

- **Batch create:** `bd create --file` (markdown) and `bd create --graph` (JSON)
- **Cross-repo routing:** `--repo` and contributor/maintainer auto-routing (the default is resolved against the local store)
- **Sibling commands:** `bd q`, `bd create-form`, `bd batch create`, `bd todo add`

Extending to those paths is straightforward follow-up if the project wants it, but it isn't required for the use case this unblocks, and keeping the change minimal contains the blast radius. Happy to file a tracking issue for broader coverage.

## Notable behavior fix

The proxied create path now resolves and validates `status.default` **before** the `--dry-run` preview is rendered. Previously the proxied dry-run always previewed `open` and skipped validation, diverging from the real create and from the embedded path (which was already correct). Now the proxied dry-run reflects the status the real create would apply and rejects an invalid default.

## Tests

- **Builder precedence unit tests** for both builders (`buildCreateIssue`, `buildCreateIssueFromInput`): flag > defer > default > open.
- **Embedded end-to-end** (`TestEmbeddedCreate/default_status_*`): default applies, flag wins, unset → open, invalid default rejected.
- **Proxied end-to-end** (`TestProxiedServerCreate_DefaultStatus`, new): config applies, flag wins, invalid default rejected, and `--dry-run` preview reflects the default — covering the proxied config-read/validate wiring the unit tests don't reach.

CLI reference docs regenerated from `bd help`.
