### PR TITLE
Add fail-closed pre-write mutation gate

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1556,15 +1556,15 @@ var rootCmd = &cobra.Command{
 			if err != nil {
 				return HandleError("failed to open uow provider: %v", err)
 			}
-			// Fire the workspace's script hooks after commits on the
-			// unit-of-work plumbing, which notified no one: hooks now fire on
-			// both write plumbings, from the plumbing rather than from each
-			// command. This is the proxied twin of the wireStorageDecorators
-			// call below. With hooks disabled the sinks are empty and the
-			// provider comes back unwrapped.
+			// Wire the admission runner even when best-effort post-commit hooks
+			// are disabled. --no-hooks must not become a bypass for a configured
+			// synchronous pre_write gate.
 			var uowSinks uow.Sinks
-			if beadsDir != "" && !config.GetBool("no-hooks") {
-				hookRunner = hooks.NewRunner(filepath.Join(beadsDir, "hooks"))
+			if beadsDir != "" {
+				hookRunner = hooks.NewRunnerForBeadsDir(beadsDir)
+				p = uow.NewPreWriteProvider(p, hookRunner)
+			}
+			if hookRunner != nil && !config.GetBool("no-hooks") {
 				uowSinks.Hook = hookRunner
 			}
 			uowProvider = uow.NewNotifyingProvider(p, uowSinks)
@@ -1674,7 +1674,7 @@ var rootCmd = &cobra.Command{
 		// (<repo>/hooks) instead of .beads/hooks; custom dolt_data_dir layouts
 		// can likewise place the Dolt data outside .beads.
 		if beadsDir != "" {
-			hookRunner = hooks.NewRunner(filepath.Join(beadsDir, "hooks"))
+			hookRunner = hooks.NewRunnerForBeadsDir(beadsDir)
 		}
 
 		// Compose the storage decorator chain: OTel instrumentation (no-op

--- a/cmd/bd/storage_chain.go
+++ b/cmd/bd/storage_chain.go
@@ -9,12 +9,16 @@ import (
 // wireStorageDecorators composes the storage chain in the order the rest of
 // bd expects:
 //
-//	caller → HookFiringStore (outer) → InstrumentedStorage → raw DoltStorage
+//	caller → HookFiringStore (optional outer) → PreWriteGateStore →
+//	         InstrumentedStorage → raw DoltStorage
 //
 // telemetry.WrapStorage is a no-op when telemetry is disabled, so the
 // instrumentation layer is only present when BD_OTEL_ENABLED=true (or a
-// legacy BD_OTEL_* selector is set). The hook layer sits outermost so
-// storage spans measure pure DB time without hook-firing overhead.
+// legacy BD_OTEL_* selector is set). The post-commit hook layer sits outermost
+// so storage spans measure pure DB time without hook-firing overhead. The
+// pre-write layer is present whenever a runner exists, including --no-hooks:
+// that flag disables best-effort notifications, never a configured admission
+// gate.
 //
 // Extracted from main.go's PersistentPreRunE so the chain composition is
 // unit-testable — the bug this PR fixes was a missing WrapStorage call,
@@ -24,6 +28,9 @@ func wireStorageDecorators(store storage.DoltStorage, hookRunner *hooks.Runner, 
 		return nil
 	}
 	store = telemetry.WrapStorage(store)
+	if hookRunner != nil {
+		store = storage.NewPreWriteGateStore(store, hookRunner)
+	}
 	if hookRunner != nil && !hooksDisabled {
 		store = storage.NewHookFiringStore(store, hookRunner)
 	}

--- a/cmd/bd/storage_chain_test.go
+++ b/cmd/bd/storage_chain_test.go
@@ -42,8 +42,12 @@ func TestWireStorageDecorators_TelemetryOff_HookOn(t *testing.T) {
 	if !ok {
 		t.Fatalf("outer decorator: got %T; want *storage.HookFiringStore", got)
 	}
-	if inner := hf.Unwrap(); inner.(*stubChainStore) != raw {
-		t.Errorf("HookFiringStore.Unwrap() should return raw store directly when telemetry off; got %T", inner)
+	gate, ok := hf.Unwrap().(*storage.PreWriteGateStore)
+	if !ok {
+		t.Fatalf("HookFiringStore.Unwrap() = %T, want *storage.PreWriteGateStore", hf.Unwrap())
+	}
+	if inner := gate.Unwrap(); inner.(*stubChainStore) != raw {
+		t.Errorf("PreWriteGateStore.Unwrap() should return raw store directly when telemetry off; got %T", inner)
 	}
 }
 
@@ -61,9 +65,13 @@ func TestWireStorageDecorators_TelemetryOn_HookOn(t *testing.T) {
 	if !ok {
 		t.Fatalf("outer decorator: got %T; want *storage.HookFiringStore", got)
 	}
-	inst, ok := hf.Unwrap().(*telemetry.InstrumentedStorage)
+	gate, ok := hf.Unwrap().(*storage.PreWriteGateStore)
 	if !ok {
-		t.Fatalf("middle decorator: got %T; want *telemetry.InstrumentedStorage", hf.Unwrap())
+		t.Fatalf("middle decorator: got %T; want *storage.PreWriteGateStore", hf.Unwrap())
+	}
+	inst, ok := gate.Unwrap().(*telemetry.InstrumentedStorage)
+	if !ok {
+		t.Fatalf("inner decorator: got %T; want *telemetry.InstrumentedStorage", gate.Unwrap())
 	}
 	if inner := inst.Unwrap(); inner.(*stubChainStore) != raw {
 		t.Errorf("InstrumentedStorage.Unwrap() should return raw store; got %T", inner)
@@ -95,9 +103,13 @@ func TestWireStorageDecorators_TelemetryOn_HookDisabled(t *testing.T) {
 	raw := &stubChainStore{}
 	got := wireStorageDecorators(raw, hooks.NewRunner("/nonexistent"), true)
 
-	inst, ok := got.(*telemetry.InstrumentedStorage)
+	gate, ok := got.(*storage.PreWriteGateStore)
 	if !ok {
-		t.Fatalf("expected *telemetry.InstrumentedStorage when hooks disabled; got %T", got)
+		t.Fatalf("expected *storage.PreWriteGateStore when hooks disabled; got %T", got)
+	}
+	inst, ok := gate.Unwrap().(*telemetry.InstrumentedStorage)
+	if !ok {
+		t.Fatalf("expected *telemetry.InstrumentedStorage inside gate when hooks disabled; got %T", gate.Unwrap())
 	}
 	if inner := inst.Unwrap(); inner.(*stubChainStore) != raw {
 		t.Errorf("InstrumentedStorage.Unwrap() should return raw store; got %T", inner)
@@ -108,8 +120,9 @@ func TestWireStorageDecorators_TelemetryOff_HookDisabled(t *testing.T) {
 	clearTelemetryEnv(t)
 	raw := &stubChainStore{}
 	got := wireStorageDecorators(raw, hooks.NewRunner("/nonexistent"), true)
-	if got.(*stubChainStore) != raw {
-		t.Errorf("with telemetry off and hooks disabled, expected raw store back; got %T", got)
+	gate, ok := got.(*storage.PreWriteGateStore)
+	if !ok || gate.Unwrap().(*stubChainStore) != raw {
+		t.Errorf("with telemetry off and hooks disabled, expected pre-write gate over raw store; got %T", got)
 	}
 }
 

--- a/docs/reference/events-journal.md
+++ b/docs/reference/events-journal.md
@@ -29,6 +29,11 @@ Beads has three things called events, and they answer different questions.
 | **Audit history** | The per-issue trail behind `bd history <id> --events`: who changed what, when, with the old and new value of the field. | A person is asking who closed this bead, and when. |
 | **Events journal** | One workspace-wide, sequence-ordered stream of committed mutations, replayable from a checkpoint. | A machine is keeping its own copy of the graph in step. |
 
+The [pre-write gate](/reference/pre-write-gate) is deliberately not an event
+system. Its synchronous `pre_write` hook admits or rejects a mutation before it
+starts; it is appropriate for an exclusive maintenance protocol, whereas script
+hooks below remain asynchronous post-commit notifications.
+
 ## Turning it on
 
 ```bash

--- a/docs/reference/pre-write-gate.md
+++ b/docs/reference/pre-write-gate.md
@@ -1,0 +1,63 @@
+---
+title: Pre-write gate
+description: Configure a synchronous, fail-closed workspace admission hook for Beads mutations.
+---
+
+# Pre-write gate
+
+Beads can synchronously ask one workspace-owned executable whether a mutation
+may begin. This is an admission boundary, not an event notification: a refusal,
+timeout, invalid executable, execution error, oversized response, or malformed
+response prevents the write. When no hook is configured, mutations retain their
+normal behavior.
+
+Place an executable at `.beads/hooks/pre_write` on Unix. On Windows, configure
+exactly one of `.beads/hooks/pre_write.exe`, `.cmd`, or `.bat`. The hook runs
+with its working directory set to the workspace root and receives no command
+arguments or issue content. Its environment is reduced to the OS command-path
+variables needed to launch it; the complete input arrives on standard input.
+
+The hook must exit successfully and write exactly one JSON object:
+
+```json
+{"allow": true}
+```
+
+To reject a mutation, return a successful JSON response with `allow: false`:
+
+```json
+{"allow": false, "reason": "exclusive maintenance is in progress"}
+```
+
+The hook input is stable and versioned:
+
+```json
+{
+  "version": 1,
+  "operation": "issue.update",
+  "repository": {
+    "root": "/absolute/workspace",
+    "beads_dir": "/absolute/workspace/.beads"
+  }
+}
+```
+
+`operation` identifies the mutation family, including `issue.create`,
+`issue.update`, `issue.close`, `issue.claim`, `issue.comment`,
+`dependency.add`, `dependency.remove`, and workspace-level changes. New
+operation names are additive. Hooks must reject unknown protocol versions and
+operation names if their own policy cannot safely decide them.
+
+The same admission layer is installed for the direct storage chain and the
+unit-of-work provider used by proxied and HTTP server paths. A transaction that
+is denied before a later write returns an error and rolls back instead of
+committing earlier writes. Read-only operations do not invoke the gate.
+
+The existing `on_create`, `on_update`, and `on_close` scripts remain
+post-commit, asynchronous notifications. `--no-hooks` disables only those
+best-effort notifications; it never bypasses a configured `pre_write` gate.
+
+Hooks run with the local user's authority. Review and protect the executable
+like any other repository automation. The runner rejects symlinks, directories,
+non-executable Unix files, ambiguous Windows candidates, and paths that resolve
+outside the configured hooks directory.

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -3,6 +3,8 @@
 package hooks
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -23,12 +25,78 @@ const (
 	HookOnCreate = "on_create"
 	HookOnUpdate = "on_update"
 	HookOnClose  = "on_close"
+	// HookPreWrite is a synchronous admission hook. Unlike the on_* hooks,
+	// it must reply with a PreWriteResponse before a mutation begins.
+	HookPreWrite = "pre_write"
 )
+
+const (
+	// PreWriteProtocolVersion is the version of the JSON request and response
+	// contract for HookPreWrite.
+	PreWriteProtocolVersion = 1
+
+	// maxPreWriteOutputBytes bounds each response stream. A pre-write hook is
+	// an admission check, not a data transport.
+	maxPreWriteOutputBytes = 32 << 10
+)
+
+// ErrPreWriteRejected is the stable sentinel returned when a configured
+// pre-write hook refuses or cannot safely evaluate a mutation.
+var ErrPreWriteRejected = errors.New("pre-write gate rejected mutation")
+
+// PreWriteRequest is the versioned JSON value sent to a pre-write hook on
+// standard input. It intentionally contains operation metadata only; issue
+// fields and command-line arguments are never injected into a hook's
+// environment.
+type PreWriteRequest struct {
+	Version    int                  `json:"version"`
+	Operation  string               `json:"operation"`
+	Repository PreWriteRepositoryID `json:"repository"`
+}
+
+// PreWriteRepositoryID identifies the workspace whose mutation is seeking
+// admission. Both paths are canonical absolute paths when a hook is present.
+type PreWriteRepositoryID struct {
+	Root     string `json:"root"`
+	BeadsDir string `json:"beads_dir"`
+}
+
+// PreWriteResponse is the only valid JSON response from a configured
+// pre-write hook. Hooks must write one object to stdout and may report a
+// bounded, human-readable reason when denying a mutation.
+type PreWriteResponse struct {
+	Allow  *bool  `json:"allow"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// PreWriteError exposes a stable classification for callers while preserving a
+// concise diagnostic for CLI users. Errors of this type always unwrap to
+// ErrPreWriteRejected.
+type PreWriteError struct {
+	Operation string
+	Kind      string
+	Reason    string
+	Err       error
+}
+
+func (e *PreWriteError) Error() string {
+	message := fmt.Sprintf("%s: operation=%s kind=%s", ErrPreWriteRejected, e.Operation, e.Kind)
+	if e.Reason != "" {
+		message += ": " + e.Reason
+	}
+	if e.Err != nil {
+		message += ": " + e.Err.Error()
+	}
+	return message
+}
+
+func (e *PreWriteError) Unwrap() error { return ErrPreWriteRejected }
 
 // Runner handles hook execution
 type Runner struct {
-	hooksDir string
-	timeout  time.Duration
+	hooksDir      string
+	workspaceRoot string
+	timeout       time.Duration
 	// inFlight counts the hooks Run started and has not finished. A bd
 	// command is short: it fires its hooks after the commit and returns, and
 	// the process exit takes every goroutine with it — including one that has
@@ -47,7 +115,18 @@ func NewRunner(hooksDir string) *Runner {
 
 // NewRunnerFromWorkspace creates a hook runner for a workspace.
 func NewRunnerFromWorkspace(workspaceRoot string) *Runner {
-	return NewRunner(filepath.Join(workspaceRoot, ".beads", "hooks"))
+	return NewRunnerForBeadsDir(filepath.Join(workspaceRoot, ".beads"))
+}
+
+// NewRunnerForBeadsDir creates a runner for one resolved Beads directory.
+// Callers that know the directory should prefer this constructor so pre-write
+// requests name the selected workspace even when .beads is redirected.
+func NewRunnerForBeadsDir(beadsDir string) *Runner {
+	return &Runner{
+		hooksDir:      filepath.Join(beadsDir, "hooks"),
+		workspaceRoot: filepath.Dir(beadsDir),
+		timeout:       10 * time.Second,
+	}
 }
 
 // Run executes a hook if it exists.

--- a/internal/hooks/prewrite.go
+++ b/internal/hooks/prewrite.go
@@ -1,0 +1,206 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// BeforeWrite synchronously admits one mutation. A missing pre_write hook is a
+// no-op; every configured-hook problem denies the write before storage runs.
+func (r *Runner) BeforeWrite(ctx context.Context, operation string) error {
+	hookPath, configured, err := r.preWriteHookPath()
+	if err != nil {
+		return r.preWriteError(operation, "configuration", "", err)
+	}
+	if !configured {
+		return nil
+	}
+
+	repository, err := r.preWriteRepository()
+	if err != nil {
+		return r.preWriteError(operation, "configuration", "", err)
+	}
+	payload, err := json.Marshal(PreWriteRequest{
+		Version:    PreWriteProtocolVersion,
+		Operation:  operation,
+		Repository: repository,
+	})
+	if err != nil {
+		return r.preWriteError(operation, "encode", "", err)
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, hookPath) // #nosec G204 -- validated workspace hook path
+	cmd.Dir = repository.Root
+	cmd.Env = preWriteEnvironment()
+	cmd.Stdin = bytes.NewReader(payload)
+	stdout := &boundedBuffer{limit: maxPreWriteOutputBytes}
+	stderr := &boundedBuffer{limit: maxPreWriteOutputBytes}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	err = runPreWriteCommand(runCtx, cmd)
+	if stdout.exceeded || stderr.exceeded {
+		return r.preWriteError(operation, "output_limit", "", errors.New("hook output exceeds 32 KiB"))
+	}
+	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		return r.preWriteError(operation, "timeout", "", runCtx.Err())
+	}
+	if err != nil {
+		return r.preWriteError(operation, "execution", boundedText(stderr.String()), err)
+	}
+
+	var response PreWriteResponse
+	decoder := json.NewDecoder(bytes.NewReader(stdout.Bytes()))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		return r.preWriteError(operation, "malformed_response", boundedText(stdout.String()), err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = errors.New("response contains multiple JSON values")
+		}
+		return r.preWriteError(operation, "malformed_response", boundedText(stdout.String()), err)
+	}
+	if response.Allow == nil {
+		return r.preWriteError(operation, "malformed_response", "", errors.New(`response is missing "allow"`))
+	}
+	if !*response.Allow {
+		return r.preWriteError(operation, "denied", boundedText(response.Reason), nil)
+	}
+	return nil
+}
+
+func (r *Runner) preWriteError(operation, kind, reason string, err error) error {
+	return &PreWriteError{
+		Operation: operation,
+		Kind:      kind,
+		Reason:    reason,
+		Err:       err,
+	}
+}
+
+func (r *Runner) preWriteRepository() (PreWriteRepositoryID, error) {
+	beadsDir, err := canonicalPath(filepath.Dir(r.hooksDir))
+	if err != nil {
+		return PreWriteRepositoryID{}, fmt.Errorf("resolve Beads directory: %w", err)
+	}
+	root := r.workspaceRoot
+	if root == "" {
+		root = filepath.Dir(beadsDir)
+	}
+	root, err = canonicalPath(root)
+	if err != nil {
+		return PreWriteRepositoryID{}, fmt.Errorf("resolve workspace root: %w", err)
+	}
+	return PreWriteRepositoryID{Root: root, BeadsDir: beadsDir}, nil
+}
+
+func (r *Runner) preWriteHookPath() (string, bool, error) {
+	names := []string{HookPreWrite}
+	if runtime.GOOS == "windows" {
+		names = []string{HookPreWrite + ".exe", HookPreWrite + ".cmd", HookPreWrite + ".bat"}
+	}
+
+	var found []string
+	for _, name := range names {
+		path := filepath.Join(r.hooksDir, name)
+		info, err := os.Lstat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return "", false, err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return "", false, fmt.Errorf("%s must be a regular file, not a symlink or directory", path)
+		}
+		if runtime.GOOS != "windows" && info.Mode()&0111 == 0 {
+			return "", false, fmt.Errorf("%s is not executable", path)
+		}
+		found = append(found, path)
+	}
+	if len(found) == 0 {
+		return "", false, nil
+	}
+	if len(found) != 1 {
+		return "", false, fmt.Errorf("multiple pre-write hooks configured: %s", strings.Join(found, ", "))
+	}
+
+	hooksDir, err := canonicalPath(r.hooksDir)
+	if err != nil {
+		return "", false, err
+	}
+	hookPath, err := canonicalPath(found[0])
+	if err != nil {
+		return "", false, err
+	}
+	rel, err := filepath.Rel(hooksDir, hookPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", false, fmt.Errorf("pre-write hook resolves outside %s", hooksDir)
+	}
+	return hookPath, true, nil
+}
+
+func canonicalPath(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func preWriteEnvironment() []string {
+	env := []string{"PATH=" + os.Getenv("PATH")}
+	if runtime.GOOS == "windows" {
+		for _, key := range []string{"SystemRoot", "ComSpec"} {
+			if value := os.Getenv(key); value != "" {
+				env = append(env, key+"="+value)
+			}
+		}
+	}
+	return env
+}
+
+func boundedText(value string) string {
+	return strings.TrimSpace(value)
+}
+
+type boundedBuffer struct {
+	limit    int
+	buffer   bytes.Buffer
+	exceeded bool
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	remaining := b.limit - b.buffer.Len()
+	if remaining <= 0 {
+		b.exceeded = true
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		_, _ = b.buffer.Write(p[:remaining])
+		b.exceeded = true
+		return len(p), nil
+	}
+	return b.buffer.Write(p)
+}
+
+func (b *boundedBuffer) Bytes() []byte { return b.buffer.Bytes() }
+
+func (b *boundedBuffer) String() string { return b.buffer.String() }

--- a/internal/hooks/prewrite_test.go
+++ b/internal/hooks/prewrite_test.go
@@ -1,0 +1,145 @@
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBeforeWriteMissingHookIsNoOp(t *testing.T) {
+	runner := NewRunnerForBeadsDir(filepath.Join(t.TempDir(), ".beads"))
+	if err := runner.BeforeWrite(t.Context(), "issue.create"); err != nil {
+		t.Fatalf("BeforeWrite without hook: %v", err)
+	}
+}
+
+func TestBeforeWritePassesVersionedRepositoryRequest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is Unix-only")
+	}
+	root := t.TempDir()
+	beadsDir := filepath.Join(root, ".beads")
+	hooksDir := filepath.Join(beadsDir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(root, "request.json")
+	writePreWriteHook(t, hooksDir, "#!/bin/sh\ncat > "+shellQuote(output)+"\nprintf '%s\\n' '{\"allow\":true}'\n")
+
+	runner := NewRunnerForBeadsDir(beadsDir)
+	if err := runner.BeforeWrite(t.Context(), "issue.create"); err != nil {
+		t.Fatalf("BeforeWrite: %v", err)
+	}
+
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var request PreWriteRequest
+	if err := json.Unmarshal(data, &request); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if request.Version != PreWriteProtocolVersion || request.Operation != "issue.create" {
+		t.Fatalf("request = %#v", request)
+	}
+	expectedRoot, err := canonicalPath(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedBeadsDir, err := canonicalPath(beadsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.Repository.Root != expectedRoot || request.Repository.BeadsDir != expectedBeadsDir {
+		t.Fatalf("repository = %#v, want root=%q beads_dir=%q", request.Repository, expectedRoot, expectedBeadsDir)
+	}
+}
+
+func TestBeforeWriteDenialAndMalformedResponseFailClosed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is Unix-only")
+	}
+	for name, response := range map[string]string{
+		"denial":    `{"allow":false,"reason":"maintenance"}`,
+		"malformed": `not json`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			hooksDir := filepath.Join(root, ".beads", "hooks")
+			if err := os.MkdirAll(hooksDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			writePreWriteHook(t, hooksDir, "#!/bin/sh\nprintf '%s\\n' "+shellQuote(response)+"\n")
+
+			err := NewRunnerForBeadsDir(filepath.Join(root, ".beads")).BeforeWrite(context.Background(), "issue.update")
+			if !errors.Is(err, ErrPreWriteRejected) {
+				t.Fatalf("BeforeWrite error = %v, want ErrPreWriteRejected", err)
+			}
+			var rejection *PreWriteError
+			if !errors.As(err, &rejection) {
+				t.Fatalf("BeforeWrite error type = %T, want *PreWriteError", err)
+			}
+			if rejection.Operation != "issue.update" {
+				t.Fatalf("operation = %q, want issue.update", rejection.Operation)
+			}
+		})
+	}
+}
+
+func TestBeforeWriteConfiguredNonExecutableHookFailsClosed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix executable-bit assertion")
+	}
+	root := t.TempDir()
+	hooksDir := filepath.Join(root, ".beads", "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksDir, HookPreWrite), []byte("#!/bin/sh\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := NewRunnerForBeadsDir(filepath.Join(root, ".beads")).BeforeWrite(t.Context(), "issue.close")
+	if !errors.Is(err, ErrPreWriteRejected) {
+		t.Fatalf("BeforeWrite error = %v, want ErrPreWriteRejected", err)
+	}
+}
+
+func TestBeforeWriteTimeoutFailsClosed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is Unix-only")
+	}
+	root := t.TempDir()
+	hooksDir := filepath.Join(root, ".beads", "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writePreWriteHook(t, hooksDir, "#!/bin/sh\nsleep 5\n")
+	runner := NewRunnerForBeadsDir(filepath.Join(root, ".beads"))
+	runner.timeout = 50 * time.Millisecond
+
+	err := runner.BeforeWrite(t.Context(), "issue.close")
+	if !errors.Is(err, ErrPreWriteRejected) {
+		t.Fatalf("BeforeWrite error = %v, want ErrPreWriteRejected", err)
+	}
+	var rejection *PreWriteError
+	if !errors.As(err, &rejection) || rejection.Kind != "timeout" {
+		t.Fatalf("rejection = %#v, want timeout", rejection)
+	}
+}
+
+func writePreWriteHook(t *testing.T, hooksDir, script string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(hooksDir, HookPreWrite), []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/internal/hooks/prewrite_unix.go
+++ b/internal/hooks/prewrite_unix.go
@@ -1,0 +1,35 @@
+//go:build unix
+
+package hooks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// runPreWriteCommand keeps the admission timeout from leaking a hook's
+// descendants. A hook that starts a helper cannot keep holding a maintenance
+// lease after its own admission attempt timed out.
+func runPreWriteCommand(ctx context.Context, cmd *exec.Cmd) error {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		if cmd.Process != nil {
+			if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+				return fmt.Errorf("kill pre-write hook process group: %w", err)
+			}
+		}
+		<-done
+		return ctx.Err()
+	}
+}

--- a/internal/hooks/prewrite_windows.go
+++ b/internal/hooks/prewrite_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package hooks
+
+import (
+	"context"
+	"os/exec"
+)
+
+// Windows has no portable process-group equivalent for arbitrary configured
+// executables. CommandContext kills the configured process at the timeout; a
+// hook that launches detached children is therefore unsupported for admission
+// control on Windows and should use a single executable that owns its lease.
+func runPreWriteCommand(ctx context.Context, cmd *exec.Cmd) error {
+	return cmd.Run()
+}

--- a/internal/storage/prewrite_gate.go
+++ b/internal/storage/prewrite_gate.go
@@ -1,0 +1,704 @@
+// Package storage — prewrite_gate.go
+//
+// PreWriteGateStore is the mandatory synchronous admission layer for a
+// configured workspace pre_write hook. It sits outside post-commit hooks, so a
+// refusal is observed before the underlying store starts a mutation.
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+	"github.com/steveyegge/beads/memoryops"
+)
+
+// PreWriteGate admits a named mutation. Implementations must return nil only
+// when the mutation may proceed. It is intentionally small so CLI, HTTP, and
+// embedded callers share the exact same storage boundary.
+type PreWriteGate interface {
+	BeforeWrite(ctx context.Context, operation string) error
+}
+
+// Mutation operation names are part of the hook's stable input contract.
+const (
+	PreWriteIssueCreate        = "issue.create"
+	PreWriteIssueUpdate        = "issue.update"
+	PreWriteIssueClose         = "issue.close"
+	PreWriteIssueReopen        = "issue.reopen"
+	PreWriteIssueClaim         = "issue.claim"
+	PreWriteIssueClaimReady    = "issue.claim_ready"
+	PreWriteIssueComment       = "issue.comment"
+	PreWriteIssueBatchCreate   = "issue.batch_create"
+	PreWriteIssueBatchClose    = "issue.batch_close"
+	PreWriteDependencyAdd      = "dependency.add"
+	PreWriteDependencyRemove   = "dependency.remove"
+	PreWriteIssueLabel         = "issue.label"
+	PreWriteIssueDelete        = "issue.delete"
+	PreWriteWorkspaceConfig    = "workspace.config"
+	PreWriteWorkspaceMemory    = "workspace.memory"
+	PreWriteWorkspaceBootstrap = "workspace.bootstrap"
+	PreWriteEventsPrune        = "events.prune"
+	PreWriteTransaction        = "transaction.mutation"
+)
+
+// PreWriteGateStore wraps a DoltStorage with synchronous pre-write admission.
+// A nil gate deliberately behaves as a no-op for embedders that do not
+// configure one; the CLI always supplies a hook-backed gate.
+type PreWriteGateStore struct {
+	DoltStorage
+	inner DoltStorage
+	gate  PreWriteGate
+}
+
+// NewPreWriteGateStore creates a storage boundary that checks gate before each
+// supported mutation path.
+func NewPreWriteGateStore(store DoltStorage, gate PreWriteGate) *PreWriteGateStore {
+	return &PreWriteGateStore{DoltStorage: store, inner: store, gate: gate}
+}
+
+// Unwrap returns the store beneath this decorator.
+func (p *PreWriteGateStore) Unwrap() DoltStorage { return p.inner }
+
+func (p *PreWriteGateStore) before(ctx context.Context, operation string) error {
+	if p.gate == nil {
+		return nil
+	}
+	return p.gate.BeforeWrite(ctx, operation)
+}
+
+func (p *PreWriteGateStore) CreateIssue(ctx context.Context, issue *types.Issue, actor string) error {
+	if err := p.before(ctx, PreWriteIssueCreate); err != nil {
+		return err
+	}
+	return p.inner.CreateIssue(ctx, issue, actor)
+}
+
+func (p *PreWriteGateStore) CreateIssues(ctx context.Context, issues []*types.Issue, actor string) error {
+	if err := p.before(ctx, PreWriteIssueBatchCreate); err != nil {
+		return err
+	}
+	return p.inner.CreateIssues(ctx, issues, actor)
+}
+
+func (p *PreWriteGateStore) UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
+	if err := p.before(ctx, PreWriteIssueUpdate); err != nil {
+		return err
+	}
+	return p.inner.UpdateIssue(ctx, id, updates, actor)
+}
+
+func (p *PreWriteGateStore) UpdateIssueChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, opts UpdateIssueOptions) error {
+	if err := p.before(ctx, PreWriteIssueUpdate); err != nil {
+		return err
+	}
+	return p.inner.UpdateIssueChecked(ctx, id, updates, actor, opts)
+}
+
+func (p *PreWriteGateStore) ReopenIssue(ctx context.Context, id string, reason string, actor string) error {
+	if err := p.before(ctx, PreWriteIssueReopen); err != nil {
+		return err
+	}
+	return p.inner.ReopenIssue(ctx, id, reason, actor)
+}
+
+func (p *PreWriteGateStore) UnclaimIssue(ctx context.Context, id string, actor string, force bool) error {
+	if err := p.before(ctx, PreWriteIssueUpdate); err != nil {
+		return err
+	}
+	return p.inner.UnclaimIssue(ctx, id, actor, force)
+}
+
+func (p *PreWriteGateStore) UnclaimIssueIfAssignee(ctx context.Context, id string, actor string, expectedAssignee string) error {
+	if err := p.before(ctx, PreWriteIssueUpdate); err != nil {
+		return err
+	}
+	return p.inner.UnclaimIssueIfAssignee(ctx, id, actor, expectedAssignee)
+}
+
+func (p *PreWriteGateStore) UpdateIssueType(ctx context.Context, id string, issueType string, actor string) error {
+	if err := p.before(ctx, PreWriteIssueUpdate); err != nil {
+		return err
+	}
+	return p.inner.UpdateIssueType(ctx, id, issueType, actor)
+}
+
+func (p *PreWriteGateStore) CloseIssue(ctx context.Context, id string, reason string, actor string, session string) error {
+	if err := p.before(ctx, PreWriteIssueClose); err != nil {
+		return err
+	}
+	return p.inner.CloseIssue(ctx, id, reason, actor, session)
+}
+
+func (p *PreWriteGateStore) CloseIssueChecked(ctx context.Context, id string, actor string, opts CloseIssueOptions) (CloseIssueResult, error) {
+	if err := p.before(ctx, PreWriteIssueClose); err != nil {
+		return CloseIssueResult{}, err
+	}
+	return p.inner.CloseIssueChecked(ctx, id, actor, opts)
+}
+
+func (p *PreWriteGateStore) DeleteIssue(ctx context.Context, id string) error {
+	if err := p.before(ctx, PreWriteIssueDelete); err != nil {
+		return err
+	}
+	return p.inner.DeleteIssue(ctx, id)
+}
+
+func (p *PreWriteGateStore) AddDependency(ctx context.Context, dep *types.Dependency, actor string) error {
+	if err := p.before(ctx, PreWriteDependencyAdd); err != nil {
+		return err
+	}
+	return p.inner.AddDependency(ctx, dep, actor)
+}
+
+func (p *PreWriteGateStore) AddDependencyWithOptions(ctx context.Context, dep *types.Dependency, actor string, opts DependencyAddOptions) error {
+	if err := p.before(ctx, PreWriteDependencyAdd); err != nil {
+		return err
+	}
+	return p.inner.AddDependencyWithOptions(ctx, dep, actor, opts)
+}
+
+func (p *PreWriteGateStore) RemoveDependency(ctx context.Context, issueID, dependsOnID string, actor string) error {
+	if err := p.before(ctx, PreWriteDependencyRemove); err != nil {
+		return err
+	}
+	return p.inner.RemoveDependency(ctx, issueID, dependsOnID, actor)
+}
+
+func (p *PreWriteGateStore) RemoveDependencyWithOptions(ctx context.Context, issueID, dependsOnID string, actor string, opts DependencyRemoveOptions) error {
+	if err := p.before(ctx, PreWriteDependencyRemove); err != nil {
+		return err
+	}
+	return p.inner.RemoveDependencyWithOptions(ctx, issueID, dependsOnID, actor, opts)
+}
+
+func (p *PreWriteGateStore) AddLabel(ctx context.Context, issueID, label, actor string) error {
+	if err := p.before(ctx, PreWriteIssueLabel); err != nil {
+		return err
+	}
+	return p.inner.AddLabel(ctx, issueID, label, actor)
+}
+
+func (p *PreWriteGateStore) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
+	if err := p.before(ctx, PreWriteIssueLabel); err != nil {
+		return err
+	}
+	return p.inner.RemoveLabel(ctx, issueID, label, actor)
+}
+
+func (p *PreWriteGateStore) AddIssueComment(ctx context.Context, issueID, author, text string) (*types.Comment, error) {
+	if err := p.before(ctx, PreWriteIssueComment); err != nil {
+		return nil, err
+	}
+	return p.inner.AddIssueComment(ctx, issueID, author, text)
+}
+
+func (p *PreWriteGateStore) SetConfig(ctx context.Context, key, value string) error {
+	if err := p.before(ctx, PreWriteWorkspaceConfig); err != nil {
+		return err
+	}
+	return p.inner.SetConfig(ctx, key, value)
+}
+
+func (p *PreWriteGateStore) SetLocalMetadata(ctx context.Context, key, value string) error {
+	if err := p.before(ctx, PreWriteWorkspaceConfig); err != nil {
+		return err
+	}
+	return p.inner.SetLocalMetadata(ctx, key, value)
+}
+
+func (p *PreWriteGateStore) MergeSlotCreate(ctx context.Context, actor string) (*types.Issue, error) {
+	if err := p.before(ctx, PreWriteWorkspaceConfig); err != nil {
+		return nil, err
+	}
+	return p.inner.MergeSlotCreate(ctx, actor)
+}
+
+func (p *PreWriteGateStore) MergeSlotAcquire(ctx context.Context, holder, actor string, wait bool) (*MergeSlotResult, error) {
+	if err := p.before(ctx, PreWriteWorkspaceConfig); err != nil {
+		return nil, err
+	}
+	return p.inner.MergeSlotAcquire(ctx, holder, actor, wait)
+}
+
+func (p *PreWriteGateStore) MergeSlotRelease(ctx context.Context, holder, actor string) error {
+	if err := p.before(ctx, PreWriteWorkspaceConfig); err != nil {
+		return err
+	}
+	return p.inner.MergeSlotRelease(ctx, holder, actor)
+}
+
+func (p *PreWriteGateStore) SlotSet(ctx context.Context, issueID, key, value, actor string) error {
+	if err := p.before(ctx, PreWriteWorkspaceConfig); err != nil {
+		return err
+	}
+	return p.inner.SlotSet(ctx, issueID, key, value, actor)
+}
+
+func (p *PreWriteGateStore) SlotClear(ctx context.Context, issueID, key, actor string) error {
+	if err := p.before(ctx, PreWriteWorkspaceConfig); err != nil {
+		return err
+	}
+	return p.inner.SlotClear(ctx, issueID, key, actor)
+}
+
+func (p *PreWriteGateStore) MergeMetadata(ctx context.Context, issueID, key string, value json.RawMessage, actor string) error {
+	if err := p.before(ctx, PreWriteWorkspaceConfig); err != nil {
+		return err
+	}
+	return p.inner.MergeMetadata(ctx, issueID, key, value, actor)
+}
+
+// RunInTransaction checks each write on the transaction facade. A later
+// denial returns from the callback and lets the underlying transaction roll
+// back every earlier write, so a denied multi-step request never commits a
+// partial mutation.
+func (p *PreWriteGateStore) RunInTransaction(ctx context.Context, commitMsg string, fn func(tx Transaction) error) error {
+	return p.inner.RunInTransaction(ctx, commitMsg, func(tx Transaction) error {
+		return fn(&preWriteTransaction{Transaction: tx, parent: p})
+	})
+}
+
+func (p *PreWriteGateStore) RunInIssueLifecycleTransaction(ctx context.Context, commitMsg string, fn func(tx IssueLifecycleTransaction) error) error {
+	return p.inner.RunInIssueLifecycleTransaction(ctx, commitMsg, func(tx IssueLifecycleTransaction) error {
+		return fn(&preWriteLifecycleTransaction{
+			preWriteTransaction: &preWriteTransaction{Transaction: tx, parent: p},
+			inner:               tx,
+		})
+	})
+}
+
+// IssueLifecycle, IssueClaimer, ReadyClaimer, BatchCreator, BatchCloser,
+// DependencyEditor, and Commenter cover the typed API front doors. Each is
+// rebuilt on this decorator so an accessor cannot silently bypass admission.
+func (p *PreWriteGateStore) IssueLifecycle() (issueops.Lifecycle, error) {
+	inner, err := p.inner.IssueLifecycle()
+	if err != nil {
+		return nil, err
+	}
+	return &preWriteLifecycle{inner: inner, parent: p}, nil
+}
+
+func (p *PreWriteGateStore) IssueClaimer() (issueops.Claimer, error) {
+	inner, err := p.inner.IssueClaimer()
+	if err != nil {
+		return nil, err
+	}
+	return &preWriteClaimer{inner: inner, parent: p}, nil
+}
+
+func (p *PreWriteGateStore) ReadyClaimer() (issueops.ReadyClaimer, error) {
+	inner, err := p.inner.ReadyClaimer()
+	if err != nil {
+		return nil, err
+	}
+	return &preWriteReadyClaimer{inner: inner, parent: p}, nil
+}
+
+func (p *PreWriteGateStore) BatchCreator() (issueops.BatchCreator, error) {
+	inner, err := p.inner.BatchCreator()
+	if err != nil {
+		return nil, err
+	}
+	return &preWriteBatchCreator{inner: inner, parent: p}, nil
+}
+
+func (p *PreWriteGateStore) BatchCloser() (issueops.BatchCloser, error) {
+	inner, err := p.inner.BatchCloser()
+	if err != nil {
+		return nil, err
+	}
+	return &preWriteBatchCloser{inner: inner, parent: p}, nil
+}
+
+func (p *PreWriteGateStore) DependencyEditor() (issueops.DependencyEditor, error) {
+	inner, err := p.inner.DependencyEditor()
+	if err != nil {
+		return nil, err
+	}
+	return &preWriteDependencyEditor{inner: inner, parent: p}, nil
+}
+
+func (p *PreWriteGateStore) Commenter() (issueops.Commenter, error) {
+	inner, err := p.inner.Commenter()
+	if err != nil {
+		return nil, err
+	}
+	return &preWriteCommenter{inner: inner, parent: p}, nil
+}
+
+func (p *PreWriteGateStore) WorkspaceConfig() (issueops.WorkspaceConfig, error) {
+	inner, err := p.inner.WorkspaceConfig()
+	if err != nil {
+		return nil, err
+	}
+	return &preWriteWorkspaceConfig{inner: inner, parent: p}, nil
+}
+
+func (p *PreWriteGateStore) Memories() (memoryops.Memories, error) {
+	inner, err := p.inner.Memories()
+	if err != nil {
+		return nil, err
+	}
+	return &preWriteMemories{inner: inner, parent: p}, nil
+}
+
+func (p *PreWriteGateStore) Deleter() (issueops.Deleter, error) {
+	inner, err := p.inner.Deleter()
+	if err != nil {
+		return nil, err
+	}
+	return &preWriteDeleter{inner: inner, parent: p}, nil
+}
+
+func (p *PreWriteGateStore) Sweeper() (issueops.Sweeper, error) {
+	inner, err := p.inner.Sweeper()
+	if err != nil {
+		return nil, err
+	}
+	return &preWriteSweeper{inner: inner, parent: p}, nil
+}
+
+func (p *PreWriteGateStore) Bootstrapper() (issueops.Bootstrapper, error) {
+	inner, err := p.inner.Bootstrapper()
+	if err != nil {
+		return nil, err
+	}
+	return &preWriteBootstrapper{inner: inner, parent: p}, nil
+}
+
+type preWriteLifecycle struct {
+	inner  issueops.Lifecycle
+	parent *PreWriteGateStore
+}
+
+func (p *preWriteLifecycle) Create(ctx context.Context, req issueops.CreateRequest) (issueops.CreateResult, error) {
+	if err := p.parent.before(ctx, PreWriteIssueCreate); err != nil {
+		return issueops.CreateResult{}, err
+	}
+	return p.inner.Create(ctx, req)
+}
+
+func (p *preWriteLifecycle) Update(ctx context.Context, req issueops.UpdateRequest) (issueops.UpdateResult, error) {
+	if err := p.parent.before(ctx, PreWriteIssueUpdate); err != nil {
+		return issueops.UpdateResult{}, err
+	}
+	return p.inner.Update(ctx, req)
+}
+
+func (p *preWriteLifecycle) Close(ctx context.Context, req issueops.CloseRequest) (issueops.CloseResult, error) {
+	if err := p.parent.before(ctx, PreWriteIssueClose); err != nil {
+		return issueops.CloseResult{}, err
+	}
+	return p.inner.Close(ctx, req)
+}
+
+func (p *preWriteLifecycle) Reopen(ctx context.Context, req issueops.ReopenRequest) (issueops.ReopenResult, error) {
+	if err := p.parent.before(ctx, PreWriteIssueReopen); err != nil {
+		return issueops.ReopenResult{}, err
+	}
+	return p.inner.Reopen(ctx, req)
+}
+
+type preWriteClaimer struct {
+	inner  issueops.Claimer
+	parent *PreWriteGateStore
+}
+
+func (p *preWriteClaimer) Claim(ctx context.Context, req issueops.ClaimRequest) (issueops.ClaimResult, error) {
+	if err := p.parent.before(ctx, PreWriteIssueClaim); err != nil {
+		return issueops.ClaimResult{}, err
+	}
+	return p.inner.Claim(ctx, req)
+}
+
+type preWriteReadyClaimer struct {
+	inner  issueops.ReadyClaimer
+	parent *PreWriteGateStore
+}
+
+func (p *preWriteReadyClaimer) ClaimNext(ctx context.Context, req issueops.ClaimNextRequest) (issueops.ClaimNextResult, error) {
+	if err := p.parent.before(ctx, PreWriteIssueClaimReady); err != nil {
+		return issueops.ClaimNextResult{}, err
+	}
+	return p.inner.ClaimNext(ctx, req)
+}
+
+type preWriteBatchCreator struct {
+	inner  issueops.BatchCreator
+	parent *PreWriteGateStore
+}
+
+func (p *preWriteBatchCreator) CreateBatch(ctx context.Context, req issueops.CreateBatchRequest) (issueops.CreateBatchResult, error) {
+	if err := p.parent.before(ctx, PreWriteIssueBatchCreate); err != nil {
+		return issueops.CreateBatchResult{}, err
+	}
+	return p.inner.CreateBatch(ctx, req)
+}
+
+type preWriteBatchCloser struct {
+	inner  issueops.BatchCloser
+	parent *PreWriteGateStore
+}
+
+func (p *preWriteBatchCloser) CloseBatch(ctx context.Context, req issueops.CloseBatchRequest) (issueops.CloseBatchResult, error) {
+	if err := p.parent.before(ctx, PreWriteIssueBatchClose); err != nil {
+		return issueops.CloseBatchResult{}, err
+	}
+	return p.inner.CloseBatch(ctx, req)
+}
+
+type preWriteDependencyEditor struct {
+	inner  issueops.DependencyEditor
+	parent *PreWriteGateStore
+}
+
+func (p *preWriteDependencyEditor) AddDependencies(ctx context.Context, req issueops.AddDependenciesRequest) (issueops.AddDependenciesResult, error) {
+	if err := p.parent.before(ctx, PreWriteDependencyAdd); err != nil {
+		return issueops.AddDependenciesResult{}, err
+	}
+	return p.inner.AddDependencies(ctx, req)
+}
+
+func (p *preWriteDependencyEditor) RemoveDependency(ctx context.Context, req issueops.RemoveDependencyRequest) (issueops.RemoveDependencyResult, error) {
+	if err := p.parent.before(ctx, PreWriteDependencyRemove); err != nil {
+		return issueops.RemoveDependencyResult{}, err
+	}
+	return p.inner.RemoveDependency(ctx, req)
+}
+
+type preWriteCommenter struct {
+	inner  issueops.Commenter
+	parent *PreWriteGateStore
+}
+
+func (p *preWriteCommenter) AddComment(ctx context.Context, req issueops.AddCommentRequest) (issueops.AddCommentResult, error) {
+	if err := p.parent.before(ctx, PreWriteIssueComment); err != nil {
+		return issueops.AddCommentResult{}, err
+	}
+	return p.inner.AddComment(ctx, req)
+}
+
+type preWriteWorkspaceConfig struct {
+	inner  issueops.WorkspaceConfig
+	parent *PreWriteGateStore
+}
+
+func (p *preWriteWorkspaceConfig) GetSetting(ctx context.Context, req issueops.GetSettingRequest) (issueops.SettingResult, error) {
+	return p.inner.GetSetting(ctx, req)
+}
+
+func (p *preWriteWorkspaceConfig) ListSettings(ctx context.Context, req issueops.ListSettingsRequest) (issueops.ListSettingsResult, error) {
+	return p.inner.ListSettings(ctx, req)
+}
+
+func (p *preWriteWorkspaceConfig) SetSetting(ctx context.Context, req issueops.SetSettingRequest) (issueops.SetSettingResult, error) {
+	if err := p.parent.before(ctx, PreWriteWorkspaceConfig); err != nil {
+		return issueops.SetSettingResult{}, err
+	}
+	return p.inner.SetSetting(ctx, req)
+}
+
+func (p *preWriteWorkspaceConfig) UnsetSetting(ctx context.Context, req issueops.UnsetSettingRequest) (issueops.UnsetSettingResult, error) {
+	if err := p.parent.before(ctx, PreWriteWorkspaceConfig); err != nil {
+		return issueops.UnsetSettingResult{}, err
+	}
+	return p.inner.UnsetSetting(ctx, req)
+}
+
+type preWriteMemories struct {
+	inner  memoryops.Memories
+	parent *PreWriteGateStore
+}
+
+func (p *preWriteMemories) Remember(ctx context.Context, req memoryops.RememberRequest) (memoryops.RememberResult, error) {
+	if err := p.parent.before(ctx, PreWriteWorkspaceMemory); err != nil {
+		return memoryops.RememberResult{}, err
+	}
+	return p.inner.Remember(ctx, req)
+}
+
+func (p *preWriteMemories) Recall(ctx context.Context, req memoryops.RecallRequest) (memoryops.RecallResult, error) {
+	return p.inner.Recall(ctx, req)
+}
+
+func (p *preWriteMemories) Forget(ctx context.Context, req memoryops.ForgetRequest) (memoryops.ForgetResult, error) {
+	if err := p.parent.before(ctx, PreWriteWorkspaceMemory); err != nil {
+		return memoryops.ForgetResult{}, err
+	}
+	return p.inner.Forget(ctx, req)
+}
+
+func (p *preWriteMemories) List(ctx context.Context, req memoryops.ListRequest) (memoryops.ListResult, error) {
+	return p.inner.List(ctx, req)
+}
+
+type preWriteDeleter struct {
+	inner  issueops.Deleter
+	parent *PreWriteGateStore
+}
+
+func (p *preWriteDeleter) Delete(ctx context.Context, req issueops.DeleteRequest) (issueops.DeleteResult, error) {
+	if err := p.parent.before(ctx, PreWriteIssueDelete); err != nil {
+		return issueops.DeleteResult{}, err
+	}
+	return p.inner.Delete(ctx, req)
+}
+
+type preWriteSweeper struct {
+	inner  issueops.Sweeper
+	parent *PreWriteGateStore
+}
+
+func (p *preWriteSweeper) Sweep(ctx context.Context, req issueops.SweepRequest) (issueops.SweepResult, error) {
+	if req.DryRun {
+		return p.inner.Sweep(ctx, req)
+	}
+	if err := p.parent.before(ctx, PreWriteIssueDelete); err != nil {
+		return issueops.SweepResult{}, err
+	}
+	return p.inner.Sweep(ctx, req)
+}
+
+type preWriteBootstrapper struct {
+	inner  issueops.Bootstrapper
+	parent *PreWriteGateStore
+}
+
+func (p *preWriteBootstrapper) Bootstrap(ctx context.Context, req issueops.BootstrapRequest) (issueops.BootstrapResult, error) {
+	if err := p.parent.before(ctx, PreWriteWorkspaceBootstrap); err != nil {
+		return issueops.BootstrapResult{}, err
+	}
+	return p.inner.Bootstrap(ctx, req)
+}
+
+type preWriteTransaction struct {
+	Transaction
+	parent *PreWriteGateStore
+}
+
+func (p *preWriteTransaction) CreateIssue(ctx context.Context, issue *types.Issue, actor string) error {
+	if err := p.parent.before(ctx, PreWriteIssueCreate); err != nil {
+		return err
+	}
+	return p.Transaction.CreateIssue(ctx, issue, actor)
+}
+
+func (p *preWriteTransaction) CreateIssues(ctx context.Context, issues []*types.Issue, actor string) error {
+	if err := p.parent.before(ctx, PreWriteIssueBatchCreate); err != nil {
+		return err
+	}
+	return p.Transaction.CreateIssues(ctx, issues, actor)
+}
+
+func (p *preWriteTransaction) UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
+	if err := p.parent.before(ctx, PreWriteIssueUpdate); err != nil {
+		return err
+	}
+	return p.Transaction.UpdateIssue(ctx, id, updates, actor)
+}
+
+func (p *preWriteTransaction) CloseIssue(ctx context.Context, id string, reason string, actor string, session string) error {
+	if err := p.parent.before(ctx, PreWriteIssueClose); err != nil {
+		return err
+	}
+	return p.Transaction.CloseIssue(ctx, id, reason, actor, session)
+}
+
+func (p *preWriteTransaction) DeleteIssue(ctx context.Context, id string) error {
+	if err := p.parent.before(ctx, PreWriteIssueDelete); err != nil {
+		return err
+	}
+	return p.Transaction.DeleteIssue(ctx, id)
+}
+
+func (p *preWriteTransaction) AddDependency(ctx context.Context, dep *types.Dependency, actor string) error {
+	if err := p.parent.before(ctx, PreWriteDependencyAdd); err != nil {
+		return err
+	}
+	return p.Transaction.AddDependency(ctx, dep, actor)
+}
+
+func (p *preWriteTransaction) AddDependencyWithOptions(ctx context.Context, dep *types.Dependency, actor string, opts DependencyAddOptions) error {
+	if err := p.parent.before(ctx, PreWriteDependencyAdd); err != nil {
+		return err
+	}
+	return p.Transaction.AddDependencyWithOptions(ctx, dep, actor, opts)
+}
+
+func (p *preWriteTransaction) RemoveDependency(ctx context.Context, issueID, dependsOnID string, actor string) error {
+	if err := p.parent.before(ctx, PreWriteDependencyRemove); err != nil {
+		return err
+	}
+	return p.Transaction.RemoveDependency(ctx, issueID, dependsOnID, actor)
+}
+
+func (p *preWriteTransaction) RemoveDependencyWithOptions(ctx context.Context, issueID, dependsOnID string, actor string, opts DependencyRemoveOptions) error {
+	if err := p.parent.before(ctx, PreWriteDependencyRemove); err != nil {
+		return err
+	}
+	return p.Transaction.RemoveDependencyWithOptions(ctx, issueID, dependsOnID, actor, opts)
+}
+
+func (p *preWriteTransaction) AddLabel(ctx context.Context, issueID, label, actor string) error {
+	if err := p.parent.before(ctx, PreWriteIssueLabel); err != nil {
+		return err
+	}
+	return p.Transaction.AddLabel(ctx, issueID, label, actor)
+}
+
+func (p *preWriteTransaction) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
+	if err := p.parent.before(ctx, PreWriteIssueLabel); err != nil {
+		return err
+	}
+	return p.Transaction.RemoveLabel(ctx, issueID, label, actor)
+}
+
+func (p *preWriteTransaction) SetConfig(ctx context.Context, key, value string) error {
+	if err := p.parent.before(ctx, PreWriteWorkspaceConfig); err != nil {
+		return err
+	}
+	return p.Transaction.SetConfig(ctx, key, value)
+}
+
+func (p *preWriteTransaction) SetMetadata(ctx context.Context, key, value string) error {
+	if err := p.parent.before(ctx, PreWriteWorkspaceConfig); err != nil {
+		return err
+	}
+	return p.Transaction.SetMetadata(ctx, key, value)
+}
+
+func (p *preWriteTransaction) SetLocalMetadata(ctx context.Context, key, value string) error {
+	if err := p.parent.before(ctx, PreWriteWorkspaceConfig); err != nil {
+		return err
+	}
+	return p.Transaction.SetLocalMetadata(ctx, key, value)
+}
+
+func (p *preWriteTransaction) AddComment(ctx context.Context, issueID, actor, comment string) error {
+	if err := p.parent.before(ctx, PreWriteIssueComment); err != nil {
+		return err
+	}
+	return p.Transaction.AddComment(ctx, issueID, actor, comment)
+}
+
+func (p *preWriteTransaction) ImportIssueComment(ctx context.Context, issueID, author, text string, createdAt time.Time) (*types.Comment, error) {
+	if err := p.parent.before(ctx, PreWriteIssueComment); err != nil {
+		return nil, err
+	}
+	return p.Transaction.ImportIssueComment(ctx, issueID, author, text, createdAt)
+}
+
+type preWriteLifecycleTransaction struct {
+	*preWriteTransaction
+	inner IssueLifecycleTransaction
+}
+
+func (p *preWriteLifecycleTransaction) ReopenIssueWithResult(ctx context.Context, id string, reason string, actor string) (bool, error) {
+	if err := p.parent.before(ctx, PreWriteIssueReopen); err != nil {
+		return false, err
+	}
+	return p.inner.ReopenIssueWithResult(ctx, id, reason, actor)
+}

