### PR TITLE
Add OrcaRouter as a named AI provider

### DIFF
--- a/cmd/bd/compact.go
+++ b/cmd/bd/compact.go
@@ -175,7 +175,7 @@ Examples:
 			// Direct mode
 			apiKey, _ := config.ResolveAIAPIKey("")
 			if apiKey == "" && !compactDryRun {
-				return HandleError("--auto mode requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key in config")
+				return HandleError("--auto mode requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, ORCAROUTER_API_KEY, or ai.api_key in config")
 			}
 
 			compactCfg := &compact.Config{

--- a/cmd/bd/find_duplicates.go
+++ b/cmd/bd/find_duplicates.go
@@ -37,7 +37,7 @@ with different wording.
 
 Approaches:
   mechanical  Token-based text similarity (default, no API key needed)
-  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key)
+  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, ORCAROUTER_API_KEY, or ai.api_key)
 
 The mechanical approach tokenizes titles and descriptions, then computes
 Jaccard similarity between all issue pairs. It's fast and free but may
@@ -103,7 +103,7 @@ func runFindDuplicates(cmd *cobra.Command, _ []string) error {
 
 	if method == "ai" {
 		if apiKey, _ := config.ResolveAIAPIKey(""); apiKey == "" {
-			return HandleErrorRespectJSON("--method ai requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key in config")
+			return HandleErrorRespectJSON("--method ai requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, ORCAROUTER_API_KEY, or ai.api_key in config")
 		}
 	}
 

--- a/docs/cli-reference/find-duplicates.md
+++ b/docs/cli-reference/find-duplicates.md
@@ -15,7 +15,7 @@ with different wording.
 
 Approaches:
   mechanical  Token-based text similarity (default, no API key needed)
-  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY or ai.api_key)
+  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, ORCAROUTER_API_KEY, or ai.api_key)
 
 The mechanical approach tokenizes titles and descriptions, then computes
 Jaccard similarity between all issue pairs. It's fast and free but may

--- a/engdocs/design/otel/otel-data-model.md
+++ b/engdocs/design/otel/otel-data-model.md
@@ -355,7 +355,7 @@ Stdout/stderr are added as span **events** (not attributes):
 
 ## 7. AI Events
 
-Emitted by the compaction engine (`bd compact`) via `internal/compact/haiku.go`, and by duplicate detection (`bd find-duplicates --method ai`) via `cmd/bd/find_duplicates.go`. Both use the Anthropic SDK with Anthropic-compatible credentials from `ANTHROPIC_API_KEY`, `MINIMAX_API_KEY`, or `ai.api_key`.
+Emitted by the compaction engine (`bd compact`) via `internal/compact/haiku.go`, and by duplicate detection (`bd find-duplicates --method ai`) via `cmd/bd/find_duplicates.go`. Both use the Anthropic SDK with Anthropic-compatible credentials from `ANTHROPIC_API_KEY`, `MINIMAX_API_KEY`, `ORCAROUTER_API_KEY`, or `ai.api_key`.
 
 > **Note**: Only `compact/haiku.go` records to the `bd.ai.*` OTel metric instruments. `find_duplicates.go` records token counts and duration as span attributes only.
 

--- a/internal/compact/haiku.go
+++ b/internal/compact/haiku.go
@@ -44,11 +44,11 @@ type haikuClient struct {
 }
 
 // newHaikuClient creates a new Haiku API client.
