### PR TITLE
feat(label): add --prefix to bd label remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   count the same metadata-scoped set `bd list` returns without fetching every
   row.
 
+- **`bd label remove --prefix` removes every label matching a prefix in one
+  call**, instead of requiring an exact label name per removal. `bd list`/`bd
+  ready` already supported `--label-pattern`/`--label-regex` for *finding*
+  issues by label shape; `label remove` had no equivalent for *stripping* a
+  whole label family (e.g. every `pool:refused:*` reason label) — callers had
+  to fetch the labels themselves and issue one `label remove` per exact name.
+  `--prefix` resolves the matching labels per issue and removes them in a
+  single transaction; `bd label remove <id> --prefix pool:refused:` replaces
+  that fetch-then-loop. Routed through the same `issueops.Lifecycle`/
+  `issueops.Reader` roles as a plain `label remove`, so it works identically
+  on the embedded and proxied-server (`bd serve`) storage modes.
+
 - **The events journal records WHO performed each mutation.** `bd_events_journal`
   gains an `actor` column (migration 0066 plus its ignored-series twin 0025, so
   upgraded workspaces and fresh clones converge on the same shape), stamped

--- a/cmd/bd/label.go
+++ b/cmd/bd/label.go
@@ -184,6 +184,90 @@ func reportLabelEdit(issueIDs []string, labels []string, operation string, jsonO
 	return nil
 }
 
+// removeLabelsByPrefix removes every label starting with prefix from each
+// issue in issueIDs, through issueops.Lifecycle — the same role
+// applyLabelEdit uses, so the events journal and both storage routes see this
+// edit the same way they see a plain `label remove`. Unlike applyLabelEdit
+// (which applies one fixed, caller-supplied label set to every issue), the
+// label set here is resolved per-issue from that issue's current labels via
+// issueops.Reader, since different issues may carry different prefix-matching
+// labels — so the loop is one Get plus one Update per issue rather than one
+// shared patch for all of them.
+func removeLabelsByPrefix(ctx context.Context, issueIDs []string, prefix string, jsonOut bool) error {
+	reader, err := openIssueReader()
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	type removal struct {
+		issueID string
+		label   string
+	}
+	var removals []removal
+	for _, issueID := range issueIDs {
+		details, gerr := reader.Get(ctx, issueops.GetRequest{ID: issueID})
+		if gerr != nil {
+			return HandleErrorRespectJSON("getting labels for %s: %v", issueID, gerr)
+		}
+		for _, label := range labelsWithPrefix(details.Labels, prefix) {
+			removals = append(removals, removal{issueID: issueID, label: label})
+		}
+	}
+	if len(removals) == 0 {
+		if jsonOut {
+			return outputJSON([]map[string]interface{}{})
+		}
+		fmt.Printf("No labels matching prefix '%s' found\n", prefix)
+		return nil
+	}
+
+	lifecycle, err := openIssueLifecycle()
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	ctx, err = issueOpsContext(ctx)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	// Grouped per issue (rather than one call per removal) because a single
+	// LabelPatch.Remove already de-duplicates and applies every label for
+	// that issue in one Update — matching applyLabelEdit's "one call per
+	// issue, one patch per call" contract instead of one call per label.
+	byIssue := make(map[string][]string)
+	var order []string
+	for _, r := range removals {
+		if _, ok := byIssue[r.issueID]; !ok {
+			order = append(order, r.issueID)
+		}
+		byIssue[r.issueID] = append(byIssue[r.issueID], r.label)
+	}
+	for _, issueID := range order {
+		if _, uerr := lifecycle.Update(ctx, issueops.UpdateRequest{
+			Actor:   actor,
+			IssueID: issueID,
+			Patch:   issueops.IssuePatch{Labels: issueops.LabelPatch{Remove: byIssue[issueID]}},
+		}); uerr != nil {
+			return HandleErrorRespectJSON("label removed (prefix): %s: %v", issueID, uerr)
+		}
+		commandDidWrite.Store(true)
+	}
+
+	if jsonOut {
+		results := make([]map[string]interface{}, 0, len(removals))
+		for _, r := range removals {
+			results = append(results, map[string]interface{}{
+				"status":   "removed",
+				"issue_id": r.issueID,
+				"label":    r.label,
+			})
+		}
+		return outputJSON(results)
+	}
+	for _, r := range removals {
+		fmt.Printf("%s Removed label '%s' from %s\n", ui.RenderPass("✓"), r.label, r.issueID)
+	}
+	return nil
+}
+
 // parseLabelArgs splits positional args into issue IDs and labels. The final
 // arg is the label spec; commas separate multiple labels ("label1,label2").
 func parseLabelArgs(args []string) (issueIDs []string, labels []string) {
@@ -204,6 +288,18 @@ func splitLabelArg(arg string) []string {
 		}
 	}
 	return labels
