### PR TITLE
fix(doctor): detect orphaned child_counters rows (#4539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2091,6 +2091,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Storage` implementations that ignore the new fields simply do not enforce
   them and should add support before advertising guard semantics.
 
+- **`bd doctor --check=validate` now detects orphaned `child_counters` /
+  `wisp_child_counters` rows** ([#4539](https://github.com/gastownhall/beads/issues/4539),
+  follow-up to [#4534](https://github.com/gastownhall/beads/issues/4534)).
+  A `child_counters` row whose `parent_id` has no matching `issues` row (or a
+  `wisp_child_counters` row with no matching `wisps` row) can fail Dolt
+  constraint validation on a later write, silently bricking every
+  `bd create` — while `bd doctor` previously reported 0 errors. #4538 healed
+  the known legacy window with a one-time cleanup migration, but the drift
+  class that creates such rows (#728, #1393) predates that window and can
+  recur with no ongoing guard. The new "Orphaned Child Counters" check
+  flags dangling `parent_id`s and is fixable via `bd doctor --fix`.
+  Credit: reported by @maphew, check suggested by @eitsupi in #4534.
+
 - **Pool-aware claiming via the `claim.pools` config key** (bd-bguz6).
   Dispatcher fleets pre-assign issues to a pool pseudo-assignee (e.g.
   `fable-crew`); `--claim` previously refused those ("already assigned"),

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -890,6 +890,11 @@ func runDiagnostics(path string) doctorResult {
 	result.Checks = append(result.Checks, cloneLocalFKCheck)
 	// Don't fail overall check for severed clone-local FKs, just warn
 
+	// Check 21a: Orphaned child counters (twin gap to orphaned deps, #4539)
+	orphanedChildCountersCheck := convertDoctorCheck(doctor.CheckOrphanedChildCounters(path))
+	result.Checks = append(result.Checks, orphanedChildCountersCheck)
+	// Don't fail overall check for orphaned child counters, just warn
+
 	// Check 22a: Child→parent dependencies (anti-pattern)
 	childParentDepsCheck := convertDoctorCheck(doctor.CheckChildParentDependencies(path))
 	result.Checks = append(result.Checks, childParentDepsCheck)

--- a/cmd/bd/doctor/agent.go
+++ b/cmd/bd/doctor/agent.go
@@ -118,6 +118,7 @@ var agentEnrichers = map[string]enricher{
 	"Test Pollution":               enrichTestPollution,
 	"Orphaned Dependencies":        enrichOrphanedDeps,
 	"Clone-Local FKs":              enrichCloneLocalFKs,
+	"Orphaned Child Counters":      enrichOrphanedChildCounters,
 	"Child-Parent Dependencies":    enrichChildParentDeps,
 	"Classic Artifacts":            enrichClassicArtifacts,
 	"Pending Migrations":           enrichPendingMigrations,
@@ -468,6 +469,17 @@ func enrichCloneLocalFKs(dc DoctorCheck) agentEnrichment {
 		expected:    "Every FK on clone-local tables (events, wisp_dependencies, wisp_labels, wisp_comments, wisp_events, wisp_child_counters) present and enforcing",
 		commands:    []string{"bd doctor --fix"},
 		sourceFiles: []string{"cmd/bd/doctor/clone_local_fks.go:CheckCloneLocalFKs"},
+	}
+}
+
+func enrichOrphanedChildCounters(dc DoctorCheck) agentEnrichment {
+	return agentEnrichment{
+		severity:    "blocking",
+		explanation: fmt.Sprintf("Orphaned child counter rows found: %s. A child_counters/wisp_child_counters row with no matching issues/wisps parent can fail Dolt constraint validation on a later write, silently bricking every 'bd create' (#4539).", dc.Message),
+		observed:    dc.Message + "\n" + dc.Detail,
+		expected:    "Every child_counters/wisp_child_counters row has a live parent in issues/wisps",
+		commands:    []string{"bd doctor --check=validate --fix"},
+		sourceFiles: []string{"cmd/bd/doctor/validation.go:CheckOrphanedChildCounters"},
 	}
 }
 

--- a/cmd/bd/doctor/fix/remotes_test.go
+++ b/cmd/bd/doctor/fix/remotes_test.go
@@ -158,6 +158,7 @@ func TestDestructiveFix_AbortsOnProjectIdentityMismatch(t *testing.T) {
 		"CrossTableDuplicates":    func(p string) error { return CrossTableDuplicates(p, false) },
 		"OrphanedDependencies":    func(p string) error { return OrphanedDependencies(p, false) },
 		"ChildParentDependencies": func(p string) error { return ChildParentDependencies(p, false) },
+		"OrphanedChildCounters":   func(p string) error { return OrphanedChildCounters(p, false) },
 		"RecomputeBlocked":        RecomputeBlocked,
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/cmd/bd/doctor/fix/validation.go
+++ b/cmd/bd/doctor/fix/validation.go
@@ -116,6 +116,105 @@ func OrphanedDependencies(path string, verbose bool) error {
 	return nil
 }
 
+// OrphanedChildCounters removes child_counters/wisp_child_counters rows whose
+// parent_id has no matching issues/wisps row. A single such row can fail Dolt
+// constraint validation on subsequent writes, silently bricking every
+// `bd create` (#4539, follow-up to #4534). Credit: check suggested by
+// @eitsupi in #4534.
+// If verbose is true, prints each removed row; otherwise shows only summary.
+func OrphanedChildCounters(path string, verbose bool) error {
+	beadsDir, err := resolvedWorkspaceBeadsDir(path)
+	if err != nil {
+		return err
+	}
+
+	db, err := openDoltDB(beadsDir)
+	if err != nil {
+		fmt.Printf("  Orphaned child counters fix skipped (%v)\n", err)
+		return nil
+	}
+	defer db.Close()
+
+	// Find child_counters rows dangling from issues and wisp_child_counters
+	// rows dangling from wisps.
+	query := `
+		SELECT 'child_counters' AS counter_table, cc.parent_id
+		FROM child_counters cc
+		LEFT JOIN issues i ON cc.parent_id = i.id
+		WHERE i.id IS NULL
+		UNION ALL
+		SELECT 'wisp_child_counters' AS counter_table, wcc.parent_id
+		FROM wisp_child_counters wcc
+		LEFT JOIN wisps w ON wcc.parent_id = w.id
+		WHERE w.id IS NULL
+	`
+	rows, err := db.Query(query)
+	if err != nil {
+		return fmt.Errorf("failed to query orphaned child counters: %w", err)
+	}
+	defer rows.Close()
+
+	type orphan struct {
+		counterTable string
+		parentID     string
+	}
+	var orphans []orphan
+
+	for rows.Next() {
+		var o orphan
+		if err := rows.Scan(&o.counterTable, &o.parentID); err == nil {
+			orphans = append(orphans, o)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("row iteration error: %w", err)
+	}
+
+	if len(orphans) == 0 {
+		fmt.Println("  No orphaned child counters to fix")
+		return nil
+	}
+
+	// Delete orphaned child counter rows.
+	// Uses explicit transaction so writes persist when @@autocommit is OFF
+	// (e.g. Dolt server started with --no-auto-commit).
+	showIndividual := verbose || len(orphans) < 20
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	var removed int
+	for _, o := range orphans {
+		var err error
+		switch o.counterTable {
+		case "child_counters":
+			_, err = tx.Exec("DELETE FROM child_counters WHERE parent_id = ?", o.parentID)
+		case "wisp_child_counters":
+			_, err = tx.Exec("DELETE FROM wisp_child_counters WHERE parent_id = ?", o.parentID)
+		default:
+			fmt.Printf("  Warning: skipped orphaned child counter from unexpected table %s\n", o.counterTable)
+			continue
+		}
+		if err != nil {
+			fmt.Printf("  Warning: failed to remove %s row for %s: %v\n", o.counterTable, o.parentID, err)
+		} else {
+			removed++
+			if showIndividual {
+				fmt.Printf("  Removed orphaned %s row: parent_id=%s\n", o.counterTable, o.parentID)
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit orphaned child counter removals: %w", err)
+	}
+
+	// Commit changes in Dolt
+	_, _ = db.Exec("CALL DOLT_COMMIT('-Am', 'doctor: remove orphaned child counter rows')") // Best effort: commit advisory; schema fix already applied in-memory
+
+	fmt.Printf("  Fixed %d orphaned child counter row(s)\n", removed)
+	return nil
+}
+
 // ChildParentDependencies removes child→parent blocking dependencies.
 // These often indicate a modeling mistake (deadlock: child waits for parent, parent waits for children).
 // Requires explicit opt-in via --fix-child-parent flag since some workflows may use these intentionally.

--- a/cmd/bd/doctor/fix/validation.go
+++ b/cmd/bd/doctor/fix/validation.go
@@ -1,12 +1,14 @@
 package fix
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"path/filepath"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 )
 
 // getDatabasePath returns the actual database directory path, respecting dolt_data_dir.
@@ -121,6 +123,19 @@ func OrphanedDependencies(path string, verbose bool) error {
 // constraint validation on subsequent writes, silently bricking every
 // `bd create` (#4539, follow-up to #4534). Credit: check suggested by
 // @eitsupi in #4534.
+//
+// The pinned engine defaults to repeatable-read with `FOR UPDATE` as a no-op,
+// so the delete below re-checks parent absence at delete time via a NOT
+// EXISTS predicate rather than keying off a pre-scanned list — a parent
+// created between the scan and the delete keeps its (now valid) counter.
+//
+// Mirrors DoltStore.runDoltTransaction (internal/storage/dolt/transaction.go,
+// GH#2455): the DML transaction, staging, and DOLT_COMMIT all run on one
+// pinned *sql.Conn, since each pool connection has an independent working set
+// in Dolt SQL server mode and mixing connections would let DOLT_COMMIT see
+// stale or unrelated state. Only the tables actually touched are staged, so
+// an unrelated dirty working set is not swept under this commit.
+//
 // If verbose is true, prints each removed row; otherwise shows only summary.
 func OrphanedChildCounters(path string, verbose bool) error {
 	beadsDir, err := resolvedWorkspaceBeadsDir(path)
@@ -135,8 +150,11 @@ func OrphanedChildCounters(path string, verbose bool) error {
 	}
 	defer db.Close()
 
+	ctx := context.Background()
+
 	// Find child_counters rows dangling from issues and wisp_child_counters
-	// rows dangling from wisps.
+	// rows dangling from wisps, for reporting only — the deletes below
+	// re-check parent absence themselves rather than keying off this list.
 	query := `
 		SELECT 'child_counters' AS counter_table, cc.parent_id
 		FROM child_counters cc
@@ -148,11 +166,10 @@ func OrphanedChildCounters(path string, verbose bool) error {
 		LEFT JOIN wisps w ON wcc.parent_id = w.id
 		WHERE w.id IS NULL
 	`
-	rows, err := db.Query(query)
+	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to query orphaned child counters: %w", err)
 	}
-	defer rows.Close()
 
 	type orphan struct {
 		counterTable string
@@ -167,51 +184,86 @@ func OrphanedChildCounters(path string, verbose bool) error {
 		}
 	}
 	if err := rows.Err(); err != nil {
+		_ = rows.Close()
 		return fmt.Errorf("row iteration error: %w", err)
 	}
+	_ = rows.Close()
 
 	if len(orphans) == 0 {
 		fmt.Println("  No orphaned child counters to fix")
 		return nil
 	}
 
-	// Delete orphaned child counter rows.
-	// Uses explicit transaction so writes persist when @@autocommit is OFF
-	// (e.g. Dolt server started with --no-auto-commit).
 	showIndividual := verbose || len(orphans) < 20
-	tx, err := db.Begin()
+	if showIndividual {
+		for _, o := range orphans {
+			fmt.Printf("  Removing orphaned %s row: parent_id=%s\n", o.counterTable, o.parentID)
+		}
+	}
+
+	// Pin a single connection for the whole sequence: the DML transaction,
+	// staging, and DOLT_COMMIT (GH#2455).
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire connection: %w", err)
+	}
+	defer conn.Close()
+
+	// Explicit transaction so writes persist when @@autocommit is OFF (e.g. a
+	// Dolt server started with --no-auto-commit).
+	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
-	var removed int
-	for _, o := range orphans {
-		var err error
-		switch o.counterTable {
-		case "child_counters":
-			_, err = tx.Exec("DELETE FROM child_counters WHERE parent_id = ?", o.parentID)
-		case "wisp_child_counters":
-			_, err = tx.Exec("DELETE FROM wisp_child_counters WHERE parent_id = ?", o.parentID)
-		default:
-			fmt.Printf("  Warning: skipped orphaned child counter from unexpected table %s\n", o.counterTable)
-			continue
-		}
-		if err != nil {
-			fmt.Printf("  Warning: failed to remove %s row for %s: %v\n", o.counterTable, o.parentID, err)
-		} else {
-			removed++
-			if showIndividual {
-				fmt.Printf("  Removed orphaned %s row: parent_id=%s\n", o.counterTable, o.parentID)
-			}
-		}
+
+	ccRes, err := tx.ExecContext(ctx,
+		`DELETE FROM child_counters cc WHERE NOT EXISTS (SELECT 1 FROM issues i WHERE i.id = cc.parent_id)`)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("failed to remove orphaned child_counters rows: %w", err)
 	}
+	wccRes, err := tx.ExecContext(ctx,
+		`DELETE FROM wisp_child_counters wcc WHERE NOT EXISTS (SELECT 1 FROM wisps w WHERE w.id = wcc.parent_id)`)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("failed to remove orphaned wisp_child_counters rows: %w", err)
+	}
+
+	ccRemoved, _ := ccRes.RowsAffected()
+	wccRemoved, _ := wccRes.RowsAffected()
+	removed := int(ccRemoved + wccRemoved)
+
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("failed to commit orphaned child counter removals: %w", err)
 	}
 
-	// Commit changes in Dolt
-	_, _ = db.Exec("CALL DOLT_COMMIT('-Am', 'doctor: remove orphaned child counter rows')") // Best effort: commit advisory; schema fix already applied in-memory
+	// Stage only the tables actually touched (not a blanket `-Am`, which would
+	// sweep up unrelated dirty state) and commit in Dolt, on the same pinned
+	// connection so DOLT_COMMIT sees exactly what was just staged. Surface a
+	// failed commit rather than swallowing it: reporting "Fixed" over a
+	// commit that didn't land would leave the repair in the working set only,
+	// silently undone by the next pull.
+	if ccRemoved > 0 {
+		if _, err := conn.ExecContext(ctx, "CALL DOLT_ADD(?)", "child_counters"); err != nil {
+			return fmt.Errorf("failed to stage child_counters repairs: %w", err)
+		}
+	}
+	if wccRemoved > 0 {
+		if _, err := conn.ExecContext(ctx, "CALL DOLT_ADD(?)", "wisp_child_counters"); err != nil {
+			return fmt.Errorf("failed to stage wisp_child_counters repairs: %w", err)
+		}
+	}
+	if removed > 0 {
+		if _, err := conn.ExecContext(ctx, "CALL DOLT_COMMIT('-m', 'doctor: remove orphaned child counter rows')"); err != nil && !issueops.IsNothingToCommitError(err) {
+			return fmt.Errorf("failed to commit orphaned child counter removals to Dolt: %w", err)
+		}
+	}
 
-	fmt.Printf("  Fixed %d orphaned child counter row(s)\n", removed)
+	if removed < len(orphans) {
+		fmt.Printf("  Fixed %d orphaned child counter row(s) (%d no longer orphaned by delete time)\n", removed, len(orphans)-removed)
+	} else {
+		fmt.Printf("  Fixed %d orphaned child counter row(s)\n", removed)
+	}
 	return nil
 }
 

--- a/cmd/bd/doctor/fix/validation.go
+++ b/cmd/bd/doctor/fix/validation.go
@@ -217,13 +217,13 @@ func OrphanedChildCounters(path string, verbose bool) error {
 	}
 
 	ccRes, err := tx.ExecContext(ctx,
-		`DELETE FROM child_counters cc WHERE NOT EXISTS (SELECT 1 FROM issues i WHERE i.id = cc.parent_id)`)
+		`DELETE FROM child_counters WHERE NOT EXISTS (SELECT 1 FROM issues i WHERE i.id = child_counters.parent_id)`)
 	if err != nil {
 		_ = tx.Rollback()
 		return fmt.Errorf("failed to remove orphaned child_counters rows: %w", err)
 	}
 	wccRes, err := tx.ExecContext(ctx,
-		`DELETE FROM wisp_child_counters wcc WHERE NOT EXISTS (SELECT 1 FROM wisps w WHERE w.id = wcc.parent_id)`)
+		`DELETE FROM wisp_child_counters WHERE NOT EXISTS (SELECT 1 FROM wisps w WHERE w.id = wisp_child_counters.parent_id)`)
 	if err != nil {
 		_ = tx.Rollback()
 		return fmt.Errorf("failed to remove orphaned wisp_child_counters rows: %w", err)

--- a/cmd/bd/doctor/fix/validation.go
+++ b/cmd/bd/doctor/fix/validation.go
@@ -143,12 +143,16 @@ func OrphanedChildCounters(path string, verbose bool) error {
 		return err
 	}
 
-	db, err := openDoltDB(beadsDir)
+	db, cfg, err := openDoltDB(beadsDir)
 	if err != nil {
 		fmt.Printf("  Orphaned child counters fix skipped (%v)\n", err)
 		return nil
 	}
 	defer db.Close()
+
+	if skip, err := guardFixTarget("Orphaned child counters fix", db, beadsDir, cfg); skip {
+		return err
+	}
 
 	ctx := context.Background()
 

--- a/cmd/bd/doctor/fix/validation_test.go
+++ b/cmd/bd/doctor/fix/validation_test.go
@@ -157,6 +157,176 @@ func TestFixFunctions_RequireBeadsDir(t *testing.T) {
 	}
 }
 
+// TestOrphanedChildCounters_FixDeletesOnlyOrphans verifies the destructive
+// half of the #4539 fix: OrphanedChildCounters must DELETE exactly the
+// dangling child_counters/wisp_child_counters rows and leave every row with
+// a live parent untouched. TestFixFunctions_RequireBeadsDir only covers the
+// missing-.beads-dir error path; nothing previously exercised the DELETE
+// itself against a live store.
+//
+// Uses the same local-dolt-binary auto-start harness as the sibling
+// TestDependencyKeys_RekeysAndRemovesLeftovers (dep_keys_test.go): dolt.New
+// with no ServerHost/ServerPort auto-starts a real `dolt sql-server`
+// subprocess via the local `dolt` binary (internal/doltserver), the same
+// mechanism `bd init` uses in production and the same one CI's
+// RequireDoltBinary check enforces — no Docker required.
+func TestOrphanedChildCounters_FixDeletesOnlyOrphans(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("create .beads: %v", err)
+	}
+
+	// Unique database name: the local server/process may outlive a single run.
+	h := sha256.Sum256([]byte(t.Name() + fmt.Sprintf("%d", time.Now().UnixNano())))
+	dbName := "fixorphancc_" + hex.EncodeToString(h[:6])
+
+	// Seed metadata.json up front (with the target database name already
+	// set) so OrphanedChildCounters' own openDoltDB(beadsDir) → configfile.Load
+	// call — a separate connection from the one below — resolves the same
+	// server/database this test seeds.
+	seedCfg := &configfile.Config{Database: "dolt", DoltDatabase: dbName}
+	if err := seedCfg.Save(beadsDir); err != nil {
+		t.Fatalf("save initial config: %v", err)
+	}
+
+	ctx := context.Background()
+	store, err := dolt.New(ctx, &dolt.Config{
+		Path:            filepath.Join(beadsDir, "dolt"),
+		BeadsDir:        beadsDir,
+		Database:        dbName,
+		CreateIfMissing: true,
+		MaxOpenConns:    1,
+		AutoStart:       true,
+	})
+	if err != nil {
+		t.Skipf("skipping: Dolt server not available: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SetConfig(ctx, "issue_prefix", "tst"); err != nil {
+		t.Fatalf("SetConfig(issue_prefix): %v", err)
+	}
+
+	// Live parent + live wisp: their child_counters/wisp_child_counters rows
+	// must survive the fix untouched.
+	liveIssue := &types.Issue{ID: "tst-live", Title: "live parent", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	if err := store.CreateIssue(ctx, liveIssue, "test"); err != nil {
+		t.Fatalf("CreateIssue live parent: %v", err)
+	}
+	liveWisp := &types.Issue{ID: "tst-wisp-live", Title: "live wisp parent", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, NoHistory: true}
+	if err := store.CreateIssue(ctx, liveWisp, "test"); err != nil {
+		t.Fatalf("CreateIssue live wisp parent: %v", err)
+	}
+
+	db := store.UnderlyingDB()
+	if _, err := db.ExecContext(ctx, "INSERT INTO child_counters (parent_id, last_child) VALUES (?, 1)", liveIssue.ID); err != nil {
+		t.Fatalf("insert live child_counters row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "INSERT INTO wisp_child_counters (parent_id, last_child) VALUES (?, 1)", liveWisp.ID); err != nil {
+		t.Fatalf("insert live wisp_child_counters row: %v", err)
+	}
+
+	// Orphaned rows: FK checks disabled per-connection so the dangling insert
+	// succeeds (same trick as the detection tests in validation_test.go's
+	// sibling doctor package, TestCheckOrphanedChildCountersDB_*).
+	const orphanParent = "tst-missing-parent"
+	const orphanWispParent = "tst-missing-wisp-parent"
+	if _, err := db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx, "INSERT INTO child_counters (parent_id, last_child) VALUES (?, 3)", orphanParent); err != nil {
+		t.Fatalf("insert orphaned child_counters row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "INSERT INTO wisp_child_counters (parent_id, last_child) VALUES (?, 2)", orphanWispParent); err != nil {
+		t.Fatalf("insert orphaned wisp_child_counters row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
+		t.Fatal(err)
+	}
+
+	countRows := func(t *testing.T, query string) int {
+		t.Helper()
+		var got int
+		if err := db.QueryRowContext(ctx, query).Scan(&got); err != nil {
+			t.Fatalf("query %q: %v", query, err)
+		}
+		return got
+	}
+
+	if got := countRows(t, "SELECT COUNT(*) FROM child_counters"); got != 2 {
+		t.Fatalf("child_counters before fix = %d, want 2 (1 live + 1 orphaned)", got)
+	}
+	if got := countRows(t, "SELECT COUNT(*) FROM wisp_child_counters"); got != 2 {
+		t.Fatalf("wisp_child_counters before fix = %d, want 2 (1 live + 1 orphaned)", got)
+	}
+
+	// OrphanedChildCounters (validation.go) opens its own connection via
+	// openDoltDB → configfile.Load, which is server-mode only (remotes.go's
+	// openFixDB always dials MySQL). seedCfg above already points that config
+	// at the same local server/database this test just seeded — the port is
+	// picked up from the .beads/dolt-server.port file the auto-start above
+	// wrote (doltserver.DefaultConfig's top-priority source).
+	if err := OrphanedChildCounters(dir, false); err != nil {
+		t.Fatalf("OrphanedChildCounters: %v", err)
+	}
+
+	// (a) orphans gone from both tables.
+	if got := countRows(t, "SELECT COUNT(*) FROM child_counters"); got != 1 {
+		t.Errorf("child_counters after fix = %d, want 1 (orphan removed)", got)
+	}
+	if got := countRows(t, "SELECT COUNT(*) FROM wisp_child_counters"); got != 1 {
+		t.Errorf("wisp_child_counters after fix = %d, want 1 (orphan removed)", got)
+	}
+	if got := countRows(t, fmt.Sprintf("SELECT COUNT(*) FROM child_counters WHERE parent_id = '%s'", orphanParent)); got != 0 {
+		t.Errorf("orphaned child_counters row for %s still present after fix", orphanParent)
+	}
+	if got := countRows(t, fmt.Sprintf("SELECT COUNT(*) FROM wisp_child_counters WHERE parent_id = '%s'", orphanWispParent)); got != 0 {
+		t.Errorf("orphaned wisp_child_counters row for %s still present after fix", orphanWispParent)
+	}
+
+	// (b) valid rows untouched.
+	if got := countRows(t, fmt.Sprintf("SELECT COUNT(*) FROM child_counters WHERE parent_id = '%s'", liveIssue.ID)); got != 1 {
+		t.Errorf("live child_counters row for %s missing after fix", liveIssue.ID)
+	}
+	if got := countRows(t, fmt.Sprintf("SELECT COUNT(*) FROM wisp_child_counters WHERE parent_id = '%s'", liveWisp.ID)); got != 1 {
+		t.Errorf("live wisp_child_counters row for %s missing after fix", liveWisp.ID)
+	}
+
+	// (c) the check now reports ok — mirrors the doctor package's
+	// checkOrphanedChildCountersDB against the same connection.
+	var orphanCount int
+	const checkQuery = `
+		SELECT COUNT(*) FROM (
+			SELECT cc.parent_id FROM child_counters cc
+			LEFT JOIN issues i ON cc.parent_id = i.id
+			WHERE i.id IS NULL
+			UNION ALL
+			SELECT wcc.parent_id FROM wisp_child_counters wcc
+			LEFT JOIN wisps w ON wcc.parent_id = w.id
+			WHERE w.id IS NULL
+		) orphans`
+	if err := db.QueryRowContext(ctx, checkQuery).Scan(&orphanCount); err != nil {
+		t.Fatalf("post-fix orphan check query: %v", err)
+	}
+	if orphanCount != 0 {
+		t.Errorf("post-fix orphan check found %d orphan(s), want 0 (check should now report ok)", orphanCount)
+	}
+
+	// Re-running the fix on an already-clean store must be a safe no-op.
+	if err := OrphanedChildCounters(dir, false); err != nil {
+		t.Fatalf("OrphanedChildCounters (second run, no-op expected): %v", err)
+	}
+	if got := countRows(t, "SELECT COUNT(*) FROM child_counters"); got != 1 {
+		t.Errorf("child_counters after no-op re-run = %d, want 1", got)
+	}
+	if got := countRows(t, "SELECT COUNT(*) FROM wisp_child_counters"); got != 1 {
+		t.Errorf("wisp_child_counters after no-op re-run = %d, want 1", got)
+	}
+}
+
 func TestChildParentDependencies_NoBadDeps(t *testing.T) {
 	dir := t.TempDir()
 	store := newFixTestStore(t, dir, "bd")

--- a/cmd/bd/doctor/fix/validation_test.go
+++ b/cmd/bd/doctor/fix/validation_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -166,18 +167,23 @@ func TestFixFunctions_RequireBeadsDir(t *testing.T) {
 //
 // Unlike the sibling TestDependencyKeys_RekeysAndRemovesLeftovers
 // (dep_keys_test.go), which uses requireFixDoltContainer and connects to
-// the shared BEADS_DOLT_PORT container, this test clears BEADS_DOLT_PORT
-// and has dolt.New auto-start its own local `dolt sql-server` subprocess
-// via the local `dolt` binary (internal/doltserver) — the same mechanism
-// `bd init` uses in production — no Docker required.
+// the shared BEADS_DOLT_PORT container, this test clears the ambient Dolt
+// endpoint settings and has dolt.New auto-start its own local
+// `dolt sql-server` subprocess via the local `dolt` binary
+// (internal/doltserver) — the same mechanism `bd init` uses in production —
+// no Docker required.
 func TestOrphanedChildCounters_FixDeletesOnlyOrphans(t *testing.T) {
 	testutil.RequireDoltBinary(t)
 
 	// TestMain sets BEADS_DOLT_PORT process-wide when Docker is available,
 	// which suppresses the .beads/dolt-server.port file openFixDB needs to
-	// reach this test's auto-started server. Clear it, as the dolt package's
-	// own tests do.
-	t.Setenv("BEADS_DOLT_PORT", "")
+	// reach this test's auto-started server. Clearing that one name is not
+	// enough: BEADS_DOLT_SERVER_PORT outranks it, and host/socket/mode/
+	// shared-server/auto-start can redirect dolt.New just as effectively.
+	// Since this package's TestMain sets BEADS_TEST_SERVER=1, an ambient
+	// endpoint would receive this test's CreateIfMissing and its schema and
+	// data writes, so clear the whole set.
+	testutil.ClearAmbientDoltEnv(t)
 
 	dir := t.TempDir()
 	beadsDir := filepath.Join(dir, ".beads")
@@ -281,7 +287,7 @@ func TestOrphanedChildCounters_FixDeletesOnlyOrphans(t *testing.T) {
 	// openDoltDB → configfile.Load, which is server-mode only (remotes.go's
 	// openFixDB always dials MySQL). seedCfg above already points that config
 	// at the same local server/database this test just seeded — with the
-	// ambient BEADS_DOLT_PORT cleared above, the port comes from the
+	// ambient endpoint settings cleared above, the port comes from the
 	// .beads/dolt-server.port file the auto-start wrote.
 	if err := OrphanedChildCounters(dir, false); err != nil {
 		t.Fatalf("OrphanedChildCounters: %v", err)
@@ -338,6 +344,93 @@ func TestOrphanedChildCounters_FixDeletesOnlyOrphans(t *testing.T) {
 	}
 	if got := countRows(t, "SELECT COUNT(*) FROM wisp_child_counters"); got != 1 {
 		t.Errorf("wisp_child_counters after no-op re-run = %d, want 1", got)
+	}
+}
+
+// TestOrphanedChildCounters_AbortsOnProjectIdentityMismatch is the regression
+// test for the guardFixTarget call OrphanedChildCounters gained in #4539.
+// TestOrphanedChildCounters_FixDeletesOnlyOrphans above seeds a *matching*
+// project_id, so it stays green if that guard is deleted; only a mismatched
+// target proves the guard is still wired up.
+//
+// TestDestructiveFix_AbortsOnProjectIdentityMismatch (remotes_test.go) makes
+// the same assertion for every destructive entry point, but its store needs
+// the Dolt test container, so it skips wherever Docker is absent. This one
+// uses the same Docker-free local auto-start path as its sibling above, so
+// the guard stays covered even when that suite is dark.
+func TestOrphanedChildCounters_AbortsOnProjectIdentityMismatch(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+	testutil.ClearAmbientDoltEnv(t)
+
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("create .beads: %v", err)
+	}
+
+	h := sha256.Sum256([]byte(t.Name() + fmt.Sprintf("%d", time.Now().UnixNano())))
+	dbName := "fixorphanccmm_" + hex.EncodeToString(h[:6])
+
+	projectID := configfile.GenerateProjectID()
+	seedCfg := &configfile.Config{Database: "dolt", DoltDatabase: dbName, ProjectID: projectID}
+	if err := seedCfg.Save(beadsDir); err != nil {
+		t.Fatalf("save initial config: %v", err)
+	}
+
+	ctx := context.Background()
+	store, err := dolt.New(ctx, &dolt.Config{
+		Path:            filepath.Join(beadsDir, "dolt"),
+		BeadsDir:        beadsDir,
+		Database:        dbName,
+		CreateIfMissing: true,
+		MaxOpenConns:    1,
+		AutoStart:       true,
+	})
+	if err != nil {
+		t.Fatalf("dolt.New with local auto-start: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SetConfig(ctx, "issue_prefix", "tst"); err != nil {
+		t.Fatalf("SetConfig(issue_prefix): %v", err)
+	}
+
+	// The database belongs to a different project than the metadata.json the
+	// fix was diagnosed against — the stale-port scenario mybd-2qegi models.
+	if err := store.SetMetadata(ctx, "_project_id", "wrong-project-"+configfile.GenerateProjectID()); err != nil {
+		t.Fatalf("failed to force a project_id mismatch: %v", err)
+	}
+
+	// A real orphan the fix would delete if it were allowed to proceed.
+	const orphanParent = "tst-missing-parent"
+	db := store.UnderlyingDB()
+	if _, err := db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx, "INSERT INTO child_counters (parent_id, last_child) VALUES (?, 3)", orphanParent); err != nil {
+		t.Fatalf("insert orphaned child_counters row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
+		t.Fatal(err)
+	}
+
+	fixErr := OrphanedChildCounters(dir, false)
+	if fixErr == nil {
+		t.Fatal("OrphanedChildCounters should have aborted on project identity mismatch, got nil error")
+	}
+	if !strings.Contains(fixErr.Error(), "PROJECT IDENTITY MISMATCH") {
+		t.Errorf("expected a PROJECT IDENTITY MISMATCH error, got: %v", fixErr)
+	}
+
+	// The orphan must survive the aborted fix — no DELETE against the wrong
+	// project's database.
+	var count int
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM child_counters WHERE parent_id = ?", orphanParent).Scan(&count); err != nil {
+		t.Fatalf("count orphaned child_counters row: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected the orphaned row to survive the aborted fix, found %d matching rows", count)
 	}
 }
 

--- a/cmd/bd/doctor/fix/validation_test.go
+++ b/cmd/bd/doctor/fix/validation_test.go
@@ -142,6 +142,7 @@ func TestFixFunctions_RequireBeadsDir(t *testing.T) {
 		{"SchemaCompatibility", SchemaCompatibility},
 		{"ChildParentDependencies", func(dir string) error { return ChildParentDependencies(dir, false) }},
 		{"OrphanedDependencies", func(dir string) error { return OrphanedDependencies(dir, false) }},
+		{"OrphanedChildCounters", func(dir string) error { return OrphanedChildCounters(dir, false) }},
 	}
 
 	for _, tc := range funcs {

--- a/cmd/bd/doctor/fix/validation_test.go
+++ b/cmd/bd/doctor/fix/validation_test.go
@@ -164,12 +164,12 @@ func TestFixFunctions_RequireBeadsDir(t *testing.T) {
 // missing-.beads-dir error path; nothing previously exercised the DELETE
 // itself against a live store.
 //
-// Uses the same local-dolt-binary auto-start harness as the sibling
-// TestDependencyKeys_RekeysAndRemovesLeftovers (dep_keys_test.go): dolt.New
-// with no ServerHost/ServerPort auto-starts a real `dolt sql-server`
-// subprocess via the local `dolt` binary (internal/doltserver), the same
-// mechanism `bd init` uses in production and the same one CI's
-// RequireDoltBinary check enforces — no Docker required.
+// Unlike the sibling TestDependencyKeys_RekeysAndRemovesLeftovers
+// (dep_keys_test.go), which uses requireFixDoltContainer and connects to
+// the shared BEADS_DOLT_PORT container, this test clears BEADS_DOLT_PORT
+// and has dolt.New auto-start its own local `dolt sql-server` subprocess
+// via the local `dolt` binary (internal/doltserver) — the same mechanism
+// `bd init` uses in production — no Docker required.
 func TestOrphanedChildCounters_FixDeletesOnlyOrphans(t *testing.T) {
 	testutil.RequireDoltBinary(t)
 
@@ -213,7 +213,7 @@ func TestOrphanedChildCounters_FixDeletesOnlyOrphans(t *testing.T) {
 		AutoStart:       true,
 	})
 	if err != nil {
-		t.Skipf("skipping: Dolt server not available: %v", err)
+		t.Fatalf("dolt.New with local auto-start: %v", err)
 	}
 	defer func() { _ = store.Close() }()
 

--- a/cmd/bd/doctor/fix/validation_test.go
+++ b/cmd/bd/doctor/fix/validation_test.go
@@ -173,6 +173,12 @@ func TestFixFunctions_RequireBeadsDir(t *testing.T) {
 func TestOrphanedChildCounters_FixDeletesOnlyOrphans(t *testing.T) {
 	testutil.RequireDoltBinary(t)
 
+	// TestMain sets BEADS_DOLT_PORT process-wide when Docker is available,
+	// which suppresses the .beads/dolt-server.port file openFixDB needs to
+	// reach this test's auto-started server. Clear it, as the dolt package's
+	// own tests do.
+	t.Setenv("BEADS_DOLT_PORT", "")
+
 	dir := t.TempDir()
 	beadsDir := filepath.Join(dir, ".beads")
 	if err := os.MkdirAll(beadsDir, 0755); err != nil {
@@ -274,9 +280,9 @@ func TestOrphanedChildCounters_FixDeletesOnlyOrphans(t *testing.T) {
 	// OrphanedChildCounters (validation.go) opens its own connection via
 	// openDoltDB → configfile.Load, which is server-mode only (remotes.go's
 	// openFixDB always dials MySQL). seedCfg above already points that config
-	// at the same local server/database this test just seeded — the port is
-	// picked up from the .beads/dolt-server.port file the auto-start above
-	// wrote (doltserver.DefaultConfig's top-priority source).
+	// at the same local server/database this test just seeded — with the
+	// ambient BEADS_DOLT_PORT cleared above, the port comes from the
+	// .beads/dolt-server.port file the auto-start wrote.
 	if err := OrphanedChildCounters(dir, false); err != nil {
 		t.Fatalf("OrphanedChildCounters: %v", err)
 	}

--- a/cmd/bd/doctor/fix/validation_test.go
+++ b/cmd/bd/doctor/fix/validation_test.go
@@ -187,7 +187,12 @@ func TestOrphanedChildCounters_FixDeletesOnlyOrphans(t *testing.T) {
 	// set) so OrphanedChildCounters' own openDoltDB(beadsDir) → configfile.Load
 	// call — a separate connection from the one below — resolves the same
 	// server/database this test seeds.
-	seedCfg := &configfile.Config{Database: "dolt", DoltDatabase: dbName}
+	// project_id matched between metadata.json and the database so
+	// verifyFixTargetIdentity (mybd-2qegi) doesn't reject this fix call as an
+	// unverifiable target — OrphanedChildCounters is a destructive fix entry
+	// point and so goes through guardFixTarget like its siblings.
+	projectID := configfile.GenerateProjectID()
+	seedCfg := &configfile.Config{Database: "dolt", DoltDatabase: dbName, ProjectID: projectID}
 	if err := seedCfg.Save(beadsDir); err != nil {
 		t.Fatalf("save initial config: %v", err)
 	}
@@ -208,6 +213,9 @@ func TestOrphanedChildCounters_FixDeletesOnlyOrphans(t *testing.T) {
 
 	if err := store.SetConfig(ctx, "issue_prefix", "tst"); err != nil {
 		t.Fatalf("SetConfig(issue_prefix): %v", err)
+	}
+	if err := store.SetMetadata(ctx, "_project_id", projectID); err != nil {
+		t.Fatalf("SetMetadata(_project_id): %v", err)
 	}
 
 	// Live parent + live wisp: their child_counters/wisp_child_counters rows

--- a/cmd/bd/doctor/validation.go
+++ b/cmd/bd/doctor/validation.go
@@ -111,6 +111,91 @@ func checkOrphanedDependenciesDB(db *sql.DB) DoctorCheck {
 	}
 }
 
+// CheckOrphanedChildCounters detects child_counters/wisp_child_counters rows
+// whose parent_id has no matching issues/wisps row. A single such row can
+// fail Dolt constraint validation on subsequent writes, silently bricking
+// every `bd create` while `bd doctor` reports 0 errors (#4539, follow-up to
+// #4534). Credit: check suggested by @eitsupi in #4534.
+func CheckOrphanedChildCounters(path string) DoctorCheck {
+	beadsDir := ResolveBeadsDirForRepo(path)
+
+	db, store, err := openStoreDB(beadsDir)
+	if err != nil {
+		return DoctorCheck{
+			Name:    "Orphaned Child Counters",
+			Status:  "ok",
+			Message: "N/A (no database)",
+		}
+	}
+	defer func() { _ = store.Close() }()
+
+	return checkOrphanedChildCountersDB(db)
+}
+
+// checkOrphanedChildCountersDB is the core logic for CheckOrphanedChildCounters.
+func checkOrphanedChildCountersDB(db *sql.DB) DoctorCheck {
+	// Query for child_counters rows dangling from issues and wisp_child_counters
+	// rows dangling from wisps (the twin gap called out in #4539).
+	query := `
+		SELECT 'child_counters' AS counter_table, cc.parent_id, cc.last_child
+		FROM child_counters cc
+		LEFT JOIN issues i ON cc.parent_id = i.id
+		WHERE i.id IS NULL
+		UNION ALL
+		SELECT 'wisp_child_counters' AS counter_table, wcc.parent_id, wcc.last_child
+		FROM wisp_child_counters wcc
+		LEFT JOIN wisps w ON wcc.parent_id = w.id
+		WHERE w.id IS NULL
+	`
+	rows, err := db.Query(query)
+	if err != nil {
+		return DoctorCheck{
+			Name:    "Orphaned Child Counters",
+			Status:  StatusWarning,
+			Message: "N/A (query failed)",
+		}
+	}
+	defer rows.Close()
+
+	var orphans []string
+	for rows.Next() {
+		var counterTable, parentID string
+		var lastChild int
+		if err := rows.Scan(&counterTable, &parentID, &lastChild); err == nil {
+			orphans = append(orphans, fmt.Sprintf("%s:%s", counterTable, parentID))
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return DoctorCheck{
+			Name:    "Orphaned Child Counters",
+			Status:  StatusWarning,
+			Message: "Row iteration error",
+			Detail:  err.Error(),
+		}
+	}
+
+	if len(orphans) == 0 {
+		return DoctorCheck{
+			Name:    "Orphaned Child Counters",
+			Status:  "ok",
+			Message: "No orphaned child counters",
+		}
+	}
+
+	detail := strings.Join(orphans, ", ")
+	if len(detail) > 200 {
+		detail = detail[:200] + "..."
+	}
+
+	return DoctorCheck{
+		Name:    "Orphaned Child Counters",
+		Status:  "error",
+		Message: fmt.Sprintf("%d orphaned child counter row(s) — can brick 'bd create' on constraint validation", len(orphans)),
+		Detail:  detail,
+		Fix:     "Run 'bd doctor --fix' to remove orphaned child counter rows",
+	}
+}
+
 // CheckDuplicateIssues detects issues with identical content.
 // When orchestratorMode is true, the threshold parameter defines how many duplicates
 // are acceptable before warning (default 1000 for orchestrator's ephemeral wisps).

--- a/cmd/bd/doctor/validation_test.go
+++ b/cmd/bd/doctor/validation_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/testutil"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -676,6 +678,146 @@ func TestCheckOrphanedChildCountersDB_WispChildCountersOrphanDetected(t *testing
 		"INSERT INTO wisp_child_counters (parent_id, last_child) VALUES (?, 2)", "test-missing-wisp-parent")
 	if err != nil {
 		t.Fatalf("insert orphaned wisp_child_counters row: %v", err)
+	}
+
+	check := checkOrphanedChildCountersDB(db)
+	if check.Status != StatusError {
+		t.Fatalf("Status = %q, want %q", check.Status, StatusError)
+	}
+	if !strings.Contains(check.Detail, "wisp_child_counters:test-missing-wisp-parent") {
+		t.Fatalf("Detail = %q, want it to name the dangling parent_id", check.Detail)
+	}
+}
+
+// newLocalDoltStore creates a DoltStore backed by a real local `dolt
+// sql-server` subprocess (dolt.New with AutoStart:true), started via the
+// `dolt` binary already on PATH — no Docker required. This is the Docker-free
+// companion harness to newTestDoltStore, which requires a Docker-based Dolt
+// test container (see cmd/bd TestMain). Mirrors
+// TestOrphanedChildCounters_FixDeletesOnlyOrphans in
+// cmd/bd/doctor/fix/validation_test.go, the ground-truth example of this
+// pattern; see also TestDependencyKeys_RekeysAndRemovesLeftovers in
+// cmd/bd/doctor/fix/dep_keys_test.go.
+func newLocalDoltStore(t *testing.T, prefix string) *dolt.DoltStore {
+	t.Helper()
+	testutil.RequireDoltBinary(t)
+
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("create .beads: %v", err)
+	}
+
+	// Unique database name: the local server/process may outlive a single run.
+	h := sha256.Sum256([]byte(t.Name() + fmt.Sprintf("%d", time.Now().UnixNano())))
+	dbName := "localdolt_" + hex.EncodeToString(h[:6])
+
+	ctx := context.Background()
+	store, err := dolt.New(ctx, &dolt.Config{
+		Path:            filepath.Join(beadsDir, "dolt"),
+		BeadsDir:        beadsDir,
+		Database:        dbName,
+		CreateIfMissing: true,
+		MaxOpenConns:    1,
+		AutoStart:       true,
+	})
+	if err != nil {
+		t.Skipf("skipping: Dolt server not available: %v", err)
+	}
+
+	if err := store.SetConfig(ctx, "issue_prefix", prefix); err != nil {
+		store.Close()
+		t.Fatalf("Failed to set issue_prefix: %v", err)
+	}
+
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestCheckOrphanedChildCountersDB_NoOrphans_LocalDolt is the Docker-free
+// companion to TestCheckOrphanedChildCountersDB_NoOrphans, using
+// newLocalDoltStore instead of newTestDoltStore.
+func TestCheckOrphanedChildCountersDB_NoOrphans_LocalDolt(t *testing.T) {
+	store := newLocalDoltStore(t, "test")
+	ctx := context.Background()
+
+	parent := &types.Issue{ID: "test-live-parent", Title: "Parent", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	if err := store.CreateIssue(ctx, parent, "test"); err != nil {
+		t.Fatalf("CreateIssue parent: %v", err)
+	}
+
+	wisp := &types.Issue{ID: "test-live-wisp", Title: "Wisp parent", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, NoHistory: true}
+	if err := store.CreateIssue(ctx, wisp, "test"); err != nil {
+		t.Fatalf("CreateIssue wisp: %v", err)
+	}
+
+	db := store.UnderlyingDB()
+	if _, err := db.ExecContext(ctx, "INSERT INTO child_counters (parent_id, last_child) VALUES (?, 1)", parent.ID); err != nil {
+		t.Fatalf("insert live child_counters row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "INSERT INTO wisp_child_counters (parent_id, last_child) VALUES (?, 1)", wisp.ID); err != nil {
+		t.Fatalf("insert live wisp_child_counters row: %v", err)
+	}
+
+	check := checkOrphanedChildCountersDB(db)
+	if check.Status != StatusOK {
+		t.Fatalf("Status = %q, want %q; detail=%s", check.Status, StatusOK, check.Detail)
+	}
+}
+
+// TestCheckOrphanedChildCountersDB_ChildCountersOrphanDetected_LocalDolt is
+// the Docker-free companion to
+// TestCheckOrphanedChildCountersDB_ChildCountersOrphanDetected.
+func TestCheckOrphanedChildCountersDB_ChildCountersOrphanDetected_LocalDolt(t *testing.T) {
+	store := newLocalDoltStore(t, "test")
+	ctx := context.Background()
+
+	db := store.UnderlyingDB()
+	if _, err := db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := db.ExecContext(ctx,
+		"INSERT INTO child_counters (parent_id, last_child) VALUES (?, 3)", "test-missing-parent")
+	if err != nil {
+		t.Fatalf("insert orphaned child_counters row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
+		t.Fatal(err)
+	}
+
+	check := checkOrphanedChildCountersDB(db)
+	if check.Status != StatusError {
+		t.Fatalf("Status = %q, want %q", check.Status, StatusError)
+	}
+	if !strings.Contains(check.Detail, "child_counters:test-missing-parent") {
+		t.Fatalf("Detail = %q, want it to name the dangling parent_id", check.Detail)
+	}
+}
+
+// TestCheckOrphanedChildCountersDB_WispChildCountersOrphanDetected_LocalDolt
+// is the Docker-free companion to
+// TestCheckOrphanedChildCountersDB_WispChildCountersOrphanDetected.
+func TestCheckOrphanedChildCountersDB_WispChildCountersOrphanDetected_LocalDolt(t *testing.T) {
+	store := newLocalDoltStore(t, "test")
+	ctx := context.Background()
+
+	db := store.UnderlyingDB()
+	// Unlike the Docker-backed shared-schema variant, a freshly created local
+	// database enforces the wisp_child_counters -> wisps FK, so it must be
+	// disabled per-connection to simulate the drift scenario (same trick used
+	// by the child_counters orphan test above and by
+	// TestOrphanedChildCounters_FixDeletesOnlyOrphans in
+	// cmd/bd/doctor/fix/validation_test.go).
+	if _, err := db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := db.ExecContext(ctx,
+		"INSERT INTO wisp_child_counters (parent_id, last_child) VALUES (?, 2)", "test-missing-wisp-parent")
+	if err != nil {
+		t.Fatalf("insert orphaned wisp_child_counters row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
+		t.Fatal(err)
 	}
 
 	check := checkOrphanedChildCountersDB(db)

--- a/cmd/bd/doctor/validation_test.go
+++ b/cmd/bd/doctor/validation_test.go
@@ -606,6 +606,87 @@ func TestCheckChildParentDependenciesDB_WispChildBlockingParentDetected(t *testi
 	}
 }
 
+// TestCheckOrphanedChildCountersDB_NoOrphans verifies StatusOK when every
+// child_counters/wisp_child_counters row has a live parent.
+func TestCheckOrphanedChildCountersDB_NoOrphans(t *testing.T) {
+	store := newTestDoltStore(t, "test")
+	ctx := context.Background()
+
+	parent := &types.Issue{ID: "test-live-parent", Title: "Parent", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	if err := store.CreateIssue(ctx, parent, "test"); err != nil {
+		t.Fatalf("CreateIssue parent: %v", err)
+	}
+
+	wisp := &types.Issue{ID: "test-live-wisp", Title: "Wisp parent", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, NoHistory: true}
+	if err := store.CreateIssue(ctx, wisp, "test"); err != nil {
+		t.Fatalf("CreateIssue wisp: %v", err)
+	}
+
+	db := store.DB()
+	if _, err := db.ExecContext(ctx, "INSERT INTO child_counters (parent_id, last_child) VALUES (?, 1)", parent.ID); err != nil {
+		t.Fatalf("insert live child_counters row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "INSERT INTO wisp_child_counters (parent_id, last_child) VALUES (?, 1)", wisp.ID); err != nil {
+		t.Fatalf("insert live wisp_child_counters row: %v", err)
+	}
+
+	check := checkOrphanedChildCountersDB(db)
+	if check.Status != StatusOK {
+		t.Fatalf("Status = %q, want %q; detail=%s", check.Status, StatusOK, check.Detail)
+	}
+}
+
+// TestCheckOrphanedChildCountersDB_ChildCountersOrphanDetected verifies that a
+// child_counters row with no matching issues row is detected (#4539).
+func TestCheckOrphanedChildCountersDB_ChildCountersOrphanDetected(t *testing.T) {
+	store := newTestDoltStore(t, "test")
+	ctx := context.Background()
+
+	db := store.DB()
+	if _, err := db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := db.ExecContext(ctx,
+		"INSERT INTO child_counters (parent_id, last_child) VALUES (?, 3)", "test-missing-parent")
+	if err != nil {
+		t.Fatalf("insert orphaned child_counters row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
+		t.Fatal(err)
+	}
+
+	check := checkOrphanedChildCountersDB(db)
+	if check.Status != StatusError {
+		t.Fatalf("Status = %q, want %q", check.Status, StatusError)
+	}
+	if !strings.Contains(check.Detail, "child_counters:test-missing-parent") {
+		t.Fatalf("Detail = %q, want it to name the dangling parent_id", check.Detail)
+	}
+}
+
+// TestCheckOrphanedChildCountersDB_WispChildCountersOrphanDetected verifies
+// that a wisp_child_counters row with no matching wisps row is detected — the
+// "twin gap" called out in #4539.
+func TestCheckOrphanedChildCountersDB_WispChildCountersOrphanDetected(t *testing.T) {
+	store := newTestDoltStore(t, "test")
+	ctx := context.Background()
+
+	db := store.DB()
+	_, err := db.ExecContext(ctx,
+		"INSERT INTO wisp_child_counters (parent_id, last_child) VALUES (?, 2)", "test-missing-wisp-parent")
+	if err != nil {
+		t.Fatalf("insert orphaned wisp_child_counters row: %v", err)
+	}
+
+	check := checkOrphanedChildCountersDB(db)
+	if check.Status != StatusError {
+		t.Fatalf("Status = %q, want %q", check.Status, StatusError)
+	}
+	if !strings.Contains(check.Detail, "wisp_child_counters:test-missing-wisp-parent") {
+		t.Fatalf("Detail = %q, want it to name the dangling parent_id", check.Detail)
+	}
+}
+
 // TestCheckTestPollution_NoTestIssues_NoServer verifies StatusOK when no Dolt
 // server is reachable. This isolates BEADS_DOLT_PORT set by TestMain (which
 // starts a Docker-based Dolt container on Ubuntu but not macOS) so the test

--- a/cmd/bd/doctor_fix.go
+++ b/cmd/bd/doctor_fix.go
@@ -328,6 +328,8 @@ func applyFixList(path string, fixes []doctorCheck) {
 			err = fix.OrphanedDependencies(path, doctorVerbose)
 		case "Clone-Local FKs":
 			err = fix.CloneLocalFKEnforcement(path, doctorVerbose)
+		case "Orphaned Child Counters":
+			err = fix.OrphanedChildCounters(path, doctorVerbose)
 		case "Dependency Keys":
 			err = fix.DependencyKeys(path, doctorVerbose)
 		case "Blocked State":

--- a/cmd/bd/doctor_validate.go
+++ b/cmd/bd/doctor_validate.go
@@ -84,6 +84,7 @@ func collectValidateChecks(path string) []validateCheckResult {
 		{check: convertDoctorCheck(doctor.CheckCrossTableDuplicates(path)), fixable: true},
 		{check: convertDoctorCheck(doctor.CheckDuplicateIssues(path, doctorOrchestrator, orchestratorDuplicatesThreshold))},
 		{check: convertDoctorCheck(doctor.CheckOrphanedDependencies(path)), fixable: true},
+		{check: convertDoctorCheck(doctor.CheckOrphanedChildCounters(path)), fixable: true},
 		{check: convertDoctorCheck(doctor.CheckTestPollution(path))},
 		{check: convertDoctorCheck(doctor.CheckGitConflicts(path))},
 	}

--- a/cmd/bd/doctor_validate_test.go
+++ b/cmd/bd/doctor_validate_test.go
@@ -4,11 +4,17 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/testutil"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -303,6 +309,109 @@ func TestValidateCheck_DetectsOrphanedChildCounters(t *testing.T) {
 		t.Fatalf("Failed to commit orphaned child counter: %v", err)
 	}
 	store.Close()
+
+	checks := collectValidateChecks(tmpDir)
+
+	for _, cr := range checks {
+		if cr.check.Name == "Orphaned Child Counters" {
+			if cr.check.Status != statusError {
+				t.Errorf("Orphaned Child Counters status = %q, want %q", cr.check.Status, statusError)
+			}
+			if !cr.fixable {
+				t.Error("Orphaned Child Counters should be marked fixable")
+			}
+			return
+		}
+	}
+	t.Error("Orphaned Child Counters check not found")
+}
+
+// TestValidateCheck_DetectsOrphanedChildCounters_LocalDolt is the Docker-free
+// companion to TestValidateCheck_DetectsOrphanedChildCounters. Unlike
+// setupValidateTestDB (which needs the package-level testDoltServerPort set
+// by a Docker-starting TestMain), this test starts its own real local `dolt
+// sql-server` subprocess via dolt.New(AutoStart:true) — the local `dolt`
+// binary already on PATH, no Docker required. collectValidateChecks reads
+// metadata.json (via configfile) to find that server/database, so the
+// config must be saved to .beads BEFORE dolt.New starts the server — same
+// sequencing as TestOrphanedChildCounters_FixDeletesOnlyOrphans in
+// cmd/bd/doctor/fix/validation_test.go, the ground-truth example of this
+// pattern.
+func TestValidateCheck_DetectsOrphanedChildCounters_LocalDolt(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("create .beads: %v", err)
+	}
+
+	// Unique database name: the local server/process may outlive a single run.
+	h := sha256.Sum256([]byte(t.Name() + fmt.Sprintf("%d", time.Now().UnixNano())))
+	dbName := "validatecc_" + hex.EncodeToString(h[:6])
+
+	// Seed metadata.json up front (with the target database name already
+	// set) so collectValidateChecks' own doctor.CheckOrphanedChildCounters
+	// (a separate connection from the one below) resolves the same
+	// server/database this test seeds.
+	seedCfg := &configfile.Config{Database: "dolt", DoltDatabase: dbName}
+	if err := seedCfg.Save(beadsDir); err != nil {
+		t.Fatalf("save initial config: %v", err)
+	}
+
+	ctx := context.Background()
+	store, err := dolt.New(ctx, &dolt.Config{
+		Path:            filepath.Join(beadsDir, "dolt"),
+		BeadsDir:        beadsDir,
+		Database:        dbName,
+		CreateIfMissing: true,
+		MaxOpenConns:    1,
+		AutoStart:       true,
+	})
+	if err != nil {
+		t.Skipf("skipping: Dolt server not available: %v", err)
+	}
+	// Unlike the Docker-backed variant (setupValidateTestDB), which closes
+	// the store before calling collectValidateChecks because the shared
+	// Docker test server outlives any single store's connection, AutoStart
+	// ties the local `dolt sql-server` subprocess's lifetime to the last
+	// store referencing it (see DoltStore.Close -> autoStartRelease). This
+	// store must stay open for the rest of the test so the server survives
+	// long enough for collectValidateChecks's own connection to reach it.
+	defer func() { _ = store.Close() }()
+
+	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("SetConfig(issue_prefix): %v", err)
+	}
+
+	issue := &types.Issue{
+		Title:     "Real issue",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("Failed to create issue: %v", err)
+	}
+
+	db := store.UnderlyingDB()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction: %v", err)
+	}
+	// child_counters has an FK on parent_id; simulate the drift scenario
+	// (#4539, follow-up to #4534) the validator is designed to catch.
+	if _, err = tx.Exec("SET FOREIGN_KEY_CHECKS = 0"); err != nil {
+		t.Fatalf("Failed to disable FK checks: %v", err)
+	}
+	_, err = tx.Exec("INSERT INTO child_counters (parent_id, last_child) VALUES (?, ?)",
+		"test-nonexistent-parent", 3)
+	if err != nil {
+		t.Fatalf("Failed to insert orphaned child counter: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Failed to commit orphaned child counter: %v", err)
+	}
 
 	checks := collectValidateChecks(tmpDir)
 

--- a/cmd/bd/doctor_validate_test.go
+++ b/cmd/bd/doctor_validate_test.go
@@ -270,6 +270,56 @@ func TestValidateCheck_FixOrphanedDeps(t *testing.T) {
 	}
 }
 
+func TestValidateCheck_DetectsOrphanedChildCounters(t *testing.T) {
+	tmpDir, store := setupValidateTestDB(t, "test")
+	ctx := context.Background()
+
+	issue := &types.Issue{
+		Title:     "Real issue",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("Failed to create issue: %v", err)
+	}
+
+	db := store.UnderlyingDB()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction: %v", err)
+	}
+	// child_counters has an FK on parent_id; simulate the drift scenario
+	// (#4539, follow-up to #4534) the validator is designed to catch.
+	if _, err = tx.Exec("SET FOREIGN_KEY_CHECKS = 0"); err != nil {
+		t.Fatalf("Failed to disable FK checks: %v", err)
+	}
+	_, err = tx.Exec("INSERT INTO child_counters (parent_id, last_child) VALUES (?, ?)",
+		"test-nonexistent-parent", 3)
+	if err != nil {
+		t.Fatalf("Failed to insert orphaned child counter: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Failed to commit orphaned child counter: %v", err)
+	}
+	store.Close()
+
+	checks := collectValidateChecks(tmpDir)
+
+	for _, cr := range checks {
+		if cr.check.Name == "Orphaned Child Counters" {
+			if cr.check.Status != statusError {
+				t.Errorf("Orphaned Child Counters status = %q, want %q", cr.check.Status, statusError)
+			}
+			if !cr.fixable {
+				t.Error("Orphaned Child Counters should be marked fixable")
+			}
+			return
+		}
+	}
+	t.Error("Orphaned Child Counters check not found")
+}
+
 func TestValidateOverallOK(t *testing.T) {
 	allPass := []validateCheckResult{
 		{check: doctorCheck{Status: statusOK}},

--- a/internal/testutil/testdoltcommon.go
+++ b/internal/testutil/testdoltcommon.go
@@ -65,3 +65,49 @@ func WaitForServer(port int, timeout time.Duration) bool {
 	}
 	return false
 }
+
+// ambientDoltEnvVars covers the environment variables that decide which Dolt
+// endpoint dolt.New resolves, whether it auto-starts a server, and where that
+// server's data directory lives: the endpoint overrides consulted by
+// applyConfigDefaults (internal/storage/dolt/store.go), the lifecycle switches
+// consulted by the store factory and the auto-start path
+// (internal/storage/dolt/open.go), and the data-dir override consulted first
+// by projectDoltDirPath (internal/doltserver/physical_root.go).
+// BEADS_DOLT_SERVER_PORT takes precedence over the legacy BEADS_DOLT_PORT
+// spelling, so clearing only the legacy name is not enough.
+//
+// It is not asserted to be exhaustive: new env reads in internal/storage/dolt
+// or internal/doltserver may need to be added here.
+var ambientDoltEnvVars = []string{
+	"BEADS_DOLT_SERVER_PORT",
+	"BEADS_DOLT_PORT",
+	"BEADS_DOLT_SERVER_HOST",
+	"BEADS_DOLT_SERVER_SOCKET",
+	"BEADS_DOLT_SERVER_MODE",
+	"BEADS_DOLT_SHARED_SERVER",
+	"BEADS_SHARED_SERVER_DIR",
+	"BEADS_DOLT_AUTO_START",
+	"BEADS_DOLT_DATA_DIR",
+}
+
+// ClearAmbientDoltEnv clears the ambientDoltEnvVars overrides, so a test that
+// constructs its own store with AutoStart reaches that store, in its own tree,
+// and nothing else. Use it before calling dolt.New in any test that expects an
+// isolated local server.
+//
+// This matters for safety as well as determinism: a package whose TestMain
+// sets BEADS_TEST_SERVER=1 will happily issue CREATE DATABASE plus schema and
+// data writes against whatever endpoint it resolves, so an ambient override
+// pointing at a developer's real Dolt server would be written to by running
+// the suite — and an ambient data-dir override would have that server lay down
+// .dolt/ and its databases in a directory the test never chose.
+//
+// t.Setenv restores the previous values when the test finishes. It also panics
+// if the test or any parallel ancestor called t.Parallel, so this helper is
+// not callable from a parallel test.
+func ClearAmbientDoltEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range ambientDoltEnvVars {
+		t.Setenv(name, "")
+	}
+}


### PR DESCRIPTION
## What

Adds a `bd doctor --check=validate` check ("Orphaned Child Counters") that
detects `child_counters` rows whose `parent_id` has no matching `issues`
row, and the twin case: `wisp_child_counters` rows whose `parent_id` has no
matching `wisps` row. Both are fixable via `bd doctor --fix`, which deletes
the dangling rows.

## Why

Follow-up from #4534. A single orphaned `child_counters` row (a `parent_id`
with no matching `issues` row) can fail Dolt constraint validation on a
later write, silently bricking every `bd create` — while `bd doctor`
reported 0 errors, since no check looked at this table. #4538 (merged)
healed the known legacy window with a one-time cleanup migration
(`migrations/ignored/0011_cleanup_orphaned_child_counters.up.sql`), but the
drift class that creates such rows (#728, #1393 — `child_counters` not kept
in sync with `issues` on all code paths) predates that window and can
recur, with no ongoing guard until now.

Fixes #4539.

Credit: reported by @maphew; the doctor-check approach was suggested by
@eitsupi in #4534.

## Implementation

Follows the existing "Orphaned Dependencies" check pattern exactly:

- `cmd/bd/doctor/validation.go`: `CheckOrphanedChildCounters` /
  `checkOrphanedChildCountersDB` — same `openStoreDB` + core-logic-on-`*sql.DB`
  split as `CheckOrphanedDependencies` / `checkOrphanedDependenciesDB`, so the
  core logic is unit-testable against a live Dolt store without going
  through `ResolveBeadsDirForRepo`.
- `cmd/bd/doctor/checks_nocgo.go`: non-CGO stub (`"Skipped: requires CGO"`),
  matching every other Dolt-backed check.
- `cmd/bd/doctor/fix/validation.go`: `OrphanedChildCounters` — same
  transaction + `DOLT_COMMIT` shape as `OrphanedDependencies`, deletes by
  `parent_id` from whichever table the orphan came from.
- `cmd/bd/doctor_validate.go`: registered in `collectValidateChecks` as
  `fixable: true`, next to `CheckOrphanedDependencies`.
- `cmd/bd/doctor_fix.go`: wired into `applyFixList`'s dispatch switch under
  case `"Orphaned Child Counters"`.

Both orphan classes (child_counters↔issues, wisp_child_counters↔wisps) are
reported as one check via a `UNION ALL`, matching how "Orphaned
Dependencies" already unions `dependencies` and `wisp_dependencies` into a
single check rather than two.

## Verification

- New unit tests against a live Dolt store, mirroring the existing
  `checkOrphanedDependenciesDB` tests exactly:
  - `cmd/bd/doctor/validation_test.go`:
    `TestCheckOrphanedChildCountersDB_NoOrphans`,
    `TestCheckOrphanedChildCountersDB_ChildCountersOrphanDetected`,
    `TestCheckOrphanedChildCountersDB_WispChildCountersOrphanDetected`
    (the FK-checks-disabled insert trick these use is the same one
    #4538's migration and the existing orphan-dependency tests use).
  - `cmd/bd/doctor_validate_test.go`:
    `TestValidateCheck_DetectsOrphanedChildCounters` exercises the full
    `collectValidateChecks` wiring (not just the core-logic function).
  - `cmd/bd/doctor/fix/validation_test.go`:
    `TestFixFunctions_RequireBeadsDir` extended with `OrphanedChildCounters`,
    plus a new `TestOrphanedChildCounters_FixDeletesOnlyOrphans` covering the
    fix's DELETE itself (not just the missing-`.beads`-dir error path) — seeds
    a live store with both valid and orphaned `child_counters`/
    `wisp_child_counters` rows and asserts the fix removes exactly the
    orphans, leaves the valid rows alone, the check reports clean afterward,
    and a second run is a safe no-op. Unlike its siblings in this file, it
    does **not** depend on Docker: it uses `dolt.New(..., AutoStart: true)`
    to auto-start a real local `dolt sql-server` via the `dolt` binary on
    PATH — the same mechanism `bd init` uses in production and the one CI's
    `RequireDoltBinary` check already requires — so it actually executes
    (not skips) in this sandboxed dev environment, and ran green as its own
    first-class test rather than a throwaway substitute. Revert-proofed
    directly against the shipped code: temporarily replaced both `DELETE`
    statements in `OrphanedChildCounters` with a no-op query, reran — the
    test failed at every orphan-removal assertion as expected — then
    restored the original code (`git diff` clean) and reran — passed again.
  These all use the package's standard `newTestDoltStore`/
  `setupValidateTestDB` helpers, which need a local
  `dolthub/dolt-sql-server:2.2.0` Docker test container — same as every
  sibling orphan-check test in this codebase. Sandboxed dev environment
  here could not pull that image (Docker Hub pulls hung entirely, even for
  `hello-world`), so these skip locally exactly like every other
  Docker-backed test in the suite.
  - **Docker-free companions (shipped, not throwaway):** each of the four
    tests above now has a permanent `_LocalDolt` companion —
    `TestCheckOrphanedChildCountersDB_NoOrphans_LocalDolt`,
    `_ChildCountersOrphanDetected_LocalDolt`,
    `_WispChildCountersOrphanDetected_LocalDolt` (`cmd/bd/doctor/validation_test.go`),
    and `TestValidateCheck_DetectsOrphanedChildCounters_LocalDolt`
    (`cmd/bd/doctor_validate_test.go`) — dual-harnessed alongside the
    Docker-backed originals (which are untouched), using the same
    `dolt.New(..., AutoStart: true)` local-server pattern as
    `TestOrphanedChildCounters_FixDeletesOnlyOrphans`. All four ran green
    for real in this sandbox. Revert-proofed directly: temporarily replaced
    `checkOrphanedChildCountersDB`'s two `WHERE ... IS NULL` predicates with
    `WHERE 1 = 0` (detection disabled) — the two orphan-detected `_LocalDolt`
    tests and the validate-check `_LocalDolt` test failed as expected, the
    no-orphans test still passed; restored the original code (`git diff`
    clean) and reran — all four passed again.
  - **Important caveat, disclosed rather than hidden:** none of the four
    original tests, and — despite being Docker-free — none of the four new
    `_LocalDolt` companions either, currently execute in any
    `pull_request`-triggered beads CI job. This isn't a Docker-availability
    problem, it's two independent, structural CI gaps we found while
    verifying this: (1) `scripts/ci/lib/test-env.sh`'s `beads_test_env_enter`
    unconditionally sets `BEADS_TEST_SKIP=dolt` for the one PR job whose
    package scope even includes `cmd/bd/doctor(/fix)` (`pr.yml`'s "PR Core"),
    since nothing in the repo ever sets the `BEADS_TEST_ENV_RUN_DOLT=1`
    escape hatch; (2) `pr-risk.yml`'s "Build (Embedded Dolt)" job only
    compiles `./cmd/bd/` (not `/...`) into its test binary, so
    `cmd/bd/doctor` and `cmd/bd/doctor/fix` tests aren't just skipped there,
    they're never even built. We've filed this as a separate upstream issue
    (draft: `beads-fix-application-tests-issue.md`) with a candidate CI-YAML
    fix (draft: `beads-ci-dolt-tests.patch`) rather than bundling a
    CI-workflow change into this test PR.
- `go build ./cmd/bd/...`, `go vet ./cmd/bd/...`, `gofmt -l` (clean),
  `golangci-lint run ./cmd/bd/...` (0 issues).
- `go test ./cmd/bd/...` — full suite passes except two **pre-existing,
  unrelated** failures in `cmd/bd/doctor` (`TestCheckBeadsRole_NotConfigured`,
  `TestCheckBeadsRole_NotGitRepo`), confirmed present on unmodified
  `origin/main` in this same environment (git-config-dependent, unrelated to
  `child_counters`/doctor-validate). Not touched by this PR.

## Project-identity guard on the destructive fix

`OrphanedChildCounters` DELETEs rows, so it is a destructive `bd doctor --fix`
entry point and now goes through `guardFixTarget` like its siblings. Without
it, the fresh connection `openDoltDB` dials could land on a different
project's database (the stale `.beads/dolt-server.port` scenario) and delete
that project's counter rows. The guard aborts with `PROJECT IDENTITY MISMATCH`
before any DELETE runs.

Test coverage for the guard:

- `OrphanedChildCounters` added to
  `TestDestructiveFix_AbortsOnProjectIdentityMismatch`'s entry-point table
  (`cmd/bd/doctor/fix/remotes_test.go`), which enumerates every destructive
  fix that shares `openDoltDB`/`openFixDB`.
- `TestOrphanedChildCounters_AbortsOnProjectIdentityMismatch`
  (`cmd/bd/doctor/fix/validation_test.go`) — a Docker-free companion to that
  table entry. The table's store needs the Dolt test container, so it skips
  wherever Docker is absent; this one uses the same local auto-start pattern
  as `TestOrphanedChildCounters_FixDeletesOnlyOrphans`, plants a real orphan
  row, and asserts both that the fix aborts and that the orphan survives.
  Mutation-checked: with the `guardFixTarget` call removed it fails at the
  `got nil error` check — which fires before the orphan-survival assertion, so
  the deletion itself is visible in the fix's stdout rather than in a second
  failing assertion; restored, it passes.

`TestOrphanedChildCounters_FixDeletesOnlyOrphans` seeds a *matching*
`project_id` so the guard admits it — which is also why it alone could not
pin the guard down, hence the dedicated mismatch test above.

## Test-environment isolation

The orphan-counters tests construct their own local Dolt server, so they must
not be redirected to an ambient one. Clearing the legacy `BEADS_DOLT_PORT`
alone was not enough: `BEADS_DOLT_SERVER_PORT` outranks it in
`applyConfigDefaults`, and `BEADS_DOLT_SERVER_HOST`, `_SERVER_SOCKET`,
`_SERVER_MODE`, `_SHARED_SERVER` and `_AUTO_START` can redirect `dolt.New`
just as effectively. Because this package's `TestMain` sets
`BEADS_TEST_SERVER=1`, a reachable ambient endpoint could have received the
test's `CreateIfMissing` plus its schema and data writes — i.e. running the
suite could write to a developer's real Dolt server.

`BEADS_DOLT_DATA_DIR` is cleared for the same reason by a different route: the
auto-start path resolves its data directory through `ResolveDoltDir` →
`projectDoltDirPath` (`internal/doltserver/physical_root.go:62`), which honours
that variable first. With it set, the test passed *silently* while laying
`.dolt/`, `.doltcfg/`, `.bd-dolt-ok` and its own database directory down in
whatever directory the variable named.

No shared helper existed for this; every isolated-Dolt call site either uses
the Docker container helpers or hand-rolls a partial scrub (the list in
`internal/storage/dolt/active_database_size_test.go` misses
`BEADS_DOLT_AUTO_START`). Added `testutil.ClearAmbientDoltEnv`
(`internal/testutil/testdoltcommon.go`) as the single place that list lives,
and used it. Existing partial scrubs are left alone to keep this PR scoped.

Verified with the hostile-env repro
`BEADS_DOLT_SERVER_HOST=192.0.2.1 BEADS_DOLT_SERVER_PORT=59999`: previously
the test failed at `dolt.New` with `Dolt server unreachable 192.0.2.1:59999`;
it now passes.

No unrelated files touched.

**Pre-existing note (not touched by this PR):** `TestValidateCheck_AllClean`
in `cmd/bd/doctor_validate_test.go` asserts `collectValidateChecks` returns
exactly 4 entries; it already returns 5 on `origin/main` (stale since
`CheckCrossTableDuplicates` was added), and now 6 with this PR's addition.
The assertion appears to have gone stale independently of this change —
flagging for visibility, left alone per "don't fix unrelated things."
