### PR TITLE
fix(init): hold destructive preflight under replacement gate (bd-dswzy)

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -283,6 +283,9 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		serverUser, _ := cmd.Flags().GetString("server-user")
 		database, _ := cmd.Flags().GetString("database")
 		destroyToken, _ := cmd.Flags().GetString("destroy-token")
+		// Keep the exact input the former destructive-confirmation block used:
+		// before config/dirname fallback and before normalization.
+		destroyTokenPrefix := prefix
 
 		// --force is a deprecated alias for --reinit-local. They share
 		// semantics for the local data-safety guard; both refuse remote
@@ -662,59 +665,6 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}
 
-		// Even with --reinit-local, warn about existing data and require
-		// confirmation. Non-interactive mode accepts --destroy-token for
-		// explicit opt-in; interactive mode prompts for typed confirmation.
-		if reinitLocal {
-			if count, err := countExistingIssues(prefix); err == nil && count > 0 {
-				fmt.Fprintf(os.Stderr, "\n%s Re-initializing will destroy the existing database.\n\n", ui.RenderWarn("WARNING:"))
-				fmt.Fprintf(os.Stderr, "  Existing issues: %d\n\n", count)
-				fmt.Fprintf(os.Stderr, "  This action CANNOT be undone. All issues, dependencies, and\n")
-				fmt.Fprintf(os.Stderr, "  Dolt commit history will be permanently lost.\n\n")
-				fmt.Fprintf(os.Stderr, "  Before proceeding, consider:\n")
-				fmt.Fprintf(os.Stderr, "    bd export > issue-export.jsonl    # Export issue records, not full DB state\n")
-				fmt.Fprintf(os.Stderr, "    bd dolt status              # Check if this is a server config issue\n\n")
-				if term.IsTerminal(int(os.Stdin.Fd())) {
-					fmt.Fprintf(os.Stderr, "Type 'destroy %d issues' to confirm: ", count)
-					scanner := bufio.NewScanner(os.Stdin)
-					scanner.Scan()
-					expected := fmt.Sprintf("destroy %d issues", count)
-					if strings.TrimSpace(scanner.Text()) != expected {
-						fmt.Fprintf(os.Stderr, "\nAborted. Database was NOT modified.\n")
-						return &exitError{Code: ExitLocalExistsRefused}
-					}
-				} else {
-					// Non-interactive (piped input, AI agent, etc.)
-					//
-					// ADR invariant (engdocs/adr/0002-init-safety-invariants.md):
-					// runtime error text must not echo a complete destructive
-					// invocation. See 'bd help init-safety' for the token
-					// format. This closes the 58f5989bf failure class where
-					// an agent copy-pasted the suggested command.
-					expectedToken := FormatDestroyToken(prefix)
-					if destroyToken == expectedToken {
-						fmt.Fprintf(os.Stderr, "Destroy token accepted. Proceeding with re-initialization.\n")
-					} else {
-						fmt.Fprintf(os.Stderr, "Refusing to destroy %d issues in non-interactive mode.\n", count)
-						fmt.Fprintf(os.Stderr, "  See 'bd help init-safety' for the required --destroy-token format.\n")
-						fmt.Fprintf(os.Stderr, "  Or export issue records first: bd export > issue-export.jsonl\n")
-						return &exitError{Code: ExitDestroyTokenMissing}
-					}
-				}
-			}
-		}
-
-		// Handle stealth mode setup
-		if stealth {
-			if err := setupStealthMode(!quiet); err != nil {
-				return fmt.Errorf("setting up stealth mode: %v", err)
-			}
-
-			// In stealth mode, skip git hooks installation
-			// since we handle it globally
-			skipHooks = true
-		}
-
 		// Check BEADS_DB environment variable if --db flag not set
 		// (PersistentPreRun doesn't run for init command)
 		if dbPath == "" {
@@ -819,14 +769,13 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}
 
