### PR TITLE
fix(storage): carry closed_by_session through the domain/UOW writer (#4662)

### DIFF
--- a/backend/conformance/portable.go
+++ b/backend/conformance/portable.go
@@ -42,6 +42,7 @@ func RunPortableMethods(t *testing.T, factory Factory) {
 	t.Run("ImportIssueComment", func(t *testing.T) { testImportIssueComment(t, factory) })
 	t.Run("AddIssueCommentBurstOrder", func(t *testing.T) { testAddIssueCommentBurstOrder(t, factory) })
 	t.Run("PromoteFromEphemeral", func(t *testing.T) { testPromoteFromEphemeral(t, factory) })
+	t.Run("PromoteClosedWispPreservesSession", func(t *testing.T) { testPromoteClosedWispPreservesSession(t, factory) })
 	t.Run("UpdateIssueID", func(t *testing.T) { testUpdateIssueID(t, factory) })
 	t.Run("DeleteIssuesBySourceRepo", func(t *testing.T) { testDeleteIssuesBySourceRepo(t, factory) })
 	t.Run("CreateIssuesWithFullOptions", func(t *testing.T) { testCreateIssuesWithFullOptions(t, factory) })
@@ -574,6 +575,33 @@ func testPromoteFromEphemeral(t *testing.T, f Factory) {
 	// Second promote fails (no longer a wisp).
 	if err := s.PromoteFromEphemeral(c, "test-w", "a"); err == nil {
 		t.Error("double promote: want error, got nil")
+	}
+}
+
+// testPromoteClosedWispPreservesSession verifies that promoting a *closed*
+// ephemeral wisp preserves its closed_by_session provenance. Before the fix
+// (GH#4662), closed_by_session was absent from the shared issue select/scan
+// and insert column set, so promotion (read wisp -> insert issue) hydrated a
+// zero value and dropped the original closing session.
+func testPromoteClosedWispPreservesSession(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-cw", Title: "Closed wisp", Ephemeral: true}), "a"))
+	must(t, s.CloseIssue(c, "test-cw", "done", "a", "sess-xyz"))
+
+	must(t, s.PromoteFromEphemeral(c, "test-cw", "a"))
+
+	got, err := s.GetIssue(c, "test-cw")
+	must(t, err)
+	if got.Ephemeral {
+		t.Error("promoted issue still Ephemeral")
+	}
+	if got.Status != types.StatusClosed {
+		t.Errorf("promoted issue status = %q, want %q", got.Status, types.StatusClosed)
+	}
+	if got.ClosedBySession != "sess-xyz" {
+		t.Errorf("closed_by_session after promote = %q, want %q (GH#4662)", got.ClosedBySession, "sess-xyz")
 	}
 }
 

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -754,6 +754,14 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 	if err := types.CheckFieldLen("owner", issue.Owner); err != nil {
 		return err
 	}
+	// The column list must stay in step with the classic writer
+	// (issueops.insertIssueIntoTable) — the shared scanner hydrates whatever
+	// either writer stored, so a column present there and missing here is not
+	// a harmless omission but a silent, writer-dependent data loss. That is
+	// what closed_by_session was: the schema defaults it to '', so a proxied
+	// create/import read back an empty closing session while the same issue
+	// created through the classic path kept it (GH#4662).
+	//
 	// Stamp a fresh non-zero row_lock at create, exactly like the classic
 	// insertIssueIntoTable (issueops/helpers.go). Without it a proxied-server
 	// (uow) create leaves row_lock at the schema DEFAULT 0, so the row's
@@ -767,7 +775,7 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 			created_at, created_by, owner, updated_at, started_at, closed_at, external_ref, spec_id,
 			compaction_level, compacted_at, compacted_at_commit, original_size,
 			sender, ephemeral, no_history, wisp_type, pinned, is_template,
-			mol_type, work_type, source_system, source_repo, close_reason,
+			mol_type, work_type, source_system, source_repo, close_reason, closed_by_session,
 			event_kind, actor, target, payload,
 			await_type, await_id, timeout_ns, waiters,
 			due_at, defer_until, metadata,
@@ -778,7 +786,7 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 			?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?,
-			?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?,
 			?, ?, ?, ?,
 			?, ?, ?,
@@ -802,6 +810,7 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 			external_ref = VALUES(external_ref),
 			source_repo = VALUES(source_repo),
 			close_reason = VALUES(close_reason),
+			closed_by_session = VALUES(closed_by_session),
 			metadata = VALUES(metadata),
 			row_lock = VALUES(row_lock)
 	`, table),
@@ -810,7 +819,7 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 		issue.CreatedAt, issue.CreatedBy, issue.Owner, issue.UpdatedAt, issue.StartedAt, issue.ClosedAt, nullStringPtr(issue.ExternalRef), issue.SpecID,
 		issue.CompactionLevel, issue.CompactedAt, nullStringPtr(issue.CompactedAtCommit), nullIntVal(issue.OriginalSize),
 		issue.Sender, issue.Ephemeral, issue.NoHistory, string(issue.WispType), issue.Pinned, issue.IsTemplate,
-		string(issue.MolType), string(issue.WorkType), issue.SourceSystem, issue.SourceRepo, issue.CloseReason,
+		string(issue.MolType), string(issue.WorkType), issue.SourceSystem, issue.SourceRepo, issue.CloseReason, issue.ClosedBySession,
 		issue.EventKind, issue.Actor, issue.Target, issue.Payload,
 		issue.AwaitType, issue.AwaitID, issue.Timeout.Nanoseconds(), formatJSONStringArray(issue.Waiters),
 		issue.DueAt, issue.DeferUntil, jsonMetadata(issue.Metadata),

--- a/internal/storage/domain/db/issue_test.go
+++ b/internal/storage/domain/db/issue_test.go
@@ -18,6 +18,9 @@ func (s *testSuite) TestIssueSQLRepository() {
 		s.Run("RecordsCreatedEvent", s.issueInsertRecordsEvent)
 		s.Run("RoutesToWispsTable", s.issueInsertWispRouting)
 		s.Run("ComputesContentHashWhenMissing", s.issueInsertComputesHash)
+		s.Run("PreservesClosedBySession", s.issueInsertPreservesClosedBySession)
+		s.Run("PreservesClosedBySessionOnWisp", s.wispInsertPreservesClosedBySession)
+		s.Run("UpsertRewritesClosedBySession", s.issueUpsertRewritesClosedBySession)
 	})
 	s.Run("InsertBatch", func() {
 		s.Run("AllIssuesInserted", s.issueInsertBatchAll)
@@ -126,6 +129,68 @@ func (s *testSuite) issueInsertRoundTrip() {
 	s.Equal(types.TypeTask, out.IssueType)
 	s.Require().NotNil(out.EstimatedMinutes)
 	s.Equal(45, *out.EstimatedMinutes)
+}
+
+// issueInsertPreservesClosedBySession proves the domain/UOW writer stores
+// closed_by_session, so an issue created through the proxied stack reads back
+// with the same closing-session provenance the classic writer preserves
+// (GH#4662).
+//
+// The column defaults to the empty string in every schema and the shared
+// scanner hydrates whatever is stored, so a writer that omits it loses the
+// value silently: the insert succeeds, the read succeeds, and only the
+// provenance is gone.
+func (s *testSuite) issueInsertPreservesClosedBySession() {
+	r := s.issueRepo()
+	in := newTestIssue("bd-cbs-1", "closed elsewhere")
+	in.Status = types.StatusClosed
+	in.CloseReason = "done"
+	in.ClosedBySession = "sess-xyz"
+
+	s.Require().NoError(r.Insert(s.Ctx(), in, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.Get(s.Ctx(), "bd-cbs-1", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Equal("sess-xyz", out.ClosedBySession, "closed_by_session must survive a domain/UOW insert")
+	s.Equal("done", out.CloseReason)
+}
+
+// wispInsertPreservesClosedBySession is the wisp-table counterpart: promotion
+// reads a wisp and re-inserts it as an issue, so the value has to survive on
+// the wisp side too or there is nothing left to promote.
+func (s *testSuite) wispInsertPreservesClosedBySession() {
+	r := s.issueRepo()
+	wisp := newTestIssue("bd-cbs-wisp", "closed wisp")
+	wisp.Ephemeral = true
+	wisp.Status = types.StatusClosed
+	wisp.ClosedBySession = "sess-wisp"
+
+	s.Require().NoError(r.Insert(s.Ctx(), wisp, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
+
+	out, err := r.Get(s.Ctx(), "bd-cbs-wisp", domain.IssueTableOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.Equal("sess-wisp", out.ClosedBySession, "closed_by_session must survive a domain/UOW wisp insert")
+}
+
+// issueUpsertRewritesClosedBySession covers the ON DUPLICATE KEY UPDATE half.
+// Import re-inserts existing IDs through this same statement, so a column
+// listed in the INSERT but missing from the upsert assignments would carry the
+// value on first write and silently keep the stale one forever after.
+func (s *testSuite) issueUpsertRewritesClosedBySession() {
+	r := s.issueRepo()
+	first := newTestIssue("bd-cbs-upsert", "first")
+	first.Status = types.StatusClosed
+	first.ClosedBySession = "sess-first"
+	s.Require().NoError(r.Insert(s.Ctx(), first, "tester", domain.InsertIssueOpts{}))
+
+	second := newTestIssue("bd-cbs-upsert", "second")
+	second.Status = types.StatusClosed
+	second.ClosedBySession = "sess-second"
+	s.Require().NoError(r.Insert(s.Ctx(), second, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.Get(s.Ctx(), "bd-cbs-upsert", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Equal("sess-second", out.ClosedBySession, "the upsert must rewrite closed_by_session, not keep the stale value")
 }
 
 func (s *testSuite) issueInsertRequiresID() {


### PR DESCRIPTION
Closes #4662

> **Scope changed after rebase (2026-08-14).** The original diff added `closed_by_session` to the shared select/scan/insert column sets. All of that landed upstream independently in #5191, so those hunks are dropped. What remains — and what is still broken on current `main` — is the second writer.

## Problem

`db.insertIssueRow` (`internal/storage/domain/db/issue.go`), the statement behind proxied create, batch create and import, has no `closed_by_session` in its INSERT column list, its VALUES, or its `ON DUPLICATE KEY UPDATE`.

The classic writer (`issueops.insertIssueIntoTable`) does carry it, and the shared scanner (`issueops.ScanIssueFrom`) reads it back. So the two writers disagree, and the disagreement is silent: the schema defaults the column to `''`, the insert succeeds, the read succeeds, and only the closing-session provenance is gone.

That is the GH#4662 data loss — `PromoteFromEphemeral` reads a wisp and re-inserts it, dropping the original closing session — still live, just relocated to the writer the proxied stack uses.

## Fix

Add `closed_by_session` to `insertIssueRow`'s insert columns, values, and upsert assignments, with a note at the chokepoint on why the two writers' column lists have to stay in step.

## Tests

Three cases in the domain/db suite (real Dolt via the test container):

- `Insert/PreservesClosedBySession` — issues table;
- `Insert/PreservesClosedBySessionOnWisp` — wisps table, since promotion reads the wisp side first;
- `Insert/UpsertRewritesClosedBySession` — the `ON DUPLICATE KEY UPDATE` half, which import re-enters; a column in the INSERT but absent from the upsert would carry the value on first write and keep a stale one forever after.

All three fail against `main` and pass with the fix:

```
--- FAIL: TestDomainDB/TestIssueSQLRepository/Insert/PreservesClosedBySession
        closed_by_session must survive a domain/UOW insert
--- FAIL: TestDomainDB/TestIssueSQLRepository/Insert/PreservesClosedBySessionOnWisp
        closed_by_session must survive a domain/UOW wisp insert
--- FAIL: TestDomainDB/TestIssueSQLRepository/Insert/UpsertRewritesClosedBySession
        the upsert must rewrite closed_by_session, not keep the stale value
```

Plus the conformance case `PromoteClosedWispPreservesSession`, kept from the original commit: it runs on every backend and is the end-to-end regression for the reported bug (close a wisp with a session, promote, assert the session survives). Confirmed passing under embedded Dolt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
