### PR TITLE
fix(bootstrap): commit .beads workspace files so adopt-from-remote leaves a clean tree (#4644)

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -740,6 +740,12 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 		return err
 	}
 
+	// Commit the workspace files bootstrap just wrote/updated (config.yaml,
+	// metadata.json, and any appended .beads/.gitignore patterns) so an
+	// adopt-from-remote flow leaves a clean working tree, matching bd init
+	// (GH#4644).
+	commitBeadsWorkspaceFiles(plan.BeadsDir)
+
 	// Open and close the store to ensure dolt_ignore'd wisp tables are
 	// created in the working set. Clone does not include these tables
 	// (they are never committed), so they must be recreated after clone.

--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -740,12 +740,6 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 		return err
 	}
 
-	// Commit the workspace files bootstrap just wrote/updated (config.yaml,
-	// metadata.json, and any appended .beads/.gitignore patterns) so an
-	// adopt-from-remote flow leaves a clean working tree, matching bd init
-	// (GH#4644).
-	commitBeadsWorkspaceFiles(plan.BeadsDir)
-
 	// Open and close the store to ensure dolt_ignore'd wisp tables are
 	// created in the working set. Clone does not include these tables
 	// (they are never committed), so they must be recreated after clone.
@@ -779,6 +773,17 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 	}
 	configureInitDoltRemote(ctx, warmupStore, plan.SyncRemote, false)
 	_ = warmupStore.Close()
+
+	// Commit the workspace files bootstrap just wrote/updated (config.yaml,
+	// metadata.json, and any appended .beads/.gitignore patterns) so an
+	// adopt-from-remote flow leaves a clean working tree, matching bd init
+	// (GH#4644).
+	//
+	// Deliberately last: every way this bootstrap can still fail (most
+	// notably the remote-migrate gate above, which returns a non-zero exit)
+	// happens before it, so a failed bootstrap never leaves a commit behind
+	// advertising a workspace it did not finish setting up.
+	commitBeadsWorkspaceFiles(plan.BeadsDir)
 
 	return nil
 }

