### PR TITLE
docs(init-safety): correct init-local-exists exit code (12, not 11)

### DIFF
--- a/docs/recovery/init-safety.md
+++ b/docs/recovery/init-safety.md
@@ -122,7 +122,9 @@ for why the token is never echoed in `bd`'s error messages.
 
 ## init-local-exists
 
-**Exit code:** `11` (`ExitLocalExistsRefused`)
+**Exit code:** `12` (`ExitDestroyTokenMissing`) for the non-interactive
+refusal below; `11` (`ExitLocalExistsRefused`) when you decline the
+interactive confirmation.
 
 **Symptom**
 


### PR DESCRIPTION
## Why

`docs/recovery/init-safety.md`'s `init-local-exists` section documents exit code `11` (`ExitLocalExistsRefused`) for the non-interactive "Refusing to destroy N issues" symptom, but that code path returns `12` (`ExitDestroyTokenMissing`) - see `init.go`'s `return &exitError{Code: ExitDestroyTokenMissing}` under that exact message. `11` is what the interactive typed-confirmation decline returns. Automation keying on the documented code refuses on the wrong branch.

Pre-existing doc bug, independent of #5310 (offered in that review thread; that PR reshuffles the preflight gate but does not touch this section).

## What

Split the section's exit-code line so each symptom carries its real code: `12` for the non-interactive refusal shown in the snippet, `11` for the interactive decline. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G74Vh4USrUkc9przesWyUJ

_claude-fable-5-high on behalf of maphew_
