### PR TITLE
fix(config): stale legacy backend:"sqlite" metadata must not shadow a live Dolt workspace (bd-oyvc2.7)

### DIFF
--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -1386,6 +1386,11 @@ func TestEmbeddedInit(t *testing.T) {
 		if cfg.Backend != configfile.BackendSQLite {
 			t.Errorf("backend: got %q, want %q", cfg.Backend, configfile.BackendSQLite)
 		}
+		// sqlite_path is the positive marker separating a real SQLite workspace
+		// from stale pre-#3151 backend:"sqlite" metadata (bd-oyvc2.7).
+		if cfg.SQLitePath == "" {
+			t.Error("init --backend=sqlite must persist sqlite_path")
+		}
 
 		// Postgres is recognized, not an unknown backend: it fails only because the
 		// required connection config is absent (bdEnv strips any ambient DSN).

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -2394,6 +2394,16 @@ func TestInitBackendFlag(t *testing.T) {
 		if cfg.Backend != configfile.BackendSQLite {
 			t.Errorf("Expected backend %q, got %q", configfile.BackendSQLite, cfg.Backend)
 		}
+		// sqlite_path is the positive new-era marker that distinguishes a real
+		// SQLite workspace from pre-#3151 legacy metadata whose stale
+		// backend:"sqlite" must keep resolving to Dolt (bd-oyvc2.7). init must
+		// always write it, and GetBackend must honor the pair.
+		if cfg.SQLitePath == "" {
+			t.Error("bd init --backend=sqlite must persist sqlite_path (positive marker, bd-oyvc2.7)")
+		}
+		if got := cfg.GetBackend(); got != configfile.BackendSQLite {
+			t.Errorf("GetBackend() = %q, want %q for an init-created SQLite workspace", got, configfile.BackendSQLite)
+		}
 	})
 
 	// Postgres is a recognized backend now: it must not be rejected as unknown,

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -279,6 +279,21 @@ func loadEnvironment() {
 	}
 }
 
+var staleSQLiteBackendWarned bool
+
+// warnStaleSQLiteBackend prints a one-line notice when metadata.json carries the
+// legacy backend:"sqlite" marker from the pre-#3151 SQLite era (no sqlite_path).
+// GetBackend resolves such configs to Dolt — the backend these workspaces have
+// actually been running since SQLite was removed — so bd opens the Dolt database
+// as before; the notice nudges the user to clean up the stale field (bd-oyvc2.7).
+func warnStaleSQLiteBackend(cfg *configfile.Config) {
+	if staleSQLiteBackendWarned || !cfg.HasStaleSQLiteBackend() {
+		return
+	}
+	staleSQLiteBackendWarned = true
+	fmt.Fprintln(os.Stderr, "Notice: .beads/metadata.json has legacy backend:\"sqlite\" (no sqlite_path); opening the Dolt database as usual. Remove the stale \"backend\" field to silence this, or run 'bd init --backend=sqlite --reinit-local' to actually use SQLite.")
+}
+
 var sharedServerEmbeddedMismatchWarned bool
 
 // warnSharedServerEmbeddedMismatch detects the case where shared-server mode
@@ -1121,6 +1136,7 @@ var rootCmd = &cobra.Command{
 		}
 		if cfg != nil {
 			warnSharedServerEmbeddedMismatch(cfg)
+			warnStaleSQLiteBackend(cfg)
 			doltCfg.ProxiedServer = cfg.IsDoltProxiedServerMode()
 			proxiedServerMode = doltCfg.ProxiedServer
 			if cmdCtx != nil {

--- a/cmd/bd/store_factory.go
+++ b/cmd/bd/store_factory.go
@@ -110,6 +110,9 @@ func newDoltStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltS
 		// metadata.json (cfg == nil, err == nil) keeps the embedded default.
 		return nil, fmt.Errorf("load %s: %w (refusing to fall back to the embedded store)", configfile.ConfigPath(beadsDir), err)
 	}
+	if cfg != nil {
+		warnStaleSQLiteBackend(cfg)
+	}
 	if cfg != nil && cfg.GetBackend() == configfile.BackendPostgres {
 		return postgres.NewFromConfig(ctx, beadsDir)
 	}

--- a/cmd/bd/store_factory_nocgo.go
+++ b/cmd/bd/store_factory_nocgo.go
@@ -57,6 +57,9 @@ func newDoltStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltS
 		// message below.
 		return nil, fmt.Errorf("load %s: %w", configfile.ConfigPath(beadsDir), err)
 	}