-		// Determine storage path.
-		//
-		// Precedence: --db > BEADS_DIR > default (.beads/dolt)
-		// If there's a redirect file, use the redirect target (GH#bd-0qel)
-		initDBPath := dbPath
-		if initDBPath == "" {
-			// Dolt backend: respect dolt_data_dir config / BEADS_DOLT_DATA_DIR env
-			initDBPath = doltserver.ResolveDoltDir(beadsDirForInit)
+		// Plan the storage root for gate acquisition without side effects.
+		// The operational path is resolved after the destructive preflight.
+		plannedDBPath := dbPath
+		if plannedDBPath == "" {
+			// Plan the physical-root gate without creating a shared-server
+			// directory before destructive reinit confirmation.
+			plannedDBPath = doltserver.DoltDirPath(beadsDirForInit)
 		}
 
 		// Determine if we should create .beads/ directory in CWD or main repo root
@@ -858,18 +807,11 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			return &exitError{Code: 1}
 		}
 
-		initDBDir := filepath.Dir(initDBPath)
-
-		// Convert both to absolute paths for comparison
+		// Convert the workspace to an absolute path before gate planning.
 		beadsDirAbs, err := filepath.Abs(beadsDir)
 		if err != nil {
 			beadsDirAbs = filepath.Clean(beadsDir)
 		}
-		initDBDirAbs, err := filepath.Abs(initDBDir)
-		if err != nil {
-			initDBDirAbs = filepath.Clean(initDBDir)
-		}
-
 		// Workspace operation gate: bd init REPLACES/creates workspace state,
 		// so it holds the workspace gate (plus any resolvable physical-root
 		// gates, e.g. a shared-server dolt dir) EXCLUSIVELY for the rest of
@@ -879,9 +821,9 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// works before .beads exists; the acquisition must come before any
 		// directory writes below, and before acquireEmbeddedLock (lock
 		// ordering: gates rank before every other beads lock).
-		initDBPathAbs, err := filepath.Abs(initDBPath)
+		plannedDBPathAbs, err := filepath.Abs(plannedDBPath)
 		if err != nil {
-			initDBPathAbs = filepath.Clean(initDBPath)
+			plannedDBPathAbs = filepath.Clean(plannedDBPath)
 		}
 		// Physical-root gates guard DIRECTORIES. With --db the path can be
 		// a database FILE; gating it verbatim would create
@@ -889,14 +831,42 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// data ungated, so normalize to the containing directory. A
 		// nonexistent path is assumed to be a directory (the default
 		// resolver paths are all dolt data dirs).
