### PR TITLE
chore: changelog entry for #4686 tree-nesting change; deterministic bd gate list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2354,6 +2354,19 @@ never reused, per the v1.1.1 precedent.)
 
 ### Fixed
 
+- **`bd list --tree` now nests only parent-child edges**
+  ([#4686](https://github.com/gastownhall/beads/pull/4686)).
+  `buildIssueTreeWithDeps` treated any dependency whose target was an epic as
+  a parent-child relationship, so a task that merely `blocks` (or `waits-for`,
+  `discovered-from`, ...) an epic rendered as that epic's child — a genuinely
+  2-layer parent tree could display as a 6+ level tangle. Nesting is now
+  driven strictly by the parent-child edge type (plus the existing dotted-ID
+  fallback), matching the storage layer's own scoping (`epic_closure.go`).
+  **Visible change for legacy databases**: a dependency other than
+  parent-child that previously nested under an epic in `bd list --tree` now
+  displays flat instead; it remains visible via `bd show`, `bd dep tree`, and
+  the compact list view.
+
 - **Multi-id `bd dep list` no longer changes its JSON shape on failure**
   (bd-nhsno). The direct route used the batched edge read only `if err == nil`
   and otherwise fell through to the neighbour path, which emits a different

--- a/cmd/bd/gate.go
+++ b/cmd/bd/gate.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 
@@ -126,8 +127,12 @@ By default, shows only open gates. Use --all to include closed gates.`,
 // honoring the same open/closed and limit semantics as the DB-wide list path.
 // Pulled out as a pure helper so the bead-scoping logic is unit-testable without
 // a live store.
+//
+// Results are sorted by issue ID before the limit is applied: unlike the
+// DB-wide path (an ORDER BY query), the input here is dependency-map
+// iteration order, which is not guaranteed stable across calls.
 func filterIssueGates(deps []*types.Issue, all bool, limit int) []*types.Issue {
-	var gates []*types.Issue
+	gates := make([]*types.Issue, 0, len(deps))
 	for _, d := range deps {
 		if d == nil || d.IssueType != types.IssueType("gate") {
 			continue
@@ -136,9 +141,10 @@ func filterIssueGates(deps []*types.Issue, all bool, limit int) []*types.Issue {
 			continue
 		}
 		gates = append(gates, d)
-		if limit > 0 && len(gates) >= limit {
-			break
-		}
+	}
+	sort.Slice(gates, func(i, j int) bool { return gates[i].ID < gates[j].ID })
+	if limit > 0 && len(gates) > limit {
+		gates = gates[:limit]
 	}
 	return gates
 }

--- a/cmd/bd/gate_test.go
+++ b/cmd/bd/gate_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"sync"
 	"testing"
@@ -1137,15 +1138,42 @@ func TestFilterIssueGates(t *testing.T) {
 	})
 
 	t.Run("limit_caps_results", func(t *testing.T) {
+		// Sorted by ID first ("g-closed" < "g-open" < "g-open2"), then capped.
 		got := filterIssueGates(deps, true, 1)
-		if len(got) != 1 || got[0].ID != "g-open" {
-			t.Fatalf("expected limit=1 -> [g-open], got %v", gateIDs(got))
+		if len(got) != 1 || got[0].ID != "g-closed" {
+			t.Fatalf("expected limit=1 -> [g-closed], got %v", gateIDs(got))
+		}
+	})
+
+	t.Run("sorted_by_id_regardless_of_input_order", func(t *testing.T) {
+		// Same dependency set, presented in a different (map-iteration-like)
+		// order, must still come back sorted by ID.
+		shuffled := []*types.Issue{deps[4], deps[1], deps[0]} // g-open2, g-closed, g-open
+		got := filterIssueGates(shuffled, true, 0)
+		want := []string{"g-closed", "g-open", "g-open2"}
+		if ids := gateIDs(got); !reflect.DeepEqual(ids, want) {
+			t.Fatalf("expected deterministic order %v, got %v", want, ids)
 		}
 	})
 
 	t.Run("empty_deps", func(t *testing.T) {
-		if got := filterIssueGates(nil, true, 0); len(got) != 0 {
+		got := filterIssueGates(nil, true, 0)
+		if len(got) != 0 {
 			t.Fatalf("expected no gates, got %v", gateIDs(got))
+		}
+		if got == nil {
+			t.Fatalf("expected non-nil empty slice, got nil")
+		}
+	})
+
+	t.Run("empty_result_marshals_to_json_empty_array_not_null", func(t *testing.T) {
+		got := filterIssueGates(nil, true, 0)
+		b, err := json.Marshal(got)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if string(b) != "[]" {
+			t.Fatalf("expected JSON [], got %s", b)
 		}
 	})
 }


### PR DESCRIPTION
## Why

Two leftovers from the 2026-07-12 review sweep of #4686 / #4675 / #4500:

- The CHANGELOG never got an entry for #4686's visible behavior change: `bd list --tree` now nests only parent-child edges, so a legacy database whose tree previously nested `blocks`/`waits-for`/`discovered-from` deps under epics displays them flat. #4675's entry already exists.
- `filterIssueGates` (from #4500) returned gates in dependency-map iteration order - nondeterministic across runs, and `--limit` kept an arbitrary subset - and marshalled an empty result as `null` instead of `[]`.

## What

- CHANGELOG `[Unreleased]` entry for #4686, in the file's existing style, spelling out the visible change for legacy databases.
- `filterIssueGates` sorts by issue ID before applying the limit (ID is the DB-wide ordering's final tiebreaker) and starts from an empty slice so JSON emits `[]`. Note this changes which gates `--limit` keeps: first-N by ID rather than first-N in map order - the old selection was nondeterministic, so no stable behavior is lost.
- Tests pin deterministic ordering under shuffled input and the `[]` JSON shape; the existing limit test updated for sort-then-limit.

## Validation

`CGO_ENABLED=0` build, `go vet`, all `Gate*` tests, `gofmt`, `git diff --check` - clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G74Vh4USrUkc9przesWyUJ

_claude-fable-5-high on behalf of maphew_
