### PR TITLE
fix(wisp gc): apply the --age test to cascade children

### DIFF
--- a/cmd/bd/wisp.go
+++ b/cmd/bd/wisp.go
@@ -880,6 +880,10 @@ func findAbandonedWisps(ctx context.Context, r molReader, cleanAll bool, ageThre
 				if isProtectedWisp(child, blockedSet, protectedStatuses) {
 					continue
 				}
+				// Children are held to the same --age contract as parents.
+				if now.Sub(child.UpdatedAt) <= ageThreshold {
+					continue
+				}
 				abandoned = append(abandoned, child)
 			}
 		}

--- a/cmd/bd/wisp.go
+++ b/cmd/bd/wisp.go
@@ -801,7 +801,9 @@ func runWispGC(cmd *cobra.Command, args []string) error {
 	for i, issue := range abandoned {
 		ids[i] = issue.ID
 	}
-	if err := deleteBatch(nil, ids, true, false, true, jsonOutput, false, "wisp gc"); err != nil {
+	// findAbandonedWisps already expanded the cascade under the --age contract;
+	// re-cascading at delete time would sweep fresh children past that filter.
+	if err := deleteBatch(nil, ids, true, false, false, jsonOutput, false, "wisp gc"); err != nil {
 		return HandleError("%v", err)
 	}
 	return nil

--- a/cmd/bd/wisp_gc_cascade_age_test.go
+++ b/cmd/bd/wisp_gc_cascade_age_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// cascadeAgeReader is a minimal molReader covering only the calls
+// findAbandonedWisps makes. The embedded nil interface makes any other call
+// panic loudly rather than return a silent zero value.
+type cascadeAgeReader struct {
+	molReader
+	issues   []*types.Issue
+	children map[string]bool
+}
+
+func (r *cascadeAgeReader) SearchIssues(context.Context, string, types.IssueFilter) ([]*types.Issue, error) {
+	return r.issues, nil
+}
+
+func (r *cascadeAgeReader) GetBlockedIssues(context.Context, types.WorkFilter) ([]*types.BlockedIssue, error) {
+	return nil, nil
+}
+
+func (r *cascadeAgeReader) GetCustomStatusesDetailed(context.Context) ([]types.CustomStatus, error) {
+	return nil, nil
+}
+
+func (r *cascadeAgeReader) IsInfraTypeCtx(context.Context, types.IssueType) bool { return false }
+
+func (r *cascadeAgeReader) FindWispDependentsRecursive(context.Context, []string) (map[string]bool, error) {
+	return r.children, nil
+}
+
+func (r *cascadeAgeReader) GetIssuesByIDs(_ context.Context, ids []string) ([]*types.Issue, error) {
+	want := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		want[id] = true
+	}
+	var out []*types.Issue
+	for _, issue := range r.issues {
+		if want[issue.ID] {
+			out = append(out, issue)
+		}
+	}
+	return out, nil
+}
+
+// TestWispGCCascadeRespectsAge is the regression test for hq-k27y.
+//
+// `bd mol wisp gc --age` selected abandoned parents by age and then pulled in
+// their transitive wisp dependents with no age test at all. A step created
+// seconds ago was therefore destroyed because something it depended on was old.
+//
+// The consequence was not a stray bead: a patrol molecule slung moments earlier
+// went down with all nine of its steps — 43 beads in one run — and the agent's
+// hook emptied instantly. Two rigs of three were hit; the third survived only
+// because a stop order reached it first.
+//
+// It also made the flag misleading in a way that punishes the obvious reaction:
+// raising --age does not make the command safer, because the child's own age is
+// never consulted. That is asserted separately below.
+//
+// GH#4430 already protects a step that has been picked up (in_progress/blocked/
+// hooked map to CategoryWIP). A freshly created step is still `open`, and open
+// maps to CategoryActive, which that guard deliberately does not protect — so
+// the fresh-child path stayed open until this check.
+func TestWispGCCascadeRespectsAge(t *testing.T) {
+	now := time.Now()
+	const threshold = time.Hour
+
+	staleParent := &types.Issue{
+		ID:        "gc-stale-parent",
+		Status:    types.StatusOpen,
+		UpdatedAt: now.Add(-24 * time.Hour),
+	}
+	// The molecule the patrol is working right now: created seconds ago,
+	// not yet picked up, so still open.
+	freshChild := &types.Issue{
+		ID:        "gc-fresh-child",
+		Status:    types.StatusOpen,
+		UpdatedAt: now.Add(-2 * time.Second),
+	}
+	// A child that really is abandoned must still be collected — the cascade
+	// exists for a reason and the fix must not disable it.
+	staleChild := &types.Issue{
+		ID:        "gc-stale-child",
+		Status:    types.StatusOpen,
+		UpdatedAt: now.Add(-48 * time.Hour),
+	}
+
+	r := &cascadeAgeReader{
+		issues:   []*types.Issue{staleParent, freshChild, staleChild},
+		children: map[string]bool{"gc-fresh-child": true, "gc-stale-child": true},
+	}
+
+	got, err := findAbandonedWisps(context.Background(), r, false, threshold, nil)
+	if err != nil {
+		t.Fatalf("findAbandonedWisps: %v", err)
+	}
+
+	collected := make(map[string]bool, len(got))
+	for _, issue := range got {
+		collected[issue.ID] = true
+	}
+
+	if collected["gc-fresh-child"] {
+		t.Errorf("fresh child %q was collected: a wisp updated %v ago must survive --age %v regardless of its parent's age (hq-k27y); collected=%v",
+			freshChild.ID, now.Sub(freshChild.UpdatedAt), threshold, collected)
+	}
+	if !collected["gc-stale-parent"] {
+		t.Errorf("stale parent %q must still be collected; collected=%v", staleParent.ID, collected)
+	}
+	if !collected["gc-stale-child"] {
+		t.Errorf("stale child %q must still be collected — the cascade must keep working for genuinely abandoned children; collected=%v", staleChild.ID, collected)
+	}
+}
+
+// TestWispGCRaisingAgeDoesNotSaveFreshChild pins the property that made the
+// defect worse than it looked: before the fix, no value of --age protected a
+// fresh child, so the natural mitigation ("use a bigger threshold") did
+// nothing. After the fix a larger threshold is strictly more protective.
+func TestWispGCRaisingAgeDoesNotSaveFreshChild(t *testing.T) {
+	now := time.Now()
+
+	for _, threshold := range []time.Duration{time.Hour, 24 * time.Hour, 720 * time.Hour} {
+		parent := &types.Issue{
+			ID:        "gc-ancient-parent",
+			Status:    types.StatusOpen,
+			UpdatedAt: now.Add(-2 * threshold),
+		}
+		child := &types.Issue{
+			ID:        "gc-newborn",
+			Status:    types.StatusOpen,
+			UpdatedAt: now.Add(-time.Second),
+		}
+		r := &cascadeAgeReader{
+			issues:   []*types.Issue{parent, child},
+			children: map[string]bool{"gc-newborn": true},
+		}
+
+		got, err := findAbandonedWisps(context.Background(), r, false, threshold, nil)
+		if err != nil {
+			t.Fatalf("findAbandonedWisps(--age %v): %v", threshold, err)
+		}
+		for _, issue := range got {
+			if issue.ID == "gc-newborn" {
+				t.Errorf("--age %v still collected a wisp created 1s ago; the threshold must apply to cascade children", threshold)
+			}
+		}
+	}
+}

--- a/cmd/bd/wisp_proxied_integration_test.go
+++ b/cmd/bd/wisp_proxied_integration_test.go
@@ -263,21 +263,24 @@ func TestProxiedServerWispGC(t *testing.T) {
 		}
 	})
 
