### PR TITLE
fix(upgrade-guard): parse the version witness as semver, and stop reading "unreadable" as "legacy"

### DIFF
--- a/cmd/bd/legacy_upgrade_guard.go
+++ b/cmd/bd/legacy_upgrade_guard.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
 	"github.com/steveyegge/beads/internal/utils"
+	"golang.org/x/mod/semver"
 )
 
 // guardLegacyUpgradeWorkspace rejects the reviewed pre-Dolt and legacy-Dolt
@@ -51,8 +52,20 @@ func guardLegacyUpgradeWorkspace(beadsDir string) error {
 		return nil
 	}
 	if serverMode {
-		if currentVersionWitness(version) {
+		switch classifyVersionWitness(version) {
+		case witnessEraCurrent:
 			return nil
+		case witnessEraUnknown:
+			// A witness that is present but unreadable is not evidence of a
+			// legacy workspace: every pre-1.0 bd wrote a plain X.Y.Z through
+			// the same best-effort writer, so no legacy release could have
+			// produced a string this parse rejects. Report the ambiguity and
+			// open the workspace instead of refusing every command over an
+			// advisory, gitignored file.
+			if ok {
+				warnUnreadableVersionWitness(beadsDir, version)
+				return nil
+			}
 		}
 		return legacyUpgradeRefusal("legacy Dolt server workspace")
 	}
@@ -251,38 +264,73 @@ func legacyServerVersion(version string) bool {
 	return ok && minor >= 55 && minor <= 62
 }
 
-// currentVersionWitness identifies a syntactically valid post-1.0 version
-// marker. A local Dolt root in server mode is ambiguous without it, so that
-// shape must be refused rather than opened as a historical schema.
-func currentVersionWitness(version string) bool {
-	parts := strings.Split(strings.TrimPrefix(version, "v"), ".")
-	if len(parts) != 3 {
-		return false
+// witnessEra is the release era a local version witness places a workspace in.
+type witnessEra int
+
+const (
+	// witnessEraUnknown means the witness is missing or cannot be read as a
+	// version. It is an absence of evidence, not evidence of a legacy layout.
+	witnessEraUnknown witnessEra = iota
+	// witnessEraLegacy means the witness names a pre-1.0 bd.
+	witnessEraLegacy
+	// witnessEraCurrent means the witness names bd 1.0 or later.
+	witnessEraCurrent
+)
+
+// classifyVersionWitness places a local version witness in a release era.
+//
+// The witness is whatever string the bd that last touched the workspace held
+// in main.Version, which release tooling injects verbatim: a plain release
+// ("1.1.0"), a release candidate ("v1.2.0-rc.1"), a build carrying metadata,
+// or a Go pseudo-version ("v1.1.1-0.20260805093327-bf97b73749ac"). All of
+// those are valid semantic versions, so the era comes from a semver parse
+// rather than from counting dots.
+func classifyVersionWitness(version string) witnessEra {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return witnessEraUnknown
 	}
-	values := make([]int, len(parts))
-	for i, part := range parts {
-		value, err := strconv.Atoi(part)
-		if err != nil || value < 0 {
-			return false
+	if canonical := "v" + strings.TrimPrefix(version, "v"); semver.IsValid(canonical) {
+		if semver.Major(canonical) == "v0" {
+			return witnessEraLegacy
 		}
-		values[i] = value
+		return witnessEraCurrent
 	}
-	return values[0] >= 1
+	// Strict semver rejects shapes a distributor could still stamp onto a
+	// legacy build, such as a zero-padded or four-component version. Classify
+	// those by their major component alone so the pre-1.0 guard never relaxes.
+	if major, _, _ := strings.Cut(strings.TrimPrefix(version, "v"), "."); major != "" {
+		if value, err := strconv.Atoi(major); err == nil && value == 0 {
+			return witnessEraLegacy
+		}
+	}
+	return witnessEraUnknown
 }
 
+// legacyVersionMinor returns the minor component of a pre-1.0 version witness.
 func legacyVersionMinor(version string) (int, bool) {
-	parts := strings.Split(strings.TrimPrefix(version, "v"), ".")
-	if len(parts) != 3 || parts[0] != "0" {
+	version = strings.TrimSpace(version)
+	canonical := "v" + strings.TrimPrefix(version, "v")
+	if !semver.IsValid(canonical) || semver.Major(canonical) != "v0" {
 		return 0, false
 	}
-	minor, err := strconv.Atoi(parts[1])
+	minor, err := strconv.Atoi(strings.TrimPrefix(semver.MajorMinor(canonical), "v0."))
 	if err != nil {
 		return 0, false
 	}
-	if _, err := strconv.Atoi(parts[2]); err != nil {
-		return 0, false
-	}
 	return minor, true
+}
+
+// legacyUpgradeWarnWriter receives guard warnings; tests redirect it.
+var legacyUpgradeWarnWriter io.Writer = os.Stderr
+
+// warnUnreadableVersionWitness reports a workspace bd opened despite being
+// unable to read its version witness, so an operator can still see that the
+// era check was inconclusive.
+func warnUnreadableVersionWitness(beadsDir, version string) {
+	fmt.Fprintf(legacyUpgradeWarnWriter,
+		"Warning: unreadable version witness %q in %s; assuming a current workspace. Run 'bd doctor' to reset version tracking.\n",
+		version, filepath.Join(beadsDir, localVersionFile))
 }
 
 func legacyUpgradeRefusal(reason string) error {

--- a/cmd/bd/legacy_upgrade_guard.go
+++ b/cmd/bd/legacy_upgrade_guard.go
@@ -43,8 +43,8 @@ func guardLegacyUpgradeWorkspace(beadsDir string) error {
 	if embeddeddolt.HasRepository(beadsDir) && !serverMode {
 		return nil
 	}
-	version, ok := legacyUpgradeVersionWitness(beadsDir)
-	if serverMode && ok && legacyServerVersion(version) {
+	version, present := legacyUpgradeVersionWitness(beadsDir)
+	if serverMode && present && legacyServerVersion(version) {
 		return legacyUpgradeRefusal(fmt.Sprintf("legacy Dolt server workspace from bd %s", version))
 	}
 	hasLocalDoltRoot := hasLegacyDoltRoot(beadsDir)
@@ -56,13 +56,17 @@ func guardLegacyUpgradeWorkspace(beadsDir string) error {
 		case witnessEraCurrent:
 			return nil
 		case witnessEraUnknown:
-			// A witness that is present but unreadable is not evidence of a
-			// legacy workspace: every pre-1.0 bd wrote a plain X.Y.Z through
-			// the same best-effort writer, so no legacy release could have
-			// produced a string this parse rejects. Report the ambiguity and
-			// open the workspace instead of refusing every command over an
-			// advisory, gitignored file.
-			if ok {
+			// A witness that is present but unreadable — including one left
+			// blank or whitespace-only by an interrupted or disk-full
+			// best-effort write — is not evidence of a legacy workspace: every
+			// pre-1.0 bd wrote a plain X.Y.Z through the same writer, so no
+			// legacy release could have produced a witness this parse rejects.
+			// Report the ambiguity and open the workspace so the admitted
+			// command can self-heal the witness, instead of refusing every
+			// command over an advisory, gitignored file. A genuinely absent
+			// witness is not present and still refuses below, preserving the
+			// pre-1.0 guard invariant.
+			if present {
 				warnUnreadableVersionWitness(beadsDir, version)
 				return nil
 			}
@@ -71,11 +75,11 @@ func guardLegacyUpgradeWorkspace(beadsDir string) error {
 	}
 	if cfg == nil || cfg.DoltMode == "" ||
 		strings.EqualFold(cfg.DoltMode, configfile.DoltModeEmbedded) {
-		if doltserver.IsSharedServerMode() && !(ok && legacyServerVersion(version)) {
+		if doltserver.IsSharedServerMode() && !(present && legacyServerVersion(version)) {
 			return nil
 		}
 		reason := "legacy Dolt workspace"
-		if _, validVersion := legacyVersionMinor(version); ok && validVersion {
+		if _, validVersion := legacyVersionMinor(version); present && validVersion {
 			reason = fmt.Sprintf("legacy Dolt workspace from bd %s", version)
 		}
 		return legacyUpgradeRefusal(reason)
@@ -245,18 +249,26 @@ func isRegularFile(path string) bool {
 	return err == nil && info.Mode().IsRegular()
 }
 
+// legacyUpgradeVersionWitness reads the advisory local version witness beneath
+// beadsDir. The returned bool reports whether a witness file is present as a
+// bounded regular file, independent of whether its trimmed contents name a
+// version. A present but blank or whitespace-only witness — the shape an
+// interrupted or disk-full best-effort writeLocalVersion leaves behind — is
+// returned as ("", true) so guardLegacyUpgradeWorkspace can tell it apart from
+// a genuinely absent witness, which is ("", false). Only a present witness is
+// ever admitted as an unknown-era workspace; a missing, non-regular, or
+// oversized witness stays absent so the pre-1.0 refusal cannot relax.
 func legacyUpgradeVersionWitness(beadsDir string) (string, bool) {
 	path := filepath.Join(beadsDir, localVersionFile)
 	info, err := os.Lstat(path)
-	if err != nil || !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > 64 {
+	if err != nil || !info.Mode().IsRegular() || info.Size() > 64 {
 		return "", false
 	}
 	data, err := os.ReadFile(path) // #nosec G304 -- bounded file beneath selected workspace
 	if err != nil || int64(len(data)) != info.Size() {
 		return "", false
 	}
-	version := strings.TrimSpace(string(data))
-	return version, version != ""
+	return strings.TrimSpace(string(data)), true
 }
 
 func legacyServerVersion(version string) bool {

--- a/cmd/bd/legacy_upgrade_guard_test.go
+++ b/cmd/bd/legacy_upgrade_guard_test.go
@@ -203,7 +203,8 @@ func TestLegacyUpgradeGuardMetadataLessSQLiteAndCurrentEmbeddedPrecedence(t *tes
 		}
 	})
 
-	t.Run("explicit server metadata with malformed version witness and local Dolt root is refused", func(t *testing.T) {
+	t.Run("explicit server metadata with malformed version witness and local Dolt root is admitted with a warning", func(t *testing.T) {
+		warnings := captureLegacyUpgradeWarnings(t)
 		beadsDir := t.TempDir()
 		if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"backend":"dolt","dolt_mode":"server"}`), 0o600); err != nil {
 			t.Fatal(err)
@@ -214,8 +215,11 @@ func TestLegacyUpgradeGuardMetadataLessSQLiteAndCurrentEmbeddedPrecedence(t *tes
 		if err := os.Mkdir(filepath.Join(beadsDir, "dolt"), 0o700); err != nil {
 			t.Fatal(err)
 		}
-		if err := guardLegacyUpgradeWorkspace(beadsDir); !isLegacyUpgradeRefusal(err) {
-			t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want migration refusal", err)
+		if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+			t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want nil", err)
+		}
+		if warnings.Len() == 0 {
+			t.Fatal("guard admitted an unreadable witness without warning")
 		}
 	})
 
@@ -250,12 +254,15 @@ func TestLegacyUpgradeGuardServerSelectionBeatsStaleEmbeddedRepository(t *testin
 	}{
 		{name: "historical witness", version: "0.62.0", wantRefusal: true},
 		{name: "missing witness", wantRefusal: true},
-		{name: "malformed witness", version: "not-a-version", wantRefusal: true},
+		{name: "malformed witness opens as unknown era", version: "not-a-version"},
 		{name: "current witness", version: "1.1.2"},
+		{name: "pseudo-version witness", version: "v1.1.1-0.20260805093327-bf97b73749ac"},
+		{name: "release candidate witness", version: "1.1.0-rc.1"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			captureLegacyUpgradeWarnings(t)
 			beadsDir := t.TempDir()
 			metadata := []byte(`{"backend":"dolt","dolt_mode":"server","dolt_database":"selected_server_db"}`)
 			if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0o600); err != nil {

--- a/cmd/bd/legacy_upgrade_guard_witness_test.go
+++ b/cmd/bd/legacy_upgrade_guard_witness_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// captureLegacyUpgradeWarnings redirects guard warnings for the duration of a
+// test and returns the buffer they land in.
+func captureLegacyUpgradeWarnings(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	previous := legacyUpgradeWarnWriter
+	legacyUpgradeWarnWriter = buf
+	t.Cleanup(func() { legacyUpgradeWarnWriter = previous })
+	return buf
+}
+
+func TestClassifyVersionWitness(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    witnessEra
+	}{
+		// The exact witness that refused five production workspaces: release
+		// tooling stamped a Go pseudo-version into main.Version and the guard
+		// counted four dot-separated fields instead of three.
+		{name: "go pseudo-version", version: "v1.1.1-0.20260805093327-bf97b73749ac", want: witnessEraCurrent},
+		{name: "plain release", version: "1.1.0", want: witnessEraCurrent},
+		{name: "v-prefixed release", version: "v1.2.0", want: witnessEraCurrent},
+		{name: "release candidate", version: "1.1.0-rc.1", want: witnessEraCurrent},
+		{name: "v-prefixed release candidate", version: "v1.2.0-rc.1", want: witnessEraCurrent},
+		{name: "build metadata", version: "1.2.0+build.5", want: witnessEraCurrent},
+		{name: "prerelease and build metadata", version: "v2.0.0-beta.1+darwin.arm64", want: witnessEraCurrent},
+		{name: "major only", version: "v3", want: witnessEraCurrent},
+		{name: "surrounding whitespace", version: "  1.1.0\n", want: witnessEraCurrent},
+
+		{name: "historical server release", version: "0.62.0", want: witnessEraLegacy},
+		{name: "historical v-prefixed release", version: "v0.9.1", want: witnessEraLegacy},
+		{name: "historical pseudo-version", version: "v0.62.0-0.20250101000000-abcdefabcdef", want: witnessEraLegacy},
+		{name: "historical release candidate", version: "0.62.0-rc.2", want: witnessEraLegacy},
+		{name: "historical four-component build", version: "0.62.0.1", want: witnessEraLegacy},
+
+		{name: "empty", version: "", want: witnessEraUnknown},
+		{name: "whitespace only", version: "   ", want: witnessEraUnknown},
+		{name: "genuine garbage", version: "not-a-version", want: witnessEraUnknown},
+		{name: "truncated binary noise", version: "\x00\x01\x02", want: witnessEraUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyVersionWitness(tt.version); got != tt.want {
+				t.Fatalf("classifyVersionWitness(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLegacyServerVersionSpansHistoricalServerEra(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{version: "0.55.0", want: true},
+		{version: "0.62.21", want: true},
+		{version: "v0.62.0-0.20250101000000-abcdefabcdef", want: true},
+		{version: "0.54.9", want: false},
+		{version: "0.63.0", want: false},
+		{version: "1.1.0", want: false},
+		{version: "v1.1.1-0.20260805093327-bf97b73749ac", want: false},
+		{version: "not-a-version", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			if got := legacyServerVersion(tt.version); got != tt.want {
+				t.Fatalf("legacyServerVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+// writeSelectedServerWorkspace lays down the ambiguous shape the guard has to
+// classify: a selected Dolt server workspace that still owns a local Dolt root.
+func writeSelectedServerWorkspace(t *testing.T, version string) string {
+	t.Helper()
+	beadsDir := t.TempDir()
+	metadata := []byte(`{"backend":"dolt","dolt_mode":"server","dolt_database":"selected_server_db"}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if version != "" {
+		if err := writeLocalVersion(filepath.Join(beadsDir, localVersionFile), version); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(beadsDir, "dolt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return beadsDir
+}
+
+func TestLegacyUpgradeGuardAdmitsNonReleaseVersionWitnesses(t *testing.T) {
+	versions := []string{
+		"v1.1.1-0.20260805093327-bf97b73749ac",
+		"1.1.0",
+		"v1.2.0",
+		"1.1.0-rc.1",
+		"1.2.0+build.5",
+	}
+
+	for _, version := range versions {
+		t.Run(version, func(t *testing.T) {
+			warnings := captureLegacyUpgradeWarnings(t)
+			beadsDir := writeSelectedServerWorkspace(t, version)
+
+			if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+				t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want nil", err)
+			}
+			if warnings.Len() != 0 {
+				t.Fatalf("guard warned about a readable witness: %q", warnings.String())
+			}
+		})
+	}
+}
+
+func TestLegacyUpgradeGuardStillRefusesPreOneWorkspaces(t *testing.T) {
+	versions := []string{
+		"0.9.1",
+		"v0.49.6",
+		"0.55.0",
+		"0.62.21",
+		"v0.62.0-0.20250101000000-abcdefabcdef",
+		"0.62.0.1",
+	}
+
+	for _, version := range versions {
+		t.Run(version, func(t *testing.T) {
+			captureLegacyUpgradeWarnings(t)
+			beadsDir := writeSelectedServerWorkspace(t, version)
+
+			if err := guardLegacyUpgradeWorkspace(beadsDir); !isLegacyUpgradeRefusal(err) {
+				t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want migration refusal", err)
+			}
+		})
+	}
+}
+
+func TestLegacyUpgradeGuardRefusesWorkspaceWithoutAnyWitness(t *testing.T) {
+	captureLegacyUpgradeWarnings(t)
+	beadsDir := writeSelectedServerWorkspace(t, "")
+
+	if err := guardLegacyUpgradeWorkspace(beadsDir); !isLegacyUpgradeRefusal(err) {
+		t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want migration refusal", err)
+	}
+}
+
+func TestLegacyUpgradeGuardWarnsInsteadOfRefusingUnreadableWitness(t *testing.T) {
+	warnings := captureLegacyUpgradeWarnings(t)
+	beadsDir := writeSelectedServerWorkspace(t, "not-a-version")
+
+	if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+		t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want nil", err)
+	}
+	warned := warnings.String()
+	if !strings.Contains(warned, "not-a-version") || !strings.Contains(warned, localVersionFile) {
+		t.Fatalf("guard warning = %q, want it to name the unreadable witness and its path", warned)
+	}
+}
+
+// TestLegacyUpgradeGuardWarningIsSelfHealing models the PersistentPreRunE
+// order — guard, then trackBdVersion — to show the warning is one-shot: the
+// admitted command rewrites the witness with this binary's own version, so the
+// next command reads it cleanly. Only a stamp bd rewrites identically every
+// run (a Homebrew --HEAD build, GH#5603) can warn repeatedly.
+func TestLegacyUpgradeGuardWarningIsSelfHealing(t *testing.T) {
+	warnings := captureLegacyUpgradeWarnings(t)
+	beadsDir := writeSelectedServerWorkspace(t, "not-a-version")
+
+	if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+		t.Fatalf("first guardLegacyUpgradeWorkspace() = %v, want nil", err)
+	}
+	if warnings.Len() == 0 {
+		t.Fatal("guard admitted an unreadable witness without warning")
+	}
+
+	// trackBdVersion rewrites the witness whenever it differs from Version.
+	if err := writeLocalVersion(filepath.Join(beadsDir, localVersionFile), Version); err != nil {
+		t.Fatal(err)
+	}
+
+	warnings.Reset()
+	if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+		t.Fatalf("second guardLegacyUpgradeWorkspace() = %v, want nil", err)
+	}
+	if warnings.Len() != 0 {
+		t.Fatalf("guard warned again after the witness healed: %q", warnings.String())
+	}
+}
+
+// TestLegacyUpgradeGuardAdmitsBrewHeadStamp covers the reporter's scenario in
+// GH#5603: Homebrew stamps HEAD-<shortsha> into main.Version for --HEAD
+// installs, bd writes it verbatim, and the workspace must still open. The
+// unknown era admits it. Silencing the repeated warning for that stable stamp
+// needs the shape recognizer in GH#5625 (anisoptera), which this does not
+// duplicate.
+func TestLegacyUpgradeGuardAdmitsBrewHeadStamp(t *testing.T) {
+	for _, stamp := range []string{"HEAD-f925f3f", "HEAD", "HEAD-f925f3f_1"} {
+		t.Run(stamp, func(t *testing.T) {
+			captureLegacyUpgradeWarnings(t)
+			beadsDir := writeSelectedServerWorkspace(t, stamp)
+
+			if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+				t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+// TestVersionWitnessRoundTrip pins the contract the guard depends on: every
+// version string bd can write, bd can read back and recognize as current.
+func TestVersionWitnessRoundTrip(t *testing.T) {
+	versions := []string{
+		Version,
+		"1.1.0",
+		"v1.2.0",
+		"1.1.0-rc.1",
+		"v1.2.0-rc.1",
+		"1.2.0+build.5",
+		"v1.1.1-0.20260805093327-bf97b73749ac",
+		"v2.0.0-beta.1+darwin.arm64",
+	}
+
+	for _, version := range versions {
+		t.Run(version, func(t *testing.T) {
+			beadsDir := t.TempDir()
+			path := filepath.Join(beadsDir, localVersionFile)
+			if err := writeLocalVersion(path, version); err != nil {
+				t.Fatal(err)
+			}
+
+			if got := readLocalVersion(path); got != version {
+				t.Fatalf("readLocalVersion() = %q, want %q", got, version)
+			}
+			witness, ok := legacyUpgradeVersionWitness(beadsDir)
+			if !ok {
+				t.Fatalf("legacyUpgradeVersionWitness() did not see the witness bd just wrote")
+			}
+			if witness != version {
+				t.Fatalf("legacyUpgradeVersionWitness() = %q, want %q", witness, version)
+			}
+			if got := classifyVersionWitness(witness); got != witnessEraCurrent {
+				t.Fatalf("classifyVersionWitness(%q) = %v, want %v", witness, got, witnessEraCurrent)
+			}
+		})
+	}
+}

--- a/cmd/bd/legacy_upgrade_guard_witness_test.go
+++ b/cmd/bd/legacy_upgrade_guard_witness_test.go
@@ -158,6 +158,95 @@ func TestLegacyUpgradeGuardRefusesWorkspaceWithoutAnyWitness(t *testing.T) {
 	}
 }
 
+// TestLegacyUpgradeGuardWarnsInsteadOfRefusingPresentButBlankWitness pins F1:
+// a witness file that exists but is blank or whitespace-only — the shape an
+// interrupted or disk-full best-effort writeLocalVersion leaves behind — must
+// be classified as an unknown-era (unreadable) witness and warned-and-opened,
+// not collapsed into the "genuinely missing" path and hard-refused. A truly
+// absent witness must still refuse so the pre-1.0 safety invariant does not
+// relax.
+func TestLegacyUpgradeGuardWarnsInsteadOfRefusingPresentButBlankWitness(t *testing.T) {
+	blankWitnesses := []struct {
+		name    string
+		content []byte
+	}{
+		{name: "zero byte", content: []byte("")},
+		{name: "newline only", content: []byte("\n")},
+		{name: "spaces and tabs", content: []byte("  \t\n")},
+	}
+
+	for _, tc := range blankWitnesses {
+		t.Run(tc.name, func(t *testing.T) {
+			warnings := captureLegacyUpgradeWarnings(t)
+			beadsDir := writeSelectedServerWorkspace(t, "")
+			// writeSelectedServerWorkspace skips the witness for an empty
+			// version, leaving a genuinely-missing witness; overwrite it with a
+			// present-but-blank file to exercise the failed-write shape.
+			if err := os.WriteFile(filepath.Join(beadsDir, localVersionFile), tc.content, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+				t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want nil for a present-but-blank witness", err)
+			}
+			if warnings.Len() == 0 {
+				t.Fatal("guard admitted a present-but-blank witness without warning")
+			}
+			if !strings.Contains(warnings.String(), localVersionFile) {
+				t.Fatalf("guard warning = %q, want it to name the witness path", warnings.String())
+			}
+		})
+	}
+
+	t.Run("genuinely missing witness still refuses", func(t *testing.T) {
+		captureLegacyUpgradeWarnings(t)
+		// No .local_version is written at all: absence must keep refusing so the
+		// pre-1.0 guard invariant does not relax alongside the blank-witness fix.
+		beadsDir := writeSelectedServerWorkspace(t, "")
+
+		if err := guardLegacyUpgradeWorkspace(beadsDir); !isLegacyUpgradeRefusal(err) {
+			t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want migration refusal for a missing witness", err)
+		}
+	})
+}
+
+// TestLegacyUpgradeVersionWitnessPresence pins the reader's present/absent
+// signal that guardLegacyUpgradeWorkspace relies on to tell a present-but-blank
+// witness (warn+open) apart from a missing one (refuse). Oversized and missing
+// witnesses must both report absent so the pre-1.0 refusal cannot relax.
+func TestLegacyUpgradeVersionWitnessPresence(t *testing.T) {
+	t.Run("present but blank reports present with empty version", func(t *testing.T) {
+		for _, content := range [][]byte{[]byte(""), []byte("\n"), []byte("  \t")} {
+			beadsDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(beadsDir, localVersionFile), content, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			version, present := legacyUpgradeVersionWitness(beadsDir)
+			if !present || version != "" {
+				t.Fatalf("legacyUpgradeVersionWitness() = (%q, %v), want (%q, true) for %q", version, present, "", content)
+			}
+		}
+	})
+
+	t.Run("missing witness reports absent", func(t *testing.T) {
+		beadsDir := t.TempDir()
+		if version, present := legacyUpgradeVersionWitness(beadsDir); present || version != "" {
+			t.Fatalf("legacyUpgradeVersionWitness() = (%q, %v), want (%q, false) for a missing witness", version, present, "")
+		}
+	})
+
+	t.Run("oversized witness reports absent", func(t *testing.T) {
+		beadsDir := t.TempDir()
+		oversized := bytes.Repeat([]byte("a"), 65)
+		if err := os.WriteFile(filepath.Join(beadsDir, localVersionFile), oversized, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if version, present := legacyUpgradeVersionWitness(beadsDir); present || version != "" {
+			t.Fatalf("legacyUpgradeVersionWitness() = (%q, %v), want (%q, false) for an oversized witness", version, present, "")
+		}
+	})
+}
+
 func TestLegacyUpgradeGuardWarnsInsteadOfRefusingUnreadableWitness(t *testing.T) {
 	warnings := captureLegacyUpgradeWarnings(t)
 	beadsDir := writeSelectedServerWorkspace(t, "not-a-version")

--- a/cmd/bd/version_tracking.go
+++ b/cmd/bd/version_tracking.go
@@ -88,6 +88,9 @@ func readLocalVersion(path string) string {
 }
 
 // writeLocalVersion writes the current version to the local version file.
+// The value is main.Version verbatim, which release tooling sets by ldflags and
+// may be a release candidate, a build carrying metadata, or a Go pseudo-version.
+// Readers must accept every shape this can write; see classifyVersionWitness.
 func writeLocalVersion(path, version string) error {
 	return os.WriteFile(path, []byte(version+"\n"), 0600)
 }

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -256,11 +256,20 @@ server selection is not overridden by a stale `.beads/embeddeddolt/` repository.
 |---|---|
 | Current embedded metadata with `.beads/embeddeddolt/` and no explicit server selection | Direct current-era upgrade |
 | Explicit server metadata plus `.local_version` from v0.55.4 through v0.62.0, whether or not `.beads/dolt/` exists | Explicit legacy Dolt export/import |
-| Explicit server metadata plus `.beads/dolt/` and a valid witness whose major version is 1 or newer | Normal current server-mode upgrade |
-| Explicit server metadata plus `.beads/dolt/` and a missing, malformed, or pre-v1 witness | Explicit legacy Dolt export/import |
+| Explicit server metadata plus `.beads/dolt/` and a witness whose major version is 1 or newer | Normal current server-mode upgrade |
+| Explicit server metadata plus `.beads/dolt/` and a missing or pre-v1 witness | Explicit legacy Dolt export/import |
+| Explicit server metadata plus `.beads/dolt/` and a witness that is present but unreadable | Normal current server-mode upgrade, with a warning |
 | Explicit server metadata without `.beads/dolt/`, and a missing, malformed, or non-historical witness | Normal current server-mode compatibility path |
 | `.beads/dolt/` with missing metadata or persisted `dolt_mode` blank/`embedded` | Explicit legacy Dolt export/import, except for the configured shared-server compatibility path described below |
 | One `.beads/*.db` file, such as `beads.db` or `vc.db` | Sealed SQLite bridge |
+
+The witness is whatever `bd` held in its own version string when it last touched
+the workspace, so it may be a plain release, a release candidate, a build
+carrying metadata, or a Go pseudo-version; all of those are read as the version
+they name. A witness that is present but unreadable is not treated as a legacy
+marker — no pre-v1 `bd` could have written one — so `bd` warns and continues
+rather than refusing every command. A *missing* witness stays ambiguous and is
+still refused.
 
 Current `bd` refuses recognized historical SQLite and legacy Dolt layouts before
 opening storage or rewriting metadata. This is intentional: preserve the source

--- a/go.mod
+++ b/go.mod
@@ -263,7 +263,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3 // indirect
-	golang.org/x/mod v0.37.0 // indirect
+	golang.org/x/mod v0.37.0
 	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 // indirect


### PR DESCRIPTION
## The outage

The cross-era upgrade guard (#4907) refused five production workspaces outright:

```
Error: legacy Dolt server workspace detected; explicit migration is required before this
bd version can open or modify the workspace. Preserve .beads unchanged and follow
docs/getting-started/upgrading.md#cross-era-upgrades
```

All five were current-era. Their `.beads/.local_version` held a Go pseudo-version,
`v1.1.1-0.20260805093327-bf97b73749ac`, and `currentVersionWitness` split it on `.`
expecting exactly three fields. It got four.

Because the guard runs in `PersistentPreRunE` before any store opens, this failed
*every* `bd` invocation — including the read-only ones an operator would reach for to
diagnose it. Measured blast radius before the witness files were hand-rewritten to
`1.1.0`: one gate sweep logged **644 failures in 6 hours**, which froze PR review gates
entirely (no bead ever left `needs-review`), stalled triage, and left demand-driven
pools at zero — one city ran 1 session against 8 declared agents. Rewriting nine
`.local_version` files took the sweep to **0 failures/6h** immediately. That workaround
is a band-aid: any tooling that writes a pseudo-version back re-breaks the fleet.

## Which side is wrong

The writer. And it isn't.

`.local_version` holds `main.Version` verbatim, and release tooling injects that by
ldflags — goreleaser passes `{{.Version}}`, `.github/workflows/release.yml` passes
`steps.version.outputs.version`, other build paths pass whatever they resolved. So the
writer can legitimately emit a plain release, a release candidate (`1.2.0-rc.1` — the
repo shipped `v1.1.0-rc.1`), a build carrying metadata, or a Go pseudo-version. Every
one of those is a valid semantic version; none is three bare numeric fields. **bd could
not read what bd wrote.**

The writer is correct and stays as it is: recording anything but the true version would
destroy the ordering `CompareVersions` and upgrade detection depend on (a pseudo-version
sorts *before* the release it names). The reader was counting dots. This PR fixes the
reader and pins the round trip so it cannot drift again.

## Two fixes

**1. Parse.** `classifyVersionWitness` parses with `golang.org/x/mod/semver` (already an
indirect dependency; promoted to direct) and reports an era instead of a boolean.
`legacyVersionMinor` shares the parse, so a pre-1.0 pseudo-version or release candidate
is now *correctly* classified as legacy where it previously fell through unrecognized.
Shapes strict semver rejects but a distributor could still stamp onto a legacy build —
zero-padded or four-component versions — are still read as legacy from their major
component alone, so the pre-1.0 guard only tightens.

**2. Policy — the part that matters.** Before this change an unparseable witness meant
"legacy workspace, refuse everything". That is what turned a trivial parse bug into a
fleet outage, and it is wrong on its own terms:

- Every pre-1.0 bd wrote a plain `X.Y.Z` through this same writer. A string that fails a
  real semver parse **cannot have come from one**. The guard was inferring "legacy" from
  data that positively excludes legacy.
- The refusal is a claim about the workspace. The evidence is "I could not parse a
  38-byte advisory text file."
- bd treats that file as advisory everywhere else: `.local_version` is gitignored,
  clone-local, and written best-effort (`_ = writeLocalVersion(...)`). `bd doctor`
  downgrades a bad value to a *warning* whose suggested fix is "run any bd command to
  reset version tracking" — which the guard made impossible.
- The consequences are wildly asymmetric. Refusing is total and fleet-wide. The
  population it protects against is empty, because a genuine 0.55–0.62 workspace has a
  *parseable* witness and is already caught one branch earlier by `legacyServerVersion`.

So a witness that is **present but unreadable** is now its own era, `witnessEraUnknown`:
bd warns and opens the workspace. A **missing** witness is unchanged and still refused —
a workspace that never announced itself is genuinely ambiguous, and that is the dominant
real-world legacy shape since the file is gitignored. Any witness that reads as pre-1.0
is still refused.

The warning is self-healing rather than permanent noise. The guard runs immediately
before `trackBdVersion`, which rewrites the witness whenever it differs from `Version`,
so the admitted command leaves a readable witness behind and the next command is silent
(`TestLegacyUpgradeGuardWarningIsSelfHealing`).

## Relationship to #5603 / #5625

#5603 reports the same defect from a different writer: Homebrew stamps `HEAD-<shortsha>`
into `main.Version` for `--HEAD` installs. Its analysis reaches the same conclusion this
PR argues — no legacy-era channel could have produced that shape — and it independently
confirms the `1.1.0-rc.1` case.

The unknown era admits those workspaces too, so this fixes the brew-`--HEAD` outage as
well (`TestLegacyUpgradeGuardAdmitsBrewHeadStamp`). It does **not** silence their
warning: a HEAD stamp is rewritten identically on every run, so it never heals. That
wants the shape recognizer in #5625 (@anisoptera), which this PR deliberately does not
duplicate, along with that PR's doctor-side fixes which are orthogonal to the guard.
**The two compose and both are worth landing.** If #5625 lands first this reduces to the
policy commit; the parse here is a superset of `versionCore` (a real semver parse rather
than cutting at the first `-`/`+`), so the merge is mechanical either way. Not opened to
supersede — see the review comment on #5625.

## Red before

15 cases across 5 tests fail against the unfixed parser, verified by expressing the
original dot-counting predicates in the new era vocabulary. Representative:

```
classifyVersionWitness("v1.1.1-0.20260805093327-bf97b73749ac") = Unknown, want Current  <- production
classifyVersionWitness("1.1.0-rc.1")                          = Unknown, want Current
classifyVersionWitness("1.2.0+build.5")                       = Unknown, want Current
classifyVersionWitness("v0.62.0-0.20250101000000-abcdefabcdef") = Unknown, want Legacy
classifyVersionWitness("0.62.0.1")                            = Unknown, want Legacy
guardLegacyUpgradeWorkspace() = legacy Dolt server workspace detected; ... , want nil
```

## Coverage

- `TestClassifyVersionWitness` — the production pseudo-version, plain `1.1.0`,
  v-prefixed release, release candidates, build metadata, prerelease+metadata,
  whitespace, the pre-1.0 side of each, empty, whitespace-only, garbage, binary noise.
- `TestVersionWitnessRoundTrip` — everything bd can write, including `Version` itself,
  bd reads back and recognizes as current. This also holds the writer inside the witness
  reader's bounded 64-byte size.
- `TestLegacyUpgradeGuardStillRefusesPreOneWorkspaces` (`0.9.1`, `v0.49.6`, `0.55.0`,
  `0.62.21`, a 0.x pseudo-version, `0.62.0.1`) and
  `TestLegacyUpgradeGuardRefusesWorkspaceWithoutAnyWitness` prove the cross-era guard
  did not relax in either direction.
- Two existing subtests that asserted "malformed ⇒ refuse" now assert
  "malformed ⇒ admit with a warning". That flip is the policy change, called out here
  rather than buried.

## Gates

- `go build ./...`, `go vet ./...` — clean
- `make ci-pr-lint` (gofmt + golangci-lint v2.10.1, native and cross-linted
  windows/amd64 nocgo) — **0 issues** both lanes
- `scripts/test.sh ./cmd/bd ./cmd/bd/doctor ./internal/configfile ./internal/beads` —
  all `ok` (`cmd/bd` 274s, the full package suite)
- `scripts/check-doc-freshness.sh`, `scripts/check-doc-flags.sh` — PASS

Not run: the rest of `make test`. `cmd/bd/doctor/fix` fails on this box before and after
the change — it needs a Dolt test container (`dial tcp 127.0.0.1: connection refused`) —
and no other package touches the guard, the witness, or version tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
