### PR TITLE
Fix: predicate-form search-counts now scope aggregates to the filtered result set

### DIFF
--- a/internal/storage/domain/db/issue_search_counts_test.go
+++ b/internal/storage/domain/db/issue_search_counts_test.go
@@ -18,6 +18,7 @@ func (s *testSuite) TestIssueSearchAcrossIssuesAndWispsWithCounts() {
 	s.Run("LimitRespected", s.searchCountsLimit)
 	s.Run("CollisionAcrossTablesKeepsTheWispCopy", s.searchCountsCollision)
 	s.Run("PredicateFormMatchesByIDsForm", s.searchCountsPredicateMatchesByIDs)
+	s.Run("PredicateFormMatchesByIDsFormOnWispPlane", s.searchCountsWispPredicateMatchesByIDs)
 }
 
 func (s *testSuite) searchCountsDepAndRDep() {
@@ -288,6 +289,48 @@ func (s *testSuite) searchCountsPredicateMatchesByIDs() {
 	s.Equal(*i.Parent, *p.Parent, "parent parity")
 	s.ElementsMatch(i.Issue.Labels, p.Issue.Labels, "labels parity")
 	s.Require().Len(p.Issue.Dependencies, len(i.Issue.Dependencies), "deps_json length parity")
+}
+
+// searchCountsWispPredicateMatchesByIDs is the wisp-plane twin of
+// searchCountsPredicateMatchesByIDs. The two forms resolve labels through
+// different tables — the wisp plane reads wisp_labels, and that unfiltered
+// join is what motivated bounding the aggregates to the driver's row set in
+// the first place (be-dlt6f: a fixed ~1.6s regardless of how narrow the search
+// was). A bound that is right on the issues plane and wrong here would leave
+// the motivating case unpinned, so assert parity on the plane that pays for it.
+func (s *testSuite) searchCountsWispPredicateMatchesByIDs() {
+	r := s.issueRepo()
+	uc := s.labelUseCase()
+
+	w := newTestIssue("bd-srxc-wpar-1", "wisp parity")
+	w.Ephemeral = true
+	s.Require().NoError(r.Insert(s.Ctx(), w, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
+	s.Require().NoError(uc.AddWispLabel(s.Ctx(), "bd-srxc-wpar-1", "alpha", "tester"))
+	s.Require().NoError(uc.AddWispLabel(s.Ctx(), "bd-srxc-wpar-1", "beta", "tester"))
+
+	// Ephemeral pins both reads to the wisp plane; IDPrefix drives the
+	// predicate form (whereSQL bounds the driver, ids empty) and IDs drives
+	// the by-IDs form. Same wisp, same filter intent.
+	yes := true
+	byPredicate, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srxc-wpar-1", Ephemeral: &yes})
+	s.Require().NoError(err)
+	s.Require().Len(byPredicate.Items, 1)
+
+	byID, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDs: []string{"bd-srxc-wpar-1"}, Ephemeral: &yes})
+	s.Require().NoError(err)
+	s.Require().Len(byID.Items, 1)
+
+	p, i := byPredicate.Items[0], byID.Items[0]
+	// Guard the premise first: labels parity is vacuous if the reference side
+	// came back empty, which is exactly what a wisp_labels bound that dropped
+	// the row would look like.
+	s.Require().NotEmpty(i.Issue.Labels, "fixture must give the reference side wisp labels")
+	s.ElementsMatch(i.Issue.Labels, p.Issue.Labels, "wisp labels parity")
+	s.Equal(i.DependencyCount, p.DependencyCount, "dependency_count parity")
+	s.Equal(i.DependentCount, p.DependentCount, "dependent_count parity")
+	s.Equal(i.CommentCount, p.CommentCount, "comment_count parity")
 }
 
 func iwcIDs(page domain.SearchCountsPage) []string {

--- a/internal/storage/domain/db/issue_search_counts_test.go
+++ b/internal/storage/domain/db/issue_search_counts_test.go
@@ -235,14 +235,22 @@ func (s *testSuite) searchCountsPredicateMatchesByIDs() {
 	s.Require().NoError(r.Insert(s.Ctx(), mid, "tester", domain.InsertIssueOpts{}))
 	a := newTestIssue("bd-srxc-par2-a", "a")
 	s.Require().NoError(r.Insert(s.Ctx(), a, "tester", domain.InsertIssueOpts{}))
+	b := newTestIssue("bd-srxc-par2-b", "b")
+	s.Require().NoError(r.Insert(s.Ctx(), b, "tester", domain.InsertIssueOpts{}))
 
-	// mid blocks a (outgoing/DependencyCount); a blocks mid (incoming/
+	// mid depends on a (outgoing/DependencyCount); b depends on mid (incoming/
 	// DependentCount); mid is a child of parent (Parent); mid has a label and
 	// a comment. Every projected count/JSON field is nonzero so a subquery
 	// that silently drops mid's rows would show up as a mismatch, not a
 	// coincidental 0 == 0.
+	//
+	// The incoming edge comes from a distinct issue b, not from a: mid -> a
+	// plus a -> mid is a 2-cycle, and Insert rejects scheduling deps that
+	// close one (domain.ErrDependencyCycle). parent cannot play that role
+	// either — a blocker that is the issue's ancestor trips
+	// ValidateBlockingHierarchy — so the incoming blocker needs its own issue.
 	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-srxc-par2-mid", "bd-srxc-par2-a", types.DepBlocks), "tester", domain.DepInsertOpts{}))
-	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-srxc-par2-a", "bd-srxc-par2-mid", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-srxc-par2-b", "bd-srxc-par2-mid", types.DepBlocks), "tester", domain.DepInsertOpts{}))
 	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-srxc-par2-mid", "bd-srxc-par2-parent", types.DepParentChild), "tester", domain.DepInsertOpts{}))
 	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-srxc-par2-mid", "alpha", "tester", domain.LabelOpts{}))
 	_, err := s.Runner().ExecContext(s.Ctx(),
@@ -263,6 +271,15 @@ func (s *testSuite) searchCountsPredicateMatchesByIDs() {
 	s.Require().Len(byID.Items, 1)
 
 	p, i := byPredicate.Items[0], byID.Items[0]
+	// Guard the premise before comparing: every parity assertion below is
+	// vacuous if the fixture left the reference side at zero, so pin the
+	// by-IDs form's counts as nonzero first. Without this a fixture that
+	// stopped producing edges would keep passing as 0 == 0.
+	s.Require().NotZero(i.DependencyCount, "fixture must give the reference side an outgoing dep")
+	s.Require().NotZero(i.DependentCount, "fixture must give the reference side an incoming dep")
+	s.Require().NotZero(i.CommentCount, "fixture must give the reference side a comment")
+	s.Require().NotEmpty(i.Issue.Labels, "fixture must give the reference side a label")
+	s.Require().NotEmpty(i.Issue.Dependencies, "fixture must give the reference side deps_json rows")
 	s.Equal(i.DependencyCount, p.DependencyCount, "dependency_count parity")
 	s.Equal(i.DependentCount, p.DependentCount, "dependent_count parity")
 	s.Equal(i.CommentCount, p.CommentCount, "comment_count parity")

--- a/internal/storage/domain/db/issue_search_counts_test.go
+++ b/internal/storage/domain/db/issue_search_counts_test.go
@@ -17,6 +17,7 @@ func (s *testSuite) TestIssueSearchAcrossIssuesAndWispsWithCounts() {
 	s.Run("SortByPriorityThenCreatedAt", s.searchCountsSortOrder)
 	s.Run("LimitRespected", s.searchCountsLimit)
 	s.Run("CollisionAcrossTablesKeepsTheWispCopy", s.searchCountsCollision)
+	s.Run("PredicateFormMatchesByIDsForm", s.searchCountsPredicateMatchesByIDs)
 }
 
 func (s *testSuite) searchCountsDepAndRDep() {
@@ -215,6 +216,61 @@ func (s *testSuite) searchCountsCollision() {
 	s.Require().Len(out.Items, 1, "the id must come back once, not once per plane")
 	s.Require().NotNil(out.Items[0].Issue)
 	s.Equal("wisp", out.Items[0].Issue.Title, "the wisps copy is canonical; the issues copy is the stale one")
+}
+
+// searchCountsPredicateMatchesByIDs pins be-dlt6f's result-equivalence
+// guarantee (see the SearchCountsSQL doc comment): narrowing each aggregate
+// subquery's input to the driver's filtered row set must change the query
+// plan, not the rows. Every count/JSON field the mega-query projects is
+// exercised (dep/rdep/comment counts, parent, labels, deps_json) so a fix
+// that accidentally drops rows from one subquery's bound would surface here.
+func (s *testSuite) searchCountsPredicateMatchesByIDs() {
+	r := s.issueRepo()
+	dep := s.depRepo()
+	labelRepo := NewLabelSQLRepository(s.Runner())
+
+	parent := newTestIssue("bd-srxc-par2-parent", "parent")
+	s.Require().NoError(r.Insert(s.Ctx(), parent, "tester", domain.InsertIssueOpts{}))
+	mid := newTestIssue("bd-srxc-par2-mid", "mid")
+	s.Require().NoError(r.Insert(s.Ctx(), mid, "tester", domain.InsertIssueOpts{}))
+	a := newTestIssue("bd-srxc-par2-a", "a")
+	s.Require().NoError(r.Insert(s.Ctx(), a, "tester", domain.InsertIssueOpts{}))
+
+	// mid blocks a (outgoing/DependencyCount); a blocks mid (incoming/
+	// DependentCount); mid is a child of parent (Parent); mid has a label and
+	// a comment. Every projected count/JSON field is nonzero so a subquery
+	// that silently drops mid's rows would show up as a mismatch, not a
+	// coincidental 0 == 0.
+	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-srxc-par2-mid", "bd-srxc-par2-a", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-srxc-par2-a", "bd-srxc-par2-mid", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-srxc-par2-mid", "bd-srxc-par2-parent", types.DepParentChild), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-srxc-par2-mid", "alpha", "tester", domain.LabelOpts{}))
+	_, err := s.Runner().ExecContext(s.Ctx(),
+		"INSERT INTO comments (id, issue_id, author, text) VALUES (UUID(), ?, ?, ?)",
+		"bd-srxc-par2-mid", "tester", "comment")
+	s.Require().NoError(err)
+
+	// IDPrefix drives the predicate form (whereSQL bounds the driver, ids is
+	// empty); IDs drives the by-IDs form. Same issue, same filter intent.
+	byPredicate, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srxc-par2-mid", SkipWisps: true})
+	s.Require().NoError(err)
+	s.Require().Len(byPredicate.Items, 1)
+
+	byID, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDs: []string{"bd-srxc-par2-mid"}, SkipWisps: true})
+	s.Require().NoError(err)
+	s.Require().Len(byID.Items, 1)
+
+	p, i := byPredicate.Items[0], byID.Items[0]
+	s.Equal(i.DependencyCount, p.DependencyCount, "dependency_count parity")
+	s.Equal(i.DependentCount, p.DependentCount, "dependent_count parity")
+	s.Equal(i.CommentCount, p.CommentCount, "comment_count parity")
+	s.Require().NotNil(i.Parent)
+	s.Require().NotNil(p.Parent)
+	s.Equal(*i.Parent, *p.Parent, "parent parity")
+	s.ElementsMatch(i.Issue.Labels, p.Issue.Labels, "labels parity")
+	s.Require().Len(p.Issue.Dependencies, len(i.Issue.Dependencies), "deps_json length parity")
 }
 
 func iwcIDs(page domain.SearchCountsPage) []string {

--- a/internal/storage/sqlbuild/counts.go
+++ b/internal/storage/sqlbuild/counts.go
@@ -73,10 +73,11 @@ func (h CountsHydration) IssueColumns() string {
 //
 // There are two forms of the same projection, selected by ids:
 //
-//   - Predicate form (ids empty): whereSQL bounds the driver in an inner
-//     subquery BEFORE the aggregate LEFT JOINs (see below); orderBySQL and
-//     limitSQL stay at the outer level, after the joins. Each count subquery
-//     aggregates its whole side table. The caller supplies its own args; the
+//   - Predicate form (ids empty): whereSQL bounds the driver in a filtered_ids
+//     CTE BEFORE the aggregate LEFT JOINs (see below); orderBySQL and limitSQL
+//     stay at the outer level, after the joins. When whereSQL is non-empty,
+//     each count subquery also bounds its scan to filtered_ids instead of
+//     aggregating its whole side table. The caller supplies its own args; the
 //     returned args slice is nil.
 //
 //   - By-IDs form (ids non-empty): whereSQL/orderBySQL/limitSQL are ignored and
@@ -97,17 +98,22 @@ func (h CountsHydration) IssueColumns() string {
 // input to ids drops only rows for other issues, so the per-issue rows it
 // aggregates — and their relative order — are unchanged.
 //
-// In the predicate form, whereSQL filters the main table in an inner subquery,
-// BEFORE the aggregate LEFT JOINs. The joins all preserve every main row, so
-// filtering before vs. after them yields the identical row set — but it changes
-// the plan Dolt picks: instead of materializing the dep/rdep/comment/label/parent
-// aggregates and joining them to every main row before the WHERE prunes the
-// result, the joins now drive off the already-narrowed set. That is the win for
-// the narrow ephemeral-work searches that dominate the hot path. Only the WHERE
-// moves inward; orderBySQL and limitSQL remain after the joins, because ORDER BY
-// and LIMIT must see the projected aggregate columns and must apply to the final
-// joined result. An empty whereSQL keeps the plain "FROM <main> i" driver: there
-// is no predicate to push down, so the derived table would only interpose a
+// In the predicate form, whereSQL filters the main table once, in a
+// filtered_ids CTE, evaluated BEFORE the aggregate LEFT JOINs. The driver and
+// every aggregate subquery (labels, dc, rc, cc, pc, d) then bound their own
+// scan to filtered_ids instead of aggregating their whole side table before
+// the outer join discards non-matching rows. The joins all preserve every
+// main row, so filtering before vs. after them yields the identical row set —
+// but it changes the plan Dolt picks, and it keeps each subquery from
+// scanning rows the driver filter will discard anyway. That is the win for
+// the narrow ephemeral-work searches that dominate the hot path. whereSQL's
+// placeholders must appear exactly once — the caller supplies args sized for
+// one occurrence — so the CTE is whereSQL's sole owner; every other reference
+// is by id only (SELECT id FROM filtered_ids), no new placeholders. orderBySQL
+// and limitSQL remain after the joins, because ORDER BY and LIMIT must see the
+// projected aggregate columns and must apply to the final joined result. An
+// empty whereSQL keeps the plain "FROM <main> i" driver and skips the CTE:
+// there is no predicate to push down, so either would only interpose a
 // needless wrapper between the planner and the base table.
 //
 // That shape REQUIRES that whereSQL reference only main-table columns (or
@@ -135,9 +141,12 @@ func SearchCountsSQL(tables FilterTables, ids []string, whereSQL, orderBySQL, li
 
 	// Per-subquery id constraints. Empty strings in the predicate form leave the
 	// projection unchanged; in the by-IDs form they push the page down so no
-	// subquery aggregates more than the page's worth of rows.
+	// subquery aggregates more than the page's worth of rows. The predicate
+	// form (whereSQL != "") bounds via the filtered_ids CTE instead of a raw id
+	// list — see driverSQL below.
 	var labelWhere, depBlocksExtra, rcDepExtra, rcWispExtra, ccWhere, pcExtra, depWhere string
-	if byIDs {
+	switch {
+	case byIDs:
 		labelWhere = fmt.Sprintf("WHERE issue_id IN (%s)", inSQL)
 		depBlocksExtra = fmt.Sprintf(" AND issue_id IN (%s)", inSQL)
 		rcDepExtra = fmt.Sprintf(" AND %s IN (%s)", DepTargetExpr, inSQL)
@@ -145,6 +154,15 @@ func SearchCountsSQL(tables FilterTables, ids []string, whereSQL, orderBySQL, li
 		ccWhere = fmt.Sprintf("WHERE issue_id IN (%s)", inSQL)
 		pcExtra = fmt.Sprintf(" AND issue_id IN (%s)", inSQL)
 		depWhere = fmt.Sprintf("WHERE issue_id IN (%s)", inSQL)
+	case whereSQL != "":
+		const filteredIDs = "SELECT id FROM filtered_ids"
+		labelWhere = fmt.Sprintf("WHERE issue_id IN (%s)", filteredIDs)
+		depBlocksExtra = fmt.Sprintf(" AND issue_id IN (%s)", filteredIDs)
+		rcDepExtra = fmt.Sprintf(" AND %s IN (%s)", DepTargetExpr, filteredIDs)
+		rcWispExtra = fmt.Sprintf(" AND %s IN (%s)", DepTargetExpr, filteredIDs)
+		ccWhere = fmt.Sprintf("WHERE issue_id IN (%s)", filteredIDs)
+		pcExtra = fmt.Sprintf(" AND issue_id IN (%s)", filteredIDs)
+		depWhere = fmt.Sprintf("WHERE issue_id IN (%s)", filteredIDs)
 	}
 
 	reverseBlockerSelect := fmt.Sprintf(`
@@ -206,25 +224,37 @@ func SearchCountsSQL(tables FilterTables, ids []string, whereSQL, orderBySQL, li
 		countsJoins = ""
 	}
 
-	// Predicate form with a filter: whereSQL filters the main table inside a
-	// derived table so the aggregate joins drive off the already-narrowed set;
-	// ORDER BY and LIMIT stay outer, after the joins. Everything else — empty
-	// whereSQL (nothing to push down) and the by-IDs form (subqueries already
-	// id-constrained) — keeps the plain driver.
+	// Predicate form with a filter: whereSQL filters the main table once, in a
+	// filtered_ids CTE, so every aggregate subquery below (labels, dc, rc, cc,
+	// pc, d) can bound its own scan to filtered_ids instead of aggregating its
+	// whole side table before the outer join discards non-matching rows
+	// (be-dlt6f: that unfiltered join cost a fixed ~1.6s regardless of how
+	// narrow the search was). whereSQL's placeholders must appear exactly once
+	// — the caller supplies args sized for one occurrence — so the CTE is the
+	// sole owner of whereSQL text; everything else references filtered_ids by
+	// id only. ORDER BY and LIMIT stay outer, after the joins. Everything else
+	// — empty whereSQL (nothing to push down) and the by-IDs form (subqueries
+	// already id-constrained) — keeps the plain driver.
 	driverSQL := fmt.Sprintf("%s i", tables.Main)
+	var cteSQL string
 	if !byIDs && whereSQL != "" {
-		driverSQL = fmt.Sprintf(`(
+		cteSQL = fmt.Sprintf(`WITH filtered_ids AS (
 			SELECT i.*
 			FROM %s i
 			%s
-		) i`, tables.Main, whereSQL)
+		)
+		`, tables.Main, whereSQL)
+		driverSQL = `(
+			SELECT i.*
+			FROM filtered_ids i
+		) i`
 	}
 	outerClause := fmt.Sprintf("%s\n\t\t%s", orderBySQL, limitSQL)
 	if byIDs {
 		outerClause = fmt.Sprintf("WHERE i.id IN (%s)", inSQL)
 	}
 
-	sqlText := fmt.Sprintf(`
+	sqlText := cteSQL + fmt.Sprintf(`
 		SELECT %s,
 			%s,
 			%s,

--- a/internal/storage/sqlbuild/sqlbuild_test.go
+++ b/internal/storage/sqlbuild/sqlbuild_test.go
@@ -323,8 +323,7 @@ func TestSearchCountsSQLShape(t *testing.T) {
 		t.Errorf("labels subquery must bound to filtered_ids, got block:\n%s", block)
 	}
 
-	noWispDeps, _ := SearchCountsSQL(IssuesFilterTables, nil, "", "", "", false, true)
->>>>>>> 1f6306fba (test(feat): red — Fix: predicate-form search aggregates the whole side table — unfiltered wisp_labels join costs a fixed ~1.6s (refs be-dlt6f))
+	noWispDeps, _ := SearchCountsSQL(IssuesFilterTables, nil, "", "", "", false, CountsHydration{SkipLabels: true})
 	if strings.Contains(noWispDeps, "UNION ALL") {
 		t.Error("counts SQL must not union wisp reverse deps when probe says absent")
 	}

--- a/internal/storage/sqlbuild/sqlbuild_test.go
+++ b/internal/storage/sqlbuild/sqlbuild_test.go
@@ -409,6 +409,128 @@ func TestSearchCountsSQLShape(t *testing.T) {
 	}
 }
 
+// leftJoinSubqueries returns the body of each "LEFT JOIN ( ... )" derived table
+// in sql, matching parentheses so a nested subquery (the reverse-blocker UNION)
+// stays inside its parent block rather than ending it early. Plain joins that
+// are not derived tables — "LEFT JOIN leases ON ..." — are skipped: they are
+// 1:1 lookups on the driver's id, not aggregates over a side table.
+func leftJoinSubqueries(sql string) []string {
+	const marker = "LEFT JOIN ("
+	var out []string
+	for i := 0; ; {
+		j := strings.Index(sql[i:], marker)
+		if j < 0 {
+			return out
+		}
+		start := i + j + len(marker)
+		depth, k := 1, start
+		for ; k < len(sql) && depth > 0; k++ {
+			switch sql[k] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+			}
+		}
+		out = append(out, sql[start:k])
+		i = k
+	}
+}
+
+// TestSearchCountsSQLPredicateFormBoundsEverySubqueryAcrossHydration pins the
+// filtered predicate form in every hydration cell, not just the fully hydrated
+// one TestSearchCountsSQLShape asserts against.
+//
+// A fixed reference count cannot do that job: filtered_ids appears 9 times
+// under full hydration but only 5 under SkipCounts and 4 under both opt-outs,
+// because SkipLabels and SkipCounts delete whole subqueries. A count tuned to
+// one cell either fails on the others or is loose enough to miss a genuinely
+// unbounded scan. The property that must hold in EVERY cell is the one the fix
+// exists to guarantee:
+//
+//   - whereSQL is rendered exactly once. The CTE is its sole owner, so every
+//     other reference is by id; a second rendering would add placeholders the
+//     caller — which sizes its own args for one occurrence, since the predicate
+//     form returns nil — never fills in.
+//   - every aggregate subquery that survives the hydration flags bounds its
+//     scan to filtered_ids, instead of aggregating its whole side table before
+//     the outer join discards the non-matching rows (be-dlt6f: that unfiltered
+//     wisp_labels join cost a fixed ~1.6s however narrow the search was).
+func TestSearchCountsSQLPredicateFormBoundsEverySubqueryAcrossHydration(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		hyd  CountsHydration
+	}{
+		{"full", CountsHydration{}},
+		{"skipLabels", CountsHydration{SkipLabels: true}},
+		{"skipCounts", CountsHydration{SkipCounts: true}},
+		{"skipLabels+skipCounts", CountsHydration{SkipLabels: true, SkipCounts: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sql, args := SearchCountsSQL(IssuesFilterTables, nil, "WHERE x = ?", "ORDER BY y", "LIMIT 5", true, tc.hyd)
+
+			if len(args) != 0 {
+				t.Errorf("predicate form must return nil args (caller supplies its own), got %d", len(args))
+			}
+			if n := strings.Count(sql, "WHERE x = ?"); n != 1 {
+				t.Errorf("WHERE x = ? must appear exactly once (else caller args desync), got %d:\n%s", n, sql)
+			}
+			if !strings.Contains(sql, "WITH filtered_ids AS (") {
+				t.Errorf("filtered predicate form must open with the filtered_ids CTE:\n%s", sql)
+			}
+			// The driver reads through the CTE rather than re-filtering the
+			// main table, so the aggregates below drive off the narrowed set.
+			if !strings.Contains(sql, "FROM filtered_ids i") {
+				t.Errorf("driver must select from filtered_ids:\n%s", sql)
+			}
+
+			joins := leftJoinSubqueries(sql)
+			if len(joins) == 0 {
+				t.Fatalf("expected at least one aggregate subquery:\n%s", sql)
+			}
+			for _, block := range joins {
+				if !strings.Contains(block, "filtered_ids") {
+					t.Errorf("aggregate subquery aggregates its whole side table instead of bounding to filtered_ids:\n%s", block)
+				}
+			}
+		})
+	}
+}
+
+// TestSearchCountsSQLSkipCountsPredicateForm covers the SkipCounts x
+// predicate-form cell specifically: the cardinality joins must be gone even
+// when a filter is present, so SkipCounts cannot smuggle an unbounded dc/rc/cc
+// scan back in through the filtered path.
+func TestSearchCountsSQLSkipCountsPredicateForm(t *testing.T) {
+	t.Parallel()
+
+	sql, _ := SearchCountsSQL(IssuesFilterTables, nil, "WHERE x = ?", "ORDER BY y", "LIMIT 5", true, CountsHydration{SkipCounts: true})
+
+	for _, gone := range []string{"dc ON dc.issue_id", "rc ON rc.dep_id", "cc ON cc.issue_id", "COALESCE(dc.cnt, 0)", "UNION ALL"} {
+		if strings.Contains(sql, gone) {
+			t.Errorf("filtered SkipCounts form must drop %q:\n%s", gone, sql)
+		}
+	}
+	// The surviving subqueries are labels, pc and d — each bounded to the CTE.
+	for _, want := range []string{
+		"WHERE issue_id IN (SELECT id FROM filtered_ids)",
+		"0 AS dep_count",
+		"0 AS rdep_count",
+		"0 AS comment_count",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("filtered SkipCounts form missing %q:\n%s", want, sql)
+		}
+	}
+	// Labels survive SkipCounts and must be bounded like any other aggregate.
+	if !strings.Contains(sql, "JSON_ARRAYAGG(label)") {
+		t.Error("SkipCounts must not drop the labels join")
+	}
+}
+
 func TestBuildReadyWorkWhereStatusFilter(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/sqlbuild/sqlbuild_test.go
+++ b/internal/storage/sqlbuild/sqlbuild_test.go
@@ -301,7 +301,30 @@ func TestSearchCountsSQLShape(t *testing.T) {
 		}
 	}
 
-	noWispDeps, _ := SearchCountsSQL(IssuesFilterTables, nil, "", "", "", false, CountsHydration{SkipLabels: true})
+	// Predicate form must bound every aggregate subquery to the filtered driver
+	// row set, not aggregate the whole side table before the outer join
+	// discards non-matching rows (be-dlt6f: unfiltered wisp_labels join costs a
+	// fixed ~1.6s regardless of how narrow the search is). The filter clause
+	// must still appear exactly once — repeating whereSQL's text once per
+	// subquery would add placeholders the caller (which supplies its own args
+	// separately; predicate form returns nil) never fills in.
+	if n := strings.Count(sql, "WHERE x = ?"); n != 1 {
+		t.Errorf("WHERE x = ? must appear exactly once (else caller args desync), got %d", n)
+	}
+	if n := strings.Count(sql, "filtered_ids"); n < 7 {
+		t.Errorf("filtered_ids must bound the driver and all 6 aggregate subqueries (labels, dc, rc-deps, rc-wisp, cc, pc, d), got %d references:\n%s", n, sql)
+	}
+	labelsStart := strings.Index(sql, "JSON_ARRAYAGG(label)")
+	labelsEnd := strings.Index(sql, "GROUP BY issue_id")
+	if labelsStart < 0 || labelsEnd < 0 || labelsEnd < labelsStart {
+		t.Fatalf("could not locate labels subquery block")
+	}
+	if block := sql[labelsStart:labelsEnd]; !strings.Contains(block, "filtered_ids") {
+		t.Errorf("labels subquery must bound to filtered_ids, got block:\n%s", block)
+	}
+
+	noWispDeps, _ := SearchCountsSQL(IssuesFilterTables, nil, "", "", "", false, true)
+>>>>>>> 1f6306fba (test(feat): red — Fix: predicate-form search aggregates the whole side table — unfiltered wisp_labels join costs a fixed ~1.6s (refs be-dlt6f))
 	if strings.Contains(noWispDeps, "UNION ALL") {
 		t.Error("counts SQL must not union wisp reverse deps when probe says absent")
 	}
@@ -316,6 +339,11 @@ func TestSearchCountsSQLShape(t *testing.T) {
 	}
 	if !strings.Contains(noWispDeps, "NULL AS labels_json") {
 		t.Error("counts SQL must project NULL labels_json when skipLabels is set")
+	}
+	// An unfiltered predicate form has no whereSQL to bound the subqueries to,
+	// so it must keep the plain unbounded shape.
+	if strings.Contains(noWispDeps, "filtered_ids") {
+		t.Error("unfiltered predicate form must not reference filtered_ids")
 	}
 
 	// By-IDs form: driver and every subquery are constrained to the ids, and the
@@ -336,6 +364,11 @@ func TestSearchCountsSQLShape(t *testing.T) {
 	}
 	if len(idArgs) != 8*2 {
 		t.Errorf("by-IDs args = %d, want %d", len(idArgs), 8*2)
+	}
+	// The by-IDs form's subqueries are already id-constrained; it must not
+	// also reference filtered_ids (that mechanism is predicate-form only).
+	if strings.Contains(byIDs, "filtered_ids") {
+		t.Error("by-IDs form must not reference filtered_ids")
 	}
 
 	// skipLabels drops the labels point and !includeWispReverseDeps drops the

--- a/release-gates/be-8qyl4-predicate-filtered-search-counts-gate.md
+++ b/release-gates/be-8qyl4-predicate-filtered-search-counts-gate.md
@@ -1,0 +1,60 @@
+# Release gate — be-8qyl4 (predicate-form search-counts filtering fix)
+
+**Date:** 2026-08-04
+**Deployer:** beads/deployer
+**Bead (deploy):** be-8qyl4 — Review: Fix: predicate-form search aggregates the whole side table — unfiltered wisp_labels join costs a fixed ~1.6s (reviewed PASS)
+**Build bead:** be-dlt6f — closed
+**Review bead:** be-k2dzk — closed, review verdict PASS
+**Source commit:** `4f0890fb8264c18a0589db78571105d05efc53f9` (provenance branch `builder/be-dlt6f` — provenance only, never a push target)
+**Branch:** `deploy/be-8qyl4-gate` (isolated, cut fresh at the reviewed SHA)
+**Base:** `origin/main` @ `0621dd6cef` ("Let httpapi.Config take the issue roles as a database source (#5337)")
+**Merge-base:** `0a3ff99f34` ("Add issueops.Claimer and route the HTTP claim through it (#5334)")
+**Merge-tree simulation:** `git merge-tree --write-tree origin/main 4f0890fb8` → tree `fdb73a0a7e`, exit 0, **zero conflicts**
+
+## Verdict: PASS
+
+## Criteria walk
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | be-k2dzk closed by beads/reviewer, `verdict: pass`, close_reason "pass". style_findings: none (gofmt -l clean on all 3 changed files, go vet clean). security_findings: none (blocker/major/minor) — full 9-category OWASP-lens walk, each explicitly justified. |
+| 2 | Acceptance criteria met | PASS | be-k2dzk records `uncovered_criteria: none` — all 5 "done-when" bullets addressed (3 directly verified, 2 covered via justified proxy). Independently re-verified against the diff below, not taken at face value. |
+| 3 | Tests pass | PASS | Documented CI-equivalent (`./scripts/test.sh -v`) run across all 7 packages that reference `SearchCountsSQL`: **1116 PASS / 0 FAIL / 925 SKIP**, exit 0. Went further than the reviewer: found and exercised the `BEADS_TEST_EMBEDDED_DOLT=1` opt-in, obtaining genuine behavioral (not just SQL-shape) verification of all 6 changed aggregate subqueries — 17/17 PASS. See "Tests run" below. |
+| 4 | No high-severity findings open | PASS | be-k2dzk: zero blocker/major/minor security findings, zero style findings. |
+| 5 | Final branch is clean | PASS | `git status` on `deploy/be-8qyl4-gate` at `4f0890fb8`: "nothing to commit, working tree clean." |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main 4f0890fb8` succeeds, single merged tree `fdb73a0a7e`, no conflicts — re-verified against the current `origin/main` tip (freshly fetched), not a stale snapshot. |
+| 7 | Single feature theme | PASS | `git diff --stat 0a3ff99f34 4f0890fb8` (true merge-base to reviewed SHA): 3 files, 143 insertions(+), 25 deletions(-) — `internal/storage/sqlbuild/counts.go` (implementation), `internal/storage/sqlbuild/sqlbuild_test.go` + `internal/storage/domain/db/issue_search_counts_test.go` (tests). One theme throughout: bind all 6 aggregate subqueries in the predicate-form counts query to the same filtered id set the driver already computes. |
+
+## Acceptance check (be-k2dzk "done-when", per be-8qyl4/be-k2dzk notes)
+
+1. **Bounds all 6 aggregate subqueries to the filtered id set.**
+   Verified directly in `internal/storage/sqlbuild/counts.go`: a new `filtered_ids` CTE feeds every subquery's WHERE clause (labels, dep-count, reverse-dep-count, comment-count, parent-count, plus the driver itself), replacing per-subquery full-table scans. **PASS.**
+2. **SQL-shape test (`TestSearchCountsSQLShape`).**
+   Ran directly: PASS, real execution (pure string-shape assertion, no live-DB dependency). **PASS.**
+3. **Parity test (predicate-form vs. by-IDs-form produce identical counts).**
+   The new sub-test in `internal/storage/domain/db/issue_search_counts_test.go` needs a live Dolt container; it SKIPs cleanly in this sandbox (`BEADS_TEST_SKIP=dolt`) — confirmed independently, not taken on the builder's or reviewer's word (see "Tests run" below). A stronger substitute was obtained instead: the cross-backend `search-counts-stats` conformance audit (`backend/conformance/audit_search-counts-stats.go`), which asserts the same counts/parent/labels contract against the embedded-Dolt oracle, PASSES for real (17/17) once `BEADS_TEST_EMBEDDED_DOLT=1` is set — behavioral proof this deployer obtained that neither builder nor reviewer reached. **PASS.**
+4. **`repro.sh` <1s on hq (live production timing).**
+   Not executable from any sandbox (no live hq access) — same limitation builder and reviewer both disclosed. Mechanism verified instead: every aggregate subquery now scans `filtered_ids` (the driver's already-narrowed set) rather than the full side table, the exact mechanism the original 2.644s→0.014s estimate was computed from. Live timing is a deploy-time check. **Proxy-verified, non-blocking** (matches reviewer's disposition).
+5. **`gc status` renders per-agent health correctly (downstream, cross-repo symptom).**
+   Out of reach of beads-repo code review by construction — cross-repo (gascity, not beads), requires this fix actually deployed to hq. This is what routing the merge-request to mayor exists to close out. **Proxy-verified, non-blocking** (matches reviewer's disposition).
+
+## Tests run on release branch
+
+| Command | Result | Notes |
+|---|---|---|
+| `./scripts/test.sh -v ./internal/storage/sqlbuild/... ./internal/storage/domain/db/... ./internal/storage/issueops/... ./internal/storage/dolt/... ./internal/storage/embeddeddolt/... ./internal/storage/uow/... ./backend/...` | **1116 PASS / 0 FAIL / 925 SKIP**, exit 0 | Every consumer of `SearchCountsSQL` (grepped repo-wide) plus the conformance-audit-hosting packages. Per-package: sqlbuild 37/0/0, domain/db 2/0/1, issueops 383/0/0, dolt 531/0/805, embeddeddolt 38/0/94, uow 123/0/25, backend 2/0/0. |
+| `BEADS_TEST_EMBEDDED_DOLT=1 ./scripts/test.sh -v -run 'TestConformance/Audit/search-counts-stats' ./internal/storage/embeddeddolt/...` | **17 PASS / 0 FAIL**, exit 0 | Real behavioral verification of `SearchIssuesWithCounts`, `WispMergeSearchCount`, and 15 other cross-backend audit cases — against the embedded-Dolt oracle, the exact aggregate paths this fix changed. |
+| `BEADS_TEST_EMBEDDED_DOLT=1 TEST_COVER=1 ./scripts/test.sh -v ./internal/storage/embeddeddolt/...` (full package, opt-in enabled) | **441 PASS / 0 FAIL / 0 SKIP**, exit 0, 55.1% coverage | Beyond-scope sanity check: confirms the opt-in doesn't surface any other regression in the package this fix's strongest evidence came from. Not required for this gate; recorded for the next deployer who touches this package. |
+| SKIP audit (925 total, all 7 packages) | All environmental | Every `--- SKIP:` line traced to one of two documented sandbox gates: `BEADS_TEST_SKIP=dolt` (no live Dolt server) or the `BEADS_TEST_EMBEDDED_DOLT=1` opt-in (unset by default, exercised separately above). 708 distinct top-level test names affected, spread across the whole storage-backend test surface — not concentrated on this diff's code paths. Matches the pre-existing sandbox limitation already on file in deployer memory; not something this diff introduced or made worse. |
+
+## Findings from review (no action required)
+
+be-k2dzk (reviewer): zero blocker/major/minor security findings (full 9-category OWASP-lens walk, each explicitly justified n/a or verified-safe — notably confirmed `whereSQL` is still interpolated exactly once in the new CTE, preserving the existing `//nolint:gosec // G201` reviewed pattern). Zero style findings (gofmt -l clean, go vet clean).
+
+## Push target
+
+`origin` (`gastownhall/beads`) push is disabled (placeholder URL) — upstream is fetch-only. `prhead` (`quad341/beads-sec003-contrib`) is the currently-active push convention — used by this session's immediately-prior deploy (be-ulyj3 / PR #5329, still open) and the deploys before it — confirmed via `git push --dry-run`.
+
+## Verdict
+
+**PASS** — push `deploy/be-8qyl4-gate` to `prhead`, open PR against `gastownhall/beads:main`. Merge decision routed to mayor (deployer does not merge).


### PR DESCRIPTION
## What

Predicate-form search queries (search-by-filter, as opposed to search-by-explicit-ID-list) compute several per-issue aggregate counts alongside the results: label counts, dependency counts, reverse-dependency counts, comment counts, and parent-issue lookups. Each of these was implemented as its own subquery joining against the *entire* underlying table, then correlating back to the filtered result rows.

That meant every predicate-form search paid a fixed cost proportional to the size of the whole table (labels, dependencies, comments, etc.) — regardless of how narrow the filter was. A search that matched 3 issues still scanned the full label-assignment table to compute label counts.

## The fix

All six aggregate subqueries now share a single `filtered_ids` CTE — the same narrowed id set the main query already computes — instead of each re-deriving (or ignoring) the filter independently. Aggregates are computed only over rows belonging to the filtered set.

## Why it matters

Removes a fixed, filter-independent cost from every predicate-form search. The narrower the filter, the bigger the relative win, but even broad searches benefit from no longer doing redundant full-table correlation work per aggregate.

## Testing

- SQL-shape test confirms the new query structure.
- Cross-backend behavioral conformance suite (search/count/parent/label assertions against a real embedded database) passes, confirming the aggregates still return identical results to the pre-fix behavior.
- Full test suite for every package that consumes this query path passes with zero failures.
- Live production timing (the original motivating ~1.6s fixed cost) and end-to-end status-rendering behavior are downstream, deploy-time checks outside the scope of this repo's test suite.