### PR TITLE
fix(init): refuse to initialize directly in the home directory (#4635)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configured. Auto-start warns and retargets, as it did before. Shared-server
   mode still fails closed there — a repo-local auto-start is a different
   database, not a port refresh — but now says so in its own words.
+- **`bd init` refuses to initialize directly in your home directory**
+  ([#4635](https://github.com/gastownhall/beads/issues/4635)). Run there, `bd
+  init` would `git init` your home directory and scaffold agent files into it —
+  `CLAUDE.md`, `AGENTS.md`, `.gitignore`, `.claude/`, `.codex/`, `.agents/` —
+  overwriting any you already keep there, and it did so silently under
+  `--non-interactive`, which engages automatically whenever stdin is not a TTY
+  (so: whenever an agent runs it). A project is virtually never the home
+  directory itself, so this now refuses with exit code `13`
+  (`ExitHomeDirRefused`), documented at
+  `docs/recovery/init-safety.md#init-home-refused`.
+
+  Deliberately narrow: it fires only when the working directory is *exactly*
+  your home directory, your home is not already a git repository (tracked
+  dotfiles are unaffected), and you did not name a `BEADS_DIR` yourself. A
+  subdirectory of home is an ordinary project and is never refused. `--force`
+  and `--reinit-local` do not override it — they bypass the local data-safety
+  guard, which is a different question from "is this the right directory". The
+  guard runs first in init's `RunE`, ahead of every path with an effect,
+  including the proxied dispatch and the store-opening `--reinit-local`
+  pre-checks.
 
 - **`bd reclaim` summarizes the leases its replica guard declined instead of
   naming every one, every run** (wy-sp2l4). A lease granted by another replica

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -321,6 +322,69 @@ func seedInitWorkspaceIdentity(
 	return nil
 }
 
+// resolveUserHomeDir returns the user's home directory.
+//
+// It prefers the OS account database over $HOME so the guard keys off the real
+// account home even when $HOME has been repointed — which happens constantly in
+// this repo's own tests, and in any sandbox that fakes a home. Both sources are
+// best-effort: in a CGO-free build user.Current() falls back to os.UserHomeDir()
+// (i.e. $HOME on Unix) itself, so this is a preference, not a guarantee of
+// $HOME-independence. Mirrors the home resolution in internal/beads'
+// isPathInSafeBoundary.
+//
+// A package var so tests can stub it.
+var resolveUserHomeDir = func() string {
+	if u, err := user.Current(); err == nil && u.HomeDir != "" {
+		return u.HomeDir
+	}
+	home, _ := os.UserHomeDir()
+	return home
+}
+
+// isUserHomeDir reports whether dir is the user's home directory (path-boundary
+// comparison, symlink/case tolerant). Used to guard `bd init` against turning
+// $HOME into a git repo (GH#4635).
+func isUserHomeDir(dir string) bool {
+	home := resolveUserHomeDir()
+	return home != "" && utils.PathsEqual(dir, home)
+}
+
+// guardInitInHomeDir refuses `bd init` directly in the user's home directory
+// when it is not already a git repo and no explicit BEADS_DIR was given.
+//
+// `bd init` would otherwise `git init` the home directory and write agent
+// scaffolding (CLAUDE.md, AGENTS.md, .gitignore, .agents/, .codex/,
+// .claude/settings.json) there, potentially clobbering existing files — a
+// silent footgun, especially under --non-interactive, which auto-engages
+// whenever stdin is not a TTY, i.e. whenever an agent runs init (GH#4635). A
+// real project is virtually never the home directory itself.
+//
+// This runs as the first thing in init's RunE, ahead of every path that has an
+// effect: the proxied dispatch (runInitProxiedServer -> EnsureGitRepo -> git
+// init), the --reinit-local/--force pre-checks (countExistingIssues opens a
+// real store, which creates the data directory and can run migrations), and
+// the mode globals RunE sets on itself. A guard placed after any of those
+// refuses only after the damage it exists to prevent.
+//
+// Fail-open by construction: an unresolvable home, an explicit BEADS_DIR, or an
+// already-tracked home all mean "not the case this guards", and init proceeds.
+func guardInitInHomeDir() error {
+	if os.Getenv("BEADS_DIR") != "" {
+		return nil
+	}
+	if isGitRepo() {
+		return nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil || !isUserHomeDir(cwd) {
+		return nil
+	}
+	return fmt.Errorf("refusing to 'bd init' directly in your home directory (%s):\n"+
+		"  this would turn it into a git repository and scaffold agent files here,\n"+
+		"  overwriting any existing ones. cd into a project directory and re-run, or set\n"+
+		"  BEADS_DIR to an explicit location if you really mean to initialize here", cwd)
+}
+
 var initCmd = &cobra.Command{
 	Use:           "init",
 	GroupID:       "setup",
@@ -361,6 +425,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
   • --contributor and --team flags are rejected (wizards require interaction)
   Also auto-detected when stdin is not a terminal or CI=true is set.`,
 	RunE: func(cmd *cobra.Command, _ []string) (retErr error) {
+		// First, before anything with an effect: never turn $HOME into a git
+		// repo (GH#4635). See guardInitInHomeDir for why the position matters.
+		if err := guardInitInHomeDir(); err != nil {
+			return err
+		}
+
 		prefix, _ := cmd.Flags().GetString("prefix")
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		contributor, _ := cmd.Flags().GetBool("contributor")

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -366,10 +366,26 @@ func isUserHomeDir(dir string) bool {
 // the mode globals RunE sets on itself. A guard placed after any of those
 // refuses only after the damage it exists to prevent.
 //
-// Fail-open by construction: an unresolvable home, an explicit BEADS_DIR, or an
-// already-tracked home all mean "not the case this guards", and init proceeds.
+// Fail-open by construction: an unresolvable home, a caller-supplied BEADS_DIR,
+// or an already-tracked home all mean "not the case this guards", and init
+// proceeds.
+//
+// The opt-in check reads beadsDirFromCaller, NOT os.Getenv("BEADS_DIR"). By the
+// time this runs the root PersistentPreRunE has already exported a beads dir it
+// discovered for itself, and beads.FindBeadsDir() accepts any ancestor .beads/
+// holding a config.yaml — including this project's own legacy user-level
+// ~/.beads/config.yaml. Keying off the live environment therefore made the
+// guard fail open for exactly the long-standing users most likely to have
+// scaffolding in $HOME worth not clobbering. `bd -C <dir> init` exported one
+// too, and that one does not even move the working directory the scaffolding
+// lands in.
+//
+// Refusals carry ExitHomeDirRefused so a script can branch on the number, like
+// init's three other refusal classes. The message is printed here rather than
+// returned so the exit code is the error's whole payload; docs/recovery/
+// init-safety.md#init-home-refused is the recovery playbook it points at.
 func guardInitInHomeDir() error {
-	if os.Getenv("BEADS_DIR") != "" {
+	if beadsDirFromCaller != "" {
 		return nil
 	}
 	if isGitRepo() {
@@ -379,10 +395,37 @@ func guardInitInHomeDir() error {
 	if err != nil || !isUserHomeDir(cwd) {
 		return nil
 	}
-	return fmt.Errorf("refusing to 'bd init' directly in your home directory (%s):\n"+
-		"  this would turn it into a git repository and scaffold agent files here,\n"+
-		"  overwriting any existing ones. cd into a project directory and re-run, or set\n"+
-		"  BEADS_DIR to an explicit location if you really mean to initialize here", cwd)
+	fmt.Fprintf(os.Stderr, "%s\n", homeDirRefusalMessage(cwd))
+	return &exitError{Code: ExitHomeDirRefused}
+}
+
+// homeDirRefusalMessage is the What/Why/Next refusal text for a `bd init` run
+// directly in an untracked home directory.
+//
+// The BEADS_DIR escape hatch is described honestly: setting it does not run the
+// init the caller asked for in $HOME, it runs a different one — an explicit
+// BEADS_DIR makes hasExplicitBeadsDir true, which skips the `git init` and the
+// CWD-local .beads semantics. Saying "set BEADS_DIR if you really mean it"
+// without that caveat sends the user somewhere they did not intend to go.
+func homeDirRefusalMessage(cwd string) string {
+	return fmt.Sprintf(`bd init refuses: %s is your home directory, and it is not a git repository.
+
+  Why: init would 'git init' your home directory and scaffold agent files
+       into it (CLAUDE.md, AGENTS.md, .gitignore, .claude/, .codex/,
+       .agents/), overwriting any you already keep there. A project is
+       virtually never the home directory itself.
+
+  Next:
+    Initialize a project instead (recommended):
+      cd ~/some-project && bd init
+
+    Keep the workspace elsewhere, with no scaffolding in your home:
+      BEADS_DIR=<path>/.beads bd init
+      (this is a DIFFERENT init: an explicit BEADS_DIR skips the git init
+       and the working-directory-local .beads, so nothing is written here)
+
+    Recovery playbook:
+      docs/recovery/init-safety.md#init-home-refused`, cwd)
 }
 
 var initCmd = &cobra.Command{

--- a/cmd/bd/init_home_guard_test.go
+++ b/cmd/bd/init_home_guard_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestIsUserHomeDir covers the guard decision used to refuse `bd init` directly
+// in the user's home directory (GH#4635). The resolver is stubbed so the test
+// does not depend on (or touch) the real home directory.
+func TestIsUserHomeDir(t *testing.T) {
+	home := t.TempDir()
+	stubHomeDir(t, home)
+
+	if !isUserHomeDir(home) {
+		t.Errorf("isUserHomeDir(home) = false, want true for %q", home)
+	}
+	if sub := filepath.Join(home, "project"); isUserHomeDir(sub) {
+		t.Errorf("isUserHomeDir(%q) = true, want false (subdir of home)", sub)
+	}
+	if parent := filepath.Dir(home); isUserHomeDir(parent) {
+		t.Errorf("isUserHomeDir(%q) = true, want false (parent of home)", parent)
+	}
+}
+
+// TestIsUserHomeDir_UnresolvableHome verifies the guard never fires when the
+// home directory cannot be resolved (fail-open: better to allow init than to
+// wrongly refuse every directory).
+func TestIsUserHomeDir_UnresolvableHome(t *testing.T) {
+	stubHomeDir(t, "")
+
+	if isUserHomeDir("/some/dir") {
+		t.Error("isUserHomeDir should be false when home is unresolvable")
+	}
+}
+
+// TestGuardInitInHomeDir covers the conditions under which the guard declines
+// to fire: an explicit BEADS_DIR, an already-tracked home, and any directory
+// that simply is not home.
+func TestGuardInitInHomeDir(t *testing.T) {
+	t.Run("refuses_in_untracked_home", func(t *testing.T) {
+		home := t.TempDir()
+		stubHomeDir(t, home)
+		chdir(t, home)
+		t.Setenv("BEADS_DIR", "")
+
+		err := guardInitInHomeDir()
+		if err == nil {
+			t.Fatal("guardInitInHomeDir() = nil, want a refusal in an untracked home")
+		}
+		if !strings.Contains(err.Error(), "refusing to 'bd init' directly in your home directory") {
+			t.Errorf("unexpected error text: %v", err)
+		}
+	})
+
+	t.Run("allows_with_explicit_beads_dir", func(t *testing.T) {
+		home := t.TempDir()
+		stubHomeDir(t, home)
+		chdir(t, home)
+		t.Setenv("BEADS_DIR", filepath.Join(home, "elsewhere", ".beads"))
+
+		if err := guardInitInHomeDir(); err != nil {
+			t.Errorf("guardInitInHomeDir() = %v, want nil when BEADS_DIR is explicit", err)
+		}
+	})
+
+	t.Run("allows_when_home_is_already_a_git_repo", func(t *testing.T) {
+		home := t.TempDir()
+		stubHomeDir(t, home)
+		chdir(t, home)
+		t.Setenv("BEADS_DIR", "")
+		gitInitAt(t, home)
+
+		if err := guardInitInHomeDir(); err != nil {
+			t.Errorf("guardInitInHomeDir() = %v, want nil when home is already tracked", err)
+		}
+	})
+
+	t.Run("allows_in_an_ordinary_project_dir", func(t *testing.T) {
+		home := t.TempDir()
+		stubHomeDir(t, home)
+		project := filepath.Join(home, "project")
+		if err := os.MkdirAll(project, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		chdir(t, project)
+		t.Setenv("BEADS_DIR", "")
+
+		if err := guardInitInHomeDir(); err != nil {
+			t.Errorf("guardInitInHomeDir() = %v, want nil for a project dir under home", err)
+		}
+	})
+}
+
+// TestInitCommand_RefusesInHomeDirBeforeAnySideEffect runs the actual init
+// command, which is where the guard's *position* is under test rather than its
+// decision. Both flag shapes below reach a side effect before the guard's
+// original location did:
+//
+//   - --reinit-local / --force run countExistingIssues, which opens a real
+//     store (creating the data directory, and able to run migrations);
+//   - --proxied-server dispatches to runInitProxiedServer, which calls
+//     EnsureGitRepo — a `git init` in the current directory.
+//
+// So the assertion is not merely "it errors": nothing may exist afterwards.
+func TestInitCommand_RefusesInHomeDirBeforeAnySideEffect(t *testing.T) {
+	cases := []struct {
+		name  string
+		flags map[string]string
+	}{
+		{name: "plain", flags: nil},
+		{name: "reinit_local", flags: map[string]string{"reinit-local": "true"}},
+		{name: "force", flags: map[string]string{"force": "true"}},
+		{name: "proxied_server", flags: map[string]string{"proxied-server": "true"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			stubHomeDir(t, home)
+			chdir(t, home)
+			t.Setenv("BEADS_DIR", "")
+			t.Setenv("BD_NON_INTERACTIVE", "1")
+			for name, value := range tc.flags {
+				setInitFlag(t, name, value)
+			}
+
+			err := initCmd.RunE(initCmd, nil)
+			if err == nil {
+				t.Fatal("bd init in an untracked home returned nil, want a refusal")
+			}
+			if !strings.Contains(err.Error(), "refusing to 'bd init' directly in your home directory") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// A refusal that still left something behind is not a refusal.
+			for _, name := range []string{".git", ".beads", "CLAUDE.md", "AGENTS.md", ".gitignore", ".agents", ".codex", ".claude"} {
+				if _, statErr := os.Stat(filepath.Join(home, name)); statErr == nil {
+					t.Errorf("init created %s in the home directory despite refusing", name)
+				}
+			}
+		})
+	}
+}
+
+// stubHomeDir points the guard's home resolver at dir for the duration of the
+// test. Stubbing rather than setting $HOME is deliberate: the resolver prefers
+// the OS account database, so $HOME alone would not move it.
+func stubHomeDir(t *testing.T, dir string) {
+	t.Helper()
+	orig := resolveUserHomeDir
+	resolveUserHomeDir = func() string { return dir }
+	t.Cleanup(func() { resolveUserHomeDir = orig })
+}
+
+// gitInitAt makes dir a git repository.
+func gitInitAt(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v\n%s", err, out)
+	}
+}
+
+// chdir switches to dir for the duration of the test.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
+
+// setInitFlag sets a flag on the shared initCmd and restores it afterwards —
+// cobra commands are package-level singletons, so a leaked flag would bleed
+// into every later test in this package.
+func setInitFlag(t *testing.T, name, value string) {
+	t.Helper()
+	flag := initCmd.Flags().Lookup(name)
+	if flag == nil {
+		t.Fatalf("init has no --%s flag", name)
+	}
+	orig := flag.Value.String()
+	origChanged := flag.Changed
+	if err := initCmd.Flags().Set(name, value); err != nil {
+		t.Fatalf("setting --%s=%s: %v", name, value, err)
+	}
+	t.Cleanup(func() {
+		_ = initCmd.Flags().Set(name, orig)
+		flag.Changed = origChanged
+	})
+}

--- a/cmd/bd/init_home_guard_test.go
+++ b/cmd/bd/init_home_guard_test.go
@@ -45,33 +45,54 @@ func TestGuardInitInHomeDir(t *testing.T) {
 		home := t.TempDir()
 		stubHomeDir(t, home)
 		chdir(t, home)
-		t.Setenv("BEADS_DIR", "")
+		stubCallerBeadsDir(t, "")
 
 		err := guardInitInHomeDir()
 		if err == nil {
 			t.Fatal("guardInitInHomeDir() = nil, want a refusal in an untracked home")
 		}
-		if !strings.Contains(err.Error(), "refusing to 'bd init' directly in your home directory") {
-			t.Errorf("unexpected error text: %v", err)
-		}
+		assertHomeDirRefusal(t, err)
 	})
 
-	t.Run("allows_with_explicit_beads_dir", func(t *testing.T) {
+	t.Run("allows_when_the_caller_supplied_beads_dir", func(t *testing.T) {
 		home := t.TempDir()
 		stubHomeDir(t, home)
 		chdir(t, home)
-		t.Setenv("BEADS_DIR", filepath.Join(home, "elsewhere", ".beads"))
+		stubCallerBeadsDir(t, filepath.Join(home, "elsewhere", ".beads"))
 
 		if err := guardInitInHomeDir(); err != nil {
-			t.Errorf("guardInitInHomeDir() = %v, want nil when BEADS_DIR is explicit", err)
+			t.Errorf("guardInitInHomeDir() = %v, want nil when the caller named a BEADS_DIR", err)
 		}
+	})
+
+	// The bypass this guard shipped with: BEADS_DIR in the live environment is
+	// not evidence the caller asked for anything. bd exports one itself for
+	// every no-DB command, and beads.FindBeadsDir() accepts an ancestor
+	// .beads/ holding nothing but a config.yaml — which is where this
+	// project's own legacy user-level config lives, at ~/.beads/config.yaml.
+	// So the users most likely to have scaffolding in $HOME worth protecting
+	// were exactly the ones the guard failed open for.
+	t.Run("refuses_when_bd_exported_beads_dir_for_itself", func(t *testing.T) {
+		home := t.TempDir()
+		stubHomeDir(t, home)
+		chdir(t, home)
+		stubCallerBeadsDir(t, "")
+		// What the root pre-run does, and what `bd -C <dir>` does: set the
+		// live env without the caller having named anything.
+		t.Setenv("BEADS_DIR", filepath.Join(home, ".beads"))
+
+		err := guardInitInHomeDir()
+		if err == nil {
+			t.Fatal("guardInitInHomeDir() = nil; a bd-exported BEADS_DIR is not caller opt-in")
+		}
+		assertHomeDirRefusal(t, err)
 	})
 
 	t.Run("allows_when_home_is_already_a_git_repo", func(t *testing.T) {
 		home := t.TempDir()
 		stubHomeDir(t, home)
 		chdir(t, home)
-		t.Setenv("BEADS_DIR", "")
+		stubCallerBeadsDir(t, "")
 		gitInitAt(t, home)
 
 		if err := guardInitInHomeDir(); err != nil {
@@ -87,7 +108,7 @@ func TestGuardInitInHomeDir(t *testing.T) {
 			t.Fatal(err)
 		}
 		chdir(t, project)
-		t.Setenv("BEADS_DIR", "")
+		stubCallerBeadsDir(t, "")
 
 		if err := guardInitInHomeDir(); err != nil {
 			t.Errorf("guardInitInHomeDir() = %v, want nil for a project dir under home", err)
@@ -122,6 +143,7 @@ func TestInitCommand_RefusesInHomeDirBeforeAnySideEffect(t *testing.T) {
 			home := t.TempDir()
 			stubHomeDir(t, home)
 			chdir(t, home)
+			stubCallerBeadsDir(t, "")
 			t.Setenv("BEADS_DIR", "")
 			t.Setenv("BD_NON_INTERACTIVE", "1")
 			for name, value := range tc.flags {
@@ -132,9 +154,7 @@ func TestInitCommand_RefusesInHomeDirBeforeAnySideEffect(t *testing.T) {
 			if err == nil {
 				t.Fatal("bd init in an untracked home returned nil, want a refusal")
 			}
-			if !strings.Contains(err.Error(), "refusing to 'bd init' directly in your home directory") {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			assertHomeDirRefusal(t, err)
 
 			// A refusal that still left something behind is not a refusal.
 			for _, name := range []string{".git", ".beads", "CLAUDE.md", "AGENTS.md", ".gitignore", ".agents", ".codex", ".claude"} {
@@ -144,6 +164,31 @@ func TestInitCommand_RefusesInHomeDirBeforeAnySideEffect(t *testing.T) {
 			}
 		})
 	}
+}
+
+// assertHomeDirRefusal checks that err is the home-directory refusal, by its
+// exit code rather than its message: the code is the scriptable contract
+// (docs/recovery/init-safety.md#init-home-refused), the wording is not.
+func assertHomeDirRefusal(t *testing.T, err error) {
+	t.Helper()
+	code, ok := exitCodeFromError(err)
+	if !ok {
+		t.Fatalf("refusal did not carry an exit code: %v", err)
+	}
+	if code != ExitHomeDirRefused {
+		t.Fatalf("exit code = %d, want %d (ExitHomeDirRefused)", code, ExitHomeDirRefused)
+	}
+}
+
+// stubCallerBeadsDir sets what the guard sees as the caller-supplied BEADS_DIR.
+// The real value is captured at package init from the inherited environment, so
+// a test cannot move it with t.Setenv — which is the whole point of the
+// snapshot, and why it has to be stubbed here instead.
+func stubCallerBeadsDir(t *testing.T, dir string) {
+	t.Helper()
+	orig := beadsDirFromCaller
+	beadsDirFromCaller = dir
+	t.Cleanup(func() { beadsDirFromCaller = orig })
 }
 
 // stubHomeDir points the guard's home resolver at dir for the duration of the
@@ -197,4 +242,98 @@ func setInitFlag(t *testing.T, name, value string) {
 		_ = initCmd.Flags().Set(name, orig)
 		flag.Changed = origChanged
 	})
+}
+
+// TestInitThroughRootCmd_RefusesInHomeDirWithDiscoveredBeadsDir is the
+// regression for the bypass, and it has to run through rootCmd rather than
+// calling initCmd.RunE directly — the whole failure lives in a hook RunE-only
+// tests skip.
+//
+// Cobra's root PersistentPreRunE runs first, and for a no-DB command like init
+// it resolves a beads dir and exports it (main.go, selectedNoDBBeadsDir ->
+// prepareSelectedNoDBContext). That resolution accepts an ancestor .beads/
+// holding nothing but a config.yaml, which is precisely the shape of this
+// project's legacy user-level ~/.beads/config.yaml. A guard reading the LIVE
+// BEADS_DIR therefore saw a value it had set for itself and stood down.
+//
+// The half that made this worth blocking on: the `git init` is separately
+// gated on the same env, so it stayed skipped — but the agent scaffolding is
+// not. CLAUDE.md, AGENTS.md and .claude/ are written relative to the working
+// directory with no BEADS_DIR gate at all, so the bypass still clobbered the
+// files in $HOME the guard exists to protect.
+//
+// --backend names a backend that cannot exist, as a circuit breaker: if the
+// guard ever fails open again, init stops at the unknown-backend error instead
+// of building a real store in someone's home directory, and the assertion
+// below reports that error rather than hanging on Dolt.
+func TestInitThroughRootCmd_RefusesInHomeDirWithDiscoveredBeadsDir(t *testing.T) {
+	home := t.TempDir()
+	stubHomeDir(t, home)
+	chdir(t, home)
+	stubCallerBeadsDir(t, "")
+
+	// The caller named nothing. Anything in BEADS_DIR from here on was put
+	// there by bd itself.
+	t.Setenv("BEADS_DIR", "")
+	t.Setenv("HOME", home)
+	t.Setenv("BD_NON_INTERACTIVE", "1")
+
+	// The legacy user-level config, which is all beads.FindBeadsDir needs.
+	beadsDir := filepath.Join(home, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("actor: someone\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Confirm the precondition rather than assuming it: if discovery stops
+	// resolving this, the test would pass for the wrong reason. Compared
+	// through EvalSymlinks because macOS reports the same temp dir as both
+	// /var/... and /private/var/....
+	if got, want := evalSymlinks(t, selectedNoDBBeadsDir(initCmd)), evalSymlinks(t, beadsDir); got != want {
+		t.Fatalf("precondition: selectedNoDBBeadsDir = %q, want %q — pre-run no longer discovers a config.yaml-only .beads, so this test no longer reproduces the bypass", got, want)
+	}
+
+	origStore, origDBPath := store, dbPath
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		store, dbPath = origStore, origDBPath
+		_ = initCmd.Flags().Set("backend", "")
+		_ = initCmd.Flags().Set("prefix", "")
+	})
+	store, dbPath = nil, ""
+
+	rootCmd.SetArgs([]string{"init", "--backend", "review4795-home-guard-sentinel", "--prefix", "hg"})
+	err := rootCmd.Execute()
+
+	if err == nil {
+		t.Fatal("bd init in an untracked home returned nil, want a refusal")
+	}
+	if strings.Contains(err.Error(), "review4795-home-guard-sentinel") {
+		t.Fatalf("init ran past the home guard and got as far as backend selection: %v", err)
+	}
+	assertHomeDirRefusal(t, err)
+
+	// The files the bypass could still clobber, none of which is gated on
+	// BEADS_DIR: scaffolding is written relative to the working directory.
+	for _, name := range []string{".git", "CLAUDE.md", "AGENTS.md", ".gitignore", ".agents", ".codex", ".claude"} {
+		if _, statErr := os.Stat(filepath.Join(home, name)); statErr == nil {
+			t.Errorf("init created %s in the home directory despite refusing", name)
+		}
+	}
+}
+
+// evalSymlinks resolves path for comparison, tolerating a path that does not
+// exist (nothing to resolve is not a test failure here).
+func evalSymlinks(t *testing.T, path string) string {
+	t.Helper()
+	if path == "" {
+		return ""
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return path
+	}
+	return resolved
 }

--- a/cmd/bd/init_safety.go
+++ b/cmd/bd/init_safety.go
@@ -39,6 +39,18 @@ const (
 	// `--discard-remote`, or `--reinit-local` over existing local issues.
 	// The caller must look up the token format via `bd help init-safety`.
 	ExitDestroyTokenMissing = 12
+
+	// ExitHomeDirRefused signals `bd init` was run directly in the user's
+	// home directory, which is not already a git repo, without the caller
+	// naming a BEADS_DIR. Refused because init would `git init` $HOME and
+	// scaffold agent files over whatever is already there (GH#4635).
+	//
+	// Not part of protocol v0 §E3, which freezes 10/11/12/130 and says a
+	// new stable code needs a spec revision. This constant gives the
+	// refusal the same in-repo scriptability the other three have — a
+	// stable number instead of grepping stderr — without claiming wire
+	// status the spec has not granted.
+	ExitHomeDirRefused = 13
 )
 
 // RemoteSafetyAction names what the init command should do once it has

--- a/cmd/bd/init_safety_help.go
+++ b/cmd/bd/init_safety_help.go
@@ -81,6 +81,8 @@ EXIT CODES
   12    refused: destructive re-init (--discard-remote, or --reinit-local
         over existing issues) without a valid --destroy-token
         (non-interactive mode)
+  13    refused: run directly in your home directory, which is not already
+        a git repository, with no BEADS_DIR named by the caller
 
 RECOVERY
 

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -80,6 +80,26 @@ type envSnapshotValue struct {
 
 var changeDirEnvSnapshot map[string]envSnapshotValue
 
+// beadsDirFromCaller is BEADS_DIR as the process INHERITED it, captured at
+// package initialization — which the language guarantees runs before main, and
+// therefore before any bd code exports a BEADS_DIR of its own.
+//
+// Reading os.Getenv("BEADS_DIR") later is a different question, and the wrong
+// one for anything that needs to know what the CALLER asked for. By the time a
+// command's RunE runs, bd has usually exported one itself:
+//
+//   - the root PersistentPreRunE resolves a beads dir for every no-DB command
+//     and exports it (selectedNoDBBeadsDir -> prepareSelectedNoDBContext ->
+//     prepareSelectedCommandContext), and that resolution bottoms out in
+//     beads.FindBeadsDir(), which accepts any ancestor .beads/ carrying so much
+//     as a config.yaml — including the legacy user-level ~/.beads/config.yaml;
+//   - `bd -C <dir>` exports one too (applyChangeDirSelection), which names a
+//     beads dir without moving the working directory.
+//
+// Neither is the caller saying "use this". Consult this snapshot, not the live
+// environment, when the answer must mean caller intent (GH#4635).
+var beadsDirFromCaller = os.Getenv("BEADS_DIR")
+
 var (
 	noColorFlag       bool
 	sandboxMode       bool

--- a/docs/recovery/init-safety.md
+++ b/docs/recovery/init-safety.md
@@ -24,6 +24,7 @@ See also: `bd help init-safety`, and
 - [init-force-refused — `bd init --force`/`--reinit-local` refused because origin has Dolt history](#init-force-refused)
 - [init-token-missing — a destructive re-init refused because `--destroy-token` is missing or wrong](#init-token-missing)
 - [init-local-exists — `bd init --reinit-local` refused because local data already exists](#init-local-exists)
+- [init-home-refused — `bd init` refused because the working directory is your home directory](#init-home-refused)
 - [pk-fork-refused — `bd dolt pull`/`push` refused because a table has different primary keys in its common ancestor](#pk-fork-refused)
 
 ---
@@ -199,6 +200,86 @@ enough to create a restorable backup before reinitializing.
 If you did NOT expect `bd init` to be the right command here, run
 `bd doctor` first — you may be looking at a server config issue that a
 re-init won't fix.
+
+---
+
+## init-home-refused
+
+**Exit code:** `13` (`ExitHomeDirRefused`)
+
+**Symptom**
+
+```
+bd init refuses: /Users/you is your home directory, and it is not a git repository.
+  Why: init would 'git init' your home directory and scaffold agent files
+       into it ...
+```
+
+**Why this happens**
+
+`bd init` in a directory that is not yet a git repository creates one, then
+writes agent scaffolding next to it: `CLAUDE.md`, `AGENTS.md`, `.gitignore`,
+`.claude/`, `.codex/`, `.agents/`. Run in your home directory, that turns
+everything you own into one git working tree and overwrites whatever agent
+files you already keep there. A project is virtually never the home directory
+itself, so `bd init` refuses rather than ask.
+
+The refusal is deliberately narrow. It fires only when **all** of these hold:
+
+- the working directory is exactly your home directory (a subdirectory of home
+  is an ordinary project and is never refused);
+- your home directory is not already a git repository — if you deliberately
+  track your dotfiles, nothing changes;
+- you did not name a beads directory yourself.
+
+`--force` and `--reinit-local` do **not** override it. They bypass the local
+data-safety guard, which is a different question from "is this the right
+directory".
+
+**Recovery paths**
+
+Pick the one that matches your intent.
+
+*You meant to initialize a project.* This is almost always the case — the
+working directory was simply not what you thought:
+
+```bash
+cd ~/some-project
+bd init
+```
+
+*You want a beads workspace whose data lives somewhere else, with no
+scaffolding in your home directory.* Name the beads directory explicitly:
+
+```bash
+BEADS_DIR=~/workspaces/notes/.beads bd init
+```
+
+Note this is a **different** init, not the refused one with the guard lifted:
+an explicit `BEADS_DIR` makes `bd init` skip both the `git init` and the
+working-directory-local `.beads`, so nothing is written into your home
+directory at all. That is the point — but if you wanted the scaffolding, this
+will not produce it.
+
+*You really do want your home directory tracked by git and scaffolded.* Make it
+a git repository first, deliberately, and the guard stands aside:
+
+```bash
+cd ~
+git init
+bd init
+```
+
+**How to detect this in a script**
+
+The refusal exits `13` and prints to stderr, so branch on the code rather than
+the text:
+
+```bash
+bd init || case $? in
+  13) echo "wrong directory — cd into the project first" ;;
+esac
+```
 
 ---
 


### PR DESCRIPTION
Closes #4635

## Problem

`bd init` in a directory that isn't a git repo unconditionally `git init`s it, writes agent scaffolding (`CLAUDE.md`, `AGENTS.md`, `.gitignore`, `.agents/`, `.codex/`, `.claude/settings.json`), and commits — with no confirmation. Run in `$HOME` this silently turns the home directory into a git repository and clobbers whatever agent files are already there.

It's worse under `--non-interactive`, which auto-engages whenever stdin isn't a TTY — i.e. whenever an *agent* runs `bd init`. All of it happens with zero prompt.

## Fix

Refuse, when the working directory **is** the user's home directory, it isn't already a git repo, and the caller didn't name a `BEADS_DIR`:

```
$ cd ~ && bd init
bd init refuses: /Users/me is your home directory, and it is not a git repository.

  Why: init would 'git init' your home directory and scaffold agent files
       into it (CLAUDE.md, AGENTS.md, .gitignore, .claude/, .codex/,
       .agents/), overwriting any you already keep there. A project is
       virtually never the home directory itself.

  Next:
    Initialize a project instead (recommended):
      cd ~/some-project && bd init

    Keep the workspace elsewhere, with no scaffolding in your home:
      BEADS_DIR=<path>/.beads bd init
      (this is a DIFFERENT init: an explicit BEADS_DIR skips the git init
       and the working-directory-local .beads, so nothing is written here)

    Recovery playbook:
      docs/recovery/init-safety.md#init-home-refused
$ echo $?
13
```

**Placement.** The guard is the first statement in init's `RunE`, ahead of every path that has an effect: the proxied dispatch (`runInitProxiedServer` → `EnsureGitRepo` → `git init`), the `--reinit-local`/`--force` pre-checks (`countExistingIssues` opens a real store, creating the data directory and able to run migrations), and the mode globals `RunE` sets on itself.

**Opt-in is caller intent, not the process environment.** The guard reads `beadsDirFromCaller` — `BEADS_DIR` as the process *inherited* it, captured at package initialization — not `os.Getenv("BEADS_DIR")`. By the time `RunE` runs, bd has usually exported one itself: the root `PersistentPreRunE` resolves a beads dir for every no-DB command and exports it, and that resolution accepts any ancestor `.beads/` holding so much as a `config.yaml` — including this project's own legacy user-level `~/.beads/config.yaml`. `bd -C <dir>` exports one too, and that one doesn't even move the working directory the scaffolding lands in.

**Refusal conventions.** Exit code `13` (`ExitHomeDirRefused`), alongside init's existing 10/11/12, so a script can branch on the number instead of grepping stderr. `docs/recovery/init-safety.md#init-home-refused` is the playbook the message points at, and `bd help init-safety` lists the code.

## Scope

Deliberately narrow. It fires only when **all** of these hold:

- the working directory is *exactly* your home directory — `mkdir proj && cd proj && bd init` is unaffected, and so is any other subdirectory;
- your home is not already a git repository — a dotfiles repo is unaffected;
- the caller did not name a `BEADS_DIR`.

`--force` and `--reinit-local` do **not** override it: they bypass the local data-safety guard, which is a different question from "is this the right directory". `/`, `/Users`, `/home` and the like stay unguarded — this is about the one directory people actually land in by accident.

## Tests

- `TestIsUserHomeDir`, `TestIsUserHomeDir_UnresolvableHome` — the decision, with the home resolver stubbed so no test touches the real home directory.
- `TestGuardInitInHomeDir` — the fail-open cases (caller-supplied `BEADS_DIR`, an already-tracked home, an ordinary project dir), plus the case that keeps the provenance fix honest: a `BEADS_DIR` that *bd* exported is not caller opt-in.
- `TestInitCommand_RefusesInHomeDirBeforeAnySideEffect` — runs init's `RunE` across plain / `--reinit-local` / `--force` / `--proxied-server` and asserts not just the refusal but that **nothing** exists afterwards: `.git`, `.beads`, `CLAUDE.md`, `AGENTS.md`, `.gitignore`, `.agents`, `.codex`, `.claude`. This is what pins the guard's *position*; moving it back down the file fails all four.
- `TestInitThroughRootCmd_RefusesInHomeDirWithDiscoveredBeadsDir` — through `rootCmd.Execute`, in a home carrying only `.beads/config.yaml`, because the bypass lives in a pre-run hook that `RunE`-only tests skip. It asserts the precondition (pre-run really does discover that directory) before asserting the refusal, and names a backend that cannot exist as a circuit breaker, so a future fail-open stops at backend selection rather than building a store in someone's home directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
