### PR TITLE
fix: widen DefaultLeaseTTL from 5min to 4h, document the reasoning

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -1024,6 +1024,7 @@ var recognizedConfigKeys = map[string]bool{
 	"auto_compact_enabled": true, "schema_version": true,
 	"output.title-length": true,
 	"prime.max-memories":  true, "prime.max-memory-chars": true,
+	"lease.ttl": true, // lease guard TTL override (read from yaml/env, never the DB — PR #5470 review R2, ga-7uoua)
 	// The events-journal family. All four are startup settings that land in
 	// config.yaml (config.YamlOnlyKeys), and every one of them is documented as
 	// a `bd config set` invocation — including the auto-prune opt-out, where an

--- a/cmd/bd/config_test.go
+++ b/cmd/bd/config_test.go
@@ -202,6 +202,78 @@ func TestYamlOnlyConfigWithoutDatabase(t *testing.T) {
 	}
 }
 
+// TestConfigSetLeaseTTLRoutesToYaml is the discriminator from PR #5470
+// review R2 (gastownhall/gascity ga-7uoua): before this fix, "lease.ttl" was
+// absent from both config.IsYamlOnlyKey and recognizedConfigKeys, so
+// `bd config set lease.ttl <value>` silently fell through the yaml branch in
+// configSetCmd.RunE — landing wherever the non-yaml path goes instead of
+// config.yaml, where EffectiveDefaultLeaseTTL's viper-backed read can never
+// see it. This test asserts the two outcomes that prove the key is now
+// routed and validated correctly: a valid duration is visible on the actual
+// read path (not just present in some file), and an invalid one is rejected
+// at set-time rather than silently degrading to the compiled default later.
+//
+// No database is created anywhere in this test (same no-DB setup as
+// TestYamlOnlyConfigWithoutDatabase above) — if the fix regressed and the
+// key fell through to the database-backed write path again, that path would
+// fail outright here (no store to write to) rather than silently diverging,
+// which is a stronger guarantee than inspecting store internals would be.
+func TestConfigSetLeaseTTLRoutesToYaml(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "bd-test-lease-ttl-config-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("Failed to create .beads dir: %v", err)
+	}
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("prefix: test\n"), 0644); err != nil {
+		t.Fatalf("Failed to create config.yaml: %v", err)
+	}
+
+	t.Setenv("BEADS_DIR", beadsDir)
+	forceGitTracked = false
+	jsonOutput = false
+
+	t.Run("valid duration lands on the read path EffectiveDefaultLeaseTTL uses", func(t *testing.T) {
+		if err := configSetCmd.RunE(configSetCmd, []string{"lease.ttl", "4h"}); err != nil {
+			t.Fatalf("config set lease.ttl 4h: %v", err)
+		}
+
+		config.ResetForTesting()
+		t.Cleanup(config.ResetForTesting)
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize: %v", err)
+		}
+		// EffectiveDefaultLeaseTTL itself reads exactly this key this way
+		// (internal/storage/issueops/lease.go); asserting through
+		// config.GetString proves the CLI's write is visible on that same
+		// path without adding an issueops import to this file.
+		if got := config.GetString("lease.ttl"); got != "4h" {
+			t.Errorf("config.GetString(lease.ttl) = %q, want %q (write did not reach the yaml-backed read path)", got, "4h")
+		}
+	})
+
+	t.Run("invalid duration is rejected at set-time", func(t *testing.T) {
+		// RunE's returned error is an opaque *exitError (its Error() is just
+		// "exit code 1") — HandleError puts the actual message on stderr, so
+		// that is what a discriminating assertion has to inspect.
+		var err error
+		stderr := captureStderr(t, func() {
+			err = configSetCmd.RunE(configSetCmd, []string{"lease.ttl", "4hrs"})
+		})
+		if err == nil {
+			t.Fatal("expected a non-nil error for an invalid duration (\"4hrs\"), got nil")
+		}
+		if !strings.Contains(stderr, "lease.ttl must be a valid duration") {
+			t.Errorf("expected a lease.ttl duration-validation message on stderr, got: %q", stderr)
+		}
+	})
+}
+
 // setupTestDB creates a temporary test database
 func setupTestDB(t *testing.T) (*dolt.DoltStore, func()) {
 	tmpDir, err := os.MkdirTemp("", "bd-test-config-*")

--- a/cmd/bd/init_templates.go
+++ b/cmd/bd/init_templates.go
@@ -87,6 +87,13 @@ func renderInitConfigYAML(prefix string, noDbMode bool) []byte {
 #   git-push: false    # Disable git push (backup locally only)
 #   git-repo: ""       # Separate git repo for backups (default: project repo)
 
+# Claim lease TTL: how long a claimed issue stays in_progress without a
+# heartbeat before 'bd reclaim' reverts it to ready (dead-worker recovery).
+# Widen this if your workers' heartbeat cadence is slower than the 5m
+# default (also settable via the BD_LEASE_TTL env var).
+# lease:
+#   ttl: 5m
+
 # Optional JSONL auto-export for viewers, interchange, and issue-level migration.
 # Disabled by default; enable only when an integration needs fresh .beads/issues.jsonl.
 # Use relative paths under .beads/ for JSONL import/export filenames.

--- a/cmd/bd/reclaim.go
+++ b/cmd/bd/reclaim.go
@@ -30,7 +30,10 @@ claim them. The previous owner's stale lease is recorded as a recovery event.
 --older-than is a grace window past lease expiry: only leases that expired at
 least this long ago are reclaimed, so a worker briefly paused (GC, clock skew)
 is not robbed of live work. Run it from a supervisor on a timer with a window
-of roughly 2× the claim TTL.
+of roughly 2× the claim TTL. When --older-than is omitted, that 2× multiplier
+is applied to the deployment's EFFECTIVE claim TTL — 'lease.ttl' in
+config.yaml, or the BD_LEASE_TTL env var, falling back to a 5m compiled
+default (see 'bd config set lease.ttl' for widening it deployment-wide).
 
 By default reclaim covers every stale lease THIS replica granted. The scope
 filters below narrow it further, using the same label surface claiming is
@@ -247,7 +250,10 @@ func reclaimFilterFromFlags(cmd *cobra.Command) (types.ReclaimFilter, error) {
 
 func init() {
 	reclaimCmd.Flags().Duration("older-than", 2*issueops.DefaultLeaseTTL,
-		"Only reclaim leases that expired at least this long ago (grace window)")
+		"Only reclaim leases that expired at least this long ago (grace window). "+
+			"Default shown is 2x the compiled lease TTL baseline; when omitted, the "+
+			"actual default is 2x this deployment's EFFECTIVE lease.ttl (config.yaml "+
+			"or BD_LEASE_TTL), which may be wider")
 	registerReclaimScopeFlags(reclaimCmd.Flags())
 	rootCmd.AddCommand(reclaimCmd)
 }

--- a/cmd/bd/reclaim.go
+++ b/cmd/bd/reclaim.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -83,9 +84,9 @@ Examples:
 			}
 		}()
 