--- a/internal/storage/prewrite_gate_test.go
+++ b/internal/storage/prewrite_gate_test.go
@@ -1,0 +1,136 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+var errMaintenanceHeld = errors.New("maintenance held")
+
+type recordingPreWriteGate struct {
+	denyAfter int
+	calls     []string
+}
+
+func (g *recordingPreWriteGate) BeforeWrite(_ context.Context, operation string) error {
+	g.calls = append(g.calls, operation)
+	if g.denyAfter > 0 && len(g.calls) >= g.denyAfter {
+		return errMaintenanceHeld
+	}
+	return nil
+}
+
+type preWriteTestStore struct {
+	DoltStorage
+	creates   int
+	committed bool
+}
+
+func (s *preWriteTestStore) CreateIssue(_ context.Context, _ *types.Issue, _ string) error {
+	s.creates++
+	return nil
+}
+
+func (s *preWriteTestStore) RunInTransaction(ctx context.Context, _ string, fn func(Transaction) error) error {
+	staged := 0
+	err := fn(&preWriteTestTransaction{staged: &staged})
+	if err == nil {
+		s.creates += staged
+		s.committed = true
+	}
+	return err
+}
+
+type preWriteTestTransaction struct {
+	Transaction
+	staged *int
+}
+
+func (t *preWriteTestTransaction) CreateIssue(_ context.Context, _ *types.Issue, _ string) error {
+	*t.staged = *t.staged + 1
+	return nil
+}
+
+func TestPreWriteGateBlocksDirectCreateBeforeStorage(t *testing.T) {
+	inner := &preWriteTestStore{}
+	gate := &recordingPreWriteGate{denyAfter: 1}
+	store := NewPreWriteGateStore(inner, gate)
+
+	err := store.CreateIssue(t.Context(), &types.Issue{ID: "bd-test"}, "tester")
+	if !errors.Is(err, errMaintenanceHeld) {
+		t.Fatalf("CreateIssue error = %v, want maintenance rejection", err)
+	}
+	if inner.creates != 0 {
+		t.Fatalf("inner creates = %d, want 0", inner.creates)
+	}
+	if got := gate.calls; len(got) != 1 || got[0] != PreWriteIssueCreate {
+		t.Fatalf("gate calls = %v, want [%s]", got, PreWriteIssueCreate)
+	}
+}
+
+func TestPreWriteGateRollsBackTransactionWhenLaterWriteIsRejected(t *testing.T) {
+	inner := &preWriteTestStore{}
+	gate := &recordingPreWriteGate{denyAfter: 2}
+	store := NewPreWriteGateStore(inner, gate)
+
+	err := store.RunInTransaction(t.Context(), "test", func(tx Transaction) error {
+		if err := tx.CreateIssue(t.Context(), &types.Issue{ID: "bd-one"}, "tester"); err != nil {
+			return err
+		}
+		return tx.CreateIssue(t.Context(), &types.Issue{ID: "bd-two"}, "tester")
+	})
+	if !errors.Is(err, errMaintenanceHeld) {
+		t.Fatalf("RunInTransaction error = %v, want maintenance rejection", err)
+	}
+	if inner.committed || inner.creates != 0 {
+		t.Fatalf("transaction committed=%v creates=%d, want rollback without writes", inner.committed, inner.creates)
+	}
+}
+
+type lifecycleTestStore struct {
+	DoltStorage
+	inner *lifecycleTestRole
+}
+
+func (s *lifecycleTestStore) IssueLifecycle() (issueops.Lifecycle, error) { return s.inner, nil }
+
+type lifecycleTestRole struct{ creates int }
+
+func (r *lifecycleTestRole) Create(_ context.Context, _ issueops.CreateRequest) (issueops.CreateResult, error) {
+	r.creates++
+	return issueops.CreateResult{}, nil
+}
+
+func (r *lifecycleTestRole) Update(context.Context, issueops.UpdateRequest) (issueops.UpdateResult, error) {
+	return issueops.UpdateResult{}, nil
+}
+
+func (r *lifecycleTestRole) Close(context.Context, issueops.CloseRequest) (issueops.CloseResult, error) {
+	return issueops.CloseResult{}, nil
+}
+
+func (r *lifecycleTestRole) Reopen(context.Context, issueops.ReopenRequest) (issueops.ReopenResult, error) {
+	return issueops.ReopenResult{}, nil
+}
+
+func TestPreWriteGateCoversLifecycleAPI(t *testing.T) {
+	role := &lifecycleTestRole{}
+	gate := &recordingPreWriteGate{denyAfter: 1}
+	store := NewPreWriteGateStore(&lifecycleTestStore{inner: role}, gate)
+
+	lifecycle, err := store.IssueLifecycle()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = lifecycle.Create(t.Context(), issueops.CreateRequest{})
+	if !errors.Is(err, errMaintenanceHeld) {
+		t.Fatalf("Lifecycle.Create error = %v, want maintenance rejection", err)
+	}
+	if role.creates != 0 {
+		t.Fatalf("inner lifecycle create calls = %d, want 0", role.creates)
+	}
+}

