### PR TITLE
fix(compact): report active database size

### DIFF
--- a/cmd/bd/compact.go
+++ b/cmd/bd/compact.go
@@ -843,6 +843,8 @@ func runCompactDolt(ctx context.Context) error {
 	elapsed := time.Since(start)
 
 	if jsonOutput {
+		// Preserve compact's legacy size_before/size_after field names;
+		// addGCSizeJSON uses a different schema and is not interchangeable.
 		result := map[string]interface{}{
 			"success":    true,
 			"dolt_path":  doltPath,

--- a/cmd/bd/compact.go
+++ b/cmd/bd/compact.go
@@ -108,7 +108,7 @@ Examples:
 
 		// Handle dolt GC mode
 		if compactDolt {
-			return runCompactDolt()
+			return runCompactDolt(ctx)
 		}
 
 		// Count active modes
@@ -741,7 +741,7 @@ func runCompactApply(ctx context.Context, store storage.DoltStorage) error {
 }
 
 // runCompactDolt runs Dolt garbage collection on the .beads/dolt directory
-func runCompactDolt() error {
+func runCompactDolt(ctx context.Context) error {
 	start := time.Now()
 
 	// Find beads directory
@@ -773,20 +773,19 @@ func runCompactDolt() error {
 		return HandleErrorWithHint(fmt.Sprintf("Dolt directory not found at %s", doltPath), "--dolt flag is only for repositories using the Dolt backend")
 	}
 
-	// Get size before GC
-	sizeBefore, err := getDirSize(doltPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not calculate directory size: %v\n", err)
-		sizeBefore = 0
-	}
+	// Measure only the active database. The shared .beads/dolt root may contain
+	// sibling databases unrelated to this GC operation.
+	sizeBefore := storeSizeBytes(ctx)
 
 	if compactDryRun {
 		if jsonOutput {
 			output := map[string]interface{}{
-				"dry_run":      true,
-				"dolt_path":    doltPath,
-				"size_before":  sizeBefore,
-				"size_display": formatBytes(sizeBefore),
+				"dry_run":   true,
+				"dolt_path": doltPath,
+			}
+			if sizeBefore >= 0 {
+				output["size_before"] = sizeBefore
+				output["size_display"] = formatBytes(sizeBefore)
 			}
 			if err := outputJSON(output); err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -795,7 +794,9 @@ func runCompactDolt() error {
 		}
 		fmt.Printf("DRY RUN - Dolt garbage collection\n\n")
 		fmt.Printf("Dolt directory: %s\n", doltPath)
-		fmt.Printf("Current size: %s\n", formatBytes(sizeBefore))
+		if sizeBefore >= 0 {
+			fmt.Printf("Current size: %s\n", formatBytes(sizeBefore))
+		}
 		fmt.Printf("\nRun without --dry-run to perform garbage collection.\n")
 		return nil
 	}
@@ -836,28 +837,30 @@ func runCompactDolt() error {
 		return SilentExit()
 	}
 
-	// Get size after GC
-	sizeAfter, err := getDirSize(doltPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not calculate directory size after GC: %v\n", err)
-		sizeAfter = 0
-	}
+	// Measure the same active-database scope after GC.
+	sizeAfter := storeSizeBytes(ctx)
 
 	elapsed := time.Since(start)
-	freed := sizeBefore - sizeAfter
-	if freed < 0 {
-		freed = 0 // GC may not always reduce size
-	}
 
 	if jsonOutput {
 		result := map[string]interface{}{
-			"success":       true,
-			"dolt_path":     doltPath,
-			"size_before":   sizeBefore,
-			"size_after":    sizeAfter,
-			"freed_bytes":   freed,
-			"freed_display": formatBytes(freed),
-			"elapsed_ms":    elapsed.Milliseconds(),
+			"success":    true,
+			"dolt_path":  doltPath,
+			"elapsed_ms": elapsed.Milliseconds(),
+		}
+		if sizeBefore >= 0 {
+			result["size_before"] = sizeBefore
+		}
+		if sizeAfter >= 0 {
+			result["size_after"] = sizeAfter
+		}
+		if sizeBefore >= 0 && sizeAfter >= 0 {
+			freed := sizeBefore - sizeAfter
+			if freed < 0 {
+				freed = 0 // GC may not always reduce size
+			}
+			result["freed_bytes"] = freed
+			result["freed_display"] = formatBytes(freed)
 		}
 		if err := outputJSON(result); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -866,7 +869,9 @@ func runCompactDolt() error {
 	}
 
 	fmt.Printf("✓ Dolt garbage collection complete\n")
-	fmt.Printf("  %s → %s (freed %s)\n", formatBytes(sizeBefore), formatBytes(sizeAfter), formatBytes(freed))
+	if line := gcSizeLine(sizeBefore, sizeAfter); line != "" {
+		fmt.Printf("  %s\n", line)
+	}
 	fmt.Printf("  Time: %v\n", elapsed)
 	return nil
 }
@@ -892,21 +897,6 @@ func isUnknownArchiveLevelFlagError(output string) bool {
 	return strings.Contains(lower, "unknown option") ||
 		strings.Contains(lower, "unknown flag") ||
 		strings.Contains(lower, "flag provided but not defined")
-}
-
-// getDirSize calculates the total size of a directory recursively
-func getDirSize(path string) (int64, error) {
-	var size int64
-	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			size += info.Size()
-		}
-		return nil
-	})
-	return size, err
 }
 
 // formatBytes formats a byte count as a human-readable string

--- a/cmd/bd/compact_gc_size_test.go
+++ b/cmd/bd/compact_gc_size_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+func TestRunCompactDoltDryRunUsesActiveDatabaseSizer(t *testing.T) {
+	output := runCompactDoltDryRunForTest(t, &gcSizeStoreStub{size: 42}, true)
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("decode dry-run JSON: %v\noutput: %s", err, output)
+	}
+	if got := result["size_before"]; got != float64(42) {
+		t.Fatalf("size_before = %#v, want 42 from ActiveDatabaseSizer", got)
+	}
+	if got := result["size_display"]; got != "42 B" {
+		t.Fatalf("size_display = %#v, want %q", got, "42 B")
+	}
+}
+
+func TestRunCompactDoltDryRunOmitsUnsupportedSize(t *testing.T) {
+	unsupported := &gcSizeStoreStub{err: &storage.ErrUnsupported{
+		Op:      "ActiveDatabaseSize",
+		Backend: "external",
+	}}
+
+	t.Run("JSON", func(t *testing.T) {
+		output := runCompactDoltDryRunForTest(t, unsupported, true)
+		var result map[string]interface{}
+		if err := json.Unmarshal([]byte(output), &result); err != nil {
+			t.Fatalf("decode dry-run JSON: %v\noutput: %s", err, output)
+		}
+		for _, key := range []string{"size_before", "size_display"} {
+			if got, ok := result[key]; ok {
+				t.Fatalf("unsupported measurement emitted %s=%#v", key, got)
+			}
+		}
+	})
+
+	t.Run("text", func(t *testing.T) {
+		output := runCompactDoltDryRunForTest(t, unsupported, false)
+		if strings.Contains(output, "Current size:") {
+			t.Fatalf("unsupported measurement emitted a text size line:\n%s", output)
+		}
+		if !strings.Contains(output, "Run without --dry-run") {
+			t.Fatalf("dry-run completion guidance missing:\n%s", output)
+		}
+	})
+}
+
+func runCompactDoltDryRunForTest(t *testing.T, candidate storage.DoltStorage, asJSON bool) string {
+	t.Helper()
+
+	oldStore, oldDryRun, oldJSON := store, compactDryRun, jsonOutput
+	t.Cleanup(func() {
+		store, compactDryRun, jsonOutput = oldStore, oldDryRun, oldJSON
+	})
+
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltDir, 0o755); err != nil {
+		t.Fatalf("create shared Dolt root: %v", err)
+	}
+	// This sibling-root content makes the old recursive-walk behavior return a
+	// value distinct from the fake active database measurement.
+	if err := os.WriteFile(filepath.Join(doltDir, "sibling-data"), make([]byte, 128), 0o644); err != nil {
+		t.Fatalf("seed sibling data: %v", err)
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+
+	store = candidate
+	compactDryRun = true
+	jsonOutput = asJSON
+	return captureStdout(t, func() error {
+		return runCompactDolt(t.Context())
+	})
+}


### PR DESCRIPTION
Use the store's optional ActiveDatabaseSizer for compact --dolt size reporting. The previous recursive walk measured the shared .beads/dolt root, so sibling databases could inflate before/after sizes.

Sizing remains advisory: unavailable measurements omit the corresponding fields and text instead of reporting a guessed zero. Compact preserves its legacy size_before and size_after JSON names; addGCSizeJSON uses a different schema and is not interchangeable here.

Do not merge this PR alone. Paired landing with #6327 is required: merge this parent first and #6327 immediately afterward, or integrate the child including its parent ancestry. Review and validate their composed source before landing either. This parent measures the active database but does not retarget external GC; standalone landing still permits measuring database A while collecting database B. The child's process fixture replaces the parent fixture, so partial reverts also require composed review and validation.

Six focused sizing, dry-run, fallback-classification and decorator tests passed normally, with race detection and shuffled order. Vet, native/Windows lint and recorded hosted verification passed on the unchanged published source. The companion's owned process fixture establishes target selection separately from these advisory-size tests. This description update does not release the paired-landing hold.

Fixes #5619

_unknown-model/unknown-reasoning on behalf of Ewen Cuthiell_