+	if cfg != nil {
+		warnStaleSQLiteBackend(cfg)
+	}
 	if cfg != nil && cfg.GetBackend() == configfile.BackendPostgres {
 		// Postgres needs no CGO (pure-Go pgx), so it works in the nocgo build too.
 		return postgres.NewFromConfig(ctx, beadsDir)

--- a/cmd/bd/store_factory_test.go
+++ b/cmd/bd/store_factory_test.go
@@ -41,6 +41,45 @@ func TestNewDoltStoreFromConfig_NoMetadata(t *testing.T) {
 	defer store.Close()
 }
 
+// TestNewDoltStoreFromConfig_StaleSQLiteMetadataOpensDolt pins the bd-oyvc2.7
+// regression (introduced by #4601): a legacy workspace whose metadata.json still
+// says backend:"sqlite" from the pre-#3151 SQLite era (no sqlite_path — the
+// positive marker `bd init --backend=sqlite` always writes) must open its Dolt
+// database, not provision a fresh empty SQLite database that false-empties every
+// issue and divorces new writes.
+func TestNewDoltStoreFromConfig_StaleSQLiteMetadataOpensDolt(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt tests")
+	}
+
+	beadsDir := t.TempDir()
+
+	// Simulate the legacy metadata shape: backend "sqlite", legacy database
+	// field, no sqlite_path.
+	cfg := &configfile.Config{
+		Database: "beads.db",
+		Backend:  configfile.BackendSQLite,
+	}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	store, err := newDoltStoreFromConfig(t.Context(), beadsDir)
+	if err != nil {
+		t.Fatalf("newDoltStoreFromConfig failed (stale sqlite metadata must open Dolt): %v", err)
+	}
+	defer store.Close()
+
+	// The workspace must be Dolt-backed: embedded dolt data exists and no
+	// SQLite database was provisioned.
+	if _, err := os.Stat(filepath.Join(beadsDir, "embeddeddolt")); err != nil {
+		t.Errorf("expected embedded dolt data dir, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(beadsDir, "beads.db")); !os.IsNotExist(err) {
+		t.Error("stale sqlite metadata must not provision .beads/beads.db")
+	}
+}
+
 // TestEmbeddedOpen_EmptyDatabaseRejected verifies that embeddeddolt.Open fails
 // with a clear error when called with an empty database name, rather than
 // deferring to a confusing "no database selected" SQL error.

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -17,7 +17,7 @@ const ConfigFileName = "metadata.json"
 
 type Config struct {
 	Database string `json:"database"`
-	Backend  string `json:"backend,omitempty"` // Storage backend: "dolt" (default), "postgres", "mysql", or "sqlite". Read via GetBackend().
+	Backend  string `json:"backend,omitempty"` // Storage backend: "dolt" (default), "postgres", "mysql", or "sqlite" (honored only with sqlite_path set). Read via GetBackend().
 
 	// Deletions configuration
 	DeletionsRetentionDays int `json:"deletions_retention_days,omitempty"` // 0 means use default (3 days)
@@ -250,9 +250,17 @@ func (c *Config) GetCapabilities() BackendCapabilities {
 }
 
 // GetBackend returns the configured storage backend. Only the explicitly-allowlisted
-// non-default backends ("postgres", "mysql") are honored; "", "dolt", and any legacy
-// or unknown value resolve to dolt so the default path stays byte-identical and a
-// typo fails safe to Dolt.
+// non-default backends are honored: "postgres", "mysql", and "sqlite" — the latter
+// only when sqlite_path is also set, the positive marker that `bd init
+// --backend=sqlite` always writes. Everything else — "", "dolt", unknown values, and
+// a bare backend:"sqlite" without sqlite_path — resolves to dolt so the default path
+// stays byte-identical and a typo fails safe to Dolt.
+//
+// The bare-sqlite rule protects pre-#3151 workspaces whose metadata.json still says
+// backend:"sqlite" but which have operated as Dolt ever since SQLite was removed:
+// honoring the stale field would provision a fresh empty SQLite database next to the
+// live Dolt data, making every issue vanish (false-empty) and divorcing new writes
+// (bd-oyvc2.7, regression from #4601). See HasStaleSQLiteBackend.
 func (c *Config) GetBackend() string {
 	if c != nil {
 		switch c.Backend {
@@ -261,10 +269,23 @@ func (c *Config) GetBackend() string {
 		case BackendMySQL:
 			return BackendMySQL
 		case BackendSQLite:
-			return BackendSQLite
+			if c.SQLitePath != "" {
+				return BackendSQLite
+			}
+			// Legacy stale marker (pre-#3151, no sqlite_path): fall through to Dolt.
 		}
 	}
 	return BackendDolt
+}
+
+// HasStaleSQLiteBackend reports whether metadata.json carries the legacy
+// backend:"sqlite" marker without the sqlite_path field that `bd init
+// --backend=sqlite` always writes. Such configs predate the removal of the
+// original SQLite backend (#3151); the workspace has been running on Dolt, and
+// GetBackend resolves it to dolt (bd-oyvc2.7). Callers can use this to suggest
+// removing the stale field.
+func (c *Config) HasStaleSQLiteBackend() bool {
+	return c != nil && c.Backend == BackendSQLite && c.SQLitePath == ""
 }
 
 // GetSQLitePath returns the SQLite database file path (relative to the beads dir, or

--- a/internal/configfile/configfile_test.go
+++ b/internal/configfile/configfile_test.go
@@ -630,9 +630,17 @@ func TestProxiedServerClientInfo_ResolvedPaths(t *testing.T) {
 }
 
 // TestGetBackendAllowlist verifies the allowlist semantics: the SQL backends
-// (postgres, mysql, sqlite) are honored; every other value (empty, legacy,
-// genuinely unknown) falls back to Dolt. This is the guard behind backend selection
-// — a typo in metadata.json must fail safe to Dolt, never to an unintended backend.
+// (postgres, mysql, sqlite-with-sqlite_path) are honored; every other value (empty,
+// legacy, genuinely unknown) falls back to Dolt. This is the guard behind backend
+// selection — a typo in metadata.json must fail safe to Dolt, never to an
+// unintended backend.
+//
+// The "stale sqlite value" case is a load-bearing regression guard (bd-oyvc2.7,
+// regression from #4601): pre-#3151 workspaces still carry backend:"sqlite" in
+// metadata.json but have operated as Dolt ever since SQLite was removed. Honoring
+// the bare field would provision a fresh empty SQLite database over live Dolt data
+// (false-empty). New-era `bd init --backend=sqlite` always writes sqlite_path, which
+// is the positive marker that makes "sqlite" honored.
 func TestGetBackendAllowlist(t *testing.T) {
 	fallsBackToDolt := []struct {
 		name string
@@ -641,6 +649,8 @@ func TestGetBackendAllowlist(t *testing.T) {
 		{name: "explicit dolt", cfg: &Config{Backend: BackendDolt}},
 		{name: "empty backend", cfg: &Config{Backend: ""}},
 		{name: "legacy config", cfg: &Config{}},
+		{name: "stale sqlite value", cfg: &Config{Backend: BackendSQLite}},
+		{name: "stale sqlite value with legacy database field", cfg: &Config{Backend: BackendSQLite, Database: "beads.db"}},
 		{name: "unknown backend", cfg: &Config{Backend: "mystery"}},
 	}
 	for _, tt := range fallsBackToDolt {
@@ -651,12 +661,43 @@ func TestGetBackendAllowlist(t *testing.T) {
 		})
 	}
 
-	honored := []string{BackendPostgres, BackendMySQL, BackendSQLite}
-	for _, backend := range honored {
-		t.Run(backend+" honored", func(t *testing.T) {
-			cfg := &Config{Backend: backend}
-			if got := cfg.GetBackend(); got != backend {
-				t.Errorf("GetBackend() = %q, want %q", got, backend)
+	honored := []struct {
+		name string
+		cfg  *Config
+		want string
+	}{
+		{name: "postgres honored", cfg: &Config{Backend: BackendPostgres}, want: BackendPostgres},
+		{name: "mysql honored", cfg: &Config{Backend: BackendMySQL}, want: BackendMySQL},
+		{name: "sqlite honored with sqlite_path", cfg: &Config{Backend: BackendSQLite, SQLitePath: "beads.db"}, want: BackendSQLite},
+		{name: "sqlite honored with custom sqlite_path", cfg: &Config{Backend: BackendSQLite, SQLitePath: "issues/tracker.db"}, want: BackendSQLite},
+	}
+	for _, tt := range honored {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.GetBackend(); got != tt.want {
+				t.Errorf("GetBackend() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHasStaleSQLiteBackend verifies detection of the legacy pre-#3151
+// backend:"sqlite" marker (no sqlite_path) that GetBackend resolves to Dolt.
+func TestHasStaleSQLiteBackend(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want bool
+	}{
+		{name: "nil config", cfg: nil, want: false},
+		{name: "legacy stale sqlite", cfg: &Config{Backend: BackendSQLite}, want: true},
+		{name: "new-era sqlite with sqlite_path", cfg: &Config{Backend: BackendSQLite, SQLitePath: "beads.db"}, want: false},
+		{name: "dolt", cfg: &Config{Backend: BackendDolt}, want: false},
+		{name: "empty", cfg: &Config{}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.HasStaleSQLiteBackend(); got != tt.want {
+				t.Errorf("HasStaleSQLiteBackend() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/storage/sqlite/fromconfig.go
+++ b/internal/storage/sqlite/fromconfig.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/steveyegge/beads/internal/configfile"
@@ -13,6 +14,13 @@ import (
 // NewFromConfig opens the SQLite backend for a workspace, reading the database file
 // path from .beads/metadata.json (default beads.db, relative to the beads dir). SQLite
 // is file-based, so there is no DSN password to manage.
+//
+// Guard (bd-oyvc2.7): when the SQLite file does not exist yet but the workspace
+// already contains a Dolt database on disk, this refuses instead of provisioning.
+// Silently creating a fresh empty SQLite database next to live Dolt data makes every
+// issue vanish from view (false-empty) and divorces new writes from the real store.
+// Fresh provisioning outside `bd init` is only legitimate when there is no
+// pre-existing Dolt data to shadow (e.g. a fresh clone of a SQLite-backed workspace).
 func NewFromConfig(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
 	cfg, err := configfile.Load(beadsDir)
 	if err != nil {
@@ -25,11 +33,63 @@ func NewFromConfig(ctx context.Context, beadsDir string) (storage.DoltStorage, e
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(beadsDir, path)
 	}
+	if _, statErr := os.Stat(path); statErr != nil {
+		if !os.IsNotExist(statErr) {
+			return nil, fmt.Errorf("sqlite: stat %s: %w", path, statErr)
+		}
+		if doltDir := existingDoltDataDir(beadsDir, cfg); doltDir != "" {
+			return nil, fmt.Errorf("sqlite: metadata.json selects the SQLite backend but %s does not exist, "+
+				"and this workspace already has a Dolt database at %s; refusing to create a fresh empty "+
+				"SQLite database next to existing Dolt data (bd-oyvc2.7).\n"+
+				"  To keep using Dolt: remove the \"backend\" and \"sqlite_path\" fields from %s.\n"+
+				"  To switch to SQLite: run 'bd init --backend=sqlite --reinit-local' (see 'bd help init-safety')",
+				path, doltDir, configfile.ConfigPath(beadsDir))
+		}
+	}
 	return Provision(ctx, path)
 }
 
+// existingDoltDataDir returns the path of a Dolt database directory already present
+// in the workspace, or "" when none exists. It checks the embedded layout
+// (.beads/embeddeddolt/<db>/.dolt) and the server-mode data dir (default .beads/dolt,
+// or the configured dolt_data_dir), where databases live either directly
+// (<dir>/.dolt) or one level down (<dir>/<db>/.dolt).
+func existingDoltDataDir(beadsDir string, cfg *configfile.Config) string {
+	roots := []string{filepath.Join(beadsDir, "embeddeddolt")}
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if custom := cfg.GetDoltDataDir(); custom != "" {
+		if filepath.IsAbs(custom) {
+			doltDir = custom
+		} else {
+			doltDir = filepath.Join(beadsDir, custom)
+		}
+	}
+	roots = append(roots, doltDir)
+
+	for _, root := range roots {
+		if info, err := os.Stat(filepath.Join(root, ".dolt")); err == nil && info.IsDir() {
+			return root
+		}
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			if info, err := os.Stat(filepath.Join(root, entry.Name(), ".dolt")); err == nil && info.IsDir() {
+				return filepath.Join(root, entry.Name())
+			}
+		}
+	}
+	return ""
+}
+
 // Provision opens the SQLite database file, applies the schema (idempotent; config
-// seeds on first provision), and returns the store. bd init calls this directly.
+// seeds on first provision), and returns the store. bd init calls this directly —
+// init is the one place where creating a fresh database over an existing workspace
+// is a deliberate, guarded choice (init has its own existing-data safety checks).
 func Provision(ctx context.Context, dbPath string) (storage.DoltStorage, error) {
 	if dbPath == "" {
 		return nil, fmt.Errorf("sqlite: empty database path")

--- a/internal/storage/sqlite/fromconfig_test.go
+++ b/internal/storage/sqlite/fromconfig_test.go
@@ -1,0 +1,126 @@
+package sqlite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+// writeSQLiteMetadata persists a new-era SQLite workspace config (backend +
+// sqlite_path, the shape runInitSQLite always writes).
+func writeSQLiteMetadata(t *testing.T, beadsDir, sqlitePath string) {
+	t.Helper()
+	cfg := &configfile.Config{
+		Backend:    configfile.BackendSQLite,
+		SQLitePath: sqlitePath,
+	}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("save metadata.json: %v", err)
+	}
+}
+
+// fakeDoltDB plants a Dolt database marker (<root>/<db>/.dolt) under beadsDir.
+func fakeDoltDB(t *testing.T, beadsDir, root, db string) string {
+	t.Helper()
+	dir := filepath.Join(beadsDir, root, db)
+	if err := os.MkdirAll(filepath.Join(dir, ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir fake dolt db: %v", err)
+	}
+	return dir
+}
+
+// TestNewFromConfig_RefusesFreshProvisionOverDoltData is the bd-oyvc2.7 guard:
+// when metadata.json selects SQLite but the database file does not exist and the
+// workspace already contains a Dolt database, NewFromConfig must refuse loudly
+// rather than silently provisioning a fresh empty SQLite database (false-empty).
+func TestNewFromConfig_RefusesFreshProvisionOverDoltData(t *testing.T) {
+	for _, layout := range []string{"embeddeddolt", "dolt"} {
+		t.Run(layout+" layout", func(t *testing.T) {
+			beadsDir := t.TempDir()
+			writeSQLiteMetadata(t, beadsDir, "beads.db")
+			fakeDoltDB(t, beadsDir, layout, "beads")
+
+			store, err := NewFromConfig(context.Background(), beadsDir)
+			if err == nil {
+				_ = store.Close()
+				t.Fatal("expected refusal, got a store")
+			}
+			if !strings.Contains(err.Error(), "refusing to create a fresh empty SQLite database") {
+				t.Errorf("error should explain the refusal, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), "bd init --backend=sqlite") {
+				t.Errorf("error should give actionable guidance, got: %v", err)
+			}
+			if _, statErr := os.Stat(filepath.Join(beadsDir, "beads.db")); !os.IsNotExist(statErr) {
+				t.Error("refusal must not leave a freshly created beads.db behind")
+			}
+		})
+	}
+}
+
+// TestNewFromConfig_OpensExistingSQLiteNextToDoltData verifies that a genuine
+// SQLite workspace (database file present) keeps opening even when Dolt artifacts
+// also exist on disk — the guard only blocks fresh provisioning, not existing data.
+func TestNewFromConfig_OpensExistingSQLiteNextToDoltData(t *testing.T) {
+	ctx := context.Background()
+	beadsDir := t.TempDir()
+	writeSQLiteMetadata(t, beadsDir, "beads.db")
+
+	// Provision first (as bd init --backend=sqlite does), then plant Dolt leftovers.
+	st, err := Provision(ctx, filepath.Join(beadsDir, "beads.db"))
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	_ = st.Close()
+	fakeDoltDB(t, beadsDir, "embeddeddolt", "beads")
+
+	store, err := NewFromConfig(ctx, beadsDir)
+	if err != nil {
+		t.Fatalf("NewFromConfig should open the existing SQLite database: %v", err)
+	}
+	_ = store.Close()
+}
+
+// TestNewFromConfig_FreshProvisionWithoutDoltData verifies the fresh-clone path:
+// SQLite metadata, no database file yet, no Dolt data — provisioning is normal.
+func TestNewFromConfig_FreshProvisionWithoutDoltData(t *testing.T) {
+	beadsDir := t.TempDir()
+	writeSQLiteMetadata(t, beadsDir, "beads.db")
+
+	store, err := NewFromConfig(context.Background(), beadsDir)
+	if err != nil {
+		t.Fatalf("NewFromConfig should provision on a fresh clone: %v", err)
+	}
+	defer store.Close()
+	if _, err := os.Stat(filepath.Join(beadsDir, "beads.db")); err != nil {
+		t.Errorf("expected beads.db to be provisioned: %v", err)
+	}
+}
+
+// TestNewFromConfig_HonorsCustomDoltDataDir verifies the guard also sees a Dolt
+// database living in a configured dolt_data_dir rather than the default layouts.
+func TestNewFromConfig_HonorsCustomDoltDataDir(t *testing.T) {
+	beadsDir := t.TempDir()
+	cfg := &configfile.Config{
+		Backend:     configfile.BackendSQLite,
+		SQLitePath:  "beads.db",
+		DoltDataDir: "customdolt",
+	}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("save metadata.json: %v", err)
+	}
+	fakeDoltDB(t, beadsDir, "customdolt", "beads")
+
+	store, err := NewFromConfig(context.Background(), beadsDir)
+	if err == nil {
+		_ = store.Close()
+		t.Fatal("expected refusal with Dolt data in custom dolt_data_dir, got a store")
+	}
+	if !strings.Contains(err.Error(), "refusing to create a fresh empty SQLite database") {
+		t.Errorf("error should explain the refusal, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Restores the pre-#4601 guard for legacy workspaces whose `.beads/metadata.json` still says `backend:"sqlite"` from the pre-#3151 SQLite era:

- `GetBackend()` honors `sqlite` only together with `sqlite_path` — the positive marker `bd init --backend=sqlite` always writes (pinned by new init tests), so every new-era SQLite workspace keeps working while bare legacy `backend:"sqlite"` resolves to Dolt again.
- Belt-and-suspenders: `sqlite.NewFromConfig` now refuses (with an actionable error naming both remedies) to provision a fresh SQLite database when the file is missing but a Dolt database already exists on disk — covering embedded, server-mode, and custom `dolt_data_dir` layouts.
- A one-line stderr notice (existing `warnSharedServerEmbeddedMismatch` idiom) nudges legacy users to remove the stale field.
- The `GetBackend` doc comment now matches the code (it previously claimed postgres/mysql-only while the switch honored sqlite).

## Why

Regression from #4601: it rewrote the `TestGetBackend` **"stale sqlite value"** pin — which existed precisely to protect these workspaces — into an assertion that sqlite is honored. On upgrade, a legacy Dolt workspace routed to the SQLite factory, silently created an empty `.beads/beads.db`, false-emptied every issue, and divorced new writes from the real store. Found in the bd-oyvc2 post-merge review of #4601; fixes **bd-oyvc2.7** (P2).

## How verified

- Unit tests: restored stale-sqlite pin + honored-with-path cases in `configfile_test.go`; new `fromconfig_test.go` guard matrix (refusal in both Dolt layouts, no file left behind, existing-file opens, fresh-clone provisions, custom `dolt_data_dir`); `store_factory_test.go` regression test proving legacy metadata opens embedded Dolt with no `beads.db` created; init tests pinning that `sqlite_path` is always persisted.
- `go build -tags gms_pure_go ./...` (plus CGO_ENABLED=0 build), `go vet`, `go test ./internal/configfile/ ./internal/storage/sqlite/` and the cmd/bd backend-selection tests under `BEADS_TEST_EMBEDDED_DOLT=1` — all green.
- Hands-on smoke: new-era `bd init --backend=sqlite` + create + list works; a Dolt workspace hand-edited to `backend:"sqlite"` lists its Dolt issues (notice printed, no beads.db created); the ambiguous marker-without-file case exits 1 with both remedies; the suggested `bd init --backend=sqlite --reinit-local` remedy works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)