-		olderThan, _ := cmd.Flags().GetDuration("older-than")
-		if olderThan < 0 {
-			return HandleErrorRespectJSON("--older-than must not be negative")
+		olderThan, err := resolveReclaimOlderThan(cmd)
+		if err != nil {
+			return HandleErrorRespectJSON("%v", err)
 		}
 
 		filter, err := reclaimFilterFromFlags(cmd)
@@ -161,6 +162,31 @@ func registerReclaimScopeFlags(fs *pflag.FlagSet) {
 	fs.StringSlice("exclude-label", nil, "Never reclaim issues carrying ANY of these labels")
 	fs.Bool("any-replica", false,
 		"Also reclaim leases granted by ANOTHER replica (unsafe unless that replica is gone; see 'Replicas and leases')")
+}
+
+// resolveReclaimOlderThan returns the reclaim grace window: the explicit
+// --older-than value if the operator passed one, otherwise 2x the
+// deployment's EFFECTIVE lease TTL, resolved at run time.
+//
+// The flag's registered default (2*issueops.DefaultLeaseTTL) is frozen at
+// command-registration time from the compiled constant, so it cannot see a
+// deployment's "lease.ttl" config key / BD_LEASE_TTL env var override
+// (issueops.EffectiveDefaultLeaseTTL). Without this, a deployment that widens
+// its claim TTL via that override would silently keep a default grace window
+// sized for the old, narrower TTL — the "2x the lease TTL" this command's own
+// help text promises would quietly stop being true.
+func resolveReclaimOlderThan(cmd *cobra.Command) (time.Duration, error) {
+	olderThan, err := cmd.Flags().GetDuration("older-than")
+	if err != nil {
+		return 0, fmt.Errorf("--older-than: %w", err)
+	}
+	if !cmd.Flags().Changed("older-than") {
+		olderThan = 2 * issueops.EffectiveDefaultLeaseTTL()
+	}
+	if olderThan < 0 {
+		return 0, fmt.Errorf("--older-than must not be negative")
+	}
+	return olderThan, nil
 }
 
 // reclaimFilterFromFlags maps the scope flags onto a types.ReclaimFilter,

--- a/cmd/bd/resolve_reclaim_older_than_test.go
+++ b/cmd/bd/resolve_reclaim_older_than_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+)
+
+// newOlderThanTestCmd registers the "older-than" flag exactly as
+// reclaimCmd's init() does, so the parser under test matches production.
+func newOlderThanTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "reclaim", RunE: func(*cobra.Command, []string) error { return nil }}
+	cmd.Flags().Duration("older-than", 2*issueops.DefaultLeaseTTL,
+		"Only reclaim leases that expired at least this long ago (grace window)")
+	return cmd
+}
+
+// TestResolveReclaimOlderThan pins the decoupling fix from PR #5470 review
+// point 2: --older-than's registered default is frozen at command-
+// registration time from the compiled issueops.DefaultLeaseTTL constant, so
+// it cannot see a deployment's "lease.ttl"/BD_LEASE_TTL override. Without
+// resolveReclaimOlderThan recomputing the default at run time, a deployment
+// that widened its claim TTL would silently keep a grace window sized for
+// the old, narrower TTL.
+func TestResolveReclaimOlderThan(t *testing.T) {
+	t.Run("no override, no flag: 2x the compiled default", func(t *testing.T) {
+		t.Setenv("BD_LEASE_TTL", "")
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize: %v", err)
+		}
+		cmd := newOlderThanTestCmd()
+		if err := cmd.ParseFlags(nil); err != nil {
+			t.Fatal(err)
+		}
+		got, err := resolveReclaimOlderThan(cmd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := 2 * issueops.DefaultLeaseTTL
+		if got != want {
+			t.Errorf("resolveReclaimOlderThan() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("deployment override, no flag: follows 2x the effective TTL", func(t *testing.T) {
+		t.Setenv("BD_LEASE_TTL", "4h")
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize: %v", err)
+		}
+		cmd := newOlderThanTestCmd()
+		if err := cmd.ParseFlags(nil); err != nil {
+			t.Fatal(err)
+		}
+		got, err := resolveReclaimOlderThan(cmd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := 8 * time.Hour
+		if got != want {
+			t.Errorf("resolveReclaimOlderThan() = %v, want 2x the 4h override = %v", got, want)
+		}
+	})
+
+	t.Run("explicit --older-than wins over the deployment override", func(t *testing.T) {
+		t.Setenv("BD_LEASE_TTL", "4h")
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize: %v", err)
+		}
+		cmd := newOlderThanTestCmd()
+		if err := cmd.ParseFlags([]string{"--older-than", "10m"}); err != nil {
+			t.Fatal(err)
+		}
+		got, err := resolveReclaimOlderThan(cmd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 10*time.Minute {
+			t.Errorf("resolveReclaimOlderThan() = %v, want the explicit 10m", got)
+		}
+	})
+
+	t.Run("explicit negative --older-than is rejected", func(t *testing.T) {
+		t.Setenv("BD_LEASE_TTL", "")
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize: %v", err)
+		}
+		cmd := newOlderThanTestCmd()
+		if err := cmd.ParseFlags([]string{"--older-than", "-1s"}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := resolveReclaimOlderThan(cmd); err == nil {
+			t.Error("resolveReclaimOlderThan() with negative --older-than = nil error, want rejection")
+		}
+	})
+}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -118,6 +118,7 @@ Any key whose name contains `api_key`, `api-key`, `secret`, `token`, or `passwor
 | `validation.on-sync` | — | `BD_VALIDATION_ON_SYNC` | `none` | Template validation before sync |
 | `validation.metadata.mode` | — | — | `none` | Metadata schema validation |
 | `hierarchy.max-depth` | — | — | `3` | Max hierarchical ID nesting depth |
+| `lease.ttl` | — | `BD_LEASE_TTL` | `5m` | Claim lease TTL before `bd reclaim` reverts a stale in_progress issue to ready (dead-worker recovery); widen this for a worker whose heartbeat cadence is slower than the default |
 | `backup.enabled` | — | `BD_BACKUP_ENABLED` | `false` | Enable periodic Dolt-native backup to `.beads/backup/` (see [below](#auto-backup)) |
 | `backup.interval` | — | `BD_BACKUP_INTERVAL` | `15m` | Minimum time between auto-backups |
 | `backup.git-push` | — | — | `false` | Auto-push backup repo |

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -929,6 +930,18 @@ func validateYamlConfigValue(key, value string) error {
 		}
 		if n < 0 {
 			return fmt.Errorf("prime.max-memory-chars must be a non-negative integer (0 = unlimited), got %q", value)
+		}
+	case "lease.ttl":
+		// Validated at write time so a typo (e.g. "4hrs" instead of "4h")
+		// is rejected here instead of silently parsing to zero later and
+		// falling back to the compiled default with no indication anything
+		// was wrong (PR #5470 review R1, gastownhall/gascity ga-7uoua).
+		d, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("lease.ttl must be a valid duration (e.g. \"5m\", \"4h\"), got %q: %w", value, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("lease.ttl must be positive, got %q", value)
 		}
 	}
 	return nil

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -78,6 +78,13 @@ var YamlOnlyKeys = map[string]bool{
 	// Hierarchy settings (GH#995)
 	"hierarchy.max-depth": true,
 
+	// Lease settings: EffectiveDefaultLeaseTTL reads this through viper
+	// (yaml/env) directly, not through the database — a DB-backed write
+	// would be silently unread on the claim/heartbeat hot path, exactly the
+	// GH#536 class this map exists to prevent (PR #5470 review R2,
+	// gastownhall/gascity ga-7uoua).
+	"lease.ttl": true,
+
 	// Backup settings (must be in yaml so GetValueSource can detect overrides)
 	"backup.enabled":  true,
 	"backup.interval": true,
@@ -936,7 +943,12 @@ func validateYamlConfigValue(key, value string) error {
 		// is rejected here instead of silently parsing to zero later and
 		// falling back to the compiled default with no indication anything
 		// was wrong (PR #5470 review R1, gastownhall/gascity ga-7uoua).
-		d, err := time.ParseDuration(value)
+		//
+		// Trim before parsing: shell quoting or a .env line can leave
+		// surrounding whitespace (e.g. "lease.ttl: \" 4h \""), which
+		// time.ParseDuration rejects outright — that would fail this
+		// otherwise-plausible input at set-time (PR #5470 review R2).
+		d, err := time.ParseDuration(strings.TrimSpace(value))
 		if err != nil {
 			return fmt.Errorf("lease.ttl must be a valid duration (e.g. \"5m\", \"4h\"), got %q: %w", value, err)
 		}

--- a/internal/config/yaml_config_test.go
+++ b/internal/config/yaml_config_test.go
@@ -769,6 +769,40 @@ func TestValidateYamlConfigValue_PrimeMaxMemoryChars(t *testing.T) {
 	}
 }
 
+// TestValidateYamlConfigValue_LeaseTTL guards `bd config set lease.ttl ...`
+// against the silent-misconfiguration hole flagged in PR #5470 review R1
+// (gastownhall/gascity ga-7uoua): time.ParseDuration rejects a bad value
+// here, at write time, instead of it being accepted and only later silently
+// parsing to zero and falling back to the compiled default.
+func TestValidateYamlConfigValue_LeaseTTL(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		expectErr bool
+	}{
+		{"valid minutes", "5m", false},
+		{"valid hours", "4h", false},
+		{"valid combined units", "1h30m", false},
+		{"invalid unit typo", "4hrs", true},
+		{"invalid non-duration", "banana", true},
+		{"invalid empty", "", true},
+		{"invalid zero", "0s", true},
+		{"invalid negative", "-5m", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateYamlConfigValue("lease.ttl", tt.value)
+			if tt.expectErr && err == nil {
+				t.Errorf("expected error for value %q, got nil", tt.value)
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("unexpected error for value %q: %v", tt.value, err)
+			}
+		})
+	}
+}
+
 func TestIsSecretKey(t *testing.T) {
 	tests := []struct {
 		key      string

--- a/internal/config/yaml_config_test.go
+++ b/internal/config/yaml_config_test.go
@@ -35,6 +35,12 @@ func TestIsYamlOnlyKey(t *testing.T) {
 		{"hierarchy.max-depth", true},
 		{"hierarchy.custom_setting", true}, // prefix match
 
+		// Lease settings (PR #5470 review R2, gastownhall/gascity ga-7uoua):
+		// EffectiveDefaultLeaseTTL reads lease.ttl through viper directly, so
+		// a DB-backed `bd config set` would be silently unread.
+		{"lease.ttl", true},
+		{"lease.other", false}, // exact match only, "lease." is not a registered prefix
+
 		// Backup settings (GH#2358)
 		{"backup.enabled", true},
 		{"backup.interval", true},

--- a/internal/storage/issueops/lease.go
+++ b/internal/storage/issueops/lease.go
@@ -22,7 +22,19 @@ import (
 // dies stops heartbeating, its lease_expires_at goes stale, and bd reclaim
 // reverts the issue to ready. Tunable per-claim via WithLeaseTTL on the
 // context, falling back to this default.
-const DefaultLeaseTTL = 5 * time.Minute
+//
+// Widened from 5min (2026-08-09, see gastownhall/gascity ga-z93p0): with no
+// caller anywhere invoking HeartbeatIssueInTx on a cadence, every claim's
+// lease went stale almost immediately regardless of worker liveness, making
+// the TTL decorrelated from actual liveness for any task longer than 5min —
+// which was most real work. 240min is set from a measured p50≈117min /
+// conservative-p90≈167min claim-to-merge duration across 26 real single-
+// worker tasks (small automated bug/tech-debt fixes), with margin. Treat
+// this TTL as a backstop for a lease that's live but stuck, not as the
+// primary "is this worker alive" check — a supervisor with an independent
+// liveness signal (process/session heartbeat, progress markers) should
+// still reclaim dead workers well before this fires.
+const DefaultLeaseTTL = 240 * time.Minute
 
 // leaseTTLContextKey overrides DefaultLeaseTTL for a single claim. Used by tests
 // (short TTLs) and callers that know their work cadence; unset in normal use.

--- a/internal/storage/issueops/lease.go
+++ b/internal/storage/issueops/lease.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/beads/internal/config"
@@ -69,7 +70,12 @@ func EffectiveDefaultLeaseTTL() time.Duration {
 	if raw == "" {
 		return DefaultLeaseTTL
 	}
-	d, err := time.ParseDuration(raw)
+	// Trim before parsing: shell quoting or a .env line can leave surrounding
+	// whitespace (e.g. BD_LEASE_TTL=" 4h "), which time.ParseDuration rejects
+	// outright — degrading otherwise-plausible operator input to the 5min
+	// default, exactly what this warning path exists to catch (PR #5470
+	// review R2, gastownhall/gascity ga-7uoua).
+	d, err := time.ParseDuration(strings.TrimSpace(raw))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: lease.ttl/BD_LEASE_TTL=%q is not a valid duration, using compiled default %v: %v\n", raw, DefaultLeaseTTL, err)
 		return DefaultLeaseTTL
@@ -167,7 +173,7 @@ func FreshRowLock() int64 {
 
 // LeaseTTL is the exported form of leaseTTL: it resolves the lease TTL for the
 // current claim from the context (WithLeaseTTL) or falls back to
-// DefaultLeaseTTL.
+// EffectiveDefaultLeaseTTL.
 func LeaseTTL(ctx context.Context) time.Duration {
 	return leaseTTL(ctx)
 }

--- a/internal/storage/issueops/lease.go
+++ b/internal/storage/issueops/lease.go
@@ -56,11 +56,29 @@ func WithLeaseTTL(ctx context.Context, ttl time.Duration) context.Context {
 // Gas City's measured 240min claim-to-merge window, ga-z93p0) without
 // changing the compiled default for every other deployment of this binary.
 // A per-claim WithLeaseTTL still wins over this when both are set.
+//
+// A value that IS set but unusable (fails to parse as a duration, or isn't
+// positive) warns to stderr and falls back to DefaultLeaseTTL rather than
+// doing so silently: reading via config.GetDuration would collapse "unset"
+// and "malformed" into the same zero value, so a typo'd BD_LEASE_TTL (e.g.
+// "4hrs" instead of "4h") would otherwise silently keep the deployment on
+// the narrow 5-minute default with no indication anything was wrong
+// (PR #5470 review R1, gastownhall/gascity ga-7uoua).
 func EffectiveDefaultLeaseTTL() time.Duration {
-	if d := config.GetDuration("lease.ttl"); d > 0 {
-		return d
+	raw := config.GetString("lease.ttl")
+	if raw == "" {
+		return DefaultLeaseTTL
 	}
-	return DefaultLeaseTTL
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: lease.ttl/BD_LEASE_TTL=%q is not a valid duration, using compiled default %v: %v\n", raw, DefaultLeaseTTL, err)
+		return DefaultLeaseTTL
+	}
+	if d <= 0 {
+		fmt.Fprintf(os.Stderr, "warning: lease.ttl/BD_LEASE_TTL=%q must be positive, using compiled default %v\n", raw, DefaultLeaseTTL)
+		return DefaultLeaseTTL
+	}
+	return d
 }
 
 // leaseTTL resolves the lease TTL for the current claim/heartbeat.

--- a/internal/storage/issueops/lease.go
+++ b/internal/storage/issueops/lease.go
@@ -15,26 +15,29 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// DefaultLeaseTTL is how long a fresh claim stays valid without a heartbeat.
-// A worker is expected to call HeartbeatIssueInTx well within this window
-// (heartbeat cadence ≫ claim cadence; see the commit-bloat note on bd heartbeat)
-// so a live claim's lease_expires_at always sits in the future. A worker that
-// dies stops heartbeating, its lease_expires_at goes stale, and bd reclaim
-// reverts the issue to ready. Tunable per-claim via WithLeaseTTL on the
-// context, falling back to this default.
+// DefaultLeaseTTL is how long a fresh claim stays valid without a heartbeat,
+// for deployments that have not set the "lease.ttl" config key / BD_LEASE_TTL
+// env var (see EffectiveDefaultLeaseTTL). A worker is expected to call
+// HeartbeatIssueInTx well within this window (heartbeat cadence ≫ claim
+// cadence; see the commit-bloat note on bd heartbeat) so a live claim's
+// lease_expires_at always sits in the future. A worker that dies stops
+// heartbeating, its lease_expires_at goes stale, and bd reclaim reverts the
+// issue to ready. Tunable per-claim via WithLeaseTTL on the context (highest
+// precedence), then EffectiveDefaultLeaseTTL's config/env override, falling
+// back to this constant.
 //
-// Widened from 5min (2026-08-09, see gastownhall/gascity ga-z93p0): with no
-// caller anywhere invoking HeartbeatIssueInTx on a cadence, every claim's
-// lease went stale almost immediately regardless of worker liveness, making
-// the TTL decorrelated from actual liveness for any task longer than 5min —
-// which was most real work. 240min is set from a measured p50≈117min /
-// conservative-p90≈167min claim-to-merge duration across 26 real single-
-// worker tasks (small automated bug/tech-debt fixes), with margin. Treat
-// this TTL as a backstop for a lease that's live but stuck, not as the
-// primary "is this worker alive" check — a supervisor with an independent
-// liveness signal (process/session heartbeat, progress markers) should
-// still reclaim dead workers well before this fires.
-const DefaultLeaseTTL = 240 * time.Minute
+// Deliberately left unwidened (2026-08-09 attempt reverted, see
+// gastownhall/gascity ga-7uoua / PR #5470 review): the original motivation
+// (gastownhall/gascity ga-z93p0 — with no caller invoking HeartbeatIssueInTx
+// on a cadence, a claim's lease went stale almost immediately regardless of
+// worker liveness, decorrelating the TTL from actual liveness for any task
+// longer than 5min) is real, but bumping this compiled constant changes the
+// default for every deployment at once — including ones that DO heartbeat on
+// a cadence tuned to 5min (e.g. a supervisor whose `bd reclaim` sweep is the
+// primary dead-worker recovery path), for whom a 240min default is a ~48x
+// regression in recovery latency shipped silently in a binary roll. Widen it
+// per-deployment via EffectiveDefaultLeaseTTL instead.
+const DefaultLeaseTTL = 5 * time.Minute
 
 // leaseTTLContextKey overrides DefaultLeaseTTL for a single claim. Used by tests
 // (short TTLs) and callers that know their work cadence; unset in normal use.
@@ -45,12 +48,27 @@ func WithLeaseTTL(ctx context.Context, ttl time.Duration) context.Context {
 	return context.WithValue(ctx, leaseTTLContextKey{}, ttl)
 }
 
+// EffectiveDefaultLeaseTTL returns this deployment's configured lease TTL —
+// "lease.ttl" in config.yaml, or the BD_LEASE_TTL env var (bound
+// automatically by the existing "BD_" viper prefix, same mechanism as
+// BD_DOLT_AUTO_PUSH / dolt.auto-push) — falling back to DefaultLeaseTTL when
+// neither is set. This is how a deployment opts into a longer default (e.g.
+// Gas City's measured 240min claim-to-merge window, ga-z93p0) without
+// changing the compiled default for every other deployment of this binary.
+// A per-claim WithLeaseTTL still wins over this when both are set.
+func EffectiveDefaultLeaseTTL() time.Duration {
+	if d := config.GetDuration("lease.ttl"); d > 0 {
+		return d
+	}
+	return DefaultLeaseTTL
+}
+
 // leaseTTL resolves the lease TTL for the current claim/heartbeat.
 func leaseTTL(ctx context.Context) time.Duration {
 	if ttl, ok := ctx.Value(leaseTTLContextKey{}).(time.Duration); ok && ttl > 0 {
 		return ttl
 	}
-	return DefaultLeaseTTL
+	return EffectiveDefaultLeaseTTL()
 }
 
 // freshRowLock returns a random non-zero int64 for the row_lock cell.

--- a/internal/storage/issueops/lease_ttl_config_test.go
+++ b/internal/storage/issueops/lease_ttl_config_test.go
@@ -1,6 +1,10 @@
 package issueops
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,4 +63,60 @@ func TestEffectiveDefaultLeaseTTL(t *testing.T) {
 			t.Errorf("leaseTTL(ctx) with WithLeaseTTL override = %v, want the per-claim override 90s", got)
 		}
 	})
+
+	t.Run("malformed BD_LEASE_TTL warns and falls back to the compiled default", func(t *testing.T) {
+		// PR #5470 review R1 (ga-7uoua): config.GetDuration silently
+		// collapses "unset" and "malformed" into the same zero value, so a
+		// typo'd unit (here "4hrs" instead of "4h") must not be silently
+		// indistinguishable from not having set the override at all.
+		t.Setenv("BD_LEASE_TTL", "4hrs")
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize: %v", err)
+		}
+
+		output := captureStderr(t, func() {
+			if got := EffectiveDefaultLeaseTTL(); got != DefaultLeaseTTL {
+				t.Errorf("EffectiveDefaultLeaseTTL() = %v, want compiled default %v on malformed input", got, DefaultLeaseTTL)
+			}
+		})
+		if !strings.Contains(output, "lease.ttl") || !strings.Contains(output, "4hrs") {
+			t.Errorf("expected a warning naming the key and the bad value, got: %q", output)
+		}
+	})
+
+	t.Run("non-positive BD_LEASE_TTL warns and falls back to the compiled default", func(t *testing.T) {
+		t.Setenv("BD_LEASE_TTL", "0s")
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize: %v", err)
+		}
+
+		output := captureStderr(t, func() {
+			if got := EffectiveDefaultLeaseTTL(); got != DefaultLeaseTTL {
+				t.Errorf("EffectiveDefaultLeaseTTL() = %v, want compiled default %v on non-positive input", got, DefaultLeaseTTL)
+			}
+		})
+		if !strings.Contains(output, "lease.ttl") {
+			t.Errorf("expected a warning naming lease.ttl, got: %q", output)
+		}
+	})
+}
+
+// captureStderr redirects os.Stderr for the duration of fn and returns what
+// was written to it.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+
+	fn()
+
+	w.Close()
+	os.Stderr = oldStderr
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
 }

--- a/internal/storage/issueops/lease_ttl_config_test.go
+++ b/internal/storage/issueops/lease_ttl_config_test.go
@@ -1,0 +1,62 @@
+package issueops
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/config"
+)
+
+// TestEffectiveDefaultLeaseTTL pins the config/env override added on PR
+// #5470 review (gastownhall/gascity ga-7uoua): DefaultLeaseTTL stays a
+// narrow, safe compiled default for every deployment, and a deployment opts
+// into a wider claim TTL via the "lease.ttl" config key (or its auto-bound
+// BD_LEASE_TTL env var, same "BD_" viper prefix as BD_DOLT_AUTO_PUSH) without
+// changing the compiled default for anyone else.
+//
+// Mutates global env/viper state via config.Initialize() — cannot run in
+// parallel with itself or with other config-mutating tests in this package.
+func TestEffectiveDefaultLeaseTTL(t *testing.T) {
+	t.Run("unset falls back to the compiled default", func(t *testing.T) {
+		t.Setenv("BD_LEASE_TTL", "")
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize: %v", err)
+		}
+		if got := EffectiveDefaultLeaseTTL(); got != DefaultLeaseTTL {
+			t.Errorf("EffectiveDefaultLeaseTTL() = %v, want compiled default %v", got, DefaultLeaseTTL)
+		}
+	})
+
+	t.Run("BD_LEASE_TTL overrides the compiled default", func(t *testing.T) {
+		t.Setenv("BD_LEASE_TTL", "4h")
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize: %v", err)
+		}
+		want := 4 * time.Hour
+		if got := EffectiveDefaultLeaseTTL(); got != want {
+			t.Errorf("EffectiveDefaultLeaseTTL() = %v, want override %v", got, want)
+		}
+	})
+
+	t.Run("leaseTTL(ctx) uses the effective default when no per-claim override is set", func(t *testing.T) {
+		t.Setenv("BD_LEASE_TTL", "4h")
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize: %v", err)
+		}
+		want := 4 * time.Hour
+		if got := leaseTTL(t.Context()); got != want {
+			t.Errorf("leaseTTL(ctx) = %v, want deployment override %v", got, want)
+		}
+	})
+
+	t.Run("WithLeaseTTL still wins over the deployment override", func(t *testing.T) {
+		t.Setenv("BD_LEASE_TTL", "4h")
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize: %v", err)
+		}
+		ctx := WithLeaseTTL(t.Context(), 90*time.Second)
+		if got := leaseTTL(ctx); got != 90*time.Second {
+			t.Errorf("leaseTTL(ctx) with WithLeaseTTL override = %v, want the per-claim override 90s", got)
+		}
+	})
+}

--- a/internal/storage/issueops/lease_ttl_config_test.go
+++ b/internal/storage/issueops/lease_ttl_config_test.go
@@ -22,6 +22,8 @@ import (
 // parallel with itself or with other config-mutating tests in this package.
 func TestEffectiveDefaultLeaseTTL(t *testing.T) {
 	t.Run("unset falls back to the compiled default", func(t *testing.T) {
+		config.ResetForTesting()
+		t.Cleanup(config.ResetForTesting)
 		t.Setenv("BD_LEASE_TTL", "")
 		if err := config.Initialize(); err != nil {
 			t.Fatalf("config.Initialize: %v", err)
@@ -32,6 +34,8 @@ func TestEffectiveDefaultLeaseTTL(t *testing.T) {
 	})
 
 	t.Run("BD_LEASE_TTL overrides the compiled default", func(t *testing.T) {
+		config.ResetForTesting()
+		t.Cleanup(config.ResetForTesting)
 		t.Setenv("BD_LEASE_TTL", "4h")
 		if err := config.Initialize(); err != nil {
 			t.Fatalf("config.Initialize: %v", err)
@@ -43,6 +47,8 @@ func TestEffectiveDefaultLeaseTTL(t *testing.T) {
 	})
 
 	t.Run("leaseTTL(ctx) uses the effective default when no per-claim override is set", func(t *testing.T) {
+		config.ResetForTesting()
+		t.Cleanup(config.ResetForTesting)
 		t.Setenv("BD_LEASE_TTL", "4h")
 		if err := config.Initialize(); err != nil {
 			t.Fatalf("config.Initialize: %v", err)
@@ -54,6 +60,8 @@ func TestEffectiveDefaultLeaseTTL(t *testing.T) {
 	})
 
 	t.Run("WithLeaseTTL still wins over the deployment override", func(t *testing.T) {
+		config.ResetForTesting()
+		t.Cleanup(config.ResetForTesting)
 		t.Setenv("BD_LEASE_TTL", "4h")
 		if err := config.Initialize(); err != nil {
 			t.Fatalf("config.Initialize: %v", err)
@@ -69,6 +77,8 @@ func TestEffectiveDefaultLeaseTTL(t *testing.T) {
 		// collapses "unset" and "malformed" into the same zero value, so a
 		// typo'd unit (here "4hrs" instead of "4h") must not be silently
 		// indistinguishable from not having set the override at all.
+		config.ResetForTesting()
+		t.Cleanup(config.ResetForTesting)
 		t.Setenv("BD_LEASE_TTL", "4hrs")
 		if err := config.Initialize(); err != nil {
 			t.Fatalf("config.Initialize: %v", err)
@@ -85,6 +95,8 @@ func TestEffectiveDefaultLeaseTTL(t *testing.T) {
 	})
 
 	t.Run("non-positive BD_LEASE_TTL warns and falls back to the compiled default", func(t *testing.T) {
+		config.ResetForTesting()
+		t.Cleanup(config.ResetForTesting)
 		t.Setenv("BD_LEASE_TTL", "0s")
 		if err := config.Initialize(); err != nil {
 			t.Fatalf("config.Initialize: %v", err)
@@ -99,10 +111,39 @@ func TestEffectiveDefaultLeaseTTL(t *testing.T) {
 			t.Errorf("expected a warning naming lease.ttl, got: %q", output)
 		}
 	})
+
+	t.Run("BD_LEASE_TTL with surrounding whitespace still parses", func(t *testing.T) {
+		// PR #5470 review R2 (ga-7uoua) MINOR: shell quoting or a .env line
+		// can leave whitespace around the value; it must not be treated as
+		// malformed input and silently degrade to the compiled default.
+		config.ResetForTesting()
+		t.Cleanup(config.ResetForTesting)
+		t.Setenv("BD_LEASE_TTL", " 4h ")
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize: %v", err)
+		}
+		want := 4 * time.Hour
+		output := captureStderr(t, func() {
+			if got := EffectiveDefaultLeaseTTL(); got != want {
+				t.Errorf("EffectiveDefaultLeaseTTL() = %v, want %v despite surrounding whitespace", got, want)
+			}
+		})
+		if output != "" {
+			t.Errorf("expected no warning for merely-padded input, got: %q", output)
+		}
+	})
 }
 
 // captureStderr redirects os.Stderr for the duration of fn and returns what
 // was written to it.
+//
+// The restore is deferred (not sequential after fn()) so a t.Fatal or panic
+// inside fn — which unwinds via runtime.Goexit, still running deferred calls
+// — does not leave os.Stderr redirected for the rest of the test binary. The
+// drain runs concurrently in a goroutine, not after w.Close(), so a write
+// larger than the pipe's buffer (64KB on darwin/linux) cannot deadlock
+// waiting for a reader that only starts once fn returns (PR #5470 review R2,
+// gastownhall/gascity ga-7uoua).
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	oldStderr := os.Stderr
@@ -111,12 +152,19 @@ func captureStderr(t *testing.T, fn func()) string {
 		t.Fatalf("os.Pipe: %v", err)
 	}
 	os.Stderr = w
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+
+	captured := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		captured <- buf.String()
+	}()
 
 	fn()
 
 	w.Close()
-	os.Stderr = oldStderr
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-	return buf.String()
+	return <-captured
 }


### PR DESCRIPTION
## What

Widen `DefaultLeaseTTL` (`internal/storage/issueops/lease.go`) from 5 minutes
to 240 minutes (4h), and document the reasoning inline.

## Why

In the Gas City deployment of `bd`, no caller invokes `bd heartbeat` /
`HeartbeatIssueInTx` on any cadence during real work — the lease is set once
at claim time and never refreshed. With a 5-minute TTL, this means a claim's
lease looks "stale" almost immediately after claiming, **regardless of
whether the worker is actually alive and working**. `bd reclaim`'s advertised
safety property ("only reclaims a lease that has ALREADY expired, never a
live one") is decorrelated from real liveness for any task longer than 5
minutes, which is most real work.

Root-caused while investigating `gastownhall/gascity#ga-z93p0` (internal
tracking bead, not on this repo). Companion fix in that deployment
(gastownhall/gastown, not this repo) adds `bd heartbeat` calls to the
work-loop formula at natural checkpoints — this PR is the complementary,
additive half: even with heartbeating added, a single long-running tool call
(build, test suite, subagent dispatch) still produces no mid-call checkpoint,
so the default should not assume sub-5-minute cadence.

## How the new value was chosen

Measured (not guessed) claim-to-merge duration across 26 real, closed,
single-worker small bug/tech-debt tasks in that deployment: local git commit
timestamp of the merged fix minus the issue's `started_at`.

    n=26, p50=117min, p90=333min (167min excluding 3 likely multi-attempt-
    contaminated outliers — those 3 carried retry/reclaim labels consistent
    with started_at spanning more than one work session, not a single sitting)

240min sits comfortably above the conservative p90 (167min) with margin.

**Caveat for reviewers:** this measurement reflects one deployment's usage
pattern (autonomous LLM agents doing small, gated bug fixes) — it is not
necessarily representative of `bd`'s general user base. If a shorter default
better serves other deployments, the existing `WithLeaseTTL` per-claim
context override is the right extension point for deployment-specific
tuning; happy to add a CLI/config-level override instead of changing the
global default if that's preferred. Flagging the tradeoff rather than
assuming 240min is universally right.

**Scope note:** in the deployment this was found in, `bd reclaim` is only
invoked as a narrowly-scoped `--id <issue> --older-than 0s` escalation after
some other signal already flagged that issue — never as a broad periodic
sweep — so this default's practical blast radius there is narrower than "the
citywide liveness check." Still worth fixing: it's cheap, additive, and
matches the documented contract for any current or future caller that
reasonably relies on it.

## Testing

- `go build ./...` — clean
- `go test ./internal/storage/issueops/... ./internal/storage/embeddeddolt/... ./internal/storage/dolt/... ./cmd/bd/... ./internal/storage/sqlbuild/... -run 'Lease|Reclaim|Heartbeat|Claim'` — passing (existing lease/reclaim tests use `WithLeaseTTL` to set their own short TTLs explicitly, so they're unaffected by the default change)
- No test in the repo hardcodes `DefaultLeaseTTL`'s value directly (checked via grep)
