### PR TITLE
fix(dep): emit deduped stub for revisited tree nodes instead of dropping them

### DIFF
--- a/internal/storage/issueops/dependency_tree.go
+++ b/internal/storage/issueops/dependency_tree.go
@@ -15,8 +15,28 @@ func GetDependencyTreeInTx(ctx context.Context, tx DBTX, issueID string, maxDept
 }
 
 func buildDependencyTreeInTx(ctx context.Context, tx DBTX, issueID string, depth, maxDepth int, reverse bool, visited map[string]bool, parentID string, edgeFromParent types.DependencyType) ([]*types.TreeNode, error) {
-	if depth >= maxDepth || visited[issueID] {
+	if depth >= maxDepth {
 		return nil, nil
+	}
+	if visited[issueID] {
+		// Diamond dependency: this node was already expanded on another path.
+		// Emit it again as a Deduped stub (no recursion) so every edge —
+		// in particular every DIRECT blocker of the root — stays visible.
+		// Dropping it made `bd dep tree` disagree with `bd dep list` on the
+		// direct-blocker set and let a blocked node render with no visible
+		// blocker (gastownhall/beads sys-7yjr8). The tree renderer shows
+		// stubs as "<id> (shown above)"; JSON carries deduped=true.
+		issue, err := GetIssueInTx(ctx, tx, issueID)
+		if err != nil {
+			return nil, err
+		}
+		return []*types.TreeNode{{
+			Issue:          *issue,
+			Depth:          depth,
+			ParentID:       parentID,
+			EdgeFromParent: edgeFromParent,
+			Deduped:        true,
+		}}, nil
 	}
 	visited[issueID] = true
 

--- a/internal/storage/issueops/dependency_tree_test.go
+++ b/internal/storage/issueops/dependency_tree_test.go
@@ -182,3 +182,87 @@ func treeIDs(tree []*types.TreeNode) []string {
 	}
 	return ids
 }
+
+// TestGetDependencyTreeInTxEmitsDedupedDirectBlocker reproduces the diamond
+// omission behind gastownhall/beads sys-7yjr8: root depends on mid and shared,
+// mid also depends on shared. When traversal reaches shared through mid first,
+// the direct root->shared blocker used to be dropped entirely, so `bd dep tree`
+// and `bd dep list` disagreed on the direct-blocker set (and a bounded reader
+// concluded the graph was stale). The visited node must be re-emitted as a
+// Deduped stub so every direct edge is visible.
+func TestGetDependencyTreeInTxEmitsDedupedDirectBlocker(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	expectIssue(mock, "root", "Root")
+	expectDependencies(mock, "root", []dependencyRow{
+		{id: "mid", depType: string(types.DepBlocks)},
+		{id: "shared", depType: string(types.DepBlocks)},
+	})
+	expectIssueBatch(mock, []string{"mid", "shared"})
+
+	// First child: mid, which expands shared beneath it.
+	expectIssue(mock, "mid", "Mid")
+	expectDependencies(mock, "mid", []dependencyRow{
+		{id: "shared", depType: string(types.DepBlocks)},
+	})
+	expectIssueBatchOne(mock, "shared")
+	expectIssue(mock, "shared", "Shared")
+	expectDependencies(mock, "shared", nil)
+
+	// Second direct child: shared again — already visited. The fix fetches it
+	// once more and emits a Deduped stub instead of dropping the edge.
+	expectIssue(mock, "shared", "Shared")
+
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	tree, err := GetDependencyTreeInTx(context.Background(), tx, "root", 5, false, false)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("GetDependencyTreeInTx: %v", err)
+	}
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+
+	if len(tree) != 4 {
+		t.Fatalf("len(tree) = %d, want 4 nodes [root mid shared shared-stub]: %v", len(tree), treeIDs(tree))
+	}
+	stub := tree[3]
+	if stub.ID != "shared" || stub.Depth != 1 || stub.ParentID != "root" {
+		t.Fatalf("stub = id %q depth %d parent %q, want shared/1/root", stub.ID, stub.Depth, stub.ParentID)
+	}
+	if stub.EdgeFromParent != types.DepBlocks {
+		t.Fatalf("stub edge = %q, want %q", stub.EdgeFromParent, types.DepBlocks)
+	}
+	if !stub.Deduped {
+		t.Fatalf("stub.Deduped = false, want true")
+	}
+	full := tree[2]
+	if full.ID != "shared" || full.Depth != 2 || full.ParentID != "mid" || full.Deduped {
+		t.Fatalf("first occurrence = id %q depth %d parent %q deduped %v, want shared/2/mid/false", full.ID, full.Depth, full.ParentID, full.Deduped)
+	}
+}
+
+func expectIssueBatchOne(mock sqlmock.Sqlmock, id string) {
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM wisps LIMIT 1")).
+		WillReturnError(sql.ErrNoRows)
+	rows := issueRows()
+	rows.AddRow(issueRowValues(id, id)...)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT " + IssueSelectColumns + " FROM issues " + sqlbuild.LeaseJoin("issues") + " WHERE id IN (?)")).
+		WithArgs(id).
+		WillReturnRows(rows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT issue_id, label FROM labels WHERE issue_id IN (?) ORDER BY issue_id, label")).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows([]string{"issue_id", "label"}))
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1655,6 +1655,10 @@ type TreeNode struct {
 	ParentID       string         `json:"parent_id"`
 	EdgeFromParent DependencyType `json:"edge_from_parent,omitempty"`
 	Truncated      bool           `json:"truncated"`
+	// Deduped marks a repeated occurrence of a node already expanded elsewhere
+	// in the tree (diamond dependency). The edge to its parent is real, but its
+	// subtree is rendered at the first occurrence only.
+	Deduped bool `json:"deduped,omitempty"`
 }
 
 // MoleculeProgressStats provides efficient progress info for large molecules.


### PR DESCRIPTION
Fixes #5282.

## What

`buildDependencyTreeInTx` silently dropped any node already visited on another path. On diamond graphs this made `bd dep tree` and `bd dep list` disagree on the **direct-blocker set** (the dropped edge was absent even from `--json` and the mermaid output), and the mirror case rendered a genuinely blocked node with an empty subtree. Full analysis and repros in #5282.

This change re-emits the revisited node as a stub — `Deduped: true`, correct `Depth`/`ParentID`/`EdgeFromParent`, no recursion — so every edge stays visible:

- The tree renderer's existing `"(shown above)"` branch (dead code until now — duplicates never survived traversal) renders the stub with zero renderer changes.
- `--json` carries the stub with `deduped: true`.
- The mermaid output regains the previously-missing edges (its `nodesSeen` map already dedupes node declarations).
- `renderTree`'s root-`[BLOCKED]` computation (GH#3565) now sees direct open blockers it previously missed when they were first reached through a sibling branch.

Cycle safety is unchanged: a stub never recurses, so traversal still terminates on cyclic graphs.

`--show-all-paths` remains unimplemented (plumbed and ignored, as before) — noted in #5282 as a separate follow-up.

## Before / after (triangle: D→E, D→F, E→F, all blocks)

```
$ bd dep list D                          # both versions
  E: ... (open) via blocks
  F: ... (open) via blocks

$ bd dep tree D                          # before
D: ... [BLOCKED]
    └── E: ...  [blocks]
        └── F: ...  [blocks]             # direct D→F edge invisible

$ bd dep tree D                          # after
D: ... [BLOCKED]
    ├── E: ...  [blocks]
        └── F: ...  [blocks]
    └── F (shown above)                  # direct edge visible, subtree not repeated
```

## Testing

- New unit test `TestGetDependencyTreeInTxEmitsDedupedDirectBlocker` (sqlmock): fails on the old traversal (stub fetch never happens), passes now; asserts the stub's depth/parent/edge/`Deduped` and that the first occurrence stays a full node.
- `go test ./internal/storage/issueops/ ./internal/types/ ./internal/storage/domain/db/` green (373 issueops tests).
- Dogfooded a build on real data: a 10-node replica of the production graph that triggered the report (deep closed chain + diamond back-edge onto an open direct blocker). Unfixed bd renders the root with one direct child and buries the open blocker at depth 5; fixed bd adds `└── <id> (shown above)` at the direct level, and `dep tree`/`dep list` agree. Also verified `--json` now contains the stub node, and the second (mirror) ordering shows the previously-hidden edge under the blocked mid node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)