-		if fi, statErr := os.Stat(initDBPathAbs); statErr == nil && !fi.IsDir() {
-			initDBPathAbs = filepath.Dir(initDBPathAbs)
+		if fi, statErr := os.Stat(plannedDBPathAbs); statErr == nil && !fi.IsDir() {
+			plannedDBPathAbs = filepath.Dir(plannedDBPathAbs)
 		}
-		initGateHandle, gateErr := acquireExclusiveWorkspaceGates(rootCtx, beadsDirAbs, "bd init", initDBPathAbs)
+		initGateHandle, gateErr := acquireInitMutationGate(rootCtx, beadsDirAbs, plannedDBPathAbs, func() error {
+			return runInitReinitPreflight(reinitLocal, destroyTokenPrefix, destroyToken)
+		})
 		if gateErr != nil {
-			return fmt.Errorf("bd init refuses to run over live bd activity on this workspace: %w", gateErr)
+			return gateErr
 		}
 		defer func() { _ = initGateHandle.Release() }()
+
+		// Resolve the operational storage path only after held-gate preflight
+		// succeeds. ResolveDoltDir retains its mkdir-on-use behavior for a
+		// real shared-server initialization.
+		initDBPath := dbPath
+		if initDBPath == "" {
+			initDBPath = doltserver.ResolveDoltDir(beadsDirForInit)
+		}
+		initDBDir := filepath.Dir(initDBPath)
+		initDBDirAbs, err := filepath.Abs(initDBDir)
+		if err != nil {
+			initDBDirAbs = filepath.Clean(initDBDir)
+		}
+
+		// Do not mutate the repository for stealth mode until a destructive
+		// reinit has passed its held-gate confirmation. Remote safety above
+		// still evaluates the flag before this point.
+		if stealth {
+			if err := setupStealthMode(!quiet); err != nil {
+				return fmt.Errorf("setting up stealth mode: %v", err)
+			}
+
+			// In stealth mode, skip git hooks installation since we handle it
+			// globally.
+			skipHooks = true
+		}
 
 		// Always create local .beads/ when using default location (CWD/.beads).
 		// The local directory is needed for metadata.json, config.yaml,
@@ -2489,6 +2459,53 @@ func countExistingIssues(_ string) (int, error) {
 		return 0, nil
 	}
 	return stats.TotalIssues, nil
+}
+
+// runInitReinitPreflight confirms the destructive local replacement while the
+// caller holds init's complete exclusive gate set.
+func runInitReinitPreflight(reinitLocal bool, prefix, destroyToken string) error {
+	if !reinitLocal {
+		return nil
+	}
+	count, err := countExistingIssues(prefix)
+	if err != nil || count == 0 {
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "\n%s Re-initializing will destroy the existing database.\n\n", ui.RenderWarn("WARNING:"))
+	fmt.Fprintf(os.Stderr, "  Existing issues: %d\n\n", count)
+	fmt.Fprintf(os.Stderr, "  This action CANNOT be undone. All issues, dependencies, and\n")
+	fmt.Fprintf(os.Stderr, "  Dolt commit history will be permanently lost.\n\n")
+	fmt.Fprintf(os.Stderr, "  Before proceeding, consider:\n")
+	fmt.Fprintf(os.Stderr, "    bd export > issue-export.jsonl    # Export issue records, not full DB state\n")
+	fmt.Fprintf(os.Stderr, "    bd dolt status              # Check if this is a server config issue\n\n")
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		fmt.Fprintf(os.Stderr, "Type 'destroy %d issues' to confirm: ", count)
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Scan()
+		expected := fmt.Sprintf("destroy %d issues", count)
+		if strings.TrimSpace(scanner.Text()) != expected {
+			fmt.Fprintf(os.Stderr, "\nAborted. Database was NOT modified.\n")
+			return &exitError{Code: ExitLocalExistsRefused}
+		}
+		return nil
+	}
+
+	// Non-interactive (piped input, AI agent, etc.)
+	//
+	// ADR invariant (engdocs/adr/0002-init-safety-invariants.md): runtime
+	// error text must not echo a complete destructive invocation. See
+	// 'bd help init-safety' for the token format. This closes the
+	// 58f5989bf failure class where an agent copy-pasted the suggestion.
+	expectedToken := FormatDestroyToken(prefix)
+	if destroyToken == expectedToken {
+		fmt.Fprintf(os.Stderr, "Destroy token accepted. Proceeding with re-initialization.\n")
+		return nil
+	}
+	fmt.Fprintf(os.Stderr, "Refusing to destroy %d issues in non-interactive mode.\n", count)
+	fmt.Fprintf(os.Stderr, "  See 'bd help init-safety' for the required --destroy-token format.\n")
+	fmt.Fprintf(os.Stderr, "  Or export issue records first: bd export > issue-export.jsonl\n")
+	return &exitError{Code: ExitDestroyTokenMissing}
 }
 
 // checkExistingBeadsData checks for existing database files

--- a/cmd/bd/workspace_gate.go
+++ b/cmd/bd/workspace_gate.go
@@ -66,6 +66,17 @@ var workspaceGateHandle *workspacegate.MultiHandle
 // const, so tests can shorten it.
 var exclusiveGateWait = 5 * time.Second
 
+// exclusiveGateOnWait reports the first contended exclusive-gate attempt.
+// Kept as a variable so ordering tests can observe contention without sleeps.
+var exclusiveGateOnWait = func(holder string) {
+	if !quietFlag {
+		// %q: the holder string comes from another process's gate sidecar;
+		// quoting neutralizes terminal escape sequences a hostile or corrupt
+		// sidecar could smuggle into stderr.
+		fmt.Fprintf(os.Stderr, "waiting for other bd commands to finish (%q)...\n", holder) //nolint:gosec // G705: stderr, not a browser context; %q additionally neutralizes terminal escapes
+	}
+}
+
 // exclusiveGateOptions builds the acquisition options for an EXCLUSIVE
 // hold: bounded wait, holder-info reason, and a single stderr note when the
 // first attempt comes back busy so the wait does not look like a hang.