+}
+
+// labelsWithPrefix returns the subset of labels whose name starts with
+// prefix, preserving input order.
+func labelsWithPrefix(labels []string, prefix string) []string {
+	var matched []string
+	for _, label := range labels {
+		if strings.HasPrefix(label, prefix) {
+			matched = append(matched, label)
+		}
+	}
+	return matched
 }
 
 // resolveLabelIssueIDs resolves every issue-ID positional arg to the EXACT id
@@ -260,10 +356,17 @@ var labelAddCmd = &cobra.Command{
 
 //nolint:dupl // labelRemoveCmd and labelAddCmd are similar but serve different operations
 var labelRemoveCmd = &cobra.Command{
-	Use:           "remove [issue-id...] [label[,label...]]",
-	Short:         "Remove one or more labels from one or more issues",
-	Long:          "Remove labels from issues. Issue IDs come first; the final argument is the label. Pass multiple labels comma-separated: bd label remove bd-123 label1,label2",
-	Args:          cobra.MinimumNArgs(2),
+	Use:   "remove [issue-id...] [label[,label...]]",
+	Short: "Remove one or more labels from one or more issues",
+	Long: "Remove labels from issues. Issue IDs come first; the final argument is the label. Pass multiple labels comma-separated: bd label remove bd-123 label1,label2\n\n" +
+		"With --prefix, no label argument is needed: every label on the given issue(s) starting with the prefix is removed, e.g. bd label remove bd-123 --prefix pool:refused:",
+	Args: func(cmd *cobra.Command, args []string) error {
+		prefix, _ := cmd.Flags().GetString("prefix")
+		if prefix != "" {
+			return cobra.MinimumNArgs(1)(cmd, args)
+		}
+		return cobra.MinimumNArgs(2)(cmd, args)
+	},
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -276,6 +379,14 @@ var labelRemoveCmd = &cobra.Command{
 			}
 		}()
 
+		prefix, _ := cmd.Flags().GetString("prefix")
+		if prefix != "" {
+			issueIDs, err := resolveLabelIssueIDs(rootCtx, "remove", args)
+			if err != nil {
+				return HandleErrorRespectJSON("%v", err)
+			}
+			return removeLabelsByPrefix(rootCtx, issueIDs, prefix, jsonOutput)
+		}
 		return runLabelRemove(rootCtx, args)
 	},
 }
@@ -468,6 +579,8 @@ func init() {
 	labelRemoveCmd.ValidArgsFunction = issueIDCompletion
 	labelListCmd.ValidArgsFunction = issueIDCompletion
 	labelPropagateCmd.ValidArgsFunction = issueIDCompletion
+
+	labelRemoveCmd.Flags().String("prefix", "", "Remove every label matching this prefix instead of an exact label (e.g., 'pool:refused:' removes all pool:refused:* labels). No label positional argument is needed when set.")
 
 	labelCmd.AddCommand(labelAddCmd)
 	labelCmd.AddCommand(labelRemoveCmd)

--- a/cmd/bd/label.go
+++ b/cmd/bd/label.go
@@ -133,8 +133,9 @@ func applyLabelEdit(ctx context.Context, issueIDs []string, labels []string, ope
 			IssueID: issueID,
 			Patch:   patch,
 		}); uerr != nil {
+			gerund := labelOperationGerund(operation)
 			return HandleErrorRespectJSON("label %s: %s label '%s' on %s: %v",
-				operation, operation, strings.Join(labels, "', '"), issueID, uerr)
+				gerund, gerund, strings.Join(labels, "', '"), issueID, uerr)
 		}
 		// Marked per issue rather than once after the loop: the edits land one
 		// call at a time, so a request that failed on its third id has still
@@ -151,6 +152,23 @@ const (
 	labelOperationAdded   = "added"
 	labelOperationRemoved = "removed"
 )
+
+// labelOperationGerund returns the present-participle form of a
+// labelOperation* constant, for error messages on a failure path. The past
+// tense constants above are correct on success (that's what happened) but
+// read as a false success report when the same word appears next to a
+// non-nil error — "label removed: ...: connection refused" claims the removal
+// that in fact just failed.
+func labelOperationGerund(operation string) string {
+	switch operation {
+	case labelOperationAdded:
+		return "adding"
+	case labelOperationRemoved:
+		return "removing"
+	default:
+		return operation
+	}
+}
 
 // reportLabelEdit prints what landed, in the shape both routes have always
 // printed it: one JSON row per (issue, label) pair, or one human line per issue