--- a/internal/storage/uow/prewrite.go
+++ b/internal/storage/uow/prewrite.go
@@ -1,0 +1,131 @@
+package uow
+
+import (
+	"context"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/issueops"
+	"github.com/steveyegge/beads/memoryops"
+)
+
+// NewPreWriteProvider applies synchronous admission at the transaction commit
+// boundary used by proxied and HTTP server storage. A rejected commit leaves
+// its unit of work uncommitted; Close then rolls it back. Empty commit messages
+// are read-only rollbacks and never invoke the gate.
+func NewPreWriteProvider(inner UnitOfWorkProvider, gate storage.PreWriteGate) UnitOfWorkProvider {
+	if gate == nil || isNilUnitOfWorkProvider(inner) {
+		return inner
+	}
+	return &preWriteProvider{inner: inner, gate: gate}
+}
+
+type preWriteProvider struct {
+	inner UnitOfWorkProvider
+	gate  storage.PreWriteGate
+}
+
+func (p *preWriteProvider) NewUOW(ctx context.Context) (UnitOfWork, error) {
+	inner, err := p.inner.NewUOW(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &preWriteUOW{UnitOfWork: inner, gate: p.gate}, nil
+}
+
+func (p *preWriteProvider) Close(ctx context.Context) error { return p.inner.Close(ctx) }
+
+func (p *preWriteProvider) Unwrap() UnitOfWorkProvider { return p.inner }
+
+type preWriteUOW struct {
+	UnitOfWork
+	gate storage.PreWriteGate
+}
+
+func (u *preWriteUOW) Commit(ctx context.Context, message string) error {
+	if message != "" {
+		if err := u.gate.BeforeWrite(ctx, storage.PreWriteTransaction); err != nil {
+			return err
+		}
+	}
+	return u.UnitOfWork.Commit(ctx, message)
+}
+
+func (p *preWriteProvider) IssueLifecycle() (issueops.Lifecycle, error) {
+	return NewIssueOperations(p)
+}
+
+func (p *preWriteProvider) IssueReader() (issueops.Reader, error) { return NewIssueReader(p) }
+
+func (p *preWriteProvider) IssueClaimer() (issueops.Claimer, error) { return NewIssueClaimer(p) }
+
+func (p *preWriteProvider) IssueRelations() (issueops.Relations, error) {
+	return NewIssueRelations(p)
+}
+
+func (p *preWriteProvider) EdgeReader() (issueops.EdgeReader, error) { return NewEdgeReader(p) }
+
+func (p *preWriteProvider) BlockingAnnotator() (issueops.BlockingAnnotator, error) {
+	return NewBlockingAnnotator(p)
+}
+
+func (p *preWriteProvider) TreeWalker() (issueops.TreeWalker, error) { return NewTreeWalker(p) }
+
+func (p *preWriteProvider) Counter() (issueops.Counter, error) { return NewCounter(p) }
+
+func (p *preWriteProvider) ReadyCounter() (issueops.ReadyCounter, error) {
+	return NewReadyCounter(p)
+}
+
+func (p *preWriteProvider) ReadyClaimer() (issueops.ReadyClaimer, error) {
+	return NewReadyClaimer(p)
+}
+
+func (p *preWriteProvider) Querier() (issueops.Querier, error) { return NewQuerier(p) }
+
+func (p *preWriteProvider) StatsReporter() (issueops.StatsReporter, error) {
+	return NewStatsReporter(p)
+}
+
+func (p *preWriteProvider) CycleDetector() (issueops.CycleDetector, error) {
+	return NewCycleDetector(p)
+}
+
+func (p *preWriteProvider) Commenter() (issueops.Commenter, error) { return NewCommenter(p) }
+
+func (p *preWriteProvider) BatchCloser() (issueops.BatchCloser, error) { return NewBatchCloser(p) }
+
+func (p *preWriteProvider) BatchCreator() (issueops.BatchCreator, error) {
+	return NewBatchCreator(p)
+}
+
+func (p *preWriteProvider) DependencyEditor() (issueops.DependencyEditor, error) {
+	return NewDependencyEditor(p)
+}
+
+func (p *preWriteProvider) Deleter() (issueops.Deleter, error) { return NewDeleter(p) }
+
+func (p *preWriteProvider) Sweeper() (issueops.Sweeper, error) { return NewSweeper(p) }
+
+func (p *preWriteProvider) Importer() (issueops.Importer, error) { return NewImporter(p) }
+
+func (p *preWriteProvider) Bootstrapper() (issueops.Bootstrapper, error) {
+	return NewBootstrapper(p)
+}
+
+func (p *preWriteProvider) InitVerifier() (issueops.InitVerifier, error) {
+	return NewInitVerifier(p)
+}
+
+func (p *preWriteProvider) WorkspaceConfig() (issueops.WorkspaceConfig, error) {
+	return NewWorkspaceConfig(p)
+}
+
+func (p *preWriteProvider) VersionReconciler() (issueops.VersionReconciler, error) {
+	return NewVersionReconciler(p)
+}
+
+func (p *preWriteProvider) Memories() (memoryops.Memories, error) { return NewMemories(p) }
+
+func (p *preWriteProvider) EventsJournalCursor() (storage.EventsJournalCursor, error) {
+	return NewEventsJournalCursor(p)
+}

--- a/internal/storage/uow/prewrite_test.go
+++ b/internal/storage/uow/prewrite_test.go
@@ -1,0 +1,76 @@
+package uow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+var errPreWriteHeld = errors.New("maintenance held")
+
+type preWriteTestGate struct{ calls int }
+
+func (g *preWriteTestGate) BeforeWrite(context.Context, string) error {
+	g.calls++
+	return errPreWriteHeld
+}
+
+type preWriteTestProvider struct{ unit *preWriteTestUOW }
+
+func (p *preWriteTestProvider) NewUOW(context.Context) (UnitOfWork, error) { return p.unit, nil }
+func (*preWriteTestProvider) Close(context.Context) error                  { return nil }
+
+type preWriteTestUOW struct {
+	UnitOfWork
+	commits int
+}
+
+func (u *preWriteTestUOW) Commit(context.Context, string) error {
+	u.commits++
+	return nil
+}
+
+func TestPreWriteProviderRejectsCommitBeforePersistence(t *testing.T) {
+	inner := &preWriteTestUOW{}
+	gate := &preWriteTestGate{}
+	provider := NewPreWriteProvider(&preWriteTestProvider{unit: inner}, gate)
+
+	unit, err := provider.NewUOW(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = unit.Commit(t.Context(), "bd: update issue")
+	if !errors.Is(err, errPreWriteHeld) {
+		t.Fatalf("Commit error = %v, want pre-write rejection", err)
+	}
+	if inner.commits != 0 {
+		t.Fatalf("inner commits = %d, want 0", inner.commits)
+	}
+	if gate.calls != 1 {
+		t.Fatalf("gate calls = %d, want 1", gate.calls)
+	}
+}
+
+func TestPreWriteProviderDoesNotGateReadOnlyRollback(t *testing.T) {
+	inner := &preWriteTestUOW{}
+	gate := &preWriteTestGate{}
+	provider := NewPreWriteProvider(&preWriteTestProvider{unit: inner}, gate)
+
+	unit, err := provider.NewUOW(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := unit.Commit(t.Context(), ""); err != nil {
+		t.Fatalf("empty Commit: %v", err)
+	}
+	if inner.commits != 1 {
+		t.Fatalf("inner commits = %d, want 1", inner.commits)
+	}
+	if gate.calls != 0 {
+		t.Fatalf("gate calls = %d, want 0", gate.calls)
+	}
+}
+
+var _ storage.PreWriteGate = (*preWriteTestGate)(nil)


### PR DESCRIPTION
## What

Adds a synchronous, repository-scoped `pre_write` admission hook at both storage mutation boundaries. It uses a versioned JSON request/response contract, bounded execution/output, timeout enforcement, canonical path and executable validation, and stable rejection errors.

The gate wraps direct storage mutations, typed lifecycle/claim/comment/dependency APIs, transaction writes, and the proxied/server unit-of-work commit boundary. Post-commit `on_*` hooks remain asynchronous; `--no-hooks` does not bypass a configured admission hook.

## Why

A caller-side wrapper cannot prevent direct `bd` or API mutation paths from racing repository maintenance. This provides the generic Beads extension point without encoding maintenance policy.

Fixes #5193.

## Validation

- `go test -tags gms_pure_go ./internal/hooks ./internal/storage ./internal/storage/uow ./cmd/bd -run 'Test(BeforeWrite|PreWrite|WireStorageDecorators)'`\n- `golangci-lint run --build-tags gms_pure_go --new-from-rev=origin/main ./internal/hooks ./internal/storage ./cmd/bd`\n- `make ci-pr-lint` reaches the repository baseline failures in unchanged files: `internal/config/permissions_open_nonlinux.go` (G304) and `internal/utils/path_case_darwin.go` (G103).\n- `make test` reached its 25-minute package timeout in this environment after initial packages passed; focused affected suites above pass.