### PR TITLE
fix(cli): emit claim failures as structured JSON under --json (wy-kxgf4)

### DIFF
--- a/cmd/bd/errors.go
+++ b/cmd/bd/errors.go
@@ -116,6 +116,21 @@ func HandleErrorWithHintRespectJSON(message, hint string) error {
 	return &exitError{Code: 1}
 }
 
+// reportClaimFailure renders a failed --claim (already-claimed, not-claimable,
+// or any other ClaimIssue error). Protocol v0 §E5 requires errors under --json
+// to be structured, and a lost claim is the most common contended-write failure
+// an agent has to branch on, so --json gets {error, schema_version:1} instead of
+// a stderr line to scrape. The plain-text wording is frozen (§E4 pins the class
+// and the holder/state in the message). The JSON object goes to stderr so that a
+// mixed batch's stdout stays the clean array of issues that did update.
+func reportClaimFailure(id string, err error) {
+	if jsonOutput {
+		jsonStderrError(fmt.Sprintf("failed to claim %s: %v", id, err), "")
+		return
+	}
+	fmt.Fprintf(os.Stderr, "Error claiming %s: %v\n", id, err)
+}
+
 func SilentExit() error {
 	return &exitError{Code: 1}
 }

--- a/cmd/bd/protocol/errors_contract_test.go
+++ b/cmd/bd/protocol/errors_contract_test.go
@@ -115,25 +115,12 @@ func TestProtocol_ErrorClass_NotClaimableNamesState(t *testing.T) {
 }
 
 // TestProtocol_ErrorClass_ClaimFailures_StructuredJSON is the §E5 half of the
-// claim error classes — and it is SKIPPED because bd-go does not satisfy it
-// today (wy-kxgf4).
-//
-// bd routes not-found through the JSON-respecting error helper, so
-// `bd show <missing> --json` emits {error, schema_version:1} (pinned above).
-// The claim path does not: `bd update <id> --claim --json` prints
-//
-//	Error claiming t04…-qqr: issue already claimed by alice
-//
-// as plain text, so an agent driving bd with --json gets an unparseable stderr
-// line for the single most common contended-write failure it must branch on.
-// The message contract (§E4) holds; the structured contract (§E5) does not.
-//
-// Per proposal §14, where bd's behavior deviates from a clause the clause wins
-// and the deviation is a bug — so this test asserts the clause and stays
-// skipped until wy-kxgf4 lands, at which point it becomes the guardrail.
+// claim error classes: a lost claim is the most common contended-write failure
+// an agent driving bd with --json has to branch on, so it must arrive as a JSON
+// object and not as a stderr line to scrape. bd emitted plain text here until
+// wy-kxgf4; the clause is the guardrail now. The stream (stdout vs stderr) is
+// deliberately not pinned — that split is proposal OQ-5.
 func TestProtocol_ErrorClass_ClaimFailures_StructuredJSON(t *testing.T) {
-	t.Skip("bd emits claim failures as plain text even with --json; violates §E5 (wy-kxgf4)")
-
 	t.Parallel()
 	w := newWorkspace(t)
 

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -377,7 +377,7 @@ create, update, show, or close operation).`,
 			// Handle claim operation atomically using compare-and-swap semantics
 			if claimFlag {
 				if err := issueStore.ClaimIssue(ctx, result.ResolvedID, actor); err != nil {
-					fmt.Fprintf(os.Stderr, "Error claiming %s: %v\n", id, err)
+					reportClaimFailure(id, err)
 					claimFailed = true
 					closeIfUnmutated(result)
 					continue

--- a/cmd/bd/update_proxied_server.go
+++ b/cmd/bd/update_proxied_server.go
@@ -112,7 +112,7 @@ func applyUpdateProxiedOne(ctx context.Context, id string, in *updateInput) (*ty
 	updated, err := issueUC.ApplyUpdate(ctx, id, spec, actor)
 	if err != nil {
 		if errors.Is(err, storage.ErrAlreadyClaimed) || errors.Is(err, storage.ErrNotClaimable) {
-			fmt.Fprintf(os.Stderr, "Error claiming %s: %v\n", id, err)
+			reportClaimFailure(id, err)
 			// A requested --claim that lost to another owner must flip the exit
 			// code even if another ID in the same batch was updated.
 			return nil, false, in.claim, nil


### PR DESCRIPTION
Protocol v0 §E5: with `--json`, errors must be a JSON object carrying at least `error` and `schema_version: 1`. bd honored this on the not-found path but not on the claim paths — `bd update <id> --claim --json` printed `Error claiming t04…-qqr: issue already claimed by alice` as plain text, so an agent driving bd with `--json` got an unparseable stderr line for the most common contended-write failure it has to branch on. §E4 (the message names the class and the holder/state) held; §E5 did not.

**Change.** Both claim paths — the direct-store loop in `update.go` and the SQL-server proxied path in `update_proxied_server.go` — now go through a `reportClaimFailure` helper. Under `--json` it emits `{error, schema_version:1}`; otherwise the plain-text wording is unchanged byte for byte (the §E4 contract tests pin it). The JSON object goes to stderr so a mixed batch's stdout stays the clean array of issues that did update — the stdout/stderr split for errors is proposal OQ-5 and is deliberately not pinned by the test.

**Test.** Un-skips `TestProtocol_ErrorClass_ClaimFailures_StructuredJSON` in `cmd/bd/protocol/errors_contract_test.go`, which was written against the clause and skipped pending this fix (wy-kxgf4). It now passes and becomes the guardrail. Full `cmd/bd/protocol` package green; `gofmt`/`go vet` clean. (The two `cmd/bd/doctor` failures on my machine are pre-existing and environment-dependent — they fail identically on clean `main`.)

Found by the WP4 conformance corpus (#4754, landed as 08881217b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)