### PR TITLE
fix(github): include bead metadata in synced issue bodies

### DIFF
--- a/cmd/bd/github.go
+++ b/cmd/bd/github.go
@@ -419,8 +419,9 @@ func runGitHubSync(cmd *cobra.Command, args []string) error {
 	engine.OnMessage = func(msg string) { _, _ = fmt.Fprintln(out, "  "+msg) }
 	engine.OnWarning = func(msg string) { _, _ = fmt.Fprintf(os.Stderr, "Warning: %s\n", msg) }
 
-	// Set up GitHub-specific pull hooks
+	// Set up GitHub-specific pull and push hooks
 	engine.PullHooks = buildGitHubPullHooks(ctx)
+	engine.PushHooks = buildGitHubPushHooks(ctx)
 
 	// Build sync options from CLI flags
 	pull := !githubSyncPushOnly
@@ -496,6 +497,22 @@ func buildGitHubPullHooks(ctx context.Context) *tracker.PullHooks {
 				issue.ID = generateIssueID(prefix)
 			}
 			return nil
+		},
+	}
+}
+
+func buildGitHubPushHooks(ctx context.Context) *tracker.PushHooks {
+	return &tracker.PushHooks{
+		FormatDescription: func(issue *types.Issue) string {
+			dependencies, depErr := store.GetDependenciesWithMetadata(ctx, issue.ID)
+			dependents, dependentErr := store.GetDependentsWithMetadata(ctx, issue.ID)
+			if depErr != nil {
+				dependencies = nil
+			}
+			if dependentErr != nil {
+				dependents = nil
+			}
+			return github.RenderGitHubIssueBody(issue, dependencies, dependents)
 		},
 	}
 }