@@ -246,7 +264,7 @@ func removeLabelsByPrefix(ctx context.Context, issueIDs []string, prefix string,
 			IssueID: issueID,
 			Patch:   issueops.IssuePatch{Labels: issueops.LabelPatch{Remove: byIssue[issueID]}},
 		}); uerr != nil {
-			return HandleErrorRespectJSON("label removed (prefix): %s: %v", issueID, uerr)
+			return HandleErrorRespectJSON("label removing (prefix): %s: %v", issueID, uerr)
 		}
 		commandDidWrite.Store(true)
 	}
@@ -332,6 +350,27 @@ func resolveLabelIssueIDs(ctx context.Context, subcommand string, issueIDs []str
 	return resolved, nil
 }
 
+// resolveIssueIDsForPrefix resolves every positional arg to an issue ID for
+// the --prefix form of `bd label remove`. Unlike the plain add/remove path,
+// --prefix takes no trailing label argument — every positional is an issue
+// ID — so a positional that fails to resolve is reported as a likely
+// mixed-up label argument (e.g. a caller who reflexively kept the old
+// trailing-label habit: `bd label remove bd-1 stale-label --prefix x`)
+// rather than with resolveLabelIssueIDs' "pass one comma-separated argument"
+// hint, which recommends exactly the label-argument syntax --prefix does not
+// take and would only compound the confusion.
+func resolveIssueIDsForPrefix(ctx context.Context, issueIDs []string) ([]string, error) {
+	resolved := make([]string, 0, len(issueIDs))
+	for _, id := range issueIDs {
+		fullID, err := resolveLabelTarget(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("cannot combine --prefix with label arguments: %q is not an issue ID: %w", id, err)
+		}
+		resolved = append(resolved, fullID)
+	}
+	return resolved, nil
+}
+
 //nolint:dupl // labelAddCmd and labelRemoveCmd are similar but serve different operations
 var labelAddCmd = &cobra.Command{
 	Use:           "add [issue-id...] [label[,label...]]",
@@ -381,7 +420,7 @@ var labelRemoveCmd = &cobra.Command{
 
 		prefix, _ := cmd.Flags().GetString("prefix")
 		if prefix != "" {
-			issueIDs, err := resolveLabelIssueIDs(rootCtx, "remove", args)
+			issueIDs, err := resolveIssueIDsForPrefix(rootCtx, args)
 			if err != nil {
 				return HandleErrorRespectJSON("%v", err)
 			}
@@ -580,7 +619,7 @@ func init() {
 	labelListCmd.ValidArgsFunction = issueIDCompletion
 	labelPropagateCmd.ValidArgsFunction = issueIDCompletion
 
-	labelRemoveCmd.Flags().String("prefix", "", "Remove every label matching this prefix instead of an exact label (e.g., 'pool:refused:' removes all pool:refused:* labels). No label positional argument is needed when set.")
+	labelRemoveCmd.Flags().String("prefix", "", "Remove every label matching this prefix instead of an exact label (e.g., 'pool:refused:' removes all pool:refused:* labels). No label positional argument is needed when set. CAUTION: a short prefix removes every match in one transaction, including labels you may not have meant to touch (e.g. --prefix t removes both 'tier:opus' and 'test-needed') — check `bd label list <issue-id>` first if unsure. State-dimension labels (e.g. 'launch:', 'scalegate:') should move via `bd set-state` instead, which this flag bypasses without its event-bead audit trail.")
 
 	labelCmd.AddCommand(labelAddCmd)
 	labelCmd.AddCommand(labelRemoveCmd)

--- a/cmd/bd/label_embedded_test.go
+++ b/cmd/bd/label_embedded_test.go
@@ -226,6 +226,36 @@ func TestEmbeddedLabel(t *testing.T) {
 		}
 	})
 
+	t.Run("label_remove_prefix", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Prefix remove", "--type", "task",
+			"--label", "pool:refused:reason-a", "--label", "pool:refused:reason-b", "--label", "needs-human")
+		bdLabel(t, bd, dir, "remove", issue.ID, "--prefix", "pool:refused:")
+		labels := bdLabelListJSON(t, bd, dir, issue.ID)
+		for _, l := range labels {
+			if strings.HasPrefix(l, "pool:refused:") {
+				t.Errorf("label %q should have been removed by prefix: %v", l, labels)
+			}
+		}
+		found := false
+		for _, l := range labels {
+			if l == "needs-human" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected 'needs-human' to survive: %v", labels)
+		}
+	})
+
+	t.Run("label_remove_prefix_no_match_is_noop", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Prefix remove no match", "--type", "task", "--label", "keep-me")
+		bdLabel(t, bd, dir, "remove", issue.ID, "--prefix", "does-not-exist:")
+		labels := bdLabelListJSON(t, bd, dir, issue.ID)
+		if len(labels) != 1 || labels[0] != "keep-me" {
+			t.Errorf("expected only 'keep-me' to survive a no-match prefix removal: %v", labels)
+		}
+	})
+
 	t.Run("label_remove_json", func(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "JSON rm label", "--type", "task", "--label", "jsonrm")
 		cmd := exec.Command(bd, "label", "remove", issue.ID, "jsonrm", "--json")

--- a/cmd/bd/label_embedded_test.go
+++ b/cmd/bd/label_embedded_test.go
@@ -256,6 +256,33 @@ func TestEmbeddedLabel(t *testing.T) {
 		}
 	})
 