@@ -73,14 +84,7 @@ func exclusiveGateOptions(reason string) workspacegate.Options {
 	return workspacegate.Options{
 		Wait:   exclusiveGateWait,
 		Reason: reason,
-		OnWait: func(holder string) {
-			if !quietFlag {
-				// %q: the holder string comes from another process's gate
-				// sidecar; quoting neutralizes terminal escape sequences a
-				// hostile or corrupt sidecar could smuggle into stderr.
-				fmt.Fprintf(os.Stderr, "waiting for other bd commands to finish (%q)...\n", holder) //nolint:gosec // G705: stderr, not a browser context; %q additionally neutralizes terminal escapes
-			}
-		},
+		OnWait: exclusiveGateOnWait,
 	}
 }
 
@@ -290,4 +294,20 @@ func acquireExclusiveWorkspaceGates(ctx context.Context, beadsDir, reason string
 	}
 	return workspacegate.AcquireAll(ctx, workspacegate.Exclusive,
 		exclusiveGateOptions(reason), gates...)
+}
+
+// acquireInitMutationGate holds init's complete exclusive gate set while its
+// destructive preflight runs. A refusal or preflight error releases the gates;
+// a successful caller owns the returned handle through replacement.
+func acquireInitMutationGate(ctx context.Context, beadsDir, physicalRoot string, preflight func() error) (*workspacegate.MultiHandle, error) {
+	h, err := acquireExclusiveWorkspaceGates(ctx, beadsDir, "bd init", physicalRoot)
+	if err != nil {
+		return nil, fmt.Errorf("bd init refuses to run over live bd activity on this workspace: %w", err)
+	}
+	if preflight != nil {
+		if err := preflight(); err != nil {
+			return nil, errors.Join(err, h.Release())
+		}
+	}
+	return h, nil
 }