-// API key resolution order: ANTHROPIC_API_KEY env var > MINIMAX_API_KEY env var > ai.api_key config > explicit apiKey parameter.
+// API key resolution order: ANTHROPIC_API_KEY > ORCAROUTER_API_KEY > MINIMAX_API_KEY > ai.api_key config > explicit apiKey parameter.
 func newHaikuClient(apiKey string) (*haikuClient, error) {
 	apiKey, keySource := config.ResolveAIAPIKey(apiKey)
 	if apiKey == "" {
-		return nil, fmt.Errorf("%w: set ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key in config", errAPIKeyRequired)
+		return nil, fmt.Errorf("%w: set ANTHROPIC_API_KEY, MINIMAX_API_KEY, ORCAROUTER_API_KEY, or ai.api_key in config", errAPIKeyRequired)
 	}
 
 	clientOptions := []option.RequestOption{option.WithAPIKey(apiKey)}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -777,9 +777,10 @@ func DefaultAIModel() string {
 
 // DefaultAIModelFor returns the model for Anthropic-compatible AI calls,
 // accounting for which provider the resolved key selects: an explicitly
-// configured ai.model always wins; otherwise a MiniMax-selected key gets a
-// MiniMax-served default (MINIMAX_MODEL env > MiniMaxDefaultModel), since
-// MiniMax does not serve the Claude default model.
+// configured ai.model always wins; otherwise a MiniMax- or OrcaRouter-selected
+// key gets a provider-served default (MINIMAX_MODEL / ORCAROUTER_MODEL env >
+// MiniMaxDefaultModel / OrcaRouterDefaultModel), since neither provider serves
+// the Claude default model.
 func DefaultAIModelFor(keySource AIAPIKeySource) string {
 	if GetValueSource("ai.model") != SourceDefault {
 		return GetString("ai.model")
@@ -790,6 +791,12 @@ func DefaultAIModelFor(keySource AIAPIKeySource) string {
 		}
 		return MiniMaxDefaultModel
 	}
+	if keySource == AIAPIKeySourceOrcaRouterEnv {
+		if m := os.Getenv("ORCAROUTER_MODEL"); m != "" {
+			return m
+		}
+		return OrcaRouterDefaultModel
+	}
 	return GetString("ai.model")
 }
 
@@ -797,11 +804,12 @@ func DefaultAIModelFor(keySource AIAPIKeySource) string {
 type AIAPIKeySource string
 
 const (
-	AIAPIKeySourceNone         AIAPIKeySource = ""
-	AIAPIKeySourceAnthropicEnv AIAPIKeySource = "ANTHROPIC_API_KEY" //nolint:gosec // Environment variable name, not a credential.
-	AIAPIKeySourceMiniMaxEnv   AIAPIKeySource = "MINIMAX_API_KEY"   //nolint:gosec // Environment variable name, not a credential.
-	AIAPIKeySourceConfig       AIAPIKeySource = "ai.api_key"
-	AIAPIKeySourceExplicit     AIAPIKeySource = "explicit"
+	AIAPIKeySourceNone          AIAPIKeySource = ""
+	AIAPIKeySourceAnthropicEnv  AIAPIKeySource = "ANTHROPIC_API_KEY"  //nolint:gosec // Environment variable name, not a credential.
+	AIAPIKeySourceMiniMaxEnv    AIAPIKeySource = "MINIMAX_API_KEY"    //nolint:gosec // Environment variable name, not a credential.
+	AIAPIKeySourceOrcaRouterEnv AIAPIKeySource = "ORCAROUTER_API_KEY" //nolint:gosec // Environment variable name, not a credential.
+	AIAPIKeySourceConfig        AIAPIKeySource = "ai.api_key"
+	AIAPIKeySourceExplicit      AIAPIKeySource = "explicit"
 
 	MiniMaxDefaultBaseURL = "https://api.minimax.io/anthropic"
 
@@ -811,14 +819,29 @@ const (
 	// must route to a model MiniMax actually hosts. Override with
 	// MINIMAX_MODEL or ai.model.
 	MiniMaxDefaultModel = "MiniMax-M2"
+
+	// OrcaRouterDefaultBaseURL is the Anthropic-compatible endpoint of
+	// OrcaRouter (https://www.orcarouter.ai). The SDK appends /v1/messages.
+	OrcaRouterDefaultBaseURL = "https://api.orcarouter.ai"
+
+	// OrcaRouterDefaultModel is used when ORCAROUTER_API_KEY selected the key
+	// and the user did not configure ai.model: OrcaRouter's Anthropic-
+	// compatible endpoint requires the anthropic/ namespace prefix and does
+	// not serve the bare Claude default model. Override with
+	// ORCAROUTER_MODEL or ai.model.
+	OrcaRouterDefaultModel = "anthropic/claude-haiku-4.5"
 )
 
 // ResolveAIAPIKey returns the API key for Anthropic-compatible AI calls.
 //
-// Precedence: ANTHROPIC_API_KEY > MINIMAX_API_KEY > ai.api_key > explicit.
+// Precedence: ANTHROPIC_API_KEY > ORCAROUTER_API_KEY > MINIMAX_API_KEY >
+// ai.api_key > explicit.
 func ResolveAIAPIKey(explicit string) (string, AIAPIKeySource) {
 	if envKey := os.Getenv("ANTHROPIC_API_KEY"); envKey != "" {
 		return envKey, AIAPIKeySourceAnthropicEnv
+	}
+	if envKey := os.Getenv("ORCAROUTER_API_KEY"); envKey != "" {
+		return envKey, AIAPIKeySourceOrcaRouterEnv
 	}
 	if envKey := os.Getenv("MINIMAX_API_KEY"); envKey != "" {
 		return envKey, AIAPIKeySourceMiniMaxEnv
@@ -834,8 +857,9 @@ func ResolveAIAPIKey(explicit string) (string, AIAPIKeySource) {
 
 // DefaultAIBaseURL returns the configured base URL for Anthropic-compatible AI calls.
 //
-// Precedence: ai.base_url (or BD_AI_BASE_URL) > MINIMAX_BASE_URL > MiniMax default
-// when MINIMAX_API_KEY selected the key. Empty means use the SDK's Anthropic default.
+// Precedence: ai.base_url (or BD_AI_BASE_URL) > MINIMAX_BASE_URL /
+// ORCAROUTER_API_BASE_URL > MiniMax / OrcaRouter default when the matching key
+// selected. Empty means use the SDK's Anthropic default.
 func DefaultAIBaseURL(keySource AIAPIKeySource) string {
 	if baseURL := GetString("ai.base_url"); baseURL != "" {
 		return baseURL
@@ -845,6 +869,12 @@ func DefaultAIBaseURL(keySource AIAPIKeySource) string {
 			return baseURL
 		}
 		return MiniMaxDefaultBaseURL
+	}
+	if keySource == AIAPIKeySourceOrcaRouterEnv {
+		if baseURL := os.Getenv("ORCAROUTER_API_BASE_URL"); baseURL != "" {
+			return baseURL
+		}
+		return OrcaRouterDefaultBaseURL
 	}
 	return ""
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -87,6 +87,7 @@ func TestResolveAIAPIKeyPrecedence(t *testing.T) {
 
 	t.Setenv("ANTHROPIC_API_KEY", "")
 	t.Setenv("MINIMAX_API_KEY", "")
+	t.Setenv("ORCAROUTER_API_KEY", "")
 	if err := Initialize(); err != nil {
 		t.Fatalf("Initialize() returned error: %v", err)
 	}
@@ -109,6 +110,12 @@ func TestResolveAIAPIKeyPrecedence(t *testing.T) {
 		t.Fatalf("MiniMax env = (%q, %q), want minimax-key/%s", key, source, AIAPIKeySourceMiniMaxEnv)
 	}
 
+	t.Setenv("ORCAROUTER_API_KEY", "orcarouter-key")
+	key, source = ResolveAIAPIKey("explicit-key")
+	if key != "orcarouter-key" || source != AIAPIKeySourceOrcaRouterEnv {
+		t.Fatalf("OrcaRouter env = (%q, %q), want orcarouter-key/%s", key, source, AIAPIKeySourceOrcaRouterEnv)
+	}
+
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-key")
 	key, source = ResolveAIAPIKey("explicit-key")
 	if key != "anthropic-key" || source != AIAPIKeySourceAnthropicEnv {
@@ -121,6 +128,7 @@ func TestDefaultAIBaseURLPrecedence(t *testing.T) {
 	defer restore()
 
 	t.Setenv("MINIMAX_BASE_URL", "")
+	t.Setenv("ORCAROUTER_API_BASE_URL", "")
 	if err := Initialize(); err != nil {
 		t.Fatalf("Initialize() returned error: %v", err)
 	}
@@ -132,10 +140,18 @@ func TestDefaultAIBaseURLPrecedence(t *testing.T) {
 	if got := DefaultAIBaseURL(AIAPIKeySourceMiniMaxEnv); got != MiniMaxDefaultBaseURL {
 		t.Fatalf("MiniMax default base URL = %q, want %q", got, MiniMaxDefaultBaseURL)
 	}
+	if got := DefaultAIBaseURL(AIAPIKeySourceOrcaRouterEnv); got != OrcaRouterDefaultBaseURL {
+		t.Fatalf("OrcaRouter default base URL = %q, want %q", got, OrcaRouterDefaultBaseURL)
+	}
 
 	t.Setenv("MINIMAX_BASE_URL", "https://minimax.example/anthropic")
 	if got := DefaultAIBaseURL(AIAPIKeySourceMiniMaxEnv); got != "https://minimax.example/anthropic" {
 		t.Fatalf("MINIMAX_BASE_URL = %q, want custom MiniMax URL", got)
+	}
+
+	t.Setenv("ORCAROUTER_API_BASE_URL", "https://orcarouter.example/v1")
+	if got := DefaultAIBaseURL(AIAPIKeySourceOrcaRouterEnv); got != "https://orcarouter.example/v1" {
+		t.Fatalf("ORCAROUTER_API_BASE_URL = %q, want custom OrcaRouter URL", got)
 	}
 
 	t.Setenv("BD_AI_BASE_URL", "https://proxy.example/anthropic")
@@ -147,6 +163,9 @@ func TestDefaultAIBaseURLPrecedence(t *testing.T) {
 	}
 	if got := DefaultAIBaseURL(AIAPIKeySourceAnthropicEnv); got != "https://proxy.example/anthropic" {
 		t.Fatalf("BD_AI_BASE_URL Anthropic override = %q, want proxy URL", got)
+	}
+	if got := DefaultAIBaseURL(AIAPIKeySourceOrcaRouterEnv); got != "https://proxy.example/anthropic" {
+		t.Fatalf("BD_AI_BASE_URL OrcaRouter override = %q, want proxy URL", got)
 	}
 }
 


### PR DESCRIPTION
## What

Adds OrcaRouter as a named provider in the API key resolution chain, alongside the existing Anthropic and MiniMax providers. With `ORCAROUTER_API_KEY` set, `bd compact` and `bd find-duplicates --method ai` route through OrcaRouter automatically; the base URL and default model are supplied by the provider, so users only set one env var.

## Why

This adds a dedicated [OrcaRouter](https://www.orcarouter.ai) provider rather than relying on the generic OpenAI-compatible endpoint, mirroring how this repo already treats MiniMax-style named providers. Named routers such as `orcarouter/auto` pick an upstream per request. OrcaRouter is an OpenAI-compatible gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind one API key, and it also provides gateway-level security controls for AI agents.

The resolution order is now `ANTHROPIC_API_KEY > ORCAROUTER_API_KEY > MINIMAX_API_KEY > ai.api_key config > explicit apiKey parameter`, and `DefaultAIBaseURL`/`DefaultAIModelFor` dispatch on the resolved key source, so `ORCAROUTER_API_BASE_URL` / `ORCAROUTER_MODEL` overrides stay consistent with the other providers.

## Verification

- `go test ./internal/config/...` — extended `TestResolveAIAPIKeyPrecedence` and `TestDefaultAIBaseURLPrecedence` cover the OrcaRouter source (precedence, default base URL, env overrides).
- `go test ./internal/compact/...` — passes.
- Live smoke test against the real OrcaRouter endpoint through `newHaikuClient` + `SummarizeTier1` succeeded (key source resolved to `ORCAROUTER_API_KEY`, correct base URL and `anthropic/`-namespaced model).

I'm an engineer on the OrcaRouter team.
