### PR TITLE
fix(create): refuse --repo into uninitialized workspace

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -13,13 +13,11 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/config"
-	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/remotecache"
 	"github.com/steveyegge/beads/internal/routing"
 	"github.com/steveyegge/beads/internal/storage"
-	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/timeparsing"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
@@ -413,8 +411,8 @@ var createCmd = &cobra.Command{
 				targetBeadsDir := routing.ExpandPath(repoPath)
 				debug.Logf("DEBUG: Routing to target repo: %s\n", targetBeadsDir)
 
-				if err := ensureBeadsDirForPath(rootCtx, targetBeadsDir, store); err != nil {
-					return HandleError("failed to initialize target repo: %v", err)
+				if err := requireInitializedRepoPath(targetBeadsDir); err != nil {
+					return HandleError("%v", err)
 				}
 
 				targetBeadsDirPath := filepath.Join(targetBeadsDir, ".beads")
@@ -953,63 +951,19 @@ func openDryRunTargetStore(ctx context.Context, repoPath string) (storage.DoltSt
 	return store, nil
 }
 
-// ensureBeadsDirForPath ensures a beads directory exists at the target path.
-// If the .beads directory doesn't exist, it creates it and initializes with
-// the same prefix as the source store (T010, T012: prefix inheritance).
-func ensureBeadsDirForPath(ctx context.Context, targetPath string, sourceStore storage.DoltStorage) error {
-	beadsDir := filepath.Join(targetPath, ".beads")
-	metadataPath := filepath.Join(beadsDir, "metadata.json")
-
-	// Check if beads directory already exists with a Dolt database.
-	// metadata.json is the canonical marker for an initialized beads dir.
+// requireInitializedRepoPath rejects a --repo target that is not already an
+// initialized beads workspace.
+//
+// Auto-initializing here strands writes in a new embedded database with no
+// remotes. `bd init` is the explicit command for creating a workspace;
+// `bd create` must only write to one that already exists.
+func requireInitializedRepoPath(targetPath string) error {
+	metadataPath := filepath.Join(targetPath, ".beads", "metadata.json")
 	if _, err := os.Stat(metadataPath); err == nil {
 		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("cannot inspect %s: %w", metadataPath, err)
 	}
-
-	// Create .beads directory
-	if err := os.MkdirAll(beadsDir, 0750); err != nil {
-		return fmt.Errorf("cannot create .beads directory: %w", err)
-	}
-
-	// Initialize database via NewFromConfigWithOptions to respect Dolt config.
-	// Set the prefix if source store has one (T012: prefix inheritance).
-	if sourceStore != nil {
-		sourcePrefix, err := sourceStore.GetConfig(ctx, "issue_prefix")
-		if err == nil && sourcePrefix != "" {
-			// Sanitize prefix for SQL database name (same as bd init).
-			dbName := strings.ReplaceAll(sourcePrefix, "-", "_")
-
-			// Open target store temporarily to set prefix.
-			// Use newDoltStore with explicit config since the target .beads
-			// directory was just created and has no metadata.json yet.
-			tempStore, err := newDoltStore(ctx, &dolt.Config{
-				BeadsDir:        beadsDir,
-				Database:        dbName,
-				CreateIfMissing: true,
-			})
-			if err != nil {
-				return fmt.Errorf("failed to initialize target database: %w", err)
-			}
-			if err := tempStore.SetConfig(ctx, "issue_prefix", sourcePrefix); err != nil {
-				_ = tempStore.Close() // Best effort cleanup on error path
-				return fmt.Errorf("failed to set prefix in target store: %w", err)
-			}
-			if err := tempStore.Close(); err != nil {
-				return fmt.Errorf("failed to close target store: %w", err)
-			}
-
-			// Write metadata.json so newDoltStoreFromConfig can find the
-			// correct database name on subsequent opens (GH#2988).
-			cfg := configfile.DefaultConfig()
-			cfg.Backend = configfile.BackendDolt
-			cfg.DoltDatabase = dbName
-			cfg.DoltMode = configfile.DoltModeEmbedded
-			cfg.ProjectID = configfile.GenerateProjectID()
-			if err := cfg.Save(beadsDir); err != nil {
-				return fmt.Errorf("failed to write metadata.json: %w", err)
-			}
-		}
-	}
-
-	return nil
+	return fmt.Errorf("target repo %s is not an initialized beads workspace (no .beads/metadata.json); "+
+		"run 'bd init' there first, or drop --repo to write to the workspace that 'bd where' resolves", targetPath)
 }

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -1073,12 +1073,9 @@ func TestEmbeddedCreateCrossRepoDryRunWithParent(t *testing.T) {
 	}
 }
 
-// TestEmbeddedCreateCrossRepoUninit verifies that bd create --repo works when
-// the target directory has NOT been initialized with bd init. This is a
-// regression test for be-sy8 / GH#2988: newDoltStoreFromConfig used to pass
-// an empty database name to the embedded Dolt engine, causing "no database
-// selected" during schema init.
-func TestEmbeddedCreateCrossRepoUninit(t *testing.T) {
+// TestEmbeddedCreateCrossRepoUninitIsRefused verifies that bd create --repo
+// refuses an uninitialized target without leaving a stray .beads directory.
+func TestEmbeddedCreateCrossRepoUninitIsRefused(t *testing.T) {
 	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
 		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
 	}
@@ -1096,27 +1093,13 @@ func TestEmbeddedCreateCrossRepoUninit(t *testing.T) {
 	}
 	initGitRepoAt(t, targetDir)
 
-	// This should succeed: ensureBeadsDirForPath creates .beads,
-	// and newDoltStoreFromConfig defaults to database "beads".
-	issue := bdCreate(t, bd, dir, "Issue in uninit target", "--repo", targetDir)
-	if issue.ID == "" {
-		t.Fatal("expected issue ID")
+	out := bdCreateFail(t, bd, dir, "Issue in uninit target", "--repo", targetDir)
+	if !strings.Contains(out, "not an initialized beads workspace") || !strings.Contains(out, "bd init") {
+		t.Errorf("error message must name the problem and the fix, got: %s", out)
 	}
 
-	// Verify issue exists in the target store
-	targetBeadsDir := filepath.Join(targetDir, ".beads")
-	tgtStore, err := newDoltStoreFromConfig(t.Context(), targetBeadsDir)
-	if err != nil {
-		t.Fatalf("failed to open target store: %v", err)
-	}
-	defer tgtStore.Close()
-
-	got, err := tgtStore.GetIssue(t.Context(), issue.ID)
-	if err != nil {
-		t.Fatalf("GetIssue in target: %v", err)
-	}
-	if got.Title != "Issue in uninit target" {
-		t.Errorf("title: got %q, want %q", got.Title, "Issue in uninit target")
+	if _, err := os.Stat(filepath.Join(targetDir, ".beads")); !os.IsNotExist(err) {
+		t.Errorf("target .beads exists after refusal (stat err = %v); want no directory", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

`bd create --repo <path>` currently calls `ensureBeadsDirForPath` when `<path>` has not been initialized. That silently creates a new embedded Dolt database with no remote, writes the issue there, and reports success. The issue is absent from the invoking workspace and cannot be pushed by its normal `bd dolt push` path.

This caused a real incident: eight issues were stranded for two weeks under a repo-local `.beads` directory before the workspace's normal queue exposed that they were missing.

`create --dry-run --repo <path>` already refuses the same uninitialized target. The real write should not be more permissive than its preview.

## Change

- Require `<path>/.beads/metadata.json` before opening a local `--repo` target.
- Tell the user to run `bd init` there or remove `--repo`.
- Preserve the remote-URL cache path unchanged.
- Invert the existing auto-init test and assert refusal leaves no `.beads` directory behind.

`bd init` remains the explicit operation for creating a workspace; `bd create` only writes to an existing one.

## Verification

```text
BEADS_TEST_EMBEDDED_DOLT=1 go test -tags=gms_pure_go ./cmd/bd -run '^TestEmbeddedCreateCrossRepo' -count=1
ok github.com/steveyegge/beads/cmd/bd
```

The same guard has been running in a downstream fork since 2026-08-07.