--- a/cmd/bd/workspace_gate_test.go
+++ b/cmd/bd/workspace_gate_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -111,6 +112,95 @@ func TestAcquireCommandWorkspaceGatesBlockedByExclusiveHolder(t *testing.T) {
 	}
 	if workspaceGateHandle != nil {
 		t.Error("failed acquisition must leave no gate handle")
+	}
+}
+
+func TestAcquireInitMutationGateKeepsReplacementExclusiveDuringPreflight(t *testing.T) {
+	resetGateTestEnv(t)
+	beadsDir := newGateTestWorkspace(t)
+	physicalRoot := filepath.Join(filepath.Dir(beadsDir), "dolt-data")
+
+	oldOnWait := exclusiveGateOnWait
+	secondWaited := make(chan struct{}, 1)
+	exclusiveGateOnWait = func(string) {
+		select {
+		case secondWaited <- struct{}{}:
+		default:
+		}
+	}
+	t.Cleanup(func() { exclusiveGateOnWait = oldOnWait })
+
+	firstPreflightEntered := make(chan struct{})
+	allowFirstPreflight := make(chan struct{})
+	type result struct {
+		h   *workspacegate.MultiHandle
+		err error
+	}
+	firstResult := make(chan result, 1)
+	go func() {
+		h, err := acquireInitMutationGate(context.Background(), beadsDir, physicalRoot, func() error {
+			close(firstPreflightEntered)
+			<-allowFirstPreflight
+			return nil
+		})
+		firstResult <- result{h: h, err: err}
+	}()
+	<-firstPreflightEntered
+
+	secondPreflightEntered := make(chan struct{})
+	secondResult := make(chan result, 1)
+	go func() {
+		h, err := acquireInitMutationGate(context.Background(), beadsDir, physicalRoot, func() error {
+			close(secondPreflightEntered)
+			return nil
+		})
+		secondResult <- result{h: h, err: err}
+	}()
+
+	select {
+	case <-secondWaited:
+	case <-secondPreflightEntered:
+		t.Fatal("second replacement entered preflight while first held the mutation gates")
+	}
+
+	close(allowFirstPreflight)
+	first := <-firstResult
+	if first.err != nil {
+		t.Fatalf("first init mutation gate: %v", first.err)
+	}
+	if err := first.h.Release(); err != nil {
+		t.Fatalf("release first init mutation gate: %v", err)
+	}
+
+	<-secondPreflightEntered
+	second := <-secondResult
+	if second.err != nil {
+		t.Fatalf("second init mutation gate: %v", second.err)
+	}
+	if err := second.h.Release(); err != nil {
+		t.Fatalf("release second init mutation gate: %v", err)
+	}
+}
+
+func TestAcquireInitMutationGateReleasesOnPreflightError(t *testing.T) {
+	resetGateTestEnv(t)
+	beadsDir := newGateTestWorkspace(t)
+	physicalRoot := filepath.Join(filepath.Dir(beadsDir), "dolt-data")
+	refusal := errors.New("destroy token rejected")
+
+	_, err := acquireInitMutationGate(context.Background(), beadsDir, physicalRoot, func() error {
+		return refusal
+	})
+	if !errors.Is(err, refusal) {
+		t.Fatalf("init mutation gate error = %v, want preflight refusal", err)
+	}
+
+	h, err := acquireInitMutationGate(context.Background(), beadsDir, physicalRoot, nil)
+	if err != nil {
+		t.Fatalf("init mutation gate remained held after refusal: %v", err)
+	}
+	if err := h.Release(); err != nil {
+		t.Fatalf("release init mutation gate: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

Hold destructive embedded reinit preflight and database replacement under one all-at-once exclusive workspace/physical-root gate:

`AcquireAll` → count existing issues / confirm destroy intent → resolve operational path → replace database → release.

The new init-specific helper releases the complete gate set on preflight refusal or error, and returns the still-held handle on success so the caller retains it through replacement.

## Why

`countExistingIssues` previously opened and closed the embedded Dolt store before init acquired its replacement gate. A concurrent `bd init --reinit-local` process could acquire the gate, replace the same Dolt files, and delete the Noms manifest while that preflight reader was still alive. Main run [30777456349](https://github.com/gastownhall/beads/actions/runs/30777456349), job [91575854462](https://github.com/gastownhall/beads/actions/runs/30777456349/job/91575854462), caught the resulting Dolt close panic in `TestEmbeddedInitConcurrent`.

This is scheduler-sensitive production ordering, not a regression from #5306: that PR changed only test scenarios and left the concurrent test and init implementation untouched.

Tracks `bd-dswzy`.

## Safety and behavior preservation

- Remote-history safety still runs before gate acquisition.
- Gate planning uses side-effect-free `DoltDirPath`; the operational `ResolveDoltDir` and its existing shared-server fallback run only after confirmation, while the gate is held.
- The destroy token uses the exact raw, pre-fallback, pre-normalization prefix used by the former block.
- Existing warning text, refusal exit codes, and the historical handling of issue-count errors are unchanged.
- `--stealth` and repository/storage mutations begin only after successful preflight.
- No retry, sleep, panic suppression, timeout increase, or weakened concurrency assertion was added.

Open contributor PR #4415 overlaps `cmd/bd/init.go` as part of its much broader flat-file backend work, but does not address this ordering race. This fix does not replace, close, or alter its backend-selection intent or future `withDoltBackend` pins.

## Verification

TDD RED was established before implementation: the deterministic gate-lifetime test failed to compile because `acquireInitMutationGate` and its observable `OnWait` seam did not exist.

Passed after implementation:

```text
./scripts/test.sh -run '^(TestAcquireInitMutationGateKeepsReplacementExclusiveDuringPreflight|TestAcquireInitMutationGateReleasesOnPreflightError|TestInitGateBusyClassifiedAsLockContention)$' ./cmd/bd
./scripts/test.sh -run '^(TestResolvePhysicalRootsSharedServerWinsOverMetadata|TestResolvePhysicalRootsSideEffectFree)$' ./internal/doltserver
golangci-lint run ./cmd/bd/...
GOTOOLCHAIN=go1.26.5 make test
```

Final baseline evidence:

- `make test`: exit 0
- `cmd/bd`: 310.403s
- `internal/doltserver`: 189.989s
- total coverage: 40.0%
- reviewed patch SHA-256: `631f53808dfe87fd342e7733046954608bec735ec4d463272c783c8c311fade0`

Two independent Sol reviewers examined the frozen composite for concurrency, cleanup, init-safety, and behavior neutrality. They found two major issues during review—pre-confirmation shared-server directory creation and accidental loss of the operational resolver fallback. Both were corrected with a pure plan/execute split; the final hash was re-reviewed and approved with no blocker or major findings.

## Risk and scope

This changes the init-safety critical path and requires substantive human maintainer review. It does not change storage schemas, confirmation policy, accepted contention outcomes, backend selection, or test inventory. The author will not self-merge it.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
