### PR TITLE
ci(conformance): run on push to main (bd-oyvc2.8)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     branches: [ main ]
   merge_group:
+  # Direct pushes to main are possible (and happen); without this trigger a
+  # push that breaks a SQL backend goes untested until someone else's PR.
+  push:
+    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## What

Adds a `push: branches: [main]` trigger to `.github/workflows/conformance.yml`, from the post-merge review of #4601 (tracked as **bd-oyvc2.8**). The workflow only ran on `pull_request`/`merge_group`, and main accepts direct pushes — so a direct push that broke a SQL backend went untested until someone else's later PR happened to run the suite.

*(This PR originally also wired `BEADS_CONFORMANCE_REQUIRE`; #4712 landed that independently — and better, covering Tier 1 as well — so this is now trigger-only, rebased on current main.)*

## The half that can't be a PR: branch protection

The review found main's ruleset ("Protect main - light", id 15646382) contains only `deletion` + `non_fast_forward` rules — **zero required status checks and zero required reviews**. A repo admin needs to update the ruleset (Settings → Rules, or via API):

```bash
gh api repos/gastownhall/beads/rulesets/15646382   # inspect
# Suggested: required_status_checks 'Storage backend conformance (real DBs)' + main CI lanes;
#            pull_request rule with required_approving_review_count >= 1
```

Recommend landing this PR first so the conformance check exists on push/PR consistently before it's made required.

## Verification

Trigger-only YAML change; concurrency group already handles `push` via the `github.ref` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)