### PR TITLE
fix(prime): detect git remote from CWD, not BEADS_DIR context

### DIFF
--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads"
-	internalbeads "github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/metrics"
 )
@@ -316,15 +316,12 @@ func isMCPActive() bool {
 	return false
 }
 
-// isEphemeralBranch detects if current branch has no upstream (ephemeral/local-only)
+// isEphemeralBranch detects if current branch has no upstream (ephemeral/local-only).
+// Uses process CWD git independently of BEADS_DIR validation (GH#4927).
 var isEphemeralBranch = func() bool {
 	// git rev-parse --abbrev-ref --symbolic-full-name @{u}
 	// Returns error code 128 if no upstream configured
-	rc, err := internalbeads.GetRepoContext()
-	if err != nil {
-		return true // Default to ephemeral if we can't determine context
-	}
-	cmd := rc.GitCmdCWD(context.Background(), "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
 	return cmd.Run() != nil
 }
 
@@ -341,13 +338,32 @@ var primeAgentProfile = func() config.AgentProfile {
 	return config.GetAgentProfile()
 }
 
-// primeHasGitRemote detects if any git remote is configured (stubbable for tests)
+// primeHasGitRemote detects if any git remote is configured (stubbable for tests).
+//
+// GH#4927: Probe the process CWD git workspace directly. Do not require a valid
+// RepoContext / BEADS_DIR — external BEADS_DIR under another account's home
+// (common in agent sandboxes) fails isPathInSafeBoundary and must not be
+// misreported as "no git remote" when `git remote` in CWD succeeds. SEC-003
+// boundary on BEADS_DIR remains enforced elsewhere.
 var primeHasGitRemote = func() bool {
-	rc, err := internalbeads.GetRepoContext()
+	return gitCWDHasRemote()
+}
+
+// gitCWDHasRemote reports whether the process CWD git repo has any remote.
+// Exported behavior for tests via the pure helper (no BEADS_DIR coupling).
+func gitCWDHasRemote() bool {
+	cmd := exec.Command("git", "remote")
+	out, err := cmd.Output()
 	if err != nil {
 		return false
 	}
-	cmd := rc.GitCmdCWD(context.Background(), "remote")
+	return len(strings.TrimSpace(string(out))) > 0
+}
+
+// gitDirHasRemote is like gitCWDHasRemote but for an explicit working tree path.
+func gitDirHasRemote(dir string) bool {
+	cmd := exec.Command("git", "remote")
+	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
 		return false

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -350,17 +350,16 @@ var primeHasGitRemote = func() bool {
 }
 
 // gitCWDHasRemote reports whether the process CWD git repo has any remote.
-// Exported behavior for tests via the pure helper (no BEADS_DIR coupling).
+// Delegates to gitDirHasRemote so the production path and the test-driven
+// path share one implementation (no BEADS_DIR coupling).
 func gitCWDHasRemote() bool {
-	cmd := exec.Command("git", "remote")
-	out, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-	return len(strings.TrimSpace(string(out))) > 0
+	return gitDirHasRemote("")
 }
 
-// gitDirHasRemote is like gitCWDHasRemote but for an explicit working tree path.
+// gitDirHasRemote reports whether the git repo at dir has any remote
+// configured. dir == "" runs git in the process's current working directory
+// (this is what gitCWDHasRemote uses); a non-empty dir lets tests probe an
+// explicit fixture repo without chdir-ing the whole process.
 func gitDirHasRemote(dir string) bool {
 	cmd := exec.Command("git", "remote")
 	cmd.Dir = dir

--- a/cmd/bd/prime_git_remote_test.go
+++ b/cmd/bd/prime_git_remote_test.go
@@ -1,5 +1,3 @@
-//go:build !cgo
-
 package main
 
 import (

--- a/cmd/bd/prime_git_remote_test.go
+++ b/cmd/bd/prime_git_remote_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -68,9 +69,22 @@ func TestGitDirHasRemote_IndependentOfBeadsDir(t *testing.T) {
 	t.Setenv("BEADS_DIR", boundaryRejectDir)
 	beads.ResetCaches()
 	git.ResetCaches()
-	if _, err := beads.GetRepoContext(); err == nil || !strings.Contains(err.Error(), "unsafe location") {
-		t.Fatalf("expected GetRepoContext() to reject %q via isPathInSafeBoundary, got err=%v", boundaryRejectDir, err)
-	}
+	// isPathInSafeBoundary (internal/beads/context.go) matches unsafePrefixes
+	// as hardcoded forward-slash literals via strings.HasPrefix. On Windows,
+	// filepath.Join renders boundaryRejectDir with backslashes, so it never
+	// matches an unsafePrefix and GetRepoContext() would not fail this way.
+	// Scope the assertion to Unix (via a subtest, so the skip doesn't abort
+	// Case 2 below) rather than deleting or weakening it. The CWD-based
+	// checks that follow exercise the actual fix and are platform-agnostic,
+	// so they stay unconditional.
+	t.Run("unsafe_location_rejected", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("SEC-003's unsafePrefixes are hardcoded forward-slash literals matched via strings.HasPrefix; filepath.Join renders backslashes on Windows so the prefix never matches — this subcase is Unix-only")
+		}
+		if _, err := beads.GetRepoContext(); err == nil || !strings.Contains(err.Error(), "unsafe location") {
+			t.Fatalf("expected GetRepoContext() to reject %q via isPathInSafeBoundary, got err=%v", boundaryRejectDir, err)
+		}
+	})
 
 	// CWD-based probe: chdir into the fixture repo
 	wd, err := os.Getwd()

--- a/cmd/bd/prime_git_remote_test.go
+++ b/cmd/bd/prime_git_remote_test.go
@@ -4,10 +4,25 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/git"
 )
 
 // GH#4927: git remote probe must not depend on BEADS_DIR / RepoContext.
+//
+// buildRepoContext (internal/beads/context.go) can fail two different ways:
+// FindBeadsDir() returning "" (context.go:107, e.g. BEADS_DIR doesn't exist)
+// and isPathInSafeBoundary rejecting an existing BEADS_DIR (context.go:112,
+// SEC-003). The pre-fix bug collapsed a GetRepoContext() error of either
+// shape into "no git remote" / "ephemeral branch". This test poisons
+// BEADS_DIR with one example of each shape and, for each, verifies (a) that
+// GetRepoContext() actually fails via the failure mode the case claims to
+// exercise, and (b) that gitCWDHasRemote/primeHasGitRemote are unaffected by
+// either.
 func TestGitDirHasRemote_IndependentOfBeadsDir(t *testing.T) {
 	dir := t.TempDir()
 	run := func(args ...string) {
@@ -31,8 +46,32 @@ func TestGitDirHasRemote_IndependentOfBeadsDir(t *testing.T) {
 		t.Fatal("expected remote after git remote add origin")
 	}
 
-	// Poison BEADS_DIR to a path under another home prefix — must not affect probe.
-	t.Setenv("BEADS_DIR", filepath.Join("/Users", "other-host", "sandboxes", "beads-runtime"))
+	t.Cleanup(func() {
+		beads.ResetCaches()
+		git.ResetCaches()
+	})
+
+	// Case 1: BEADS_DIR points at a real directory under a rejected prefix
+	// (SEC-003's unsafePrefixes includes "/var"), seeded with a beads.db so
+	// FindBeadsDir() actually returns it instead of falling through — this is
+	// what makes GetRepoContext() fail via isPathInSafeBoundary specifically,
+	// not via FindBeadsDir()=="".
+	boundaryRejectDir := filepath.Join("/var", "tmp", "beads-poison-"+strconv.Itoa(os.Getpid()))
+	if err := os.MkdirAll(boundaryRejectDir, 0o755); err != nil {
+		t.Skipf("cannot create fixture dir under %s: %v", boundaryRejectDir, err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(boundaryRejectDir) })
+	if err := os.WriteFile(filepath.Join(boundaryRejectDir, "beads.db"), nil, 0o644); err != nil {
+		t.Fatalf("failed to seed poison beads.db: %v", err)
+	}
+
+	t.Setenv("BEADS_DIR", boundaryRejectDir)
+	beads.ResetCaches()
+	git.ResetCaches()
+	if _, err := beads.GetRepoContext(); err == nil || !strings.Contains(err.Error(), "unsafe location") {
+		t.Fatalf("expected GetRepoContext() to reject %q via isPathInSafeBoundary, got err=%v", boundaryRejectDir, err)
+	}
+
 	// CWD-based probe: chdir into the fixture repo
 	wd, err := os.Getwd()
 	if err != nil {
@@ -44,10 +83,28 @@ func TestGitDirHasRemote_IndependentOfBeadsDir(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chdir(wd) })
 
 	if !gitCWDHasRemote() {
-		t.Fatal("gitCWDHasRemote should see origin even with foreign BEADS_DIR set")
+		t.Fatal("gitCWDHasRemote should see origin even with a boundary-rejected BEADS_DIR set")
 	}
 	// And primeHasGitRemote uses the same path
 	if !primeHasGitRemote() {
-		t.Fatal("primeHasGitRemote should see origin even with foreign BEADS_DIR set")
+		t.Fatal("primeHasGitRemote should see origin even with a boundary-rejected BEADS_DIR set")
+	}
+
+	// Case 2: BEADS_DIR points at a path that simply doesn't exist on disk —
+	// this is the FindBeadsDir()=="" failure mode (context.go:107). CWD is
+	// now the fixture repo (no .beads anywhere in its ancestry), so the walk
+	// in FindBeadsDir also comes up empty.
+	t.Setenv("BEADS_DIR", filepath.Join(dir, "does-not-exist", ".beads"))
+	beads.ResetCaches()
+	git.ResetCaches()
+	if _, err := beads.GetRepoContext(); err == nil || !strings.Contains(err.Error(), "no .beads directory found") {
+		t.Fatalf("expected GetRepoContext() to fail via FindBeadsDir()==\"\", got err=%v", err)
+	}
+
+	if !gitCWDHasRemote() {
+		t.Fatal("gitCWDHasRemote should see origin even with a nonexistent BEADS_DIR set")
+	}
+	if !primeHasGitRemote() {
+		t.Fatal("primeHasGitRemote should see origin even with a nonexistent BEADS_DIR set")
 	}
 }

--- a/cmd/bd/prime_git_remote_test.go
+++ b/cmd/bd/prime_git_remote_test.go
@@ -1,0 +1,55 @@
+//go:build !cgo
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// GH#4927: git remote probe must not depend on BEADS_DIR / RepoContext.
+func TestGitDirHasRemote_IndependentOfBeadsDir(t *testing.T) {
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init", "-q")
+	run("git", "config", "user.name", "fixture")
+	run("git", "config", "user.email", "fixture@example.com")
+
+	if gitDirHasRemote(dir) {
+		t.Fatal("expected no remote after init")
+	}
+
+	run("git", "remote", "add", "origin", "https://example.invalid/repo.git")
+	if !gitDirHasRemote(dir) {
+		t.Fatal("expected remote after git remote add origin")
+	}
+
+	// Poison BEADS_DIR to a path under another home prefix — must not affect probe.
+	t.Setenv("BEADS_DIR", filepath.Join("/Users", "other-host", "sandboxes", "beads-runtime"))
+	// CWD-based probe: chdir into the fixture repo
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+
+	if !gitCWDHasRemote() {
+		t.Fatal("gitCWDHasRemote should see origin even with foreign BEADS_DIR set")
+	}
+	// And primeHasGitRemote uses the same path
+	if !primeHasGitRemote() {
+		t.Fatal("primeHasGitRemote should see origin even with foreign BEADS_DIR set")
+	}
+}


### PR DESCRIPTION

## Summary

`bd prime` and `bd codex-hook` misreported "no git remote configured" whenever `BEADS_DIR` pointed to a path under a different account's home prefix (a common layout in externally isolated agent sandboxes), even though the actual git workspace in the process CWD had an `origin` remote. As reported by @blackjiro in #4927, the root cause is that `primeHasGitRemote` called `internalbeads.GetRepoContext()` and treated any error as "no remote" — and `buildRepoContext()` legitimately rejects a foreign-home `BEADS_DIR` via `isPathInSafeBoundary()`, so a BEADS_DIR safety rejection was being reinterpreted as a false fact about the separate git workspace. This change makes `primeHasGitRemote` and `isEphemeralBranch` probe the process CWD's git repo directly via `git remote` / `git rev-parse --abbrev-ref --symbolic-full-name @{u}`, independent of `RepoContext`/`BEADS_DIR` validation, matching the narrow fix the issue proposed. The `SEC-003` `BEADS_DIR` safety boundary itself is untouched.

## Test plan

- [x] Targeted, default (cgo) build: `go test ./cmd/bd/ -run 'TestGitDirHasRemote_IndependentOfBeadsDir' -v -count=1` — `--- PASS: TestGitDirHasRemote_IndependentOfBeadsDir (0.11s)` / `ok  	github.com/steveyegge/beads/cmd/bd	1.472s`
- [x] Pure-Go build still vets clean: `CGO_ENABLED=0 go vet ./cmd/bd/`
- [x] Full package suite: `go test ./cmd/bd/ -count=1 -timeout 25m` — clean, 486s, no failures, on a probe branch with this change merged onto `origin/main` at `3830f0a34`.

A note on the second commit: the regression test initially carried `//go:build !cgo`, while all 255 other test files in `cmd/bd` use `//go:build cgo`. Under the default cgo build the file was therefore excluded and the test never ran. The constraint is removed in `3948870d1` so it executes in both modes — the targeted run above is under the default build, i.e. the mode that previously skipped it.

Closes #4927

## Third surface that moves: auto-backup

`cmd/bd/backup_auto.go:37` (`isBackupAutoEnabled`) also gates on `primeHasGitRemote()`, and through it so do `bd config get backup.enabled` (`cmd/bd/config.go:379`) and `bd backup` status (`cmd/bd/backup.go:125`). Widening the probe means auto-backup now switches **on** in the #4927 layout — a `BEADS_DIR` under a foreign home while the CWD is a git repo with a remote — because storage resolves via `FindBeadsDir()` with no SEC-003 gate, so the store is open and `maybeAutoBackup` in `PersistentPostRun` registers a `file://` backup remote and full-syncs where main did nothing. The plain "no `.beads` directory found" case does not reach that far (`maybeAutoBackup` returns early at `store == nil`), so there the change is limited to `bd config get backup.enabled` reporting `true` instead of `false`.

This is intended — a real remote does exist in that layout — but it is a third surface beyond `bd prime` / `bd codex-hook`, recorded here so it is not a surprise to whoever bisects auto-backup later. (Raised by @maphew in review.)

## Correction to commit `3948870d1`'s message

That commit's message claims all 255 sibling test files in `cmd/bd` carry `//go:build cgo`. That number is wrong and the commit is already pushed, so the correction lives here rather than in rewritten history. @maphew gave 275 tagged / 173 untagged; that does not match this tree either. Measured at this HEAD over the 423 `*_test.go` files directly in `cmd/bd` (non-recursive — `find` pulls in 536 including subpackages like `cmd/bd/doctor`, which are not siblings):

- **423 total — 264 carry some `//go:build` constraint, 159 carry none.**
- Of the 264: 234 carry exactly `//go:build cgo`; 23 more combine cgo with another term (`cgo && integration`, `cgo && unix`, `cgo && linux`, `cgo && e2e`, `embeddeddolt && cgo`) — **257 mention cgo**.
- 7 tagged files do not mention cgo at all (`!windows`, `!cgo`, `scripttests`, `race`, `chaos`, `linux`, `!race`).
- 4 files carry legacy `// +build` lines, all redundant duplicates of a modern `//go:build` already counted.

The commit's *action* — removing the inverted `//go:build !cgo` that excluded the new test from the default build — was and is correct; only the supporting count was wrong.

