### PR TITLE
feat(labels): exclusive label namespaces, flag-gated (bd-7u5ki)

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/git"
+	"github.com/steveyegge/beads/internal/labelns"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/remotecache"
 	"github.com/steveyegge/beads/internal/tracker"
@@ -72,6 +73,18 @@ Custom Status States:
   This enables issues to use statuses like 'awaiting_review' in addition to
   the built-in statuses (open, in_progress, blocked, deferred, closed).
 
+Exclusive Label Namespaces:
+  Labels are free-form, but routing conventions like tier:<model> assume one
+  label per prefix; a second one silently narrows fleet eligibility to zero.
+  Declare prefixes exclusive (at most one label per issue) with:
+
+    bd config set labels.exclusive-prefixes "tier:,review:"
+
+  Adding a second label in an exclusive namespace is then rejected on every
+  write path ('bd label add --replace' swaps instead). Import warns and keeps
+  violating labels; 'bd doctor' reports existing violations. Unset the key to
+  restore fully free-form labels (the default).
+
 Suppressing Doctor Warnings:
   Suppress specific bd doctor warnings by check name slug:
     bd config set doctor.suppress.pending-migrations true
@@ -88,6 +101,7 @@ Examples:
   bd config set jira.url "https://company.atlassian.net"
   bd config set jira.project "PROJ"
   bd config set status.custom "awaiting_review,awaiting_testing"
+  bd config set labels.exclusive-prefixes "tier:,review:"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
   bd config set dolt.local-only true                   # Skip wiring a Dolt sync remote during bd init
@@ -207,6 +221,12 @@ var configSetCmd = &cobra.Command{
 		if key == "status.custom" && value != "" {
 			if _, err := types.ParseCustomStatusConfig(value); err != nil {
 				return HandleError("invalid status.custom value: %v", err)
+			}
+		}
+
+		if key == labelns.ConfigKey && value != "" {
+			if _, err := labelns.ValidatePrefixes(value); err != nil {
+				return HandleError("invalid %s value: %v", labelns.ConfigKey, err)
 			}
 		}
 
@@ -873,7 +893,7 @@ Examples:
 // a new tracker is added (GH#4427).
 var recognizedConfigPrefixes = []string{
 	"export.", "import.", "dolt.", "custom.",
-	"status.", "types.", "doctor.suppress.", "routing.", "sync.", "git.",
+	"status.", "types.", "labels.", "doctor.suppress.", "routing.", "sync.", "git.",
 	"directory.", "repos.", "external_projects.", "validation.",
 	"hierarchy.", "ai.", "backup.", "federation.", "metrics.", "agent.",
 }

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/debug"
+	"github.com/steveyegge/beads/internal/labelns"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/remotecache"
 	"github.com/steveyegge/beads/internal/routing"
@@ -459,7 +460,18 @@ var createCmd = &cobra.Command{
 			}
 		}
 
+		var exclusivePrefixes []string
+		if store != nil {
+			raw, _ := store.GetConfig(rootCtx, labelns.ConfigKey)
+			exclusivePrefixes = labelns.ParsePrefixes(raw)
+		}
+		inheritedLabels = dropConflictingInheritedLabels(labels, inheritedLabels, exclusivePrefixes)
 		labels = mergeCreateLabels(labels, inheritedLabels)