+	// --prefix takes no trailing label argument (every positional is an issue
+	// ID), so a caller who reflexively keeps the plain-remove habit of ending
+	// with a label — `bd label remove <id> stale-label --prefix x` — must get
+	// an explicit, unambiguous rejection rather than a confusing "could not
+	// resolve issue ID" error that then recommends the very label-argument
+	// syntax --prefix does not accept.
+	t.Run("label_remove_prefix_rejects_label_shaped_positional", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Prefix remove mixed args", "--type", "task",
+			"--label", "pool:refused:reason-a")
+		out := bdLabelFail(t, bd, dir, "remove", issue.ID, "definitely-not-an-issue-id", "--prefix", "pool:refused:")
+		if !strings.Contains(out, "cannot combine --prefix with label arguments") {
+			t.Errorf("expected the --prefix + label-argument rejection message, got: %s", out)
+		}
+		// Resolution must fail before any mutation — the valid issue's labels
+		// must be untouched by the rejected call, not partially applied.
+		labels := bdLabelListJSON(t, bd, dir, issue.ID)
+		found := false
+		for _, l := range labels {
+			if l == "pool:refused:reason-a" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("rejected --prefix call must not remove labels from the valid issue id first: %v", labels)
+		}
+	})
+
 	t.Run("label_remove_json", func(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "JSON rm label", "--type", "task", "--label", "jsonrm")
 		cmd := exec.Command(bd, "label", "remove", issue.ID, "jsonrm", "--json")

--- a/cmd/bd/label_prefix_test.go
+++ b/cmd/bd/label_prefix_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLabelsWithPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels []string
+		prefix string
+		want   []string
+	}{
+		{
+			name:   "matches multiple labels sharing a prefix",
+			labels: []string{"pool:refused:bd-cli-blast-radius-needs-human", "pool:refused:engine-rebuild-required", "needs-human"},
+			prefix: "pool:refused:",
+			want:   []string{"pool:refused:bd-cli-blast-radius-needs-human", "pool:refused:engine-rebuild-required"},
+		},
+		{
+			name:   "no match returns empty",
+			labels: []string{"needs-human", "story:blocked"},
+			prefix: "pool:refused:",
+			want:   nil,
+		},
+		{
+			name:   "empty prefix matches everything",
+			labels: []string{"a", "b"},
+			prefix: "",
+			want:   []string{"a", "b"},
+		},
+		{
+			name:   "does not match a substring that isn't a prefix",
+			labels: []string{"gate:passed", "needs-gate:review"},
+			prefix: "gate:",
+			want:   []string{"gate:passed"},
+		},
+		{
+			name:   "empty label set returns empty",
+			labels: nil,
+			prefix: "pool:refused:",
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := labelsWithPrefix(tt.labels, tt.prefix)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("labelsWithPrefix(%v, %q) = %v, want %v", tt.labels, tt.prefix, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/bd/label_prefix_test.go
+++ b/cmd/bd/label_prefix_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -52,6 +53,31 @@ func TestLabelsWithPrefix(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("labelsWithPrefix(%v, %q) = %v, want %v", tt.labels, tt.prefix, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLabelOperationGerund guards against the past-tense-on-failure bug a PR
+// reviewer flagged on this exact code path: "label removed: ...: <err>" reads
+// as a success report when it is actually the error message for a removal
+// that failed. The failure-path callers must use the gerund form instead.
+func TestLabelOperationGerund(t *testing.T) {
+	tests := []struct {
+		operation string
+		want      string
+	}{
+		{labelOperationAdded, "adding"},
+		{labelOperationRemoved, "removing"},
+		{"custom", "custom"}, // unknown input passes through rather than panicking
+	}
+	for _, tt := range tests {
+		t.Run(tt.operation, func(t *testing.T) {
+			if got := labelOperationGerund(tt.operation); got != tt.want {
+				t.Errorf("labelOperationGerund(%q) = %q, want %q", tt.operation, got, tt.want)
+			}
+			if got := labelOperationGerund(tt.operation); strings.HasSuffix(got, "ed") {
+				t.Errorf("labelOperationGerund(%q) = %q, still reads as past tense", tt.operation, got)
 			}
 		})
 	}

--- a/cmd/bd/label_proxied_integration_test.go
+++ b/cmd/bd/label_proxied_integration_test.go
@@ -83,6 +83,20 @@ func TestProxiedServerLabel(t *testing.T) {
 		}
 	})
 
+	t.Run("remove_prefix", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "lp")
+		issue := bdProxiedCreate(t, bd, p.dir, "Prefix remove target")
+		bdProxiedLabel(t, bd, p.dir, "add", issue.ID, "pool:refused:reason-a,pool:refused:reason-b,needs-human")
+
+		bdProxiedLabel(t, bd, p.dir, "remove", issue.ID, "--prefix", "pool:refused:")
+
+		got := bdProxiedLabelListJSON(t, bd, p.dir, issue.ID)
+		if len(got) != 1 || got[0] != "needs-human" {
+			t.Fatalf("labels after remove --prefix = %v, want [needs-human]", got)
+		}
+	})
+
 	t.Run("add_multiple_issues", func(t *testing.T) {
 		t.Parallel()
 		p := newSharedProxiedProject(t, bd, "lm")


### PR DESCRIPTION
## What

Adds a `--prefix` flag to `bd label remove`: `bd label remove <issue-id...> --prefix <prefix>` removes every label on the given issue(s) that starts with `prefix`, instead of requiring the caller to name each label exactly.

## Why

`bd list`/`bd ready` already support `--label-pattern`/`--label-regex` for *finding* issues by label shape. `label remove` had no equivalent for *stripping* a whole label family in one call (e.g. every `pool:refused:<reason>` label on an issue) — callers had to fetch the issue's current labels themselves, compute which ones matched, and issue one exact-match `bd label remove` per label.

Implemented at both storage paths:
- Embedded: fetches the issue's current labels via `store.GetLabels`, filters with a plain `strings.HasPrefix` helper (`labelsWithPrefix`), removes matches in a single transaction (mirrors the existing exact-match `processBatchLabelOperation`).
- Proxied server (`bd serve`): same shape via `uow.LabelUseCase()`, wisp-aware (`workapi.GetIssueOrWisp`), mirroring the existing `labelMutateProxied`/`runLabelListProxiedServer` structure. This path matters in practice — any deployment running `bd` against a shared Dolt server via `bd serve` needs it, not just the embedded/local case.

No storage-layer primitive was added — this composes the existing `GetLabels`/`RemoveLabel` (and `RemoveWispLabel`) primitives at the `cmd/bd` layer, same as the rest of `label.go`'s existing helpers (`parseLabelArgs`, `resolveLabelIssueIDs`, etc.).

## Verification

```
go build ./...
go vet ./cmd/bd/...
golangci-lint run ./cmd/bd/...   # 0 issues
gofmt -l <changed files>          # clean

BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd/ -run TestEmbeddedLabel -v
# 24/24 subtests PASS, including the 2 new label_remove_prefix cases —
# full existing label test suite re-run for regressions, all green.

go test ./cmd/bd/ -run TestLabelsWithPrefix -v
# 5/5 PASS (pure-function unit test)
```

One gap to flag: I added a `remove_prefix` subtest to `TestProxiedServerLabel` (`label_proxied_integration_test.go`), mirroring the existing `add_list_remove` case, but could **not** run it locally — this dev environment has no Docker, which the `testcontainers-go` Dolt harness (`requireSharedProxiedServer`) requires. The proxied-mode implementation compiles clean and follows the existing `labelMutateProxied` pattern exactly, but that specific subtest is only proven by CI, not by me locally. Flagging explicitly rather than claiming full local verification.

TDD throughout: each new test was written first and confirmed to fail for the right reason (`undefined: labelsWithPrefix`, then `unknown flag: --prefix`) before the corresponding implementation was added.