### PR TITLE
fix(output): route graph renderers and ratchet stdout writes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -301,6 +301,12 @@ linters:
         - pattern: '^types\.(IssueFilter|WorkFilter)$'
           pkg: '^github\.com/steveyegge/beads/internal/types$'
           msg: "do not write a filter here: take one back from a builder in internal/workapi, or pass the whole request to issueops.Reader. internal/httpapi may never name these types; cmd/bd denies them by default and lists the files that legitimately build their own, with the reason for each, in .golangci.yml - see issueops/reader.go"
+        - pattern: '^fmt\.Print(f|ln)?$'
+          pkg: '^fmt$'
+          msg: "do not write list/graph output through process stdout: route format output through the command writer; mark an intentional non-format path locally"
+        - pattern: '^os\.Stdout$'
+          pkg: '^os$'
+          msg: "do not write list/graph output through process stdout: route format output through the command writer; mark an intentional non-format path locally"
     errcheck:
       exclude-functions:
         - (*database/sql.DB).Close
@@ -327,10 +333,10 @@ linters:
 
   exclusions:
     rules:
-      # forbidigo holds TWO rules - the filter-construction guard and the
-      # label-plane guard - and the entries from here to the test exemption are
-      # their entire scope. This one keeps both off the rest of the tree; the
-      # settings block above says why.
+      # forbidigo holds four rules: filter construction, label-plane access,
+      # and the two process-stdout forms used by list/graph output. The entries
+      # from here to the test exemption define their scopes. This first one
+      # keeps every rule off the rest of the tree; the settings block says why.
       #
       # The previous version of this comment said there was exactly one rule and
       # that a second "would need this widened or replaced". That came true, and
@@ -341,6 +347,14 @@ linters:
       # it is not fine for the files that do - see the three `text:`-scoped
       # entries below.
       - path-except: '^(internal/httpapi/|cmd/bd/)'
+        linters:
+          - forbidigo
+      # Process stdout is forbidden only across the list/graph file families.
+      # Existing non-format paths in those families carry local, reviewed
+      # exceptions; a new file or output site is denied by default. Scoping by
+      # the diagnostic text keeps the filter and label rules unchanged.
+      - path-except: '^cmd/bd/(list|graph).*\.go$'
+        text: 'do not write list/graph output through process stdout'
         linters:
           - forbidigo
       #

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -303,9 +303,11 @@ linters:
           msg: "do not write a filter here: take one back from a builder in internal/workapi, or pass the whole request to issueops.Reader. internal/httpapi may never name these types; cmd/bd denies them by default and lists the files that legitimately build their own, with the reason for each, in .golangci.yml - see issueops/reader.go"
         - pattern: '^fmt\.Print(f|ln)?$'
           pkg: '^fmt$'
+          # Keep the prefix in sync with the list/graph text exclusion below.
           msg: "do not write list/graph output through process stdout: route format output through the command writer; mark an intentional non-format path locally"
         - pattern: '^os\.Stdout$'
           pkg: '^os$'
+          # Keep the prefix in sync with the list/graph text exclusion below.
           msg: "do not write list/graph output through process stdout: route format output through the command writer; mark an intentional non-format path locally"
     errcheck:
       exclude-functions:
@@ -354,6 +356,7 @@ linters:
       # exceptions; a new file or output site is denied by default. Scoping by
       # the diagnostic text keeps the filter and label rules unchanged.
       - path-except: '^cmd/bd/(list|graph).*\.go$'
+        # This prefix must match both fmt.Print and os.Stdout messages above.
         text: 'do not write list/graph output through process stdout'
         linters:
           - forbidigo

--- a/cmd/bd/graph.go
+++ b/cmd/bd/graph.go
@@ -336,22 +336,22 @@ func renderGraphCheck(cycles [][]*types.Issue) error {
 	}
 
 	if result.Clean {
-		fmt.Printf("\n%s Graph integrity check passed\n\n", ui.RenderPass("✓"))
+		fmt.Printf("\n%s Graph integrity check passed\n\n", ui.RenderPass("✓")) //nolint:forbidigo // Graph check is outside the renderer contract.
 	} else {
-		fmt.Printf("\n%s Graph integrity issues found\n\n", ui.RenderFail("✗"))
+		fmt.Printf("\n%s Graph integrity issues found\n\n", ui.RenderFail("✗")) //nolint:forbidigo // Graph check is outside the renderer contract.
 	}
 
 	if len(result.Cycles) > 0 {
-		fmt.Printf("%s Cycles (%d):\n\n", ui.RenderFail("⚠"), len(result.Cycles))
+		fmt.Printf("%s Cycles (%d):\n\n", ui.RenderFail("⚠"), len(result.Cycles)) //nolint:forbidigo // Graph check is outside the renderer contract.
 		for _, cycle := range result.Cycles {
-			fmt.Printf("  %s → %s\n", strings.Join(cycle, " → "), cycle[0])
+			fmt.Printf("  %s → %s\n", strings.Join(cycle, " → "), cycle[0]) //nolint:forbidigo // Graph check is outside the renderer contract.
 		}
-		fmt.Println()
+		fmt.Println() //nolint:forbidigo // Graph check is outside the renderer contract.
 	} else {
-		fmt.Printf("  %s No dependency cycles\n", ui.RenderPass("✓"))
+		fmt.Printf("  %s No dependency cycles\n", ui.RenderPass("✓")) //nolint:forbidigo // Graph check is outside the renderer contract.
 	}
 