+		if conflicts := labelns.Conflicts(exclusivePrefixes, labels); len(conflicts) > 0 {
+			c := conflicts[0]
+			return HandleError("namespace %q is exclusive (%s) and allows at most one label, got %s",
+				c.Prefix, labelns.ConfigKey, strings.Join(c.Labels, ", "))
+		}
 
 		if dryRun {
 			return renderDryRun()
@@ -793,6 +805,32 @@ func buildCreateIssue(params createIssueParams) *types.Issue {
 		DeferUntil:         params.DeferUntil,
 		Metadata:           params.Metadata,
 	}
+}
+
+// dropConflictingInheritedLabels resolves exclusive-namespace collisions
+// between explicit -l labels and labels inherited from --parent: the explicit
+// label wins and the inherited one is dropped, so a child can override e.g. a
+// tier: routing label without needing --no-inherit-labels (bd-7u5ki).
+// Collisions among the explicit labels themselves are left for the caller to
+// reject.
+func dropConflictingInheritedLabels(explicit, inherited, exclusivePrefixes []string) []string {
+	if len(exclusivePrefixes) == 0 || len(inherited) == 0 {
+		return inherited
+	}
+	taken := make(map[string]bool)
+	for _, label := range explicit {
+		if prefix := labelns.Match(exclusivePrefixes, label); prefix != "" {
+			taken[prefix] = true
+		}
+	}
+	kept := make([]string, 0, len(inherited))
+	for _, label := range inherited {
+		if prefix := labelns.Match(exclusivePrefixes, label); prefix != "" && taken[prefix] {
+			continue
+		}
+		kept = append(kept, label)
+	}
+	return kept
 }
 
 func mergeCreateLabels(labels, inheritedLabels []string) []string {

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -624,6 +624,13 @@ func runDiagnostics(path string) doctorResult {
 	blockedConsistencyCheck := convertWithCategory(doctor.CheckBlockedConsistencyWithStore(sharedStore), doctor.CategoryData)
 	result.Checks = append(result.Checks, blockedConsistencyCheck)
 
+	// Exclusive label namespaces (bd-7u5ki): only reports when the workspace
+	// opted in via labels.exclusive-prefixes. Warn-only: violations predate
+	// the config (or arrived via import, which deliberately keeps them), and
+	// the cleanup is a routine label remove/swap.
+	exclusiveLabelsCheck := convertWithCategory(doctor.CheckExclusiveLabelNamespacesWithStore(sharedStore), doctor.CategoryData)
+	result.Checks = append(result.Checks, exclusiveLabelsCheck)
+
 	// Check 11: Claude integration
 	claudeCheck := convertWithCategory(doctor.CheckClaude(path), doctor.CategoryIntegration)
 	result.Checks = append(result.Checks, claudeCheck)

--- a/cmd/bd/doctor/exclusive_labels.go
+++ b/cmd/bd/doctor/exclusive_labels.go
@@ -1,0 +1,88 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/labelns"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+)
+
+// ExclusiveLabelsCheckName is the doctor check name for exclusive label
+// namespace violations (bd-7u5ki).
+const ExclusiveLabelsCheckName = "Exclusive Label Namespaces"
+
+// maxExclusiveLabelDetailLines caps the per-issue lines in the check detail
+// so a widespread violation doesn't flood doctor output.
+const maxExclusiveLabelDetailLines = 10
+
+// CheckExclusiveLabelNamespacesWithStore reports non-closed issues carrying
+// more than one label in a namespace configured exclusive via
+// labels.exclusive-prefixes. Write-path enforcement only guards new label
+// additions, so violations written before the config was set (or merged in
+// by import, which warns instead of failing) stay invisible to routing
+// consumers until cleaned up — this check is how adopters find them.
+func CheckExclusiveLabelNamespacesWithStore(ss *SharedStore) DoctorCheck {
+	store := ss.Store()
+	if store == nil {
+		return DoctorCheck{
+			Name:    ExclusiveLabelsCheckName,
+			Status:  StatusOK,
+			Message: "No database yet",
+		}
+	}
+	return checkExclusiveLabelNamespaces(context.Background(), store)
+}
+
+func checkExclusiveLabelNamespaces(ctx context.Context, store *dolt.DoltStore) DoctorCheck {
+	raw, err := store.GetConfig(ctx, labelns.ConfigKey)
+	if err != nil {
+		return DoctorCheck{
+			Name:    ExclusiveLabelsCheckName,
+			Status:  StatusWarning,
+			Message: "Unable to read " + labelns.ConfigKey,
+			Detail:  err.Error(),
+		}
+	}
+	prefixes := labelns.ParsePrefixes(raw)
+	if len(prefixes) == 0 {
+		return DoctorCheck{
+			Name:    ExclusiveLabelsCheckName,
+			Status:  StatusOK,
+			Message: "No exclusive label namespaces configured (" + labelns.ConfigKey + ")",
+		}
+	}
+	violations, err := issueops.FindExclusiveLabelViolations(ctx, store.UnderlyingDB(), prefixes)
+	if err != nil {
+		return DoctorCheck{
+			Name:    ExclusiveLabelsCheckName,
+			Status:  StatusWarning,
+			Message: "Unable to scan labels for exclusive-namespace violations",
+			Detail:  err.Error(),
+		}
+	}
+	if len(violations) == 0 {
+		return DoctorCheck{
+			Name:    ExclusiveLabelsCheckName,
+			Status:  StatusOK,
+			Message: fmt.Sprintf("No violations in exclusive namespaces (%s)", strings.Join(prefixes, ", ")),
+		}
+	}
+	lines := make([]string, 0, maxExclusiveLabelDetailLines+1)
+	for i, v := range violations {
+		if i == maxExclusiveLabelDetailLines {
+			lines = append(lines, fmt.Sprintf("... and %d more", len(violations)-maxExclusiveLabelDetailLines))
+			break
+		}
+		lines = append(lines, fmt.Sprintf("%s: %s", v.IssueID, strings.Join(v.Labels, ", ")))
+	}
+	return DoctorCheck{
+		Name:    ExclusiveLabelsCheckName,
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("%d issue(s) carry more than one label in an exclusive namespace — routing filters may silently exclude them", len(violations)),
+		Detail:  strings.Join(lines, "\n"),
+		Fix:     "Remove the extra label: bd label remove <id> <label>, or swap with: bd label add --replace <id> <label>",
+	}
+}

--- a/cmd/bd/doctor/fix/migrate.go
+++ b/cmd/bd/doctor/fix/migrate.go
@@ -228,6 +228,9 @@ func importJSONLIntoStore(ctx context.Context, store storage.DoltStorage, jsonlP
 	err = store.CreateIssuesWithFullOptions(ctx, issues, actor, storage.BatchCreateOptions{
 		OrphanHandling:       storage.OrphanAllow,
 		SkipPrefixValidation: true,
+		// Replays existing data: exclusive-label violations warn via bd
+		// doctor instead of failing the replay (bd-7u5ki).
+		ExclusiveLabelConflictWarn: true,
 	})
 	if err != nil {
 		return 0, err

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -183,7 +183,11 @@ type importResultJSON struct {
 	TieKeptLocalIDs     []string       `json:"tie_kept_local_ids,omitempty"`
 	StaleSkippedIDs     []string       `json:"stale_skipped_ids,omitempty"`
 	SkippedDependencies []string       `json:"skipped_dependencies,omitempty"`
-	DryRun              bool           `json:"dry_run,omitempty"`
+	// ExclusiveLabelConflicts lists issues carrying more than one label in an
+	// exclusive namespace (labels.exclusive-prefixes); import warns and keeps
+	// the labels rather than failing (bd-7u5ki).
+	ExclusiveLabelConflicts []string `json:"exclusive_label_conflicts,omitempty"`
+	DryRun                  bool     `json:"dry_run,omitempty"`
 }
 
 func runImportFromReader(ctx context.Context, r io.Reader, source string) error {
@@ -293,6 +297,7 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 		result.UpdatedIssues = append(result.UpdatedIssues, importResult.UpdatedIssues...)
 		result.TieKeptLocalIDs = append(result.TieKeptLocalIDs, importResult.TieKeptLocalIDs...)
 		result.StaleSkippedIDs = append(result.StaleSkippedIDs, importResult.StaleSkippedIDs...)
+		result.ExclusiveLabelConflicts = append(result.ExclusiveLabelConflicts, importResult.ExclusiveLabelConflicts...)
 	}
 
 	if result.Created > 0 || result.Memories > 0 {
@@ -339,6 +344,9 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 	}
 	for _, skipped := range result.SkippedDependencies {
 		fmt.Fprintf(os.Stderr, "Skipped dependency: %s\n", skipped)
+	}
+	for _, conflict := range result.ExclusiveLabelConflicts {
+		fmt.Fprintf(os.Stderr, "Warning: exclusive label conflict kept as-is (clean up with 'bd label remove' or 'bd label add --replace'): %s\n", conflict)
 	}
 	return nil
 }

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -64,6 +64,11 @@ type ImportResult struct {
 	// row for these (second-granularity timestamp ties, bd-hj85c); their
 	// aux data still merges.
 	TieKeptLocalIDs []string
+	// ExclusiveLabelConflicts lists issues that violate a configured
+	// exclusive label namespace (labels.exclusive-prefixes, bd-7u5ki).
+	// Import replays history, so violations warn instead of failing and the
+	// labels are kept as written; bd doctor reports them for cleanup.
+	ExclusiveLabelConflicts []string
 }
 
 // ImportChange describes how an import row modified an existing local issue.
@@ -106,6 +111,8 @@ func importIssuesCore(ctx context.Context, _ string, store storage.DoltStorage, 
 	// (local update committed between the pre-filter read and the batch
 	// write). The transaction may retry, so dedup by ID.
 	staleRejectedSet := make(map[string]struct{})
+	var exclusiveLabelConflicts []string
+	exclusiveLabelConflictSet := make(map[string]struct{})
 	err := store.CreateIssuesWithFullOptions(ctx, issues, getActorWithGit(), storage.BatchCreateOptions{
 		OrphanHandling:                 storage.OrphanAllow,
 		SkipPrefixValidation:           opts.SkipPrefixValidation,
@@ -122,6 +129,15 @@ func importIssuesCore(ctx context.Context, _ string, store storage.DoltStorage, 
 		},
 		OnStaleRejected: func(issueID string) {
 			staleRejectedSet[issueID] = struct{}{}
+		},
+		ExclusiveLabelConflictWarn: true,
+		OnExclusiveLabelConflict: func(issueID, prefix string, labels []string) {
+			conflict := fmt.Sprintf("%s: namespace %q has %s", issueID, prefix, strings.Join(labels, ", "))
+			if _, ok := exclusiveLabelConflictSet[conflict]; ok {
+				return
+			}
+			exclusiveLabelConflictSet[conflict] = struct{}{}
+			exclusiveLabelConflicts = append(exclusiveLabelConflicts, conflict)
 		},
 	})
 	if err != nil {
@@ -148,14 +164,15 @@ func importIssuesCore(ctx context.Context, _ string, store storage.DoltStorage, 
 		updatedCount++
 	}
 	return &ImportResult{
-		Created:             len(importedIDs),
-		Updated:             updatedCount,
-		Skipped:             len(staleSkippedIDs),
-		ImportedIDs:         importedIDs,
-		StaleSkippedIDs:     staleSkippedIDs,
-		SkippedDependencies: skippedDependencies,
-		UpdatedIssues:       updatedIssues,
-		TieKeptLocalIDs:     changePlan.TieKeptLocal,
+		Created:                 len(importedIDs),
+		Updated:                 updatedCount,
+		Skipped:                 len(staleSkippedIDs),
+		ImportedIDs:             importedIDs,
+		StaleSkippedIDs:         staleSkippedIDs,
+		SkippedDependencies:     skippedDependencies,
+		UpdatedIssues:           updatedIssues,
+		TieKeptLocalIDs:         changePlan.TieKeptLocal,
+		ExclusiveLabelConflicts: exclusiveLabelConflicts,
 	}, nil
 }
 

--- a/cmd/bd/label.go
+++ b/cmd/bd/label.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/labelns"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
@@ -146,11 +147,39 @@ var labelAddCmd = &cobra.Command{
 			}
 		}
 
+		var exclusivePrefixes []string
+		if replace, _ := cmd.Flags().GetBool("replace"); replace {
+			raw, _ := store.GetConfig(ctx, labelns.ConfigKey)
+			exclusivePrefixes = labelns.ParsePrefixes(raw)
+		}
+
 		return processBatchLabelOperation(issueIDs, labels, "added", jsonOutput,
-			func(ctx context.Context, tx storage.Transaction, issueID, lbl, act string) error {
-				return tx.AddLabel(ctx, issueID, lbl, act)
-			})
+			exclusiveReplaceAddTxFunc(exclusivePrefixes))
 	},
+}
+
+// exclusiveReplaceAddTxFunc returns the per-(issue,label) add operation for
+// 'bd label add'. With exclusive prefixes supplied (--replace), a label in an
+// exclusive namespace first removes any other label the issue carries in that
+// namespace, so the add swaps instead of tripping the exclusivity guard in
+// the storage layer (bd-7u5ki). Without prefixes it is a plain AddLabel.
+func exclusiveReplaceAddTxFunc(exclusivePrefixes []string) func(context.Context, storage.Transaction, string, string, string) error {
+	return func(ctx context.Context, tx storage.Transaction, issueID, lbl, act string) error {
+		if prefix := labelns.Match(exclusivePrefixes, lbl); prefix != "" {
+			existing, err := tx.GetLabels(ctx, issueID)
+			if err != nil {
+				return err
+			}
+			for _, have := range existing {
+				if have != lbl && labelns.Match(exclusivePrefixes, have) == prefix {
+					if err := tx.RemoveLabel(ctx, issueID, have, act); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		return tx.AddLabel(ctx, issueID, lbl, act)
+	}
 }
 
 //nolint:dupl // labelRemoveCmd and labelAddCmd are similar but serve different operations
@@ -379,6 +408,8 @@ var labelPropagateCmd = &cobra.Command{
 }
 
 func init() {
+	labelAddCmd.Flags().Bool("replace", false, "In exclusive label namespaces (labels.exclusive-prefixes), swap out any existing label in the same namespace instead of failing")
+
 	// Issue ID completions
 	labelAddCmd.ValidArgsFunction = issueIDCompletion
 	labelRemoveCmd.ValidArgsFunction = issueIDCompletion

--- a/cmd/bd/label_exclusive_test.go
+++ b/cmd/bd/label_exclusive_test.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/labelns"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// newExclusiveLabelStore returns a test store with tier: and review:
+// configured as exclusive label namespaces (bd-7u5ki).
+func newExclusiveLabelStore(t *testing.T) *dolt.DoltStore {
+	t.Helper()
+	st := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	if err := st.SetConfig(context.Background(), labelns.ConfigKey, "tier:,review"); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	return st
+}
+
+func mustCreateLabeledIssue(t *testing.T, st *dolt.DoltStore, labels ...string) *types.Issue {
+	t.Helper()
+	issue := &types.Issue{Title: "x", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Labels: labels}
+	if err := st.CreateIssue(context.Background(), issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	return issue
+}
+
+func TestExclusiveLabels_AddLabelRejected(t *testing.T) {
+	ctx := context.Background()
+	st := newExclusiveLabelStore(t)
+	issue := mustCreateLabeledIssue(t, st, "tier:fable")
+
+	err := st.AddLabel(ctx, issue.ID, "tier:opus", "tester")
+	if err == nil || !strings.Contains(err.Error(), "exclusive") {
+		t.Fatalf("expected exclusive-namespace rejection, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "tier:fable") {
+		t.Fatalf("error should name the existing label, got %v", err)
+	}
+
+	// Re-adding the same label stays idempotent.
+	if err := st.AddLabel(ctx, issue.ID, "tier:fable", "tester"); err != nil {
+		t.Fatalf("re-adding existing label: %v", err)
+	}
+	// The colon-less config form ("review") normalizes to review: and enforces.
+	if err := st.AddLabel(ctx, issue.ID, "review:fable", "tester"); err != nil {
+		t.Fatalf("first review: label: %v", err)
+	}
+	if err := st.AddLabel(ctx, issue.ID, "review:opus", "tester"); err == nil {
+		t.Fatal("expected second review: label to be rejected")
+	}
+	// Labels outside exclusive namespaces stay free-form.
+	if err := st.AddLabel(ctx, issue.ID, "area:x", "tester"); err != nil {
+		t.Fatalf("non-namespaced label: %v", err)
+	}
+	if err := st.AddLabel(ctx, issue.ID, "area:y", "tester"); err != nil {
+		t.Fatalf("second non-namespaced label: %v", err)
+	}
+}
+
+func TestExclusiveLabels_UnconfiguredKeepsFreeFormLabels(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	issue := mustCreateLabeledIssue(t, st, "tier:fable")
+
+	if err := st.AddLabel(ctx, issue.ID, "tier:opus", "tester"); err != nil {
+		t.Fatalf("unconfigured workspace must accept both labels: %v", err)
+	}
+	labels, _ := st.GetLabels(ctx, issue.ID)
+	if len(labels) != 2 {
+		t.Fatalf("expected 2 labels, got %v", labels)
+	}
+}
+
+func TestExclusiveLabels_CreateWithConflictRejected(t *testing.T) {
+	ctx := context.Background()
+	st := newExclusiveLabelStore(t)
+
+	issue := &types.Issue{Title: "x", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask,
+		Labels: []string{"tier:fable", "tier:opus"}}
+	err := st.CreateIssue(ctx, issue, "tester")
+	if err == nil || !strings.Contains(err.Error(), "exclusive") {
+		t.Fatalf("expected create to reject conflicting labels, got %v", err)
+	}
+}
+
+func TestExclusiveLabels_UpdateSwapsInOneCommand(t *testing.T) {
+	ctx := context.Background()
+	st := newExclusiveLabelStore(t)
+	issue := mustCreateLabeledIssue(t, st, "tier:fable")
+
+	// --remove-label tier:fable --add-label tier:opus in one update: removes
+	// must run before adds or the add trips the exclusivity guard.
+	if err := applyLabelUpdates(ctx, st, issue.ID, "tester", nil, []string{"tier:opus"}, []string{"tier:fable"}); err != nil {
+		t.Fatalf("applyLabelUpdates swap: %v", err)
+	}
+	labels, _ := st.GetLabels(ctx, issue.ID)
+	if len(labels) != 1 || labels[0] != "tier:opus" {
+		t.Fatalf("expected [tier:opus], got %v", labels)
+	}
+}
+
+func TestExclusiveLabels_ReplaceTxFuncSwaps(t *testing.T) {
+	ctx := context.Background()
+	st := newExclusiveLabelStore(t)
+	issue := mustCreateLabeledIssue(t, st, "tier:fable")
+
+	txFunc := exclusiveReplaceAddTxFunc([]string{"tier:", "review:"})
+	err := st.RunInTransaction(ctx, "", func(tx storage.Transaction) error {
+		return txFunc(ctx, tx, issue.ID, "tier:opus", "tester")
+	})
+	if err != nil {
+		t.Fatalf("replace add: %v", err)
+	}
+	labels, _ := st.GetLabels(ctx, issue.ID)
+	if len(labels) != 1 || labels[0] != "tier:opus" {
+		t.Fatalf("expected [tier:opus], got %v", labels)
+	}
+
+	// Without prefixes (no --replace), the same helper is a plain add and the
+	// storage guard rejects the conflict.
+	plain := exclusiveReplaceAddTxFunc(nil)
+	err = st.RunInTransaction(ctx, "", func(tx storage.Transaction) error {
+		return plain(ctx, tx, issue.ID, "tier:fable", "tester")
+	})
+	if err == nil || !strings.Contains(err.Error(), "exclusive") {
+		t.Fatalf("expected rejection without --replace, got %v", err)
+	}
+}
+
+func TestExclusiveLabels_ImportWarnsAndKeepsLabels(t *testing.T) {
+	ctx := context.Background()
+	st := newExclusiveLabelStore(t)
+
+	issue := &types.Issue{ID: "test-imp1", Title: "imported", Status: types.StatusOpen, Priority: 2,
+		IssueType: types.TypeTask, Labels: []string{"tier:fable", "tier:opus"}}
+	var reported [][3]string
+	err := st.CreateIssuesWithFullOptions(ctx, []*types.Issue{issue}, "importer", storage.BatchCreateOptions{
+		OrphanHandling:             storage.OrphanAllow,
+		SkipPrefixValidation:       true,
+		ExclusiveLabelConflictWarn: true,
+		OnExclusiveLabelConflict: func(issueID, prefix string, labels []string) {
+			reported = append(reported, [3]string{issueID, prefix, strings.Join(labels, ",")})
+		},
+	})
+	if err != nil {
+		t.Fatalf("import-style create must warn, not fail: %v", err)
+	}
+	if len(reported) == 0 {
+		t.Fatal("expected the violation to be reported through the callback")
+	}
+	if reported[0][0] != "test-imp1" || reported[0][1] != "tier:" {
+		t.Fatalf("unexpected report: %v", reported[0])
+	}
+	labels, _ := st.GetLabels(ctx, "test-imp1")
+	if len(labels) != 2 {
+		t.Fatalf("import must keep violating labels (no silent data loss), got %v", labels)
+	}
+}
+
+func TestFindExclusiveLabelViolations(t *testing.T) {
+	ctx := context.Background()
+	st := newExclusiveLabelStore(t)
+	prefixes := []string{"tier:", "review:"}
+
+	// A violating issue (written import-style, bypassing the write guard),
+	// a clean issue, and a closed violating issue that must be skipped.
+	violating := &types.Issue{ID: "test-v1", Title: "v", Status: types.StatusOpen, Priority: 2,
+		IssueType: types.TypeTask, Labels: []string{"tier:fable", "tier:opus"}}
+	closed := &types.Issue{ID: "test-v2", Title: "c", Status: types.StatusClosed, Priority: 2,
+		IssueType: types.TypeTask, Labels: []string{"tier:fable", "tier:opus"}}
+	if err := st.CreateIssuesWithFullOptions(ctx, []*types.Issue{violating, closed}, "importer", storage.BatchCreateOptions{
+		OrphanHandling:             storage.OrphanAllow,
+		SkipPrefixValidation:       true,
+		ExclusiveLabelConflictWarn: true,
+	}); err != nil {
+		t.Fatalf("seed violations: %v", err)
+	}
+	mustCreateLabeledIssue(t, st, "tier:fable", "area:x")
+
+	violations, err := issueops.FindExclusiveLabelViolations(ctx, st.UnderlyingDB(), prefixes)
+	if err != nil {
+		t.Fatalf("FindExclusiveLabelViolations: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected exactly 1 violation, got %v", violations)
+	}
+	v := violations[0]
+	if v.IssueID != "test-v1" || v.Prefix != "tier:" || len(v.Labels) != 2 {
+		t.Fatalf("unexpected violation: %+v", v)
+	}
+
+	// No prefixes configured: nothing to scan.
+	none, err := issueops.FindExclusiveLabelViolations(ctx, st.UnderlyingDB(), nil)
+	if err != nil || none != nil {
+		t.Fatalf("expected nil, nil for empty prefixes, got %v, %v", none, err)
+	}
+}
+
+func TestDropConflictingInheritedLabels(t *testing.T) {
+	prefixes := []string{"tier:"}
+
+	got := dropConflictingInheritedLabels([]string{"tier:opus"}, []string{"tier:fable", "area:x"}, prefixes)
+	if len(got) != 1 || got[0] != "area:x" {
+		t.Fatalf("explicit tier: label should evict inherited one, got %v", got)
+	}
+	got = dropConflictingInheritedLabels([]string{"area:y"}, []string{"tier:fable"}, prefixes)
+	if len(got) != 1 || got[0] != "tier:fable" {
+		t.Fatalf("inherited label without explicit conflict should survive, got %v", got)
+	}
+	got = dropConflictingInheritedLabels([]string{"tier:opus"}, []string{"tier:fable"}, nil)
+	if len(got) != 1 || got[0] != "tier:fable" {
+		t.Fatalf("no exclusive prefixes: inheritance unchanged, got %v", got)
+	}
+}

--- a/cmd/bd/repo.go
+++ b/cmd/bd/repo.go
@@ -305,6 +305,9 @@ Also triggers Dolt push/pull if a remote is configured.`,
 					if importErr := store.CreateIssuesWithFullOptions(ctx, issues, "repo-sync", storage.BatchCreateOptions{
 						OrphanHandling:       storage.OrphanAllow,
 						SkipPrefixValidation: true,
+						// Replays existing data: exclusive-label violations warn via bd
+						// doctor instead of failing the replay (bd-7u5ki).
+						ExclusiveLabelConflictWarn: true,
 					}); importErr != nil {
 						fmt.Fprintf(os.Stderr, "Warning: failed to import from %s: %v\n", repoPath, importErr)
 						continue
@@ -376,6 +379,9 @@ Also triggers Dolt push/pull if a remote is configured.`,
 			if err := store.CreateIssuesWithFullOptions(ctx, issues, "repo-sync", storage.BatchCreateOptions{
 				OrphanHandling:       storage.OrphanAllow,
 				SkipPrefixValidation: true,
+				// Replays existing data: exclusive-label violations warn via bd
+				// doctor instead of failing the replay (bd-7u5ki).
+				ExclusiveLabelConflictWarn: true,
 			}); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to import from %s: %v\n", repoPath, err)
 				continue

--- a/cmd/bd/show_unit_helpers.go
+++ b/cmd/bd/show_unit_helpers.go
@@ -51,16 +51,18 @@ func applyLabelUpdates(ctx context.Context, st storage.DoltStorage, issueID, act
 		}
 	}
 
-	// Add labels
-	for _, label := range addLabels {
-		if err := st.AddLabel(ctx, issueID, label, actor); err != nil {
+	// Removes run before adds so a single update can swap a label in an
+	// exclusive namespace (--remove-label tier:x --add-label tier:y) without
+	// tripping the exclusivity guard on the add (bd-7u5ki).
+	for _, label := range removeLabels {
+		if err := st.RemoveLabel(ctx, issueID, label, actor); err != nil {
 			return err
 		}
 	}
 
-	// Remove labels
-	for _, label := range removeLabels {
-		if err := st.RemoveLabel(ctx, issueID, label, actor); err != nil {
+	// Add labels
+	for _, label := range addLabels {
+		if err := st.AddLabel(ctx, issueID, label, actor); err != nil {
 			return err
 		}
 	}

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -862,7 +862,13 @@ bd label [command]
 Add labels to issues. Issue IDs come first; the final argument is the label. Pass multiple labels comma-separated: bd label add bd-123 label1,label2
 
 ```
-bd label add [issue-id...] [label[,label...]]
+bd label add [issue-id...] [label[,label...]] [flags]
+```
+
+**Flags:**
+
+```
+      --replace   In exclusive label namespaces (labels.exclusive-prefixes), swap out any existing label in the same namespace instead of failing
 ```
 
 #### bd label list
@@ -2773,6 +2779,18 @@ Custom Status States:
   This enables issues to use statuses like 'awaiting_review' in addition to
   the built-in statuses (open, in_progress, blocked, deferred, closed).
 
+Exclusive Label Namespaces:
+  Labels are free-form, but routing conventions like tier:&lt;model&gt; assume one
+  label per prefix; a second one silently narrows fleet eligibility to zero.
+  Declare prefixes exclusive (at most one label per issue) with:
+
+    bd config set labels.exclusive-prefixes "tier:,review:"
+
+  Adding a second label in an exclusive namespace is then rejected on every
+  write path ('bd label add --replace' swaps instead). Import warns and keeps
+  violating labels; 'bd doctor' reports existing violations. Unset the key to
+  restore fully free-form labels (the default).
+
 Suppressing Doctor Warnings:
   Suppress specific bd doctor warnings by check name slug:
     bd config set doctor.suppress.pending-migrations true
@@ -2789,6 +2807,7 @@ Examples:
   bd config set jira.url "https://company.atlassian.net"
   bd config set jira.project "PROJ"
   bd config set status.custom "awaiting_review,awaiting_testing"
+  bd config set labels.exclusive-prefixes "tier:,review:"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
   bd config set dolt.local-only true                   # Skip wiring a Dolt sync remote during bd init

--- a/docs/cli-reference/config.md
+++ b/docs/cli-reference/config.md
@@ -55,6 +55,18 @@ Custom Status States:
   This enables issues to use statuses like 'awaiting_review' in addition to
   the built-in statuses (open, in_progress, blocked, deferred, closed).
 
+Exclusive Label Namespaces:
+  Labels are free-form, but routing conventions like tier:&lt;model&gt; assume one
+  label per prefix; a second one silently narrows fleet eligibility to zero.
+  Declare prefixes exclusive (at most one label per issue) with:
+
+    bd config set labels.exclusive-prefixes "tier:,review:"
+
+  Adding a second label in an exclusive namespace is then rejected on every
+  write path ('bd label add --replace' swaps instead). Import warns and keeps
+  violating labels; 'bd doctor' reports existing violations. Unset the key to
+  restore fully free-form labels (the default).
+
 Suppressing Doctor Warnings:
   Suppress specific bd doctor warnings by check name slug:
     bd config set doctor.suppress.pending-migrations true
@@ -71,6 +83,7 @@ Examples:
   bd config set jira.url "https://company.atlassian.net"
   bd config set jira.project "PROJ"
   bd config set status.custom "awaiting_review,awaiting_testing"
+  bd config set labels.exclusive-prefixes "tier:,review:"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
   bd config set dolt.local-only true                   # Skip wiring a Dolt sync remote during bd init

--- a/docs/cli-reference/label.md
+++ b/docs/cli-reference/label.md
@@ -21,6 +21,12 @@ Add labels to issues. Issue IDs come first; the final argument is the label. Pas
 bd label add [issue-id...] [label[,label...]] [flags]
 ```
 
+**Flags:**
+
+```
+      --replace   In exclusive label namespaces (labels.exclusive-prefixes), swap out any existing label in the same namespace instead of failing
+```
+
 ## bd label list
 
 List labels for an issue

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -274,6 +274,7 @@ These are written to the Dolt database by `bd config set` and have no env var ov
 | `status.custom` | Custom statuses with optional behavior categories (see [below](#custom-statuses-and-types)) |
 | `types.custom` | Comma-separated list of custom issue types |
 | `types.infra` | Infra types routed to the wisps table instead of the versioned issues table |
+| `labels.exclusive-prefixes` | Label prefixes limited to one label per issue (see [below](#exclusive-label-namespaces)) |
 | `compact_tier1_days`, `compact_tier2_days` | Age thresholds in days for `bd admin compact` tier eligibility (defaults `30` and `90`) |
 | `issue_id_mode` | `hash` (default) \| `counter` (see [below](#sequential-counter-ids)) |
 | `min_hash_length`, `max_hash_length` | Adaptive ID bounds (defaults `3` and `8`) |
@@ -308,7 +309,26 @@ bd config set types.custom "agent,molecule,event"
 
 Use `bd statuses` and `bd types` to list everything configured.
 
-### Sequential Counter IDs
+### Exclusive Label Namespaces
+
+Labels are free-form, but conventions like `tier:<model>` treat a prefix as single-valued — and a bead that ends up with both `tier:fable` and `tier:opus` doesn't widen its eligibility, it silently vanishes from routing (one filter matches the first label while another excludes on the second). Declare such prefixes exclusive so a bead carries at most one label per namespace:
+
+```bash
+bd config set labels.exclusive-prefixes "tier:,review:"
+```
+
+With a namespace configured, every write path rejects a second label in it — `bd create -l`, `bd update --add-label`, `bd label add`, and `bd label propagate` — naming the existing label in the error. To swap instead of remove-then-add:
+
+```bash
+bd label add bd-a1b2 tier:opus --replace   # removes tier:fable, adds tier:opus
+```
+
+Boundary behavior:
+
+- **Off by default.** An empty or unset key leaves all labels free-form; multi-valued prefixes like `area:` keep working unless you list them.
+- **Explicit beats inherited.** A child created with `--parent` and an explicit label in an exclusive namespace drops the parent's label in that namespace instead of failing.
+- **Import warns instead of failing.** `bd import` replays history that may predate the config, so violations are kept and reported, not rejected.
+- **`bd doctor` reports existing violations** (server mode), so you can clean up before or after turning enforcement on.
 
 By default, beads generates hash-based IDs (e.g. `bd-a3f2`). For projects that prefer short sequential IDs (`bd-1`, `bd-2`, ...), enable counter mode:
 

--- a/internal/labelns/labelns.go
+++ b/internal/labelns/labelns.go
@@ -1,0 +1,126 @@
+// Package labelns implements exclusive label namespaces (bd-7u5ki): a
+// workspace may declare label prefixes (e.g. "tier:") for which an issue
+// carries at most one label. Labels are otherwise free-form strings, so
+// without enforcement a second label in a routing namespace (tier:fable +
+// tier:opus) silently narrows fleet eligibility to zero instead of widening
+// it — ready-front listings match the label they query for while claim
+// filters exclude on the other one, leaving the bead invisible to dispatch.
+//
+// Enforcement is opt-in: the ConfigKey value is a comma-separated prefix
+// list, and an empty or unset value (the default) leaves every label
+// namespace multi-valued, exactly the pre-feature behavior.
+package labelns
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ConfigKey is the workspace config key holding the comma-separated list of
+// exclusive label prefixes (e.g. "tier:,review:"). Empty or unset means no
+// namespace is exclusive.
+const ConfigKey = "labels.exclusive-prefixes"
+
+// ParsePrefixes parses a ConfigKey value into normalized prefixes: entries
+// are trimmed, empty entries dropped, duplicates removed, and every prefix is
+// guaranteed to end with ":" so "tier" and "tier:" configure the same
+// namespace. Malformed entries are skipped rather than rejected — read paths
+// must stay permissive because the config value may predate stricter
+// validation; ValidatePrefixes is the strict gate for writes.
+func ParsePrefixes(raw string) []string {
+	parts := strings.Split(raw, ",")
+	prefixes := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" || part == ":" {
+			continue
+		}
+		if !strings.HasSuffix(part, ":") {
+			part += ":"
+		}
+		if _, ok := seen[part]; ok {
+			continue
+		}
+		seen[part] = struct{}{}
+		prefixes = append(prefixes, part)
+	}
+	return prefixes
+}
+
+// ValidatePrefixes checks a candidate ConfigKey value, returning the parsed
+// prefixes or an error describing the first invalid entry. Used by
+// 'bd config set' so a bad value is rejected at write time.
+func ValidatePrefixes(raw string) ([]string, error) {
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		name := strings.TrimSuffix(part, ":")
+		if name == "" {
+			return nil, fmt.Errorf("prefix %q has no name before the colon", part)
+		}
+		if strings.Contains(name, ":") {
+			return nil, fmt.Errorf("prefix %q may contain at most one colon, at the end", part)
+		}
+		if strings.ContainsAny(name, " \t") {
+			return nil, fmt.Errorf("prefix %q contains whitespace", part)
+		}
+		if name == "provides" {
+			return nil, fmt.Errorf("'provides:' labels are reserved for cross-project capabilities and are inherently multi-valued")
+		}
+	}
+	prefixes := ParsePrefixes(raw)
+	if len(prefixes) == 0 {
+		return nil, fmt.Errorf("value contains no prefixes (unset the key to disable enforcement)")
+	}
+	return prefixes, nil
+}
+
+// Match returns the configured exclusive prefix the label falls under, or ""
+// when the label is not in any exclusive namespace. With overlapping prefixes
+// configured, the first match in config order wins.
+func Match(prefixes []string, label string) string {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(label, prefix) {
+			return prefix
+		}
+	}
+	return ""
+}
+
+// Conflict records an exclusive-namespace violation: two or more distinct
+// labels sharing one exclusive prefix.
+type Conflict struct {
+	Prefix string
+	Labels []string
+}
+
+// Conflicts returns one Conflict per exclusive prefix that more than one
+// distinct label falls under. Conflicts follow the config order of prefixes;
+// each Conflict's labels keep their input order, deduplicated, so callers get
+// deterministic error text.
+func Conflicts(prefixes, labels []string) []Conflict {
+	if len(prefixes) == 0 || len(labels) < 2 {
+		return nil
+	}
+	byPrefix := make(map[string][]string)
+	seen := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		if _, dup := seen[label]; dup {
+			continue
+		}
+		seen[label] = struct{}{}
+		if prefix := Match(prefixes, label); prefix != "" {
+			byPrefix[prefix] = append(byPrefix[prefix], label)
+		}
+	}
+	var conflicts []Conflict
+	for _, prefix := range prefixes {
+		if len(byPrefix[prefix]) > 1 {
+			conflicts = append(conflicts, Conflict{Prefix: prefix, Labels: byPrefix[prefix]})
+		}
+	}
+	return conflicts
+}

--- a/internal/labelns/labelns_test.go
+++ b/internal/labelns/labelns_test.go
@@ -1,0 +1,92 @@
+package labelns
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParsePrefixes(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single with colon", "tier:", []string{"tier:"}},
+		{"single without colon", "tier", []string{"tier:"}},
+		{"mixed forms dedup", "tier,tier:", []string{"tier:"}},
+		{"multiple with whitespace", " tier: , review ", []string{"tier:", "review:"}},
+		{"drops empties and bare colon", ",,:,tier:", []string{"tier:"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParsePrefixes(tt.raw)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParsePrefixes(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidatePrefixes(t *testing.T) {
+	valid := []string{"tier:", "tier", "tier:,review:", " tier , review: "}
+	for _, raw := range valid {
+		if _, err := ValidatePrefixes(raw); err != nil {
+			t.Errorf("ValidatePrefixes(%q) unexpected error: %v", raw, err)
+		}
+	}
+	invalid := []string{
+		"",                // no prefixes at all
+		",,",              // parses to nothing
+		":",               // no name before colon
+		"a:b:",            // interior colon
+		"has space:",      // whitespace
+		"provides:",       // reserved multi-valued namespace
+		"provides",        // reserved, colon-less form
+		"tier:,provides:", // reserved among valid entries
+	}
+	for _, raw := range invalid {
+		if _, err := ValidatePrefixes(raw); err == nil {
+			t.Errorf("ValidatePrefixes(%q) expected error, got nil", raw)
+		}
+	}
+}
+
+func TestMatch(t *testing.T) {
+	prefixes := []string{"tier:", "review:"}
+	if got := Match(prefixes, "tier:fable"); got != "tier:" {
+		t.Errorf("Match(tier:fable) = %q, want tier:", got)
+	}
+	if got := Match(prefixes, "area:x"); got != "" {
+		t.Errorf("Match(area:x) = %q, want empty", got)
+	}
+	if got := Match(nil, "tier:fable"); got != "" {
+		t.Errorf("Match with no prefixes = %q, want empty", got)
+	}
+}
+
+func TestConflicts(t *testing.T) {
+	prefixes := []string{"tier:", "review:"}
+
+	if got := Conflicts(prefixes, []string{"tier:fable", "review:opus", "area:x"}); len(got) != 0 {
+		t.Errorf("expected no conflicts, got %v", got)
+	}
+	if got := Conflicts(prefixes, []string{"tier:fable", "tier:fable"}); len(got) != 0 {
+		t.Errorf("duplicate of the same label should not conflict, got %v", got)
+	}
+	if got := Conflicts(nil, []string{"tier:fable", "tier:opus"}); len(got) != 0 {
+		t.Errorf("no prefixes configured should never conflict, got %v", got)
+	}
+
+	got := Conflicts(prefixes, []string{"review:a", "tier:fable", "tier:opus", "review:b"})
+	want := []Conflict{
+		{Prefix: "tier:", Labels: []string{"tier:fable", "tier:opus"}},
+		{Prefix: "review:", Labels: []string{"review:a", "review:b"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Conflicts = %v, want %v", got, want)
+	}
+}

--- a/internal/storage/batch.go
+++ b/internal/storage/batch.go
@@ -53,4 +53,15 @@ type BatchCreateOptions struct {
 	// them as skipped rather than created. May fire more than once per issue
 	// if the enclosing transaction retries; callers should dedup by ID.
 	OnStaleRejected func(issueID string)
+	// ExclusiveLabelConflictWarn downgrades exclusive-label-namespace
+	// violations (labels.exclusive-prefixes, bd-7u5ki) from a hard error to
+	// the OnExclusiveLabelConflict callback, keeping the labels as written.
+	// Set by import, which replays history that may predate the namespace
+	// config and must not hard-fail or silently drop labels; interactive
+	// create paths leave it false and fail the create instead.
+	ExclusiveLabelConflictWarn bool
+	// OnExclusiveLabelConflict reports each exclusive-namespace violation
+	// when ExclusiveLabelConflictWarn is set. May fire more than once per
+	// issue if the enclosing transaction retries; callers should dedup.
+	OnExclusiveLabelConflict func(issueID, prefix string, labels []string)
 }

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/steveyegge/beads/internal/labelns"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/depid"
 	"github.com/steveyegge/beads/internal/types"
@@ -19,7 +20,10 @@ type BatchContext struct {
 	CustomTypes     []string
 	ConfigPrefix    string
 	AllowedPrefixes string
-	Opts            storage.BatchCreateOptions
+	// ExclusiveLabelPrefixes holds the parsed labels.exclusive-prefixes config
+	// (bd-7u5ki); empty means no namespace is exclusive.
+	ExclusiveLabelPrefixes []string
+	Opts                   storage.BatchCreateOptions
 }
 
 // NewBatchContext reads config from the database and returns a BatchContext.
@@ -39,12 +43,18 @@ func NewBatchContext(ctx context.Context, tx *sql.Tx, opts storage.BatchCreateOp
 	var allowedPrefixes string
 	_ = tx.QueryRowContext(ctx, "SELECT value FROM config WHERE `key` = ?", "allowed_prefixes").Scan(&allowedPrefixes)
 
+	exclusiveRaw, err := GetConfigInTx(ctx, tx, labelns.ConfigKey)
+	if err != nil {
+		return nil, err
+	}
+
 	return &BatchContext{
-		CustomStatuses:  customStatuses,
-		CustomTypes:     customTypes,
-		ConfigPrefix:    configPrefix,
-		AllowedPrefixes: allowedPrefixes,
-		Opts:            opts,
+		CustomStatuses:         customStatuses,
+		CustomTypes:            customTypes,
+		ConfigPrefix:           configPrefix,
+		AllowedPrefixes:        allowedPrefixes,
+		ExclusiveLabelPrefixes: labelns.ParsePrefixes(exclusiveRaw),
+		Opts:                   opts,
 	}, nil
 }
 
@@ -145,7 +155,7 @@ func CreateIssueInTxWithResult(ctx context.Context, tx *sql.Tx, bc *BatchContext
 		result.markChanged(eventTable)
 	}
 
-	labelResult, err := PersistLabels(ctx, tx, issue, actor, eventTable)
+	labelResult, err := PersistLabels(ctx, tx, bc, issue, actor, eventTable)
 	if err != nil {
 		return result, err
 	}
@@ -608,7 +618,7 @@ func InsertIssueIfNew(ctx context.Context, tx *sql.Tx, issueTable string, issue 
 	return existingCount == 0, false, nil
 }
 
-func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue, actor, eventTable string) (CreateIssueResult, error) {
+func PersistLabels(ctx context.Context, tx *sql.Tx, bc *BatchContext, issue *types.Issue, actor, eventTable string) (CreateIssueResult, error) {
 	var result CreateIssueResult
 	if len(issue.Labels) == 0 {
 		return result, nil
@@ -616,6 +626,9 @@ func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue, actor, e
 	labelTable := "labels"
 	if IsWisp(issue) {
 		labelTable = "wisp_labels"
+	}
+	if err := checkExclusiveLabelsForPersist(ctx, tx, bc, issue, labelTable); err != nil {
+		return result, err
 	}
 	seen := make(map[string]struct{}, len(issue.Labels))
 	for _, label := range issue.Labels {
@@ -650,6 +663,40 @@ func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue, actor, e
 		result.markChanged(eventTable)
 	}
 	return result, nil
+}
+
+// checkExclusiveLabelsForPersist enforces labels.exclusive-prefixes
+// (bd-7u5ki) on the create/import label path. The incoming snapshot's labels
+// are checked together with any labels already stored for the issue, because
+// an import upsert merges aux data into an existing row. Interactive create
+// paths fail hard; import sets ExclusiveLabelConflictWarn because it replays
+// history that may predate the namespace config, so each violation is
+// reported through the callback and the labels are kept as-is (no silent
+// data loss — bd doctor surfaces the violations for cleanup).
+func checkExclusiveLabelsForPersist(ctx context.Context, tx *sql.Tx, bc *BatchContext, issue *types.Issue, labelTable string) error {
+	if bc == nil || len(bc.ExclusiveLabelPrefixes) == 0 {
+		return nil
+	}
+	existing, err := GetLabelsInTx(ctx, tx, labelTable, issue.ID)
+	if err != nil {
+		return fmt.Errorf("check exclusive labels for %s: %w", issue.ID, err)
+	}
+	combined := append(append([]string{}, existing...), issue.Labels...)
+	conflicts := labelns.Conflicts(bc.ExclusiveLabelPrefixes, combined)
+	if len(conflicts) == 0 {
+		return nil
+	}
+	if bc.Opts.ExclusiveLabelConflictWarn {
+		if bc.Opts.OnExclusiveLabelConflict != nil {
+			for _, c := range conflicts {
+				bc.Opts.OnExclusiveLabelConflict(issue.ID, c.Prefix, c.Labels)
+			}
+		}
+		return nil
+	}
+	c := conflicts[0]
+	return fmt.Errorf("issue %s: namespace %q is exclusive (%s) and allows at most one label, got %s",
+		issue.ID, c.Prefix, labelns.ConfigKey, strings.Join(c.Labels, ", "))
 }
 
 func PersistComments(ctx context.Context, tx *sql.Tx, issue *types.Issue) (CreateIssueResult, error) {

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/labelns"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -142,6 +143,9 @@ func AddLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID,
 			eventTable = et
 		}
 	}
+	if err := checkExclusiveLabelInTx(ctx, tx, labelTable, issueID, label); err != nil {
+		return err
+	}
 	//nolint:gosec // G201: labelTable is from WispTableRouting ("labels" or "wisp_labels")
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`INSERT IGNORE INTO %s (issue_id, label) VALUES (?, ?)`, labelTable), issueID, label); err != nil {
 		return fmt.Errorf("add label: %w", err)
@@ -153,6 +157,91 @@ func AddLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID,
 		return fmt.Errorf("add label: record event: %w", err)
 	}
 	return nil
+}
+
+// checkExclusiveLabelInTx rejects the add when the label falls in a
+// configured exclusive namespace (labels.exclusive-prefixes, bd-7u5ki) the
+// issue already carries a different label in. It lives at the shared insert
+// choke point so every interactive mutation path — bd label add, bd update
+// --add-label, bd label propagate — gets the same guard. With no prefixes
+// configured (the default) only the config lookup runs.
+func checkExclusiveLabelInTx(ctx context.Context, tx DBTX, labelTable, issueID, label string) error {
+	raw, err := GetConfigInTx(ctx, tx, labelns.ConfigKey)
+	if err != nil {
+		return fmt.Errorf("add label: %w", err)
+	}
+	prefixes := labelns.ParsePrefixes(raw)
+	if len(prefixes) == 0 {
+		return nil
+	}
+	prefix := labelns.Match(prefixes, label)
+	if prefix == "" {
+		return nil
+	}
+	existing, err := GetLabelsInTx(ctx, tx, labelTable, issueID)
+	if err != nil {
+		return fmt.Errorf("add label: %w", err)
+	}
+	for _, have := range existing {
+		if have != label && labelns.Match(prefixes, have) == prefix {
+			return fmt.Errorf("cannot add label %q to %s: namespace %q is exclusive (%s) and the issue already has %q — remove it first, or swap in one step with 'bd label add --replace'",
+				label, issueID, prefix, labelns.ConfigKey, have)
+		}
+	}
+	return nil
+}
+
+// ExclusiveLabelViolation reports an issue carrying more than one label in a
+// configured exclusive namespace.
+type ExclusiveLabelViolation struct {
+	IssueID string
+	Prefix  string
+	Labels  []string
+}
+
+// FindExclusiveLabelViolations scans the permanent labels table for
+// non-closed issues violating the given exclusive prefixes. bd doctor uses it
+// so adopters can find pre-existing violations before (or after) enabling
+// labels.exclusive-prefixes — write-path enforcement only guards new label
+// additions. Closed issues are skipped (no routing consumer reads them), as
+// are wisp labels (wisps are ephemeral and expire via TTL compaction).
+func FindExclusiveLabelViolations(ctx context.Context, db DBTX, prefixes []string) ([]ExclusiveLabelViolation, error) {
+	if len(prefixes) == 0 {
+		return nil, nil
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT l.issue_id, l.label
+		FROM labels l JOIN issues i ON i.id = l.issue_id
+		WHERE i.status != 'closed'
+		ORDER BY l.issue_id, l.label`)
+	if err != nil {
+		return nil, fmt.Errorf("scan exclusive labels: %w", err)
+	}
+	defer rows.Close()
+
+	labelsByIssue := make(map[string][]string)
+	var issueOrder []string
+	for rows.Next() {
+		var issueID, label string
+		if err := rows.Scan(&issueID, &label); err != nil {
+			return nil, fmt.Errorf("scan exclusive labels: %w", err)
+		}
+		if _, ok := labelsByIssue[issueID]; !ok {
+			issueOrder = append(issueOrder, issueID)
+		}
+		labelsByIssue[issueID] = append(labelsByIssue[issueID], label)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("scan exclusive labels: %w", err)
+	}
+
+	var violations []ExclusiveLabelViolation
+	for _, issueID := range issueOrder {
+		for _, c := range labelns.Conflicts(prefixes, labelsByIssue[issueID]) {
+			violations = append(violations, ExclusiveLabelViolation{IssueID: issueID, Prefix: c.Prefix, Labels: c.Labels})
+		}
+	}
+	return violations, nil
 }
 
 // RemoveLabelInTx removes a label from an issue and records an event within


### PR DESCRIPTION
## Summary

Implements **bd-7u5ki**: exclusive label namespaces, flag-gated.

Labels are free-form strings, so a bead can carry both `tier:fable` and `tier:opus` — and the two downstream consumers disagree about which one counts: the ready-front listing matches the label you query for (bead looks routable) while the claim filter excludes on the other one (bead is unclaimable). A second label in a routing namespace silently narrows eligibility to zero. Motivating incident: two dep-chained wyvern constellations stalled invisibly on 2026-07-13.

A workspace can now opt in:

```bash
bd config set labels.exclusive-prefixes "tier:,review:"
```

after which an issue may carry **at most one label per configured prefix**. Off by default — an empty/unset key is byte-for-byte today's behavior.

## Design decisions (per the spec's open questions)

- **Reject vs replace:** reject by default, with `bd label add --replace` to swap in one step (the spec's suggested middle ground). The error names the existing label.
- **Enforcement point:** the two storage choke points, so every mutation path is covered without per-command duplication:
  - `issueops.AddLabelInTx` — `bd label add`, `bd update --add-label`, `bd label propagate`
  - `issueops.PersistLabels` (via `BatchContext`) — `bd create -l`, `create --file/--graph`, import, repo-sync, doctor-fix migrate
- **Import replays history:** import and other replay paths set `ExclusiveLabelConflictWarn` — violations are reported per conflict on stderr and the labels are **kept** (no silent data loss). `bd doctor` is the cleanup tool.
- **Adoption lint:** new `bd doctor` check *Exclusive Label Namespaces* (warn-only, Data category) lists non-closed violators so adopters can clean up before flipping enforcement on.

## Ergonomics

- `bd update` now processes `--remove-label` before `--add-label`, so a one-command swap (`--remove-label tier:x --add-label tier:y`) works under enforcement.
- `bd create --parent`: an explicit label evicts the inherited parent label in the same exclusive namespace instead of failing the create.
- `bd config set` validates the key; `provides:` is rejected (reserved and inherently multi-valued). `tier` and `tier:` normalize to the same prefix.

## Testing

- Pure unit tests: `internal/labelns` (parse/validate/match/conflicts).
- Integration tests (Dolt test server): rejection on add, idempotent re-add, unconfigured workspaces untouched, create-path rejection, one-command update swap, `--replace` swap, import warn-and-keep with callback, doctor violation scan (closed issues skipped).
- Verified end-to-end against a real workspace: config validation, create/label-add rejection, `--replace`, update swap, inheritance override, import warning, and the doctor check (85-check run, reports OK when unconfigured).
- `golangci-lint run` clean on touched packages; docs gates pass (`test/docsync`, CLI-docs drift, freshness).
- Pre-existing failures `TestImportFromLocalJSONL_LegacyFormats` (cmd/bd) and `TestValidation*` (cmd/bd/doctor) reproduce on clean `main` and are unrelated.

## Docs

`docs/reference/configuration.md` gains an *Exclusive Label Namespaces* section; CLI reference regenerated from the updated `config`/`label` help text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