-	t.Run("cascade_sweeps_dependent_step_wisps", func(t *testing.T) {
+	t.Run("cascade_respects_age_for_dependent_step_wisps", func(t *testing.T) {
 		t.Parallel()
 		p := newSharedProxiedProject(t, bd, "wgc")
 		parentWisp := bdProxiedCreate(t, bd, p.dir, "Abandoned parent wisp", "--ephemeral")
-		childWisp := bdProxiedCreate(t, bd, p.dir, "Fresh child wisp", "--ephemeral")
+		staleChild := bdProxiedCreate(t, bd, p.dir, "Stale child wisp", "--ephemeral")
+		freshChild := bdProxiedCreate(t, bd, p.dir, "Fresh child wisp", "--ephemeral")
 
 		db := openProxiedDB(t, p)
-		if _, err := db.Exec(
-			"INSERT INTO wisp_dependencies (id, issue_id, depends_on_wisp_id, type, created_at, created_by) VALUES (UUID(), ?, ?, ?, NOW(), 'test')",
-			childWisp.ID, parentWisp.ID, "blocks"); err != nil {
-			t.Fatalf("plant child->parent wisp edge: %v", err)
+		for _, childID := range []string{staleChild.ID, freshChild.ID} {
+			if _, err := db.Exec(
+				"INSERT INTO wisp_dependencies (id, issue_id, depends_on_wisp_id, type, created_at, created_by) VALUES (UUID(), ?, ?, ?, NOW(), 'test')",
+				childID, parentWisp.ID, "blocks"); err != nil {
+				t.Fatalf("plant child->parent wisp edge: %v", err)
+			}
 		}
-		if _, err := db.Exec("UPDATE wisps SET updated_at = ? WHERE id = ?",
-			time.Now().UTC().Add(-2*time.Hour), parentWisp.ID); err != nil {
-			t.Fatalf("backdate parent wisp: %v", err)
+		if _, err := db.Exec("UPDATE wisps SET updated_at = ? WHERE id IN (?, ?)",
+			time.Now().UTC().Add(-2*time.Hour), parentWisp.ID, staleChild.ID); err != nil {
+			t.Fatalf("backdate parent and stale child wisps: %v", err)
 		}
 
 		out, err := bdProxiedRun(t, bd, p.dir, "mol", "wisp", "gc", "--age", "1h", "--json")
@@ -297,8 +300,19 @@ func TestProxiedServerWispGC(t *testing.T) {
 		if !cleaned[parentWisp.ID] {
 			t.Errorf("expected abandoned parent %s cleaned", parentWisp.ID)
 		}
-		if !cleaned[childWisp.ID] {
-			t.Errorf("expected dependent child %s cascaded even though it's not itself old", childWisp.ID)
+		if !cleaned[staleChild.ID] {
+			t.Errorf("expected stale dependent child %s cascaded", staleChild.ID)
+		}
+		if cleaned[freshChild.ID] {
+			t.Errorf("fresh child %s must survive gc despite stale parent, deleted: %v", freshChild.ID, got.Deleted)
+		}
+
+		var count int
+		if err := db.QueryRow("SELECT COUNT(*) FROM wisps WHERE id = ?", freshChild.ID).Scan(&count); err != nil {
+			t.Fatalf("query fresh child wisp: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("expected fresh child %s to remain in wisps table", freshChild.ID)
 		}
 	})
 

--- a/cmd/bd/wisp_proxied_server.go
+++ b/cmd/bd/wisp_proxied_server.go
@@ -166,9 +166,12 @@ func runWispGCProxiedServer(ctx context.Context, dryRun bool, ageThreshold time.
 	}
 
 	res, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (domain.DeleteIssuesResult, string, error) {
+		// findAbandonedWisps already expanded the cascade under the --age
+		// contract; a second cascade here would sweep fresh children past
+		// that filter.
 		res, err := uw.IssueUseCase().DeleteIssues(ctx, domain.DeleteIssuesParams{
 			IDs:                  ids,
-			Cascade:              true,
+			Cascade:              false,
 			UpdateTextReferences: true,
 		}, actor)
 		if err != nil {


### PR DESCRIPTION
## The contract that was broken

`bd mol wisp gc --help` states that a wisp counts as abandoned when it "has not been updated within `--age` **AND** is not closed". Parents were held to that contract. Children reached through the dependency cascade were not: a child was collected purely because something it transitively depends on is old, so `--age` had no meaning for children at all.

Raising the threshold is not a workaround. With `--age 720h`, a step created a moment ago is still destroyed when its parent is older than 720 hours — the second test covers exactly this.

## Relation to #4430

`isProtectedWisp` (added in #4430) covers steps that have already been picked up — `in_progress`, `blocked`, `hooked`. A *freshly created* step is still `open`, and `open` maps to `CategoryActive`, which that guard deliberately does not protect. This change closes the remaining path; it does not overlap with the existing guard.

## Repro

Both tests are beads-only unit tests in `cmd/bd`, driven through a fake `molReader`. No orchestrator, no external agent framework, no live database:

- `TestWispGCCascadeRespectsAge` — a stale parent no longer drags a fresh child into the abandoned set.
- `TestWispGCRaisingAgeDoesNotSaveFreshChild` — raising `--age` does not rescue the child, showing the threshold was inoperative for children rather than merely too low.

Both fail before the change and pass after.

## What this cost in practice

A molecule slung seconds earlier went down with all nine of its steps — 43 beads in one run — and the agent's hook emptied instantly. Two rigs of three were hit; the third survived only because a stop order reached it first.

## Verification

Full `go test ./cmd/bd/` run, with the patch and on a clean worktree at the same revision (`0e069115a`):

- identical failure sets both times — `TestConfigValidateReadOnlyIsHermetic`, `TestPrepareSelectedCommandContext_DoesNotMergeCallerConfigForUnsetKeys`, `TestPrepareSelectedCommandContext_RebindsTargetConfig`, `TestTestServerConnection`. These are pre-existing on this machine and unrelated to wisp GC; I did not investigate their cause.
- passing count 1533 → 1535, the difference being exactly the two tests added here; skip count 540 in both runs.
- `TestWispGCProtectsActiveWisps` runs green under `BEADS_TEST_EMBEDDED_DOLT=1` (33s, embedded dolt), so the existing cascade protection is not regressed.

## Scope

Single layer (`cmd/bd`), 4 lines of logic plus tests. Per the contributor guidelines the rationale lives in the commit message and here rather than in inline comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)