--- a/internal/github/mapping.go
+++ b/internal/github/mapping.go
@@ -120,8 +120,9 @@ func GitHubIssueToBeads(gh *Issue, config *MappingConfig) *IssueConversion {
 	labelNames := gh.LabelNames()
 
 	issue := &types.Issue{
+		ID:           ExtractBDIDFromGitHubSyncBlock(gh.Body),
 		Title:        gh.Title,
-		Description:  gh.Body,
+		Description:  StripGitHubSyncBlock(gh.Body),
 		ExternalRef:  &htmlURL,
 		SourceSystem: sourceSystem,
 		IssueType:    types.IssueType(typeFromLabels(labelNames, config)),
@@ -151,9 +152,13 @@ func GitHubIssueToBeads(gh *Issue, config *MappingConfig) *IssueConversion {
 
 // BeadsIssueToGitHubFields converts a beads Issue to GitHub API update fields.
 func BeadsIssueToGitHubFields(issue *types.Issue, config *MappingConfig) map[string]interface{} {
+	body := issue.Description
+	if !strings.Contains(body, "<!-- bd-github-sync: start -->") {
+		body = RenderGitHubIssueBody(issue, nil, nil)
+	}
 	fields := map[string]interface{}{
 		"title": issue.Title,
-		"body":  issue.Description,
+		"body":  body,
 	}
 
 	// Build labels from type, priority, and status
@@ -192,6 +197,179 @@ func BeadsIssueToGitHubFields(issue *types.Issue, config *MappingConfig) map[str
 	}
 
 	return fields
+}
+
+func RenderGitHubIssueBody(issue *types.Issue, dependencies, dependents []*types.IssueWithDependencyMetadata) string {
+	if issue == nil {
+		return ""
+	}
+
+	base := StripGitHubSyncBlock(issue.Description)
+	var b strings.Builder
+	b.WriteString(strings.TrimSpace(base))
+	if b.Len() > 0 {
+		b.WriteString("\n\n")
+	}
+	b.WriteString("<!-- bd-github-sync: start -->\n")
+	if strings.TrimSpace(issue.ID) != "" {
+		b.WriteString(fmt.Sprintf("<!-- bd: %s sync=github-v1 -->\n", strings.TrimSpace(issue.ID)))
+	}
+	b.WriteString("## Beads\n\n")
+	if strings.TrimSpace(issue.ID) != "" {
+		b.WriteString(fmt.Sprintf("Source: `%s`\n", strings.TrimSpace(issue.ID)))
+	}
+	appendGitHubTasklistSection(&b, "Dependencies", dependencies, true)
+	appendGitHubTasklistSection(&b, "Blocked by this issue", dependents, false)
+	b.WriteString("<!-- bd-github-sync: end -->")
+	return strings.TrimSpace(b.String())
+}
+
+func appendGitHubTasklistSection(b *strings.Builder, title string, issues []*types.IssueWithDependencyMetadata, incoming bool) {
+	if len(issues) == 0 {
+		return
+	}
+	b.WriteString("\n")
+	b.WriteString("### ")
+	b.WriteString(title)
+	b.WriteString("\n")
+	for _, item := range issues {
+		if item == nil {
+			continue
+		}
+		label := githubDependencyLabel(item.DependencyType, incoming)
+		b.WriteString("- [ ] ")
+		b.WriteString(githubTaskTarget(&item.Issue))
+		if text := githubTaskTitle(item.Title); text != "" {
+			b.WriteString(" — ")
+			b.WriteString(text)
+		}
+		if item.ID != "" || label != "" {
+			b.WriteString(" (")
+			parts := make([]string, 0, 2)
+			if item.ID != "" {
+				parts = append(parts, fmt.Sprintf("`%s`", item.ID))
+			}
+			if label != "" {
+				parts = append(parts, label)
+			}
+			b.WriteString(strings.Join(parts, ", "))
+			b.WriteString(")")
+		}
+		b.WriteString("\n")
+	}
+}
+
+func githubDependencyLabel(depType types.DependencyType, incoming bool) string {
+	switch depType {
+	case types.DepBlocks:
+		if incoming {
+			return "blocked by"
+		}
+		return "blocks"
+	case types.DepParentChild:
+		if incoming {
+			return "parent"
+		}
+		return "child"
+	case types.DepWaitsFor:
+		if incoming {
+			return "waits for"
+		}
+		return "waited on by"
+	case types.DepConditionalBlocks:
+		if incoming {
+			return "conditionally blocked by"
+		}
+		return "conditionally blocks"
+	}
+	return string(depType)
+}
+
+func githubTaskTarget(issue *types.Issue) string {
+	if issue == nil {
+		return "`unknown`"
+	}
+	if issue.ExternalRef != nil {
+		if n := githubIssueNumberFromRef(*issue.ExternalRef); n != "" {
+			return "#" + n
+		}
+	}
+	if strings.TrimSpace(issue.ID) != "" {
+		return fmt.Sprintf("`%s`", strings.TrimSpace(issue.ID))
+	}
+	return "`unknown`"
+}
+
+func githubIssueNumberFromRef(ref string) string {
+	marker := "/issues/"
+	idx := strings.LastIndex(ref, marker)
+	if idx == -1 {
+		return ""
+	}
+	rest := ref[idx+len(marker):]
+	end := 0
+	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return ""
+	}
+	return rest[:end]
+}
+
+func githubTaskTitle(title string) string {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return ""
+	}
+	if i := strings.IndexAny(title, "\r\n"); i >= 0 {
+		title = strings.TrimSpace(title[:i])
+	}
+	return title
+}
+
+// StripGitHubSyncBlock removes the generated Beads sync footer from a GitHub
+// issue body before storing it as the local issue description.
+func StripGitHubSyncBlock(body string) string {
+	const start = "<!-- bd-github-sync: start -->"
+	const end = "<!-- bd-github-sync: end -->"
+	for {
+		startIdx := strings.Index(body, start)
+		if startIdx == -1 {
+			break
+		}
+		endIdx := strings.Index(body[startIdx:], end)
+		if endIdx == -1 {
+			break
+		}
+		endIdx = startIdx + endIdx + len(end)
+		body = body[:startIdx] + body[endIdx:]
+	}
+	return strings.TrimSpace(body)
+}
+
+func ExtractBDIDFromGitHubSyncBlock(body string) string {
+	idx := strings.Index(body, "<!-- bd:")
+	if idx == -1 {
+		return ""
+	}
+	rest := body[idx+len("<!-- bd:"):]
+	end := strings.Index(rest, "-->")
+	if end == -1 {
+		return ""
+	}
+	fields := strings.Fields(strings.TrimSpace(rest[:end]))
+	for _, field := range fields {
+		field = strings.Trim(field, ",")
+		if strings.HasPrefix(field, "id=") {
+			return strings.Trim(strings.TrimPrefix(field, "id="), "`\"'")
+		}
+		if strings.HasPrefix(field, "sync=") {
+			continue
+		}
+		return strings.Trim(field, "`\"'")
+	}
+	return ""
 }
 
 // priorityToLabel converts beads priority (0-4) to GitHub priority label value.

--- a/internal/github/mapping_test.go
+++ b/internal/github/mapping_test.go
@@ -2,6 +2,7 @@
 package github
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -328,6 +329,7 @@ func TestBeadsIssueToGitHubFields(t *testing.T) {
 	config := DefaultMappingConfig()
 
 	beadsIssue := &types.Issue{
+		ID:          "bd-abc123",
 		Title:       "New feature request",
 		Description: "Add dark mode support",
 		IssueType:   types.TypeFeature,
@@ -342,8 +344,15 @@ func TestBeadsIssueToGitHubFields(t *testing.T) {
 	if fields["title"] != "New feature request" {
 		t.Errorf("fields[\"title\"] = %v, want \"New feature request\"", fields["title"])
 	}
-	if fields["body"] != "Add dark mode support" {
-		t.Errorf("fields[\"body\"] = %v, want \"Add dark mode support\"", fields["body"])
+	body, ok := fields["body"].(string)
+	if !ok {
+		t.Fatalf("fields[\"body\"] is not string")
+	}
+	if !strings.Contains(body, "Add dark mode support") {
+		t.Errorf("body = %q, want original description", body)
+	}
+	if !strings.Contains(body, "<!-- bd: bd-abc123 sync=github-v1 -->") {
+		t.Errorf("body = %q, want hidden bd ID marker", body)
 	}
 
 	// Verify labels include type, priority, and status
@@ -395,6 +404,98 @@ func TestBeadsIssueToGitHubFields_ClosedState(t *testing.T) {
 
 	if fields["state"] != "closed" {
 		t.Errorf("fields[\"state\"] = %v, want \"closed\"", fields["state"])
+	}
+}
+
+func TestRenderGitHubIssueBodyIncludesDependencyTasklists(t *testing.T) {
+	blockerRef := "https://github.com/org/repo/issues/12"
+	dependentRef := "https://github.com/org/repo/issues/34"
+	issue := &types.Issue{
+		ID:          "bd-target",
+		Description: "target body",
+	}
+	deps := []*types.IssueWithDependencyMetadata{
+		{
+			Issue: types.Issue{
+				ID:          "bd-blocker",
+				Title:       "blocking issue",
+				ExternalRef: &blockerRef,
+			},
+			DependencyType: types.DepBlocks,
+		},
+	}
+	dependents := []*types.IssueWithDependencyMetadata{
+		{
+			Issue: types.Issue{
+				ID:          "bd-dependent",
+				Title:       "dependent issue",
+				ExternalRef: &dependentRef,
+			},
+			DependencyType: types.DepBlocks,
+		},
+	}
+
+	body := RenderGitHubIssueBody(issue, deps, dependents)
+
+	for _, want := range []string{
+		"target body",
+		"<!-- bd: bd-target sync=github-v1 -->",
+		"### Dependencies",
+		"- [ ] #12 — blocking issue (`bd-blocker`, blocked by)",
+		"### Blocked by this issue",
+		"- [ ] #34 — dependent issue (`bd-dependent`, blocks)",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestGitHubIssueToBeadsStripsGeneratedSyncBlock(t *testing.T) {
+	config := DefaultMappingConfig()
+	ghIssue := &Issue{
+		ID:     123,
+		Number: 7,
+		Title:  "Synced issue",
+		Body: "User-authored body\n\n<!-- bd-github-sync: start -->\n" +
+			"<!-- bd: bd-abc sync=github-v1 -->\n" +
+			"## Beads\n\nSource: `bd-abc`\n" +
+			"<!-- bd-github-sync: end -->\n",
+		State:   "open",
+		HTMLURL: "https://github.com/org/repo/issues/7",
+	}
+
+	conversion := GitHubIssueToBeads(ghIssue, config)
+	if conversion.Issue.ID != "bd-abc" {
+		t.Fatalf("ID = %q, want bd ID from hidden marker", conversion.Issue.ID)
+	}
+	if conversion.Issue.Description != "User-authored body" {
+		t.Fatalf("Description = %q, want generated sync block stripped", conversion.Issue.Description)
+	}
+}
+
+func TestExtractBDIDFromGitHubSyncBlockSupportsLegacyMarker(t *testing.T) {
+	body := "body\n\n<!-- bd: bd_0x2c-tkg7 -->"
+	if got := ExtractBDIDFromGitHubSyncBlock(body); got != "bd_0x2c-tkg7" {
+		t.Fatalf("ExtractBDIDFromGitHubSyncBlock() = %q, want legacy marker ID", got)
+	}
+}
+
+func TestBeadsIssueToGitHubFieldsPreservesPreRenderedDependencyTasklists(t *testing.T) {
+	config := DefaultMappingConfig()
+	body := "body\n\n<!-- bd-github-sync: start -->\n" +
+		"<!-- bd: bd-target sync=github-v1 -->\n" +
+		"## Beads\n\nSource: `bd-target`\n\n" +
+		"### Dependencies\n" +
+		"- [ ] #12 — blocking issue (`bd-blocker`, blocked by)\n" +
+		"<!-- bd-github-sync: end -->"
+	fields := BeadsIssueToGitHubFields(&types.Issue{
+		ID:          "bd-target",
+		Title:       "target",
+		Description: body,
+	}, config)
+	if fields["body"] != body {
+		t.Fatalf("body was re-rendered without dependency tasklists:\n%v", fields["body"])
 	}
 }
 

--- a/internal/github/tracker.go
+++ b/internal/github/tracker.go
@@ -135,8 +135,10 @@ func (t *Tracker) FetchIssue(ctx context.Context, identifier string) (*tracker.T
 func (t *Tracker) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker.TrackerIssue, error) {
 	fields := BeadsIssueToGitHubFields(issue, t.config)
 	labels, _ := fields["labels"].([]string)
+	title, _ := fields["title"].(string)
+	body, _ := fields["body"].(string)
 
-	created, err := t.client.CreateIssue(ctx, issue.Title, issue.Description, labels)
+	created, err := t.client.CreateIssue(ctx, title, body, labels)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- render a managed GitHub issue-body block with the source bead ID marker
- surface dependency and dependent edges as GitHub tasklists
- strip the generated block on pull so local bead descriptions stay clean

## Scope
- Closes #4307
- Comment/thread mirroring is intentionally out of scope per the integration charter.
- Adjacent PR #4329 is about push dedup; this PR changes the rendered body and preserves pre-rendered bodies so dependency tasklists are not dropped by create/update mapping.

## Test Plan
- `go test -tags gms_pure_go ./internal/github -count=1`
- `go test -tags gms_pure_go ./cmd/bd -run 'Test.*GitHub|TestGetGitHub|TestParseGitHub|TestGitHubIssue' -count=1`
- `make test`
- `make build`

## Notes
- `scripts/pr-preflight.sh --search "github sync bd id dependency tasklist 4307" --repo gastownhall/beads` could not complete in this environment because `gh` resolves to a non-GitHub wrapper. I used GitHub REST search instead and found no open duplicate PR for #4307 or the marker/tasklist scope.