--- a/cmd/bd/commit_beads_workspace_test.go
+++ b/cmd/bd/commit_beads_workspace_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// gitRun runs a git command in dir and fails the test on error.
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+// gitPorcelain returns `git status --porcelain` output for dir.
+func gitPorcelain(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git status failed: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// TestCommitBeadsWorkspaceFiles verifies that the bootstrap workspace-commit
+// helper leaves a clean working tree after .beads/ files are written/updated,
+// and that it does not sweep up unrelated staged changes (GH#4644).
+func TestCommitBeadsWorkspaceFiles(t *testing.T) {
+	repo := t.TempDir()
+	gitRun(t, repo, "init")
+	gitRun(t, repo, "config", "user.email", "test@example.com")
+	gitRun(t, repo, "config", "user.name", "Test")
+
+	beadsDir := filepath.Join(repo, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	gitignore := filepath.Join(beadsDir, ".gitignore")
+
+	// Simulate an already-adopted repo: a committed but stale .gitignore.
+	if err := os.WriteFile(gitignore, []byte("dolt/\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "add", ".beads/.gitignore")
+	gitRun(t, repo, "commit", "-m", "initial beads gitignore")
+	if s := gitPorcelain(t, repo); s != "" {
+		t.Fatalf("expected clean tree after initial commit, got:\n%s", s)
+	}
+
+	// A concurrent, unrelated staged change the user is preparing.
+	unrelated := filepath.Join(repo, "unrelated.txt")
+	if err := os.WriteFile(unrelated, []byte("wip\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "add", "unrelated.txt")
+
+	// Bootstrap appends a missing pattern (as EnsureGitignoreForBeadsDir does)
+	// and writes fresh workspace files, leaving them dirty/untracked.
+	if err := os.WriteFile(gitignore, []byte("dolt/\nembeddeddolt/\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("backend: dolt\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	commitBeadsWorkspaceFiles(beadsDir)
+
+	// The .beads/ files must now be committed (not left dirty).
+	status := gitPorcelain(t, repo)
+	for _, line := range strings.Split(status, "\n") {
+		if strings.Contains(line, ".beads/") {
+			t.Errorf("expected .beads/ files committed, still dirty: %q\n(full status:\n%s)", line, status)
+		}
+	}
+
+	// The unrelated staged change must be left untouched (still staged).
+	if !strings.Contains(status, "unrelated.txt") {
+		t.Errorf("expected unrelated.txt to remain staged, status:\n%s", status)
+	}
+
+	// The commit message identifies the bootstrap workspace sync.
+	logCmd := exec.Command("git", "log", "-1", "--pretty=%s")
+	logCmd.Dir = repo
+	logOut, err := logCmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logOut), "bd bootstrap") {
+		t.Errorf("expected bootstrap commit message, got: %s", logOut)
+	}
+}
+
+// TestCommitBeadsWorkspaceFiles_NoGitRepo verifies the helper is a safe no-op
+// outside a git repository.
+func TestCommitBeadsWorkspaceFiles_NoGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, ".gitignore"), []byte("dolt/\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Must not panic or error; nothing to assert beyond "does not blow up".
+	commitBeadsWorkspaceFiles(beadsDir)
+}

--- a/cmd/bd/commit_beads_workspace_test.go
+++ b/cmd/bd/commit_beads_workspace_test.go
@@ -30,27 +30,60 @@ func gitPorcelain(t *testing.T, dir string) string {
 	return strings.TrimSpace(string(out))
 }
 
-// TestCommitBeadsWorkspaceFiles verifies that the bootstrap workspace-commit
-// helper leaves a clean working tree after .beads/ files are written/updated,
-// and that it does not sweep up unrelated staged changes (GH#4644).
-func TestCommitBeadsWorkspaceFiles(t *testing.T) {
-	repo := t.TempDir()
+// gitOut runs a git command in dir and returns its trimmed stdout.
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %s failed: %v", strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// newBeadsRepo creates a git repo with a committed .beads/.gitignore, the
+// starting point of an already-adopted workspace.
+func newBeadsRepo(t *testing.T) (repo, beadsDir string) {
+	t.Helper()
+	repo = t.TempDir()
 	gitRun(t, repo, "init")
 	gitRun(t, repo, "config", "user.email", "test@example.com")
 	gitRun(t, repo, "config", "user.name", "Test")
 
-	beadsDir := filepath.Join(repo, ".beads")
+	beadsDir = filepath.Join(repo, ".beads")
 	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	gitignore := filepath.Join(beadsDir, ".gitignore")
-
-	// Simulate an already-adopted repo: a committed but stale .gitignore.
-	if err := os.WriteFile(gitignore, []byte("dolt/\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(beadsDir, ".gitignore"), []byte("dolt/\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	gitRun(t, repo, "add", ".beads/.gitignore")
 	gitRun(t, repo, "commit", "-m", "initial beads gitignore")
+	return repo, beadsDir
+}
+
+// writeBootstrapWorkspaceFiles simulates what the bootstrap sync path leaves
+// on disk: an appended .gitignore pattern plus fresh config/metadata.
+func writeBootstrapWorkspaceFiles(t *testing.T, beadsDir string) {
+	t.Helper()
+	files := map[string]string{
+		".gitignore":    "dolt/\nembeddeddolt/\n",
+		"config.yaml":   "backend: dolt\n",
+		"metadata.json": "{}\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(beadsDir, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestCommitBeadsWorkspaceFiles verifies that the bootstrap workspace-commit
+// helper leaves a clean working tree after .beads/ files are written/updated,
+// and that it does not sweep up unrelated staged changes (GH#4644).
+func TestCommitBeadsWorkspaceFiles(t *testing.T) {
+	repo, beadsDir := newBeadsRepo(t)
 	if s := gitPorcelain(t, repo); s != "" {
 		t.Fatalf("expected clean tree after initial commit, got:\n%s", s)
 	}
@@ -64,15 +97,7 @@ func TestCommitBeadsWorkspaceFiles(t *testing.T) {
 
 	// Bootstrap appends a missing pattern (as EnsureGitignoreForBeadsDir does)
 	// and writes fresh workspace files, leaving them dirty/untracked.
-	if err := os.WriteFile(gitignore, []byte("dolt/\nembeddeddolt/\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("backend: dolt\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte("{}\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeBootstrapWorkspaceFiles(t, beadsDir)
 
 	commitBeadsWorkspaceFiles(beadsDir)
 
@@ -98,6 +123,119 @@ func TestCommitBeadsWorkspaceFiles(t *testing.T) {
 	}
 	if !strings.Contains(string(logOut), "bd bootstrap") {
 		t.Errorf("expected bootstrap commit message, got: %s", logOut)
+	}
+}
+
+// TestCommitBeadsWorkspaceFiles_LeavesCollateralBeadsContentAlone verifies the
+// helper commits only the three workspace files bootstrap owns. Legitimate
+// tracked content lives under .beads/ too (formulas, a git-tracked
+// issues.jsonl), and a `.beads/` directory pathspec would silently sweep a
+// user's pending edit to any of it into bootstrap's commit.
+func TestCommitBeadsWorkspaceFiles_LeavesCollateralBeadsContentAlone(t *testing.T) {
+	repo, beadsDir := newBeadsRepo(t)
+
+	// Tracked, committed content inside .beads/ that bootstrap does not own.
+	issues := filepath.Join(beadsDir, "issues.jsonl")
+	if err := os.WriteFile(issues, []byte("{\"id\":\"bd-1\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	formulaDir := filepath.Join(beadsDir, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	formula := filepath.Join(formulaDir, "mol-x.formula.toml")
+	if err := os.WriteFile(formula, []byte("formula = \"mol-x\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "add", ".beads/issues.jsonl", ".beads/formulas/mol-x.formula.toml")
+	gitRun(t, repo, "commit", "-m", "beads content")
+
+	// The user has both mid-edit when bootstrap runs.
+	if err := os.WriteFile(issues, []byte("{\"id\":\"bd-1\"}\n{\"id\":\"bd-2\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(formula, []byte("formula = \"mol-x\"\nversion = 2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeBootstrapWorkspaceFiles(t, beadsDir)
+
+	commitBeadsWorkspaceFiles(beadsDir)
+
+	status := gitPorcelain(t, repo)
+	for _, want := range []string{"issues.jsonl", "formulas/mol-x.formula.toml"} {
+		if !strings.Contains(status, want) {
+			t.Errorf("expected %s to stay uncommitted (bootstrap does not own it), status:\n%s", want, status)
+		}
+	}
+	for _, owned := range beadsWorkspaceFiles {
+		if strings.Contains(status, ".beads/"+owned) {
+			t.Errorf("expected .beads/%s to be committed, status:\n%s", owned, status)
+		}
+	}
+}
+
+// TestCommitBeadsWorkspaceFiles_LinkedWorktreeDoesNotTouchMainCheckout
+// verifies the commit lands in the checkout that physically contains the
+// .beads directory, never the main checkout.
+//
+// RepoContext deliberately resolves RepoRoot to the MAIN checkout for a linked
+// worktree (buildRepoContext -> git.GetMainRepoRoot), so routing this helper's
+// git operations through it would advance a HEAD the user never asked
+// bootstrap to touch.
+func TestCommitBeadsWorkspaceFiles_LinkedWorktreeDoesNotTouchMainCheckout(t *testing.T) {
+	main, _ := newBeadsRepo(t)
+
+	worktree := filepath.Join(t.TempDir(), "wt")
+	gitRun(t, main, "worktree", "add", "-b", "feature", worktree)
+
+	mainHeadBefore := gitOut(t, main, "rev-parse", "HEAD")
+	mainBranchBefore := gitOut(t, main, "rev-parse", "--abbrev-ref", "HEAD")
+	worktreeHeadBefore := gitOut(t, worktree, "rev-parse", "HEAD")
+
+	worktreeBeads := filepath.Join(worktree, ".beads")
+	if err := os.MkdirAll(worktreeBeads, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeBootstrapWorkspaceFiles(t, worktreeBeads)
+
+	commitBeadsWorkspaceFiles(worktreeBeads)
+
+	if got := gitOut(t, main, "rev-parse", "HEAD"); got != mainHeadBefore {
+		t.Errorf("main checkout HEAD moved: %s -> %s (bootstrap must not commit on another checkout's branch)", mainHeadBefore, got)
+	}
+	if got := gitOut(t, main, "rev-parse", "--abbrev-ref", "HEAD"); got != mainBranchBefore {
+		t.Errorf("main checkout branch changed: %s -> %s", mainBranchBefore, got)
+	}
+	if got := gitOut(t, worktree, "rev-parse", "HEAD"); got == worktreeHeadBefore {
+		t.Errorf("worktree HEAD did not advance; workspace files were not committed where they live")
+	}
+	if s := gitPorcelain(t, worktree); strings.Contains(s, ".beads/") {
+		t.Errorf("expected worktree .beads/ workspace files committed, still dirty:\n%s", s)
+	}
+}
+
+// TestCommitBeadsWorkspaceFiles_BypassesHooks verifies the commit runs with
+// hooks disabled. --no-verify alone does NOT skip prepare-commit-msg, and a
+// hook that calls back into bd would deadlock against the embedded Dolt lock
+// bootstrap may still hold. Mirrors bd init's `-c core.hooksPath=` invocation
+// and its auto_commit_bypasses_hooks regression.
+func TestCommitBeadsWorkspaceFiles_BypassesHooks(t *testing.T) {
+	repo, beadsDir := newBeadsRepo(t)
+
+	hookPath := filepath.Join(repo, ".git", "hooks", "prepare-commit-msg")
+	hook := "#!/bin/sh\necho hook-fired >> .hook-ran\nexit 1\n"
+	if err := os.WriteFile(hookPath, []byte(hook), 0o755); err != nil { //nolint:gosec // G306: a git hook must be executable
+		t.Fatal(err)
+	}
+
+	writeBootstrapWorkspaceFiles(t, beadsDir)
+	commitBeadsWorkspaceFiles(beadsDir)
+
+	if _, err := os.Stat(filepath.Join(repo, ".hook-ran")); err == nil {
+		t.Error("expected the bootstrap commit to bypass git hooks, but prepare-commit-msg ran")
+	}
+	if s := gitPorcelain(t, repo); strings.Contains(s, ".beads/") {
+		t.Errorf("expected workspace files committed despite the failing hook, still dirty:\n%s", s)
 	}
 }
 

--- a/cmd/bd/sync_git.go
+++ b/cmd/bd/sync_git.go
@@ -5,12 +5,62 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/doltremote"
 )
+
+// commitBeadsWorkspaceFiles stages and commits the tracked .beads/ workspace
+// files (metadata.json, config.yaml, .gitignore) that the bootstrap sync path
+// writes, so adopting a project from a remote does not leave the working tree
+// dirty — matching what `bd init` does on a fresh repo (GH#4644).
+//
+// Best-effort and side-effect-scoped: it no-ops outside a (non-bare) git repo,
+// only runs when there are actual changes under .beads/, and commits with an
+// explicit .beads/ pathspec so any unrelated staged changes are left untouched.
+// Uses --no-verify so bootstrap-installed hooks cannot recurse into bd while
+// the embedded Dolt lock may still be held, mirroring bd init.
+func commitBeadsWorkspaceFiles(beadsDir string) {
+	repoDir := filepath.Dir(beadsDir)
+
+	// args are fixed git subcommands; the only variable is beadsDir, always
+	// passed after a "--" pathspec separator so it cannot be read as a flag or
+	// command, and it is an internal .beads directory path.
+	gitIn := func(args ...string) *exec.Cmd {
+		c := exec.Command("git", args...) //nolint:gosec // G702: see comment above — fixed subcommands + "--"-separated internal path
+		c.Dir = repoDir
+		return c
+	}
+
+	// Only proceed inside a non-bare git repo.
+	if gitIn("rev-parse", "--git-dir").Run() != nil {
+		return
+	}
+	if out, err := gitIn("rev-parse", "--is-bare-repository").Output(); err == nil &&
+		strings.TrimSpace(string(out)) == "true" {
+		return
+	}
+
+	// Nothing changed under .beads/? Then there is nothing to commit.
+	status, err := gitIn("status", "--porcelain", "--", beadsDir).Output()
+	if err != nil || strings.TrimSpace(string(status)) == "" {
+		return
+	}
+
+	if err := gitIn("add", "--", beadsDir).Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to stage beads workspace files: %v\n", err)
+		return
+	}
+	commit := gitIn("commit", "--no-verify", "-m", "bd bootstrap: sync beads workspace files", "--", beadsDir)
+	if out, err := commit.CombinedOutput(); err != nil {
+		if !strings.Contains(string(out), "nothing to commit") {
+			fmt.Fprintf(os.Stderr, "Warning: failed to commit beads workspace files: %v\n", err)
+		}
+	}
+}
 
 // isGitRepo checks if the current working directory is in a git repository.
 // NOTE: This intentionally checks CWD, not the beads repo. It's used as a guard

--- a/cmd/bd/sync_git.go
+++ b/cmd/bd/sync_git.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -13,53 +14,120 @@ import (
 	"github.com/steveyegge/beads/internal/doltremote"
 )
 
-// commitBeadsWorkspaceFiles stages and commits the tracked .beads/ workspace
-// files (metadata.json, config.yaml, .gitignore) that the bootstrap sync path
-// writes, so adopting a project from a remote does not leave the working tree
-// dirty — matching what `bd init` does on a fresh repo (GH#4644).
-//
-// Best-effort and side-effect-scoped: it no-ops outside a (non-bare) git repo,
-// only runs when there are actual changes under .beads/, and commits with an
-// explicit .beads/ pathspec so any unrelated staged changes are left untouched.
-// Uses --no-verify so bootstrap-installed hooks cannot recurse into bd while
-// the embedded Dolt lock may still be held, mirroring bd init.
-func commitBeadsWorkspaceFiles(beadsDir string) {
-	repoDir := filepath.Dir(beadsDir)
+// beadsWorkspaceFiles are the only files inside .beads/ that the bootstrap
+// sync path writes, and therefore the only files commitBeadsWorkspaceFiles is
+// allowed to commit. Everything else under .beads/ (formulas, a git-tracked
+// issues.jsonl, ...) is ordinary user content that may be mid-edit, and must
+// never be swept into bootstrap's commit.
+var beadsWorkspaceFiles = []string{"metadata.json", "config.yaml", ".gitignore"}
 
-	// args are fixed git subcommands; the only variable is beadsDir, always
-	// passed after a "--" pathspec separator so it cannot be read as a flag or
-	// command, and it is an internal .beads directory path.
+// commitBeadsWorkspaceFiles stages and commits the .beads/ workspace files
+// that the bootstrap sync path writes (metadata.json, config.yaml, and any
+// patterns appended to .beads/.gitignore), so adopting a project from a remote
+// does not leave the working tree dirty — matching what `bd init` does on a
+// fresh repo (GH#4644).
+//
+// Best-effort and side-effect-scoped:
+//
+//   - Exact file pathspecs, never the .beads/ directory: an unrelated change
+//     the user has pending under .beads/ stays out of the commit.
+//   - Committed in the checkout that physically contains beadsDir, resolved
+//     with `git -C <beadsDir> rev-parse --show-toplevel`. This is deliberately
+//     NOT beads.GetRepoContext(): RepoContext.RepoRoot resolves to the MAIN
+//     checkout for a linked worktree (buildRepoContext -> git.GetMainRepoRoot),
+//     so binding git operations to it would commit on the other checkout's
+//     branch and advance a HEAD the user never asked bootstrap to touch.
+//   - No-ops outside a git repo, in a bare repo (no worktree, so
+//     --show-toplevel fails), and when nothing under the owned paths changed.
+//   - Commits with `-c core.hooksPath=` in addition to --no-verify, mirroring
+//     bd init: --no-verify alone does not skip prepare-commit-msg, and a
+//     bootstrap-installed hook can recurse into bd while the embedded Dolt
+//     lock is still held.
+func commitBeadsWorkspaceFiles(beadsDir string) {
+	root, relBeadsDir, ok := gitWorktreeRootContaining(beadsDir)
+	if !ok {
+		return
+	}
+
+	var pathspecs []string
+	for _, name := range beadsWorkspaceFiles {
+		if _, err := os.Stat(filepath.Join(beadsDir, name)); err != nil {
+			continue
+		}
+		pathspecs = append(pathspecs, path.Join(relBeadsDir, name))
+	}
+	if len(pathspecs) == 0 {
+		return
+	}
+
+	// args are fixed git subcommands; the only variables are repo-relative
+	// pathspecs for bootstrap's own workspace files, always passed after a
+	// "--" separator so they cannot be read as a flag or command.
 	gitIn := func(args ...string) *exec.Cmd {
-		c := exec.Command("git", args...) //nolint:gosec // G702: see comment above — fixed subcommands + "--"-separated internal path
-		c.Dir = repoDir
+		c := exec.Command("git", args...) //nolint:gosec // G702: see comment above — fixed subcommands + "--"-separated internal paths
+		c.Dir = root
 		return c
 	}
-
-	// Only proceed inside a non-bare git repo.
-	if gitIn("rev-parse", "--git-dir").Run() != nil {
-		return
-	}
-	if out, err := gitIn("rev-parse", "--is-bare-repository").Output(); err == nil &&
-		strings.TrimSpace(string(out)) == "true" {
-		return
+	withPaths := func(args ...string) []string {
+		return append(append(args, "--"), pathspecs...)
 	}
 
-	// Nothing changed under .beads/? Then there is nothing to commit.
-	status, err := gitIn("status", "--porcelain", "--", beadsDir).Output()
+	// Nothing changed in the files bootstrap owns? Then there is nothing to
+	// commit. (A repo that gitignores .beads/ entirely lands here too:
+	// ignored files never show up in status.)
+	status, err := gitIn(withPaths("status", "--porcelain")...).Output()
 	if err != nil || strings.TrimSpace(string(status)) == "" {
 		return
 	}
 
-	if err := gitIn("add", "--", beadsDir).Run(); err != nil {
+	if err := gitIn(withPaths("add")...).Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to stage beads workspace files: %v\n", err)
 		return
 	}
-	commit := gitIn("commit", "--no-verify", "-m", "bd bootstrap: sync beads workspace files", "--", beadsDir)
+	commit := gitIn(withPaths(
+		"-c", "core.hooksPath=",
+		"commit", "--no-verify",
+		"-m", "bd bootstrap: sync beads workspace files",
+	)...)
 	if out, err := commit.CombinedOutput(); err != nil {
 		if !strings.Contains(string(out), "nothing to commit") {
 			fmt.Fprintf(os.Stderr, "Warning: failed to commit beads workspace files: %v\n", err)
 		}
 	}
+}
+
+// gitWorktreeRootContaining returns the root of the git working tree that
+// physically contains dir, plus dir's slash-separated path relative to that
+// root. ok is false outside a git repo, in a bare repo (no working tree), or
+// if dir somehow resolves outside the reported root.
+//
+// Both paths go through filepath.EvalSymlinks before they are compared: git
+// reports the canonical path (/private/var/... on macOS) while the caller may
+// hold the symlinked one (/var/...), and an unresolved comparison would make
+// every containment check fail.
+func gitWorktreeRootContaining(dir string) (root, relDir string, ok bool) {
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel").Output() //nolint:gosec // G204: dir is an internal .beads path, passed as an argument to a fixed subcommand
+	if err != nil {
+		return "", "", false
+	}
+	root = strings.TrimSpace(string(out))
+	if root == "" {
+		return "", "", false
+	}
+
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", "", false
+	}
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return "", "", false
+	}
+	rel, err := filepath.Rel(resolvedRoot, resolvedDir)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", "", false
+	}
+	return root, filepath.ToSlash(rel), true
 }
 
 // isGitRepo checks if the current working directory is in a git repository.


### PR DESCRIPTION
Closes #4644

## Problem

The standalone `bd bootstrap` sync path (`executeSyncAction` → `finalizeSyncedBootstrap`) writes `.beads/config.yaml` and `metadata.json`, and appends any newer required patterns to an existing `.beads/.gitignore` via `EnsureGitignoreForBeadsDir` — but never commits them. The working tree (and a *tracked* `.beads/.gitignore`) is left dirty with no notice.

`bd init` on a fresh repo, by contrast, explicitly stages and commits `.beads/`. So repos that were **bootstrapped/adopted** rather than freshly `bd init`'d accumulate a dirty `.gitignore` hunk every time a bd upgrade adds a new required pattern.

## Fix

Add `commitBeadsWorkspaceFiles`, called right after `finalizeSyncedBootstrap` in the sync path. It brings the bootstrap flow to parity with init, but is deliberately conservative:

- **no-ops** outside a (non-bare) git repo;
- only acts when `git status --porcelain -- .beads/` shows actual changes;
- commits with an **explicit `.beads/` pathspec**, so any unrelated staged changes the user had in flight are left untouched (this is stricter than init's bare `git commit`);
- uses `--no-verify` (mirroring bd init) so bootstrap-installed hooks can't recurse into bd while the embedded Dolt lock may still be held.

The `bd init` sync path (which calls `finalizeSyncedBootstrap` and then does its own `git add .beads/` + commit) is unaffected — by the time its commit runs there's nothing new under `.beads/`, so it's a clean no-op.

## Tests

- `TestCommitBeadsWorkspaceFiles`: after a stale committed `.gitignore` is appended-to and fresh workspace files are written, the tree is clean afterward, an unrelated staged file remains staged, and the commit is labeled `bd bootstrap: …`.
- `TestCommitBeadsWorkspaceFiles_NoGitRepo`: safe no-op outside a git repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)