-	fmt.Println()
+	fmt.Println() //nolint:forbidigo // Graph check is outside the renderer contract.
 
 	if !result.Clean {
 		return SilentExit()

--- a/cmd/bd/graph.go
+++ b/cmd/bd/graph.go
@@ -198,7 +198,9 @@ func renderGraphAllSubgraphs(out io.Writer, subgraphs []*TemplateSubgraph) error
 	if graphOpen {
 		for i, subgraph := range subgraphs {
 			layout := computeLayout(subgraph)
-			renderGraphCompact(layout, subgraph)
+			if err := renderGraphCompact(out, layout, subgraph); err != nil {
+				return err
+			}
 			if i < len(subgraphs)-1 {
 				if err := writeGraphLine(out, strings.Repeat("─", 60)); err != nil {
 					return err
@@ -215,11 +217,17 @@ func renderGraphAllSubgraphs(out io.Writer, subgraphs []*TemplateSubgraph) error
 				return err
 			}
 		} else if graphCompact {
-			renderGraphCompact(layout, subgraph)
+			if err := renderGraphCompact(out, layout, subgraph); err != nil {
+				return err
+			}
 		} else if graphBox {
-			renderGraph(layout, subgraph)
+			if err := renderGraph(out, layout, subgraph); err != nil {
+				return err
+			}
 		} else {
-			renderGraphVisual(layout, subgraph)
+			if err := renderGraphVisual(out, layout, subgraph); err != nil {
+				return err
+			}
 		}
 		if !graphDOT && i < len(subgraphs)-1 {
 			if err := writeGraphLine(out, strings.Repeat("─", 60)); err != nil {
@@ -249,8 +257,7 @@ func renderGraphSingleSubgraph(out io.Writer, subgraph *TemplateSubgraph) error 
 	}
 
 	if graphOpen {
-		renderGraphCompact(layout, subgraph)
-		return nil
+		return renderGraphCompact(out, layout, subgraph)
 	}
 
 	if graphDOT {
@@ -258,13 +265,12 @@ func renderGraphSingleSubgraph(out io.Writer, subgraph *TemplateSubgraph) error 
 	} else if graphHTML {
 		return renderGraphHTML(out, layout, subgraph)
 	} else if graphCompact {
-		renderGraphCompact(layout, subgraph)
+		return renderGraphCompact(out, layout, subgraph)
 	} else if graphBox {
-		renderGraph(layout, subgraph)
+		return renderGraph(out, layout, subgraph)
 	} else {
-		renderGraphVisual(layout, subgraph)
+		return renderGraphVisual(out, layout, subgraph)
 	}
-	return nil
 }
 
 var graphCheckCmd = &cobra.Command{
@@ -929,14 +935,15 @@ func computeLayout(subgraph *TemplateSubgraph) *GraphLayout {
 	return layout
 }
 
-// renderGraph renders the ASCII visualization
-func renderGraph(layout *GraphLayout, subgraph *TemplateSubgraph) {
+// renderGraph renders the ASCII visualization.
+func renderGraph(out io.Writer, layout *GraphLayout, subgraph *TemplateSubgraph) error {
+	w := &graphExportWriter{out: out}
 	if len(layout.Nodes) == 0 {
-		fmt.Println("Empty graph")
-		return
+		w.println("Empty graph")
+		return w.wrapError("graph")
 	}
 
-	fmt.Printf("\n%s Dependency graph for %s:\n\n", ui.RenderAccent("📊"), layout.RootID)
+	w.printf("\n%s Dependency graph for %s:\n\n", ui.RenderAccent("📊"), layout.RootID)
 
 	// Calculate box width based on longest title
 	maxTitleLen := 0
@@ -952,8 +959,8 @@ func renderGraph(layout *GraphLayout, subgraph *TemplateSubgraph) {
 	// For simplicity, we'll render layer by layer with arrows between them
 
 	// First, show the legend
-	fmt.Println("  Status: ○ open  ◐ in_progress  ● blocked  ✓ closed")
-	fmt.Println()
+	w.println("  Status: ○ open  ◐ in_progress  ● blocked  ✓ closed")
+	w.println()
 
 	// Build dependency counts from subgraph
 	blocksCounts, blockedByCounts := computeDependencyCounts(subgraph)
@@ -983,22 +990,22 @@ func renderGraph(layout *GraphLayout, subgraph *TemplateSubgraph) {
 	// Render horizontally (simplified - just show boxes with arrows)
 	for layerIdx, boxes := range layerBoxes {
 		// Print layer header
-		fmt.Printf("  Layer %d", layerIdx)
+		w.printf("  Layer %d", layerIdx)
 		if layerIdx == 0 {
-			fmt.Print(" (ready)")
+			w.printf(" (ready)")
 		}
-		fmt.Println()
+		w.println()
 
 		for _, box := range boxes {
-			fmt.Println(box)
+			w.println(box)
 		}
 
 		// Print arrows to next layer if not last
 		if layerIdx < len(layerBoxes)-1 {
-			fmt.Println("      │")
-			fmt.Println("      ▼")
+			w.println("      │")
+			w.println("      ▼")
 		}
-		fmt.Println()
+		w.println()
 	}
 
 	// Show dependency summary
@@ -1010,28 +1017,30 @@ func renderGraph(layout *GraphLayout, subgraph *TemplateSubgraph) {
 			}
 		}
 		if blocksDeps > 0 {
-			fmt.Printf("  Dependencies: %d blocking relationships\n", blocksDeps)
+			w.printf("  Dependencies: %d blocking relationships\n", blocksDeps)
 		}
 	}
 
 	// Show summary
-	fmt.Printf("  Total: %d issues across %d layers\n\n", len(layout.Nodes), len(layout.Layers))
+	w.printf("  Total: %d issues across %d layers\n\n", len(layout.Nodes), len(layout.Layers))
+	return w.wrapError("graph")
 }
 
 // renderGraphCompact renders the graph in compact tree format
 // One line per issue, more scannable, uses tree connectors (├──, └──, │)
-func renderGraphCompact(layout *GraphLayout, subgraph *TemplateSubgraph) {
+func renderGraphCompact(out io.Writer, layout *GraphLayout, subgraph *TemplateSubgraph) error {
+	w := &graphExportWriter{out: out}
 	if len(layout.Nodes) == 0 {
-		fmt.Println("Empty graph")
-		return
+		w.println("Empty graph")
+		return w.wrapError("graph")
 	}
 
-	fmt.Printf("\n%s Dependency graph for %s (%d issues, %d layers)\n\n",
+	w.printf("\n%s Dependency graph for %s (%d issues, %d layers)\n\n",
 		ui.RenderAccent("📊"), layout.RootID, len(layout.Nodes), len(layout.Layers))
 
 	// Legend
-	fmt.Println("  Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred")
-	fmt.Println()
+	w.println("  Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred")
+	w.println()
 
 	// Build parent-child map from subgraph dependencies
 	children := make(map[string][]string) // parent -> children
@@ -1063,7 +1072,7 @@ func renderGraphCompact(layout *GraphLayout, subgraph *TemplateSubgraph) {
 		if layerIdx == 0 {
 			layerHeader += " (ready)"
 		}
-		fmt.Printf("  %s\n", ui.RenderAccent(layerHeader))
+		w.printf("  %s\n", ui.RenderAccent(layerHeader))
 
 		for i, id := range layer {
 			node := layout.Nodes[id]
@@ -1078,7 +1087,7 @@ func renderGraphCompact(layout *GraphLayout, subgraph *TemplateSubgraph) {
 				connector = "└── "
 			}
 
-			fmt.Printf("  %s%s\n", connector, line)
+			w.printf("  %s%s\n", connector, line)
 
 			// Render children (if this issue has children in the subgraph)
 			if childIDs, ok := children[id]; ok && len(childIDs) > 0 {
@@ -1086,15 +1095,16 @@ func renderGraphCompact(layout *GraphLayout, subgraph *TemplateSubgraph) {
 				if isLast {
 					childPrefix = "    "
 				}
-				renderCompactChildren(layout, childIDs, children, childPrefix, 1)
+				renderCompactChildren(w, layout, childIDs, children, childPrefix, 1)
 			}
 		}
-		fmt.Println()
+		w.println()
 	}
+	return w.wrapError("graph")
 }
 
 // renderCompactChildren recursively renders children in tree format
-func renderCompactChildren(layout *GraphLayout, childIDs []string, children map[string][]string, prefix string, depth int) {
+func renderCompactChildren(w *graphExportWriter, layout *GraphLayout, childIDs []string, children map[string][]string, prefix string, depth int) {
 	for i, childID := range childIDs {
 		node := layout.Nodes[childID]
 		if node == nil {
@@ -1108,7 +1118,7 @@ func renderCompactChildren(layout *GraphLayout, childIDs []string, children map[
 		}
 
 		line := formatCompactNode(node)
-		fmt.Printf("  %s%s%s\n", prefix, connector, line)
+		w.printf("  %s%s%s\n", prefix, connector, line)
 
 		// Recurse for nested children
 		if grandchildren, ok := children[childID]; ok && len(grandchildren) > 0 {
@@ -1118,7 +1128,7 @@ func renderCompactChildren(layout *GraphLayout, childIDs []string, children map[
 			} else {
 				childPrefix += "│   "
 			}
-			renderCompactChildren(layout, grandchildren, children, childPrefix, depth+1)
+			renderCompactChildren(w, layout, grandchildren, children, childPrefix, depth+1)
 		}
 	}
 }

--- a/cmd/bd/graph_apply.go
+++ b/cmd/bd/graph_apply.go
@@ -382,14 +382,14 @@ func createIssuesFromGraph(planFile string, dryRun bool, opts GraphApplyOptions)
 	if jsonOutput {
 		return outputJSON(result)
 	}
-	fmt.Printf("Created %d issues\n", len(result.IDs))
+	fmt.Printf("Created %d issues\n", len(result.IDs)) //nolint:forbidigo // Graph create is outside the renderer contract.
 	keys := make([]string, 0, len(result.IDs))
 	for key := range result.IDs {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		fmt.Printf("  %s -> %s\n", key, result.IDs[key])
+		fmt.Printf("  %s -> %s\n", key, result.IDs[key]) //nolint:forbidigo // Graph create is outside the renderer contract.
 	}
 	return nil
 }
@@ -441,9 +441,10 @@ func emitGraphApplyDryRun(plan *GraphApplyPlan, opts GraphApplyOptions) error {
 		return outputJSON(preview)
 	}
 
+	//nolint:forbidigo // Graph create is outside the renderer contract.
 	fmt.Printf("Dry run: would create %d issue(s) and %d edge(s) (%d parent-child link(s))\n",
 		preview.NodeCount, preview.EdgeCount, preview.ParentDeps)
-	fmt.Printf("Note: %s.\n", graphApplyDryRunTransactionValidationNote)
+	fmt.Printf("Note: %s.\n", graphApplyDryRunTransactionValidationNote) //nolint:forbidigo // Graph create is outside the renderer contract.
 	for _, row := range rows {
 		extras := ""
 		if row.ID != "" {
@@ -458,7 +459,7 @@ func emitGraphApplyDryRun(plan *GraphApplyPlan, opts GraphApplyOptions) error {
 		case row.ParentID != "":
 			extras += fmt.Sprintf(" parent_id=%s", row.ParentID)
 		}
-		fmt.Printf("  %s [%s] P%d %q%s\n", row.Key, row.Type, row.Priority, row.Title, extras)
+		fmt.Printf("  %s [%s] P%d %q%s\n", row.Key, row.Type, row.Priority, row.Title, extras) //nolint:forbidigo // Graph create is outside the renderer contract.
 	}
 	return nil
 }

--- a/cmd/bd/graph_export_test.go
+++ b/cmd/bd/graph_export_test.go
@@ -497,3 +497,92 @@ func TestGraphExportDispatchPropagatesWriterErrors(t *testing.T) {
 		}
 	})
 }
+
+func TestGraphHumanRenderModesUseSuppliedWriter(t *testing.T) {
+	oldDOT, oldHTML := graphDOT, graphHTML
+	oldOpen, oldCompact, oldBox := graphOpen, graphCompact, graphBox
+	oldJSON := jsonOutput
+	t.Cleanup(func() {
+		graphDOT, graphHTML = oldDOT, oldHTML
+		graphOpen, graphCompact, graphBox = oldOpen, oldCompact, oldBox
+		jsonOutput = oldJSON
+	})
+
+	modes := []struct {
+		name          string
+		configure     func()
+		want          []string
+		wantSeparator bool
+		composes      bool
+	}{
+		{
+			name: "visual", configure: func() {}, wantSeparator: true, composes: true,
+			want: []string{"Dependency graph for test-a:", "test-c P2", "Total: 4 issues across 3 layers"},
+		},
+		{
+			name: "compact", configure: func() { graphCompact = true }, wantSeparator: true, composes: true,
+			want: []string{"Dependency graph for test-a (4 issues, 3 layers)", "LAYER 2", "test-c P2 Blocked task"},
+		},
+		{
+			name: "box", configure: func() { graphBox = true }, wantSeparator: true, composes: true,
+			want: []string{"Dependency graph for test-a:", "Blocked task", "Total: 4 issues across 3 layers"},
+		},
+		{
+			name: "open", configure: func() { graphOpen = true }, wantSeparator: true, composes: true,
+			want: []string{"Dependency graph for test-a (3 issues, 3 layers)", "LAYER 2", "test-c P2 Blocked task"},
+		},
+		{
+			name: "DOT", configure: func() { graphDOT = true }, composes: true,
+			want: []string{"digraph beads {", "rankdir=LR;", `"test-c"`},
+		},
+		{
+			name: "HTML", configure: func() { graphHTML = true },
+			want: []string{"<!DOCTYPE html>", "const nodes =", `"id":"test-c"`},
+		},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			graphDOT, graphHTML = false, false
+			graphOpen, graphCompact, graphBox, jsonOutput = false, false, false, false
+			mode.configure()
+
+			subgraph, _ := makeTestSubgraph()
+			var out bytes.Buffer
+			if err := renderGraphAllSubgraphs(&out, []*TemplateSubgraph{subgraph, subgraph}); err != nil {
+				t.Fatalf("renderGraphAllSubgraphs: %v", err)
+			}
+			got := out.String()
+			for _, want := range mode.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("supplied writer did not capture %q in %s output:\n%s", want, mode.name, got)
+				}
+			}
+			if hasSeparator := strings.Contains(got, strings.Repeat("─", 60)); hasSeparator != mode.wantSeparator {
+				t.Fatalf("%s separator present = %v, want %v", mode.name, hasSeparator, mode.wantSeparator)
+			}
+			if mode.composes {
+				var single bytes.Buffer
+				if err := renderGraphSingleSubgraph(&single, subgraph); err != nil {
+					t.Fatalf("renderGraphSingleSubgraph: %v", err)
+				}
+				separator := ""
+				if mode.wantSeparator {
+					separator = strings.Repeat("─", 60) + "\n"
+				}
+				if want := single.String() + separator + single.String(); got != want {
+					t.Fatalf("all-%s output did not compose from two complete single outputs", mode.name)
+				}
+			}
+
+			writer := &graphFailWriter{err: io.ErrClosedPipe, failAt: 1}
+			err := renderGraphSingleSubgraph(writer, subgraph)
+			if !errors.Is(err, io.ErrClosedPipe) {
+				t.Fatalf("renderGraphSingleSubgraph error = %v, want %v", err, io.ErrClosedPipe)
+			}
+			if writer.writes != writer.failAt {
+				t.Fatalf("%s renderer made %d writes after failure at %d", mode.name, writer.writes, writer.failAt)
+			}
+		})
+	}
+}

--- a/cmd/bd/graph_visual.go
+++ b/cmd/bd/graph_visual.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/types"
@@ -16,37 +15,23 @@ type dagEdgeInfo struct {
 	targetRow int
 }
 
-// renderGraphVisual renders a terminal-native DAG with nodes arranged in
-// layer columns (left-to-right) and box-drawing edges between them.
-// Each layer is a vertical column of node boxes, with edges drawn in
-// gutter areas between columns.
-func renderGraphVisual(layout *GraphLayout, subgraph *TemplateSubgraph) {
-	renderGraphVisualTo(os.Stdout, layout, subgraph)
-}
-
-// renderGraphVisualTo is the writer-aware test seam for the terminal visual
-// renderer. The production wrapper intentionally retains its existing stdout
-// destination and ignored write-error behavior.
-func renderGraphVisualTo(out io.Writer, layout *GraphLayout, subgraph *TemplateSubgraph) {
-	printf := func(format string, args ...interface{}) {
-		_, _ = fmt.Fprintf(out, format, args...)
-	}
-	println := func(args ...interface{}) {
-		_, _ = fmt.Fprintln(out, args...)
-	}
+// renderGraphVisual renders a terminal-native DAG to the supplied writer, with
+// nodes arranged in layer columns and box-drawing edges between them.
+func renderGraphVisual(out io.Writer, layout *GraphLayout, subgraph *TemplateSubgraph) error {
+	w := &graphExportWriter{out: out}
 
 	if len(layout.Nodes) == 0 {
-		println("Empty graph")
-		return
+		w.println("Empty graph")
+		return w.wrapError("graph")
 	}
 
-	printf("\n%s Dependency graph for %s:\n\n", ui.RenderAccent("📊"), layout.RootID)
-	println("  Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred")
-	println()
+	w.printf("\n%s Dependency graph for %s:\n\n", ui.RenderAccent("📊"), layout.RootID)
+	w.println("  Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred")
+	w.println()
 
 	numLayers := len(layout.Layers)
 	if numLayers == 0 {
-		return
+		return w.wrapError("graph")
 	}
 
 	// Calculate consistent node box width
@@ -91,8 +76,8 @@ func renderGraphVisualTo(out io.Writer, layout *GraphLayout, subgraph *TemplateS
 			headerLine.WriteString(strings.Repeat(" ", gutterW))
 		}
 	}
-	println(headerLine.String())
-	println()
+	w.println(headerLine.String())
+	w.println()
 
 	// Render each output line
 	for y := 0; y < totalLines; y++ {
@@ -124,10 +109,10 @@ func renderGraphVisualTo(out io.Writer, layout *GraphLayout, subgraph *TemplateS
 			}
 		}
 
-		println(strings.TrimRight(line.String(), " "))
+		w.println(strings.TrimRight(line.String(), " "))
 	}
 
-	println()
+	w.println()
 
 	// Summary
 	blocksDeps := 0
@@ -137,9 +122,10 @@ func renderGraphVisualTo(out io.Writer, layout *GraphLayout, subgraph *TemplateS
 		}
 	}
 	if blocksDeps > 0 {
-		printf("  Dependencies: %d blocking relationships\n", blocksDeps)
+		w.printf("  Dependencies: %d blocking relationships\n", blocksDeps)
 	}
-	printf("  Total: %d issues across %d layers\n\n", len(layout.Nodes), len(layout.Layers))
+	w.printf("  Total: %d issues across %d layers\n\n", len(layout.Nodes), len(layout.Layers))
+	return w.wrapError("graph")
 }
 
 // computeDAGNodeWidth calculates a consistent width for all DAG node boxes

--- a/cmd/bd/graph_visual_test.go
+++ b/cmd/bd/graph_visual_test.go
@@ -13,7 +13,9 @@ func TestRenderGraphVisual(t *testing.T) {
 	subgraph, layout := makeTestSubgraph()
 
 	var output bytes.Buffer
-	renderGraphVisualTo(&output, layout, subgraph)
+	if err := renderGraphVisual(&output, layout, subgraph); err != nil {
+		t.Fatalf("renderGraphVisual: %v", err)
+	}
 	got := output.String()
 
 	// Verify layer headers
@@ -68,7 +70,9 @@ func TestRenderGraphVisual_Empty(t *testing.T) {
 	}
 
 	var output bytes.Buffer
-	renderGraphVisualTo(&output, layout, emptySubgraph)
+	if err := renderGraphVisual(&output, layout, emptySubgraph); err != nil {
+		t.Fatalf("renderGraphVisual: %v", err)
+	}
 
 	if !strings.Contains(output.String(), "Empty graph") {
 		t.Error("Empty visual output should say 'Empty graph'")
@@ -89,7 +93,9 @@ func TestRenderGraphVisual_SingleNode(t *testing.T) {
 	layout := computeLayout(subgraph)
 
 	var output bytes.Buffer
-	renderGraphVisualTo(&output, layout, subgraph)
+	if err := renderGraphVisual(&output, layout, subgraph); err != nil {
+		t.Fatalf("renderGraphVisual: %v", err)
+	}
 	got := output.String()
 
 	if !strings.Contains(got, "solo-1") {

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -117,7 +117,7 @@ func printSkipLabelsFooter(skipLabels bool) {
 	if !skipLabels || isQuiet() {
 		return
 	}
-	fmt.Print(skipLabelsFooterText())
+	fmt.Print(skipLabelsFooterText()) //nolint:forbidigo // Pretty/tree output is outside the --format contract.
 }
 
 // formatSkipLabelsConflictError builds the user-facing error message for AD-02
@@ -306,7 +306,7 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 			}
 
 			if len(treeIssues) == 0 {
-				fmt.Printf("Issue '%s' has no children\n", in.ParentID)
+				fmt.Printf("Issue '%s' has no children\n", in.ParentID) //nolint:forbidigo // Pretty/tree output is outside the --format contract.
 				return nil
 			}
 
@@ -362,7 +362,7 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 		for _, issue := range issues {
 			formatAgentIssue(&buf, issue, blocking.blockedBy[issue.ID], blocking.blocks[issue.ID], blocking.parent[issue.ID])
 		}
-		fmt.Print(buf.String())
+		fmt.Print(buf.String()) //nolint:forbidigo // Agent output is outside the --format contract.
 		printTruncationHint(truncated, in.effectiveLimit)
 		return nil
 	} else if in.longFormat {
@@ -383,7 +383,7 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 	}
 
 	if err := ui.ToPager(buf.String(), ui.PagerOptions{NoPager: in.noPager}); err != nil {
-		if _, writeErr := fmt.Fprint(os.Stdout, buf.String()); writeErr != nil {
+		if _, writeErr := fmt.Fprint(os.Stdout, buf.String()); writeErr != nil { //nolint:forbidigo // Pager fallback is outside the --format contract.
 			fmt.Fprintf(os.Stderr, "Error writing output: %v\n", writeErr)
 		}
 	}

--- a/cmd/bd/list_proxied_server.go
+++ b/cmd/bd/list_proxied_server.go
@@ -274,7 +274,7 @@ func renderProxiedListText(ctx context.Context, out io.Writer, issues []*types.I
 		for _, issue := range issues {
 			formatAgentIssue(&buf, issue, blocking.blockedBy[issue.ID], blocking.blocks[issue.ID], blocking.parent[issue.ID])
 		}
-		fmt.Print(buf.String())
+		fmt.Print(buf.String()) //nolint:forbidigo // Agent output is outside the --format contract.
 		printTruncationHint(truncated, in.effectiveLimit)
 		return nil
 	case in.longFormat:
@@ -293,7 +293,7 @@ func renderProxiedListText(ctx context.Context, out io.Writer, issues []*types.I
 	}
 
 	if err := ui.ToPager(buf.String(), ui.PagerOptions{NoPager: in.noPager}); err != nil {
-		if _, werr := fmt.Fprint(os.Stdout, buf.String()); werr != nil {
+		if _, werr := fmt.Fprint(os.Stdout, buf.String()); werr != nil { //nolint:forbidigo // Pager fallback is outside the --format contract.
 			fmt.Fprintf(os.Stderr, "Error writing output: %v\n", werr)
 		}
 	}

--- a/cmd/bd/list_show_filter_modes.go
+++ b/cmd/bd/list_show_filter_modes.go
@@ -246,7 +246,7 @@ func runListProxiedHierarchicalParent(ctx context.Context, uw uow.UnitOfWork, in
 		return err
 	}
 	if len(treeIssues) == 0 {
-		fmt.Printf("Issue '%s' has no children\n", in.ParentID)
+		fmt.Printf("Issue '%s' has no children\n", in.ParentID) //nolint:forbidigo // Pretty/tree output is outside the --format contract.
 		return nil
 	}
 

--- a/cmd/bd/list_tree.go
+++ b/cmd/bd/list_tree.go
@@ -131,7 +131,7 @@ func printPrettyTree(childrenMap map[string][]*types.Issue, parentID string, pre
 		if isLast {
 			connector = "└── "
 		}
-		fmt.Printf("%s%s%s\n", prefix, connector, formatPrettyIssue(child))
+		fmt.Printf("%s%s%s\n", prefix, connector, formatPrettyIssue(child)) //nolint:forbidigo // Pretty-tree output is outside the --format contract.
 
 		extension := "│   "
 		if isLast {
@@ -200,15 +200,15 @@ func listFooterLine(total, open, inProgress int, truncated, readyFiltered bool) 
 func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, depsMode string, truncated, readyFiltered bool) {
 	if showHeader {
 		// Clear screen and show header
-		fmt.Print("\033[2J\033[H")
-		fmt.Println(strings.Repeat("=", 80))
-		fmt.Printf("Beads - Open & In Progress (%s)\n", time.Now().Format("15:04:05"))
-		fmt.Println(strings.Repeat("=", 80))
-		fmt.Println()
+		fmt.Print("\033[2J\033[H")                                                     //nolint:forbidigo // Pretty-tree output is outside the --format contract.
+		fmt.Println(strings.Repeat("=", 80))                                           //nolint:forbidigo // Pretty-tree output is outside the --format contract.
+		fmt.Printf("Beads - Open & In Progress (%s)\n", time.Now().Format("15:04:05")) //nolint:forbidigo // Pretty-tree output is outside the --format contract.
+		fmt.Println(strings.Repeat("=", 80))                                           //nolint:forbidigo // Pretty-tree output is outside the --format contract.
+		fmt.Println()                                                                  //nolint:forbidigo // Pretty-tree output is outside the --format contract.
 	}
 
 	if len(issues) == 0 {
-		fmt.Println("No issues found.")
+		fmt.Println("No issues found.") //nolint:forbidigo // Pretty-tree output is outside the --format contract.
 		return
 	}
 
@@ -225,14 +225,14 @@ func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDe
 	}
 
 	for _, issue := range roots {
-		fmt.Println(formatPrettyIssue(issue))
+		fmt.Println(formatPrettyIssue(issue)) //nolint:forbidigo // Pretty-tree output is outside the --format contract.
 		dr.annotationsFor(issue.ID, "")
 		printPrettyTree(childrenMap, issue.ID, "", dr)
 	}
 
 	// Summary — counts describe the shown page; never label a truncated page "Total".
-	fmt.Println()
-	fmt.Println(strings.Repeat("-", 80))
+	fmt.Println()                        //nolint:forbidigo // Pretty-tree output is outside the --format contract.
+	fmt.Println(strings.Repeat("-", 80)) //nolint:forbidigo // Pretty-tree output is outside the --format contract.
 	openCount := 0
 	inProgressCount := 0
 	for _, issue := range issues {
@@ -243,11 +243,11 @@ func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDe
 			inProgressCount++
 		}
 	}
-	fmt.Println(listFooterLine(len(issues), openCount, inProgressCount, truncated, readyFiltered))
-	fmt.Println()
-	fmt.Println("Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred")
-	fmt.Println("Priority: P0–P4 (label only; not a status icon)")
+	fmt.Println(listFooterLine(len(issues), openCount, inProgressCount, truncated, readyFiltered)) //nolint:forbidigo // Pretty-tree output is outside the --format contract.
+	fmt.Println()                                                                                  //nolint:forbidigo // Pretty-tree output is outside the --format contract.
+	fmt.Println("Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred")                  //nolint:forbidigo // Pretty-tree output is outside the --format contract.
+	fmt.Println("Priority: P0–P4 (label only; not a status icon)")                                 //nolint:forbidigo // Pretty-tree output is outside the --format contract.
 	if dr != nil {
-		fmt.Printf("Deps:   %s = depends-on / relationship (points to target); siblings ordered so dependencies come first; ↗ = target outside current view\n", depGlyph)
+		fmt.Printf("Deps:   %s = depends-on / relationship (points to target); siblings ordered so dependencies come first; ↗ = target outside current view\n", depGlyph) //nolint:forbidigo // Pretty-tree output is outside the --format contract.
 	}
 }

--- a/cmd/bd/list_tree_deps.go
+++ b/cmd/bd/list_tree_deps.go
@@ -182,7 +182,7 @@ func (dr *depRender) annotationsFor(nodeID, childPrefix string) {
 	})
 	for _, r := range inView {
 		tag := ui.RenderMuted(fmt.Sprintf("%s %-20s", depGlyph, "["+r.label+"]"))
-		fmt.Println(childPrefix + tag + " " + r.target + " " + r.title)
+		fmt.Println(childPrefix + tag + " " + r.target + " " + r.title) //nolint:forbidigo // Pretty-tree output is outside the --format contract.
 	}
 
 	// Out-of-view edges: collapse to a single summary line so a filtered view
@@ -198,6 +198,6 @@ func (dr *depRender) annotationsFor(nodeID, childPrefix string) {
 		}
 		summary := fmt.Sprintf("%s ↗ %d outside this view: %s%s",
 			depGlyph, len(outView), strings.Join(named, ", "), suffix)
-		fmt.Println(childPrefix + ui.RenderMuted(summary))
+		fmt.Println(childPrefix + ui.RenderMuted(summary)) //nolint:forbidigo // Pretty-tree output is outside the --format contract.
 	}
 }


### PR DESCRIPTION
Route default, compact, open, box, visual, DOT and HTML graph output through the command-supplied writer. Embeddings using `SetOut` receive the whole non-JSON graph, and renderers preserve and return the first write failure.

The existing `graphExportWriter` handles output consistently. Typed `forbidigo` rules reject process-stdout writes across the list and graph file families. Intentional pretty/tree, pager, JSON, graph-check and graph-create behavior keeps visible line-local exceptions; shared JSON output retains its current contract.

This completes the renderer and lint follow-ups identified in the review of #5610. The renderer-only issue #5622 is a subset of #5617.

Current-main integration preserves both original commits and the footer's `readyFiltered` and `statusSelector` inputs. The resolved footer conflict adds the existing pretty-tree lint exceptions while retaining current status-scope disclosure. Validation covers all 33 tests in the graph export, visual and list-footer files normally and under race detection, vet, native/Windows lint, and two typed stdout mutation controls. Each control must produce exactly one scoped finding against a clean changed-file baseline. Fresh hosted checks remain required.

Fixes #5617

Human graph renderers now return their first write error, matching the existing DOT/HTML behavior; this does not establish SIGPIPE behavior. The revision cross-references both typed lint diagnostic messages and their text-scoped exclusion. Existing justified line-local exemptions remain. Only comments changed in this revision; the prior physical typed-lint controls and renderer tests are retained without representing them as new executions. Fresh hosted verification remains required.

_unknown-model/unknown-reasoning on behalf of Ewen Cuthiell_
