### PR TITLE
fix(dolt): include config table when explicitly committing via bd dolt commit / bd vc commit

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -523,16 +523,27 @@ For more options (--stdin, custom messages), see: bd vc commit`,
 		if st == nil {
 			return HandleError("no store available")
 		}
+		// GH#4934: explicit operator commit must include the config table.
+		// Plain Commit() excludes config (GH#2455), so a config-only dirty
+		// working set printed "Committed." while committing nothing.
 		msg, _ := cmd.Flags().GetString("message")
 		if msg == "" {
-			msg = fmt.Sprintf("bd: dolt commit (auto-commit) by %s", getActor())
-		}
-		if err := st.Commit(ctx, msg); err != nil {
-			if isDoltNothingToCommit(err) {
+			committed, err := st.CommitPending(ctx, getActor())
+			if err != nil {
+				return HandleError("%v", err)
+			}
+			if !committed {
 				fmt.Println("Nothing to commit.")
 				return nil
 			}
-			return HandleError("%v", err)
+		} else {
+			if err := st.CommitWithConfig(ctx, msg); err != nil {
+				if isDoltNothingToCommit(err) {
+					fmt.Println("Nothing to commit.")
+					return nil
+				}
+				return HandleError("%v", err)
+			}
 		}
 		commandDidExplicitDoltCommit = true
 		fmt.Println("Committed.")

--- a/cmd/bd/vc.go
+++ b/cmd/bd/vc.go
@@ -176,8 +176,11 @@ Examples:
 			return HandleErrorRespectJSON("commit message is required (use -m, --message, or --stdin)")
 		}
 
+		// GH#4934: operator-initiated vc commit must include config (same trust
+		// level as bd dolt commit). Plain Commit() excludes config and can report
+		// success while leaving a config-only working set dirty forever.
 		commandDidExplicitDoltCommit = true
-		if err := store.Commit(ctx, vcCommitMessage); err != nil {
+		if err := store.CommitWithConfig(ctx, vcCommitMessage); err != nil {
 			if isDoltNothingToCommit(err) {
 				if jsonOutput {
 					return outputJSON(map[string]interface{}{"committed": false, "message": "nothing to commit"})

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2110,10 +2110,14 @@ const (
 	// commit with operator guidance so the pull never auto-commits unsafe
 	// config (GH#2455 + GH#2474).
 	configIncludeUserKVOnly
-	// configIncludeAll stages every dirty config row. Used only to conclude a
-	// merge whose conflicts the operator resolved explicitly (bd federation
-	// sync --strategy): that resolution is intentional, so a resolved
-	// issue_prefix (or any config row) must be committed, not dropped.
+	// configIncludeAll stages every dirty config row. Used by
+	// CommitMergeResolution to conclude a merge whose conflicts the operator
+	// resolved explicitly (bd federation sync --strategy), and by
+	// CommitWithConfig for the explicit operator commit paths (bd dolt commit
+	// / bd vc commit via CommitPending, plus bd config set / bd init / bd
+	// rename-prefix): in both cases the operator explicitly asked for this, so
+	// any dirty config row (issue_prefix included) must be committed, not
+	// dropped.
 	configIncludeAll
 )
 
@@ -2146,12 +2150,13 @@ func (s *DoltStore) Commit(ctx context.Context, message string) error {
 // configConflictsAreMemoryConvergent) — so widening the commit screen to the
 // whole kv. namespace cannot auto-resolve a genuine kv.* conflict; it only stops
 // generic `bd kv set` writes from wedging the pull. Config is staged explicitly
-// (via DOLT_ADD in commitWorkingSet) rather than through CommitWithConfig's
-// DOLT_COMMIT('-Am'), which was observed not to stage config reliably under the
-// server-mode stored-procedure path. Committing this clone's own kv.* rows as the
-// merge basis is the same explicit, user-initiated action CommitPending ('bd dolt
-// commit') already performs, so it does not widen the concurrent-writer race
-// GH#2455 guards against.
+// via per-table DOLT_ADD in commitWorkingSet — the same mechanism CommitWithConfig
+// now uses (GH#4934) — rather than a blanket DOLT_COMMIT('-Am'), which was
+// observed not to stage config reliably under the server-mode stored-procedure
+// path. Committing this clone's own kv.* rows as the merge basis is the same
+// explicit, user-initiated action CommitPending ('bd dolt commit') already
+// performs, so it does not widen the concurrent-writer race GH#2455 guards
+// against.
 func (s *DoltStore) commitBeforePull(ctx context.Context, message string) error {
 	return s.commitWorkingSet(ctx, message, configIncludeUserKVOnly)
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2305,22 +2305,17 @@ func (s *DoltStore) assertDirtyConfigUserKVOnly(ctx context.Context, conn *sql.C
 
 // CommitWithConfig creates a Dolt commit that includes the config table.
 // Use this instead of Commit when the caller intentionally modified config
-// (e.g., CommitPending after 'bd config set', 'bd init', or 'bd rename-prefix').
-// GH#2455: Commit() excludes config to prevent sweeping up stale changes.
+// (e.g., CommitPending after 'bd config set', 'bd init', 'bd rename-prefix',
+// or the explicit operator path 'bd dolt commit' / 'bd vc commit').
+//
+// GH#2455: Commit() excludes config to prevent sweeping up stale changes into
+// unrelated auto-commits. Explicit operator commits use this method instead.
+//
+// GH#4934: Implemented via commitWorkingSet(configIncludeAll) with explicit
+// DOLT_ADD per dirty table (including config). DOLT_COMMIT('-Am') was observed
+// not to stage config reliably under the server-mode stored-procedure path.
 func (s *DoltStore) CommitWithConfig(ctx context.Context, message string) error {
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to acquire connection: %w", err)
-	}
-	defer conn.Close()
-
-	if _, err := conn.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?, '--author', ?)", message, s.commitAuthorString()); err != nil {
-		if isDoltNothingToCommit(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to commit: %w", err)
-	}
-	return nil
+	return s.commitWorkingSet(ctx, message, configIncludeAll)
 }
 
 // doltAddAndCommit stages the specified tables and commits on a pinned


### PR DESCRIPTION

## Summary

Reporter @swedeinasia-flow found that when the only dirty table in a Dolt working set is `config`, `bd dolt commit` prints "Committed." and exits 0 while committing nothing, because the underlying `Commit()` path intentionally excludes config (GH#2455) to stop auto-commits from sweeping up stale changes. That left the working set permanently dirty and `bd doctor` warning forever, and the issue documented that the maintainer-suggested fallback, `bd vc commit`, hit the identical dead end because it called the same `Commit()` method. The issue also noted that `DOLT_COMMIT('-Am')` had been unreliable for staging config under the server-mode stored-procedure path.

This change makes both explicit, operator-initiated commit paths include the config table instead of excluding it: `cmd/bd/dolt.go`'s `bd dolt commit` now calls `store.CommitPending` (no `-m`) or `store.CommitWithConfig` (with `-m`) instead of `store.Commit`, and `cmd/bd/vc.go`'s `bd vc commit` now calls `store.CommitWithConfig` instead of `store.Commit`. `CommitWithConfig` itself is reimplemented in `internal/storage/dolt/store.go` on top of `commitWorkingSet(configIncludeAll)`, which stages each dirty table — including config — with an explicit `DOLT_ADD` rather than relying on `DOLT_COMMIT('-Am')`, directly addressing the staging-reliability note from the issue. The plain `Commit()` path used by auto-commit is unchanged, so the GH#2455 config exclusion still applies there.

## Test plan

- [x] `go build ./cmd/bd/... ./internal/storage/dolt/...` — compiles cleanly with the changed commit paths.
- [x] `go test ./cmd/bd/ -run 'TestVcCommitStdinFlag|TestDoltPushPullCommitNeedStore' -v -count=1` — targeted run against the two changed files' existing CLI-level tests:
  ```
  --- PASS: TestDoltPushPullCommitNeedStore (0.00s)
  --- PASS: TestVcCommitStdinFlag (0.00s)
  PASS
  ok  	github.com/steveyegge/beads/cmd/bd	1.579s
  ```
- [x] Full-package regression: `go test ./cmd/bd/ -count=1 -timeout 25m` passed cleanly (no failures) in 546s on a probe branch merged with `origin/main` at `3830f0a34`.

## Limitations

- Docker is not available in this environment, so the Dolt-backed test server (`testcontainers`) never starts here. The tests that most directly exercise this change's actual behavior — `TestCommit_ExcludesConfig`, `TestCommitWithConfig_IncludesConfig`, and `TestCommitPending` in `internal/storage/dolt` — were **skipped** in my local run ("Docker not available, skipping Dolt tests" / "Test Dolt server not running, skipping test"), not executed. The targeted `cmd/bd` run above confirms the changed call sites compile and their existing CLI-flag-level tests still pass, but it does not exercise real config-only-dirty-working-set commit behavior against a live Dolt store. I don't have visibility into whether Docker was available for the separately-run full-suite verification cited above either, so that citation should be read as "no failures reported," not as confirmation that the Dolt-backed tests ran rather than skipped.
