### PR TITLE
fix(upgrade-guard): parse .local_version as semver; unreadable witness is unknown, not legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **bd refused workspaces stamped by bd.** The cross-era upgrade guard read
+  `.beads/.local_version` by splitting on `.` and demanding exactly three
+  numeric parts, so any version string with a prerelease or build suffix failed
+  to parse — and an unparseable witness was reported as a legacy pre-1.0
+  workspace. bd then refused the workspace outright, for every command,
+  including the diagnostics that would explain why. This is not a hypothetical
+  input: `.goreleaser.yml` and `release.yml` stamp the release tag verbatim
+  into `main.Version` (this repository already carries `v1.1.0-rc.1` and
+  `v1.1.0-rc.2`), module-pinned builds stamp a Go pseudo-version such as
+  `v1.1.1-0.20260805093327-bf97b73749ac`, and `writeLocalVersion` records
+  whichever of those the binary holds. Reader and writer disagreed: bd could
+  not read back what bd had written. It took five production workspaces down,
+  each recovered only by hand-editing the marker.
+
+  The witness is now parsed with `golang.org/x/mod/semver`, so every string the
+  writer can emit round-trips, and the read bound rose from 64 to 256 bytes
+  because a decorated pseudo-version can legitimately exceed 64. The same
+  dot-counting bug also made the guard fail *open* on a decorated pre-1.0
+  witness (`0.62.0-rc.1` did not parse, so `legacyServerVersion` never matched);
+  that direction is fixed too.
+
+  **Failure policy changed.** A witness that is present but unparseable is now
+  *unknown*, not *legacy*: bd warns on stderr and proceeds. A parse failure is a
+  fact about the reader, not about the workspace, and answering an unanswerable
+  question with the most destructive available verdict is what turned a parsing
+  bug into a fleet outage. The confirmed verdicts stay fail-closed — a witness
+  that parses as pre-1.0 is still refused, a workspace with no witness at all is
+  still refused (`.local_version` has existed since 0.29.0, so its absence is
+  itself evidence of an older vintage), and the historical-SQLite and
+  removed-backend refusals are untouched.
+
 ## [1.2.1] - 2026-08-11
 
 (Released as 1.2.1: the v1.2.0 tag burned pre-publish on a freebsd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,6 +378,39 @@ stopgap (`BD_IGNORE_SCHEMA_SKEW=1`).
   `go install github.com/steveyegge/beads/cmd/bd@latest` resolves to this
   release instead of the accidental one. (The retract block is also
   carried on main so future tags keep the retractions.)
+||||||| parent of 646a58168 (fix(upgrade-guard): parse .local_version as semver; unreadable witness is unknown, not legacy)
+### Fixed
+
+- **bd refused workspaces stamped by bd.** The cross-era upgrade guard read
+  `.beads/.local_version` by splitting on `.` and demanding exactly three
+  numeric parts, so any version string with a prerelease or build suffix failed
+  to parse — and an unparseable witness was reported as a legacy pre-1.0
+  workspace. bd then refused the workspace outright, for every command,
+  including the diagnostics that would explain why. This is not a hypothetical
+  input: `.goreleaser.yml` and `release.yml` stamp the release tag verbatim
+  into `main.Version` (this repository already carries `v1.1.0-rc.1` and
+  `v1.1.0-rc.2`), module-pinned builds stamp a Go pseudo-version such as
+  `v1.1.1-0.20260805093327-bf97b73749ac`, and `writeLocalVersion` records
+  whichever of those the binary holds. Reader and writer disagreed: bd could
+  not read back what bd had written. It took five production workspaces down,
+  each recovered only by hand-editing the marker.
+
+  The witness is now parsed with `golang.org/x/mod/semver`, so every string the
+  writer can emit round-trips, and the read bound rose from 64 to 256 bytes
+  because a decorated pseudo-version can legitimately exceed 64. The same
+  dot-counting bug also made the guard fail *open* on a decorated pre-1.0
+  witness (`0.62.0-rc.1` did not parse, so `legacyServerVersion` never matched);
+  that direction is fixed too.
+
+  **Failure policy changed.** A witness that is present but unparseable is now
+  *unknown*, not *legacy*: bd warns on stderr and proceeds. A parse failure is a
+  fact about the reader, not about the workspace, and answering an unanswerable
+  question with the most destructive available verdict is what turned a parsing
+  bug into a fleet outage. The confirmed verdicts stay fail-closed — a witness
+  that parses as pre-1.0 is still refused, a workspace with no witness at all is
+  still refused (`.local_version` has existed since 0.29.0, so its absence is
+  itself evidence of an older vintage), and the historical-SQLite and
+  removed-backend refusals are untouched.
 
 ## [1.2.1] - 2026-08-11
 

--- a/cmd/bd/legacy_upgrade_guard.go
+++ b/cmd/bd/legacy_upgrade_guard.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
+
+	"golang.org/x/mod/semver"
 
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/configfile"
@@ -42,8 +45,8 @@ func guardLegacyUpgradeWorkspace(beadsDir string) error {
 	if embeddeddolt.HasRepository(beadsDir) && !serverMode {
 		return nil
 	}
-	version, ok := legacyUpgradeVersionWitness(beadsDir)
-	if serverMode && ok && legacyServerVersion(version) {
+	version, present := legacyUpgradeVersionWitness(beadsDir)
+	if serverMode && present && legacyServerVersion(version) {
 		return legacyUpgradeRefusal(fmt.Sprintf("legacy Dolt server workspace from bd %s", version))
 	}
 	hasLocalDoltRoot := hasLegacyDoltRoot(beadsDir)
@@ -54,15 +57,25 @@ func guardLegacyUpgradeWorkspace(beadsDir string) error {
 		if currentVersionWitness(version) {
 			return nil
 		}
+		// A witness that is on disk but does not parse answers "this bd could
+		// not read a version file", not "this workspace predates the 1.0 era".
+		// Refusing on it turns every unrecognized version format into a total
+		// outage: bd rejects the workspace outright, including the diagnostics
+		// that would explain why. Warn and proceed instead; the confirmed
+		// verdicts above and below stay fail-closed.
+		if present && unreadableVersionWitness(version) {
+			warnUnreadableVersionWitness(beadsDir, version)
+			return nil
+		}
 		return legacyUpgradeRefusal("legacy Dolt server workspace")
 	}
 	if cfg == nil || cfg.DoltMode == "" ||
 		strings.EqualFold(cfg.DoltMode, configfile.DoltModeEmbedded) {
-		if doltserver.IsSharedServerMode() && !(ok && legacyServerVersion(version)) {
+		if doltserver.IsSharedServerMode() && !(present && legacyServerVersion(version)) {
 			return nil
 		}
 		reason := "legacy Dolt workspace"
-		if _, validVersion := legacyVersionMinor(version); ok && validVersion {
+		if _, validVersion := legacyVersionMinor(version); present && validVersion {
 			reason = fmt.Sprintf("legacy Dolt workspace from bd %s", version)
 		}
 		return legacyUpgradeRefusal(reason)
@@ -232,15 +245,34 @@ func isRegularFile(path string) bool {
 	return err == nil && info.Mode().IsRegular()
 }
 
+// maxVersionWitnessBytes bounds the witness read. It is far above any version
+// string bd can stamp -- a Go pseudo-version carrying both a prerelease and
+// build metadata runs to roughly 70 bytes -- while keeping the read bounded.
+// The previous 64-byte bound was itself tight enough to reject a legitimate
+// version, which the guard would then have read as no witness at all.
+const maxVersionWitnessBytes = 256
+
+// legacyUpgradeVersionWitness reads the recorded version marker. The second
+// result reports whether the workspace carries a witness at all, which is a
+// separate question from whether its contents parse: no witness means no bd new
+// enough to track versions (0.29.0 and later) ever wrote here, while a witness
+// this bd cannot read means only that it does not recognize the format. A
+// blank witness carries no claim either way and counts as no witness.
+//
+// The version is empty when the marker exists but could not be read within its
+// size bound; that is an unreadable witness, not an absent one.
 func legacyUpgradeVersionWitness(beadsDir string) (string, bool) {
 	path := filepath.Join(beadsDir, localVersionFile)
 	info, err := os.Lstat(path)
-	if err != nil || !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > 64 {
+	if err != nil || !info.Mode().IsRegular() || info.Size() <= 0 {
 		return "", false
+	}
+	if info.Size() > maxVersionWitnessBytes {
+		return "", true
 	}
 	data, err := os.ReadFile(path) // #nosec G304 -- bounded file beneath selected workspace
 	if err != nil || int64(len(data)) != info.Size() {
-		return "", false
+		return "", true
 	}
 	version := strings.TrimSpace(string(data))
 	return version, version != ""
@@ -251,39 +283,97 @@ func legacyServerVersion(version string) bool {
 	return ok && minor >= 55 && minor <= 62
 }
 
-// currentVersionWitness identifies a syntactically valid post-1.0 version
-// marker. A local Dolt root in server mode is ambiguous without it, so that
-// shape must be refused rather than opened as a historical schema.
+// currentVersionWitness identifies a post-1.0 version marker. A local Dolt root
+// in server mode is ambiguous without one, so that shape must be refused rather
+// than opened as a historical schema.
 func currentVersionWitness(version string) bool {
-	parts := strings.Split(strings.TrimPrefix(version, "v"), ".")
-	if len(parts) != 3 {
-		return false
-	}
-	values := make([]int, len(parts))
-	for i, part := range parts {
-		value, err := strconv.Atoi(part)
-		if err != nil || value < 0 {
-			return false
-		}
-		values[i] = value
-	}
-	return values[0] >= 1
+	major, _, ok := versionWitnessMajorMinor(version)
+	return ok && major >= 1
+}
+
+// unreadableVersionWitness reports whether a witness carries something this bd
+// cannot read as a version at all. It is deliberately the complement of a real
+// semver parse rather than a blocklist: any format bd, its release pipeline, or
+// a downstream packager invents later lands here as unknown instead of being
+// misreported as a pre-1.0 workspace.
+func unreadableVersionWitness(version string) bool {
+	_, _, ok := versionWitnessMajorMinor(version)
+	return !ok
 }
 
 func legacyVersionMinor(version string) (int, bool) {
-	parts := strings.Split(strings.TrimPrefix(version, "v"), ".")
-	if len(parts) != 3 || parts[0] != "0" {
-		return 0, false
-	}
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return 0, false
-	}
-	if _, err := strconv.Atoi(parts[2]); err != nil {
+	major, minor, ok := versionWitnessMajorMinor(version)
+	if !ok || major != 0 {
 		return 0, false
 	}
 	return minor, true
 }
+
+// versionWitnessMajorMinor parses the recorded marker as semver and returns its
+// major and minor components.
+//
+// The witness holds whatever bd stamped into main.Version, and that is a full
+// semver string, not three integers: .goreleaser.yml and release.yml both stamp
+// the release tag verbatim (the repository already carries v1.1.0-rc.1 and
+// v1.1.0-rc.2), and module-pinned builds stamp a Go pseudo-version such as
+// v1.1.1-0.20260805093327-bf97b73749ac. Splitting on "." and demanding exactly
+// three parts rejected every one of those, so bd could not read back what bd
+// had written. Parsing with the same library the module system uses keeps the
+// reader's accepted set equal to the writer's emitted set.
+func versionWitnessMajorMinor(version string) (int, int, bool) {
+	canonical := "v" + strings.TrimPrefix(strings.TrimSpace(version), "v")
+	if !semver.IsValid(canonical) {
+		return 0, 0, false
+	}
+	// MajorMinor yields "vX.Y", or "vX" when the witness omitted the minor.
+	majorMinor := strings.TrimPrefix(semver.MajorMinor(canonical), "v")
+	majorText, minorText, hasMinor := strings.Cut(majorMinor, ".")
+	major, err := strconv.Atoi(majorText)
+	if err != nil {
+		return 0, 0, false
+	}
+	if !hasMinor {
+		return major, 0, true
+	}
+	minor, err := strconv.Atoi(minorText)
+	if err != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
+}
+
+// warnUnreadableVersionWitness reports an unrecognized marker once per
+// workspace. Proceeding on an unreadable witness is a judgement call, so it has
+// to be visible; the guard also runs against every ancestor directory during
+// undiscovered-workspace probing, so the same workspace must not warn twice.
+func warnUnreadableVersionWitness(beadsDir, version string) {
+	unreadableWitnessMu.Lock()
+	warned := unreadableWitnessWarned[beadsDir]
+	if !warned {
+		if unreadableWitnessWarned == nil {
+			unreadableWitnessWarned = map[string]bool{}
+		}
+		unreadableWitnessWarned[beadsDir] = true
+	}
+	unreadableWitnessMu.Unlock()
+	if warned {
+		return
+	}
+
+	detail := fmt.Sprintf("holds %q, which is not a recognized version", version)
+	if version == "" {
+		detail = "could not be read within its size bound"
+	}
+	fmt.Fprintf(os.Stderr,
+		"warning: %s in %s %s; treating the workspace as current. "+
+			"Run 'bd doctor' if this is unexpected.\n",
+		localVersionFile, beadsDir, detail)
+}
+
+var (
+	unreadableWitnessMu     sync.Mutex
+	unreadableWitnessWarned map[string]bool
+)
 
 func legacyUpgradeRefusal(reason string) error {
 	return legacyUpgradeRefusalError{reason: reason}

--- a/cmd/bd/legacy_upgrade_guard_test.go
+++ b/cmd/bd/legacy_upgrade_guard_test.go
@@ -203,7 +203,13 @@ func TestLegacyUpgradeGuardMetadataLessSQLiteAndCurrentEmbeddedPrecedence(t *tes
 		}
 	})
 
-	t.Run("explicit server metadata with malformed version witness and local Dolt root is refused", func(t *testing.T) {
+	// A witness this bd cannot parse is an unanswerable question, not a
+	// confirmed cross-era workspace, so it warns and proceeds. This case used
+	// to be refused; that policy turned an unrecognized version format into a
+	// total refusal of every command against the workspace. The confirmed
+	// verdicts -- a witness that parses as pre-1.0, and a workspace with no
+	// witness at all -- stay refused above and below.
+	t.Run("explicit server metadata with malformed version witness and local Dolt root is admitted as unknown", func(t *testing.T) {
 		beadsDir := t.TempDir()
 		if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"backend":"dolt","dolt_mode":"server"}`), 0o600); err != nil {
 			t.Fatal(err)
@@ -214,8 +220,8 @@ func TestLegacyUpgradeGuardMetadataLessSQLiteAndCurrentEmbeddedPrecedence(t *tes
 		if err := os.Mkdir(filepath.Join(beadsDir, "dolt"), 0o700); err != nil {
 			t.Fatal(err)
 		}
-		if err := guardLegacyUpgradeWorkspace(beadsDir); !isLegacyUpgradeRefusal(err) {
-			t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want migration refusal", err)
+		if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+			t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want nil for an unreadable witness", err)
 		}
 	})
 
@@ -250,8 +256,14 @@ func TestLegacyUpgradeGuardServerSelectionBeatsStaleEmbeddedRepository(t *testin
 	}{
 		{name: "historical witness", version: "0.62.0", wantRefusal: true},
 		{name: "missing witness", wantRefusal: true},
-		{name: "malformed witness", version: "not-a-version", wantRefusal: true},
+		// Unreadable is unknown, not legacy: the guard warns and proceeds
+		// rather than answering an unanswerable question with a refusal.
+		{name: "malformed witness", version: "not-a-version"},
 		{name: "current witness", version: "1.1.2"},
+		// The shapes bd's own release pipeline and module-pinned builds stamp.
+		{name: "prerelease witness", version: "1.1.0-rc.1"},
+		{name: "pseudo-version witness", version: "v1.1.1-0.20260805093327-bf97b73749ac"},
+		{name: "legacy prerelease witness", version: "0.62.0-rc.1", wantRefusal: true},
 	}
 
 	for _, tt := range tests {

--- a/cmd/bd/legacy_upgrade_witness_test.go
+++ b/cmd/bd/legacy_upgrade_witness_test.go
@@ -1,0 +1,303 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCurrentVersionWitnessAcceptsEveryShapeTheWriterEmits pins the round-trip
+// contract at the parse level: every version string bd's own build and release
+// pipeline can stamp into main.Version must classify as a post-1.0 witness.
+//
+// The regression this covers took five production cities down. The witness
+// parser split on "." and demanded exactly three parts, so a Go pseudo-version
+// (v1.1.1-0.20260805093327-bf97b73749ac -> four parts) and a release-candidate
+// tag (1.1.0-rc.1 -> four parts) both failed to parse and were reported as
+// legacy pre-1.0 workspaces. Every bd invocation against those workspaces was
+// refused outright.
+func TestCurrentVersionWitnessAcceptsEveryShapeTheWriterEmits(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		// The exact string recovered from the production workspaces.
+		{name: "go pseudo-version", version: "v1.1.1-0.20260805093327-bf97b73749ac", want: true},
+		// The hand-repair value used to unblock the fleet.
+		{name: "bare release", version: "1.1.0", want: true},
+		// goreleaser and release.yml both stamp the tag with the v stripped,
+		// but downstream packagers keep it.
+		{name: "v-prefixed release", version: "v1.2.1", want: true},
+		// v1.1.0-rc.1 and v1.1.0-rc.2 are real tags in this repository, so
+		// release.yml has already built binaries stamped exactly this way.
+		{name: "prerelease", version: "1.1.0-rc.1", want: true},
+		{name: "v-prefixed prerelease", version: "v1.1.0-rc.2", want: true},
+		{name: "build metadata", version: "1.2.1+build.20260805", want: true},
+		{name: "prerelease and build metadata", version: "v1.2.1-rc.1+linux.amd64", want: true},
+		// Two-component versions are still post-1.0.
+		{name: "major minor only", version: "v1.2", want: true},
+
+		// Pre-1.0 must stay classified as legacy in every shape.
+		{name: "legacy release", version: "0.62.0", want: false},
+		{name: "legacy pseudo-version", version: "v0.62.0-0.20251201093327-bf97b73749ac", want: false},
+		{name: "legacy prerelease", version: "0.55.4-rc.1", want: false},
+
+		// Not versions at all.
+		{name: "empty", version: "", want: false},
+		{name: "garbage", version: "not-a-version", want: false},
+		{name: "path-like garbage", version: "/usr/local/bin/bd", want: false},
+		{name: "leading junk", version: "bd version 1.2.1", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := currentVersionWitness(tt.version); got != tt.want {
+				t.Fatalf("currentVersionWitness(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLegacyVersionMinorAcceptsPrereleaseAndPseudoVersions covers the other
+// direction of the same dot-counting bug. legacyVersionMinor drives the
+// external-legacy-server refusal, so a pre-1.0 workspace whose witness carried
+// a prerelease or pseudo-version suffix was silently admitted -- the guard
+// failed open on exactly the shape it exists to catch.
+func TestLegacyVersionMinorAcceptsPrereleaseAndPseudoVersions(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		wantMinor int
+		wantOK    bool
+	}{
+		{name: "plain legacy", version: "0.62.0", wantMinor: 62, wantOK: true},
+		{name: "v-prefixed legacy", version: "v0.55.4", wantMinor: 55, wantOK: true},
+		{name: "legacy prerelease", version: "0.62.0-rc.1", wantMinor: 62, wantOK: true},
+		{name: "legacy pseudo-version", version: "v0.60.0-0.20251201093327-bf97b73749ac", wantMinor: 60, wantOK: true},
+		{name: "legacy build metadata", version: "0.58.1+deb12u1", wantMinor: 58, wantOK: true},
+		{name: "post-1.0 is not legacy", version: "1.1.0", wantOK: false},
+		{name: "pseudo-version is not legacy", version: "v1.1.1-0.20260805093327-bf97b73749ac", wantOK: false},
+		{name: "garbage", version: "not-a-version", wantOK: false},
+		{name: "empty", version: "", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			minor, ok := legacyVersionMinor(tt.version)
+			if ok != tt.wantOK {
+				t.Fatalf("legacyVersionMinor(%q) ok = %v, want %v", tt.version, ok, tt.wantOK)
+			}
+			if ok && minor != tt.wantMinor {
+				t.Fatalf("legacyVersionMinor(%q) minor = %d, want %d", tt.version, minor, tt.wantMinor)
+			}
+		})
+	}
+}
+
+// TestLegacyServerVersionWindowSurvivesSuffixes proves the 0.55-0.62 refusal
+// window still closes on decorated legacy witnesses and does not swallow
+// neighbouring versions.
+func TestLegacyServerVersionWindowSurvivesSuffixes(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{version: "0.54.9", want: false},
+		{version: "0.55.0", want: true},
+		{version: "0.62.21", want: true},
+		{version: "0.63.0", want: false},
+		{version: "v0.62.0-rc.1", want: true},
+		{version: "v0.55.0-0.20251201093327-bf97b73749ac", want: true},
+		{version: "v1.1.1-0.20260805093327-bf97b73749ac", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			if got := legacyServerVersion(tt.version); got != tt.want {
+				t.Fatalf("legacyServerVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLocalVersionWitnessRoundTrip is the contract the outage violated:
+// whatever bd writes into .beads/.local_version, bd must be able to read back
+// and classify. It drives the real writer rather than a literal so the two
+// sides cannot drift apart again.
+func TestLocalVersionWitnessRoundTrip(t *testing.T) {
+	// Every shape main.Version can hold: the compiled-in default, the tag
+	// forms release.yml and .goreleaser.yml stamp, and the pseudo-version
+	// downstream module-pinned builds stamp.
+	written := []string{
+		Version,
+		"1.2.1",
+		"v1.2.1",
+		"1.1.0-rc.1",
+		"v1.1.0-rc.2",
+		"v1.1.1-0.20260805093327-bf97b73749ac",
+		"1.2.1+build.20260805",
+		"v1.2.1-rc.1.0.20260805093327-bf97b73749ac+build.20260805.linux.amd64",
+	}
+
+	for _, version := range written {
+		t.Run(version, func(t *testing.T) {
+			beadsDir := t.TempDir()
+			path := filepath.Join(beadsDir, localVersionFile)
+			if err := writeLocalVersion(path, version); err != nil {
+				t.Fatalf("writeLocalVersion(%q) = %v", version, err)
+			}
+
+			// The advisory reader and the guard's witness reader must agree.
+			if got := readLocalVersion(path); got != version {
+				t.Fatalf("readLocalVersion() = %q, want %q", got, version)
+			}
+			witness, present := legacyUpgradeVersionWitness(beadsDir)
+			if !present {
+				t.Fatalf("legacyUpgradeVersionWitness() reported no witness for %q", version)
+			}
+			if witness != version {
+				t.Fatalf("legacyUpgradeVersionWitness() = %q, want %q", witness, version)
+			}
+			if !currentVersionWitness(witness) {
+				t.Fatalf("bd wrote %q but currentVersionWitness() refuses to read it back", version)
+			}
+
+			// End to end: the workspace shape that took the fleet down.
+			writeServerModeDoltWorkspace(t, beadsDir)
+			if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+				t.Fatalf("guard refused a workspace stamped by bd itself (%q): %v", version, err)
+			}
+		})
+	}
+}
+
+// TestLegacyUpgradeGuardTreatsUnreadableWitnessAsUnknown pins the failure
+// policy. A witness bd cannot parse answers "I could not read a version file",
+// not "this is a legacy workspace". The guard warns and proceeds instead of
+// refusing every command, which is what turned a parse bug into a fleet outage.
+func TestLegacyUpgradeGuardTreatsUnreadableWitnessAsUnknown(t *testing.T) {
+	unreadable := []string{
+		"not-a-version",
+		"/usr/local/bin/bd",
+		"bd version 1.2.1",
+		"1.2.1.4",
+	}
+
+	for _, version := range unreadable {
+		t.Run(version, func(t *testing.T) {
+			beadsDir := t.TempDir()
+			writeServerModeDoltWorkspace(t, beadsDir)
+			if err := os.WriteFile(filepath.Join(beadsDir, localVersionFile), []byte(version+"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+				t.Fatalf("unreadable witness %q was refused as legacy: %v", version, err)
+			}
+		})
+	}
+}
+
+// TestLegacyUpgradeGuardStillRefusesConfirmedLegacy proves the other direction:
+// loosening the unreadable case must not loosen the confirmed case. A witness
+// that parses as pre-1.0 is a confirmed cross-era workspace and stays refused,
+// and so does a workspace with no witness at all -- .local_version has existed
+// since 0.29.0, so its absence is itself evidence of a pre-0.29 vintage.
+func TestLegacyUpgradeGuardStillRefusesConfirmedLegacy(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		write   bool
+	}{
+		{name: "confirmed legacy release", version: "0.62.0", write: true},
+		{name: "confirmed legacy prerelease", version: "0.62.0-rc.1", write: true},
+		{name: "confirmed legacy pseudo-version", version: "v0.60.0-0.20251201093327-bf97b73749ac", write: true},
+		{name: "confirmed pre-1.0 outside the server window", version: "0.49.6", write: true},
+		{name: "absent witness", write: false},
+		{name: "empty witness", version: "", write: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			beadsDir := t.TempDir()
+			writeServerModeDoltWorkspace(t, beadsDir)
+			if tt.write {
+				if err := os.WriteFile(filepath.Join(beadsDir, localVersionFile), []byte(tt.version+"\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := guardLegacyUpgradeWorkspace(beadsDir); !isLegacyUpgradeRefusal(err) {
+				t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want cross-era migration refusal", err)
+			}
+		})
+	}
+}
+
+// TestLegacyUpgradeGuardAdmitsWitnessTooLargeToRead covers the bounded read
+// itself. A marker larger than the read bound yields no version, which the
+// guard must treat as unreadable rather than as absent -- the old 64-byte bound
+// was tight enough to clip a legitimate pseudo-version carrying build metadata.
+func TestLegacyUpgradeGuardAdmitsWitnessTooLargeToRead(t *testing.T) {
+	beadsDir := t.TempDir()
+	writeServerModeDoltWorkspace(t, beadsDir)
+	oversized := "v1.2.1+" + strings.Repeat("a", maxVersionWitnessBytes)
+	if err := os.WriteFile(filepath.Join(beadsDir, localVersionFile), []byte(oversized+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	version, present := legacyUpgradeVersionWitness(beadsDir)
+	if !present {
+		t.Fatal("an oversized marker was reported as no witness at all")
+	}
+	if version != "" {
+		t.Fatalf("legacyUpgradeVersionWitness() = %q, want empty for an unread marker", version)
+	}
+	if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+		t.Fatalf("oversized witness was refused as legacy: %v", err)
+	}
+}
+
+// TestUnreadableVersionWitnessWarns proves the fail-open path stays visible.
+// Proceeding on an unreadable marker is a judgement call, so it must reach
+// stderr, and it must not repeat for the same workspace across the guard's
+// ancestor walk.
+func TestUnreadableVersionWitnessWarns(t *testing.T) {
+	beadsDir := t.TempDir()
+	writeServerModeDoltWorkspace(t, beadsDir)
+	if err := os.WriteFile(filepath.Join(beadsDir, localVersionFile), []byte("not-a-version\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	first := captureStderr(t, func() {
+		if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+			t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want nil", err)
+		}
+	})
+	if !strings.Contains(first, "not-a-version") || !strings.Contains(first, localVersionFile) {
+		t.Fatalf("guard proceeded silently on an unreadable witness; stderr = %q", first)
+	}
+
+	second := captureStderr(t, func() {
+		if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+			t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want nil", err)
+		}
+	})
+	if second != "" {
+		t.Fatalf("warning repeated for the same workspace; stderr = %q", second)
+	}
+}
+
+// writeServerModeDoltWorkspace lays down the exact shape the production cities
+// had: explicit Dolt server metadata plus a local .beads/dolt root. That is the
+// only shape whose verdict the version witness decides.
+func writeServerModeDoltWorkspace(t *testing.T, beadsDir string) {
+	t.Helper()
+	metadata := []byte(`{"backend":"dolt","dolt_mode":"server"}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(beadsDir, "dolt"), 0o700); err != nil && !os.IsExist(err) {
+		t.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -263,7 +263,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3 // indirect
-	golang.org/x/mod v0.37.0 // indirect
+	golang.org/x/mod v0.37.0
 	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 // indirect


### PR DESCRIPTION
## The defect

`cmd/bd/legacy_upgrade_guard.go` read `.beads/.local_version` by splitting on `.` and demanding exactly three numeric parts:

```go
parts := strings.Split(strings.TrimPrefix(version, "v"), ".")
if len(parts) != 3 { return false }
```

Any version string carrying a prerelease or build suffix splits into four parts, fails, and — because an unparseable witness was classified as *legacy* — bd refused the workspace outright, for **every** command:

```
Error: legacy Dolt server workspace detected; explicit migration is required before this
bd version can open or modify the workspace. Preserve .beads unchanged and follow
docs/getting-started/upgrading.md#cross-era-upgrades
```

**Measured blast radius:** every `bd` invocation against five production workspaces failed. Every order that shells out to bd died with it — `gate-sweep` alone logged **644 failures in 6 hours**, plus `dolt-health`, `reaper`, `mol-dog-compactor`, `github-intake-sync-app`, `pr-merge-ready-patrol`, `mol-dog-doctor`, `jsonl-export`. Because `gate-sweep` advances review gates, PR review state stopped moving entirely and demand-driven pools fell to zero. Recovery was hand-editing nine marker files — which any tool that stamps a version back would instantly undo.

## Which side is wrong: the reader

The writer is `writeLocalVersion(path, Version)` in `cmd/bd/version_tracking.go`. It records whatever the binary holds in `main.Version`, and that is a **full semver string, not three integers**:

- `.goreleaser.yml` — `-X main.Version={{.Version}}`
- `.github/workflows/release.yml` — `version=${GITHUB_REF_NAME#v}`, stamped verbatim

This repository **already carries the tags `v1.1.0-rc.1` and `v1.1.0-rc.2`**, so the official release pipeline has already built binaries that stamp `1.1.0-rc.1`. Module-pinned builds stamp a Go pseudo-version such as `v1.1.1-0.20260805093327-bf97b73749ac`. All four parts. bd could not read back what bd had written, using nothing but this project's own release pipeline.

The writer is **not** wrong and is unchanged: `1.1.0-rc.1` and a pseudo-version are truthful identifications of the binary, and narrowing them would destroy information (you could no longer tell `rc.1` from `rc.2`). The contract to repair is "the reader accepts the writer's full output domain", and it is now pinned by a round-trip test that drives the real writer rather than a literal.

## The parse fix

- `versionWitnessMajorMinor` parses with `golang.org/x/mod/semver` — the same library the module system uses — instead of counting dots. `golang.org/x/mod` was already an indirect dependency; it is now direct, with no version change and no `go.sum` churn.
- The read bound rose from 64 to 256 bytes. A pseudo-version carrying both a prerelease and build metadata legitimately exceeds 64, at which point the guard read a valid marker as *no marker at all* — the same trap, one layer down.
- **The bug also failed open in the other direction.** `legacyVersionMinor` counted dots too, so a decorated pre-1.0 witness like `0.62.0-rc.1` never matched `legacyServerVersion` and a genuine legacy workspace was **admitted**. One real parser fixes both directions; the guard gets *stronger*, not weaker.

## The failure policy — the part that mattered

A witness that is present but unparseable is now **unknown**, not **legacy**: bd warns on stderr and proceeds.

A parse failure is a fact about the *reader*, not about the *workspace*. Every other refusal in this guard answers a **confirmed** question — a historical SQLite layout, a removed backend, a witness that parses as pre-1.0. "I could not read a version file" was the only one answering an *unanswerable* question with a confirmed, maximally destructive verdict. That is what turned a four-vs-three dot count into an outage. This mirrors the resolution already reached for the identical shape in `gc`'s `checkVersionCompat`: **fail open on an unanswerable question, fail closed on a confirmed one.**

Three further reasons the asymmetry is not close:

1. **A false refusal is unrecoverable in-band.** It blocks every command *including `bd doctor`*, so the tool cannot diagnose or heal itself. A false admission is loud and recoverable: the workspace still passes through `ReconcileVersion`, which independently refuses downgrades. This guard is a pre-flight heuristic in front of real versioned migration machinery, not the only line of defense.
2. **Refusing on garbage catches ~zero true positives.** `.local_version` has existed since **0.29.0**, and this guard targets the **0.55–0.62** era. Every workspace in the targeted era writes a *well-formed* `0.5x.y` witness. The legacy shape is positively identifiable; nothing is lost by requiring positive evidence.
3. **Fixing only the parser leaves the trap armed.** Semver covers a lot, but a distro packager's `1.2.1-ubuntu3`, a `+dirty` marker, or any future format re-detonates it. The policy fix covers the whole class.

Proceeding is a judgement call, so it is **visible** — a stderr warning, deduplicated per workspace so the guard's ancestor walk cannot spam it:

```
warning: .local_version in /path/.beads holds "not-a-version", which is not a recognized
version; treating the workspace as current. Run 'bd doctor' if this is unexpected.
```

**The confirmed verdicts stay fail-closed.** A witness that parses as pre-1.0 is still refused. A workspace with **no** witness is still refused — absence is itself evidence of a pre-0.29 vintage, so it is a confirmed answer, not an unanswerable one — and a blank witness carries no claim, so it still counts as absent. The `dolt/`-root embedded branch is structurally determined and deliberately untouched (`TestLegacyUpgradeGuardRefusesOldDoltRootWithoutTrustingVersionWitness` still passes unmodified).

## Proof

New `cmd/bd/legacy_upgrade_witness_test.go`. **Red before the fix** on the exact production string plus every other writer-emitted shape:

```
--- FAIL: .../go_pseudo-version          (v1.1.1-0.20260805093327-bf97b73749ac)
--- FAIL: .../prerelease                 (1.1.0-rc.1)
--- FAIL: .../v-prefixed_prerelease      (v1.1.0-rc.2)
--- FAIL: .../build_metadata             (1.2.1+build.20260805)
--- FAIL: .../major_minor_only           (v1.2)
--- FAIL: TestLegacyVersionMinorAcceptsPrereleaseAndPseudoVersions/legacy_prerelease
--- FAIL: TestLegacyServerVersionWindowSurvivesSuffixes/v0.62.0-rc.1
--- FAIL: TestLocalVersionWitnessRoundTrip/v1.1.1-0.20260805093327-bf97b73749ac
--- FAIL: TestLegacyUpgradeGuardTreatsUnreadableWitnessAsUnknown/not-a-version
```

`TestLegacyUpgradeGuardStillRefusesConfirmedLegacy` passed **before and after** — the guard direction that must not move never moved.

**Both directions, with real binaries** built from `origin/main` and from this branch:

| `.local_version` | before | after |
|---|---|---|
| `v1.1.1-0.20260805093327-bf97b73749ac` | **REFUSED** as legacy | admitted |
| `1.1.0-rc.1` | **REFUSED** as legacy | admitted |
| `1.2.1+build.20260805` | **REFUSED** as legacy | admitted |
| `not-a-version` | **REFUSED** as legacy | admitted + warning |
| `0.62.0` | refused as legacy | **refused as legacy** |

**Round trip:** `TestLocalVersionWitnessRoundTrip` calls the real `writeLocalVersion`, then reads back through both `readLocalVersion` and `legacyUpgradeVersionWitness` and runs the full guard against the production workspace shape — for `Version` itself plus every tag and pseudo-version form the pipeline emits. Writer and reader can no longer drift apart.

Two pre-existing subtests that encoded the old policy were updated deliberately, with the rationale in-line, not flipped silently.

## Gates

| Gate | Result |
|---|---|
| `go build ./...` | pass |
| `go vet ./...` | pass (also `CGO_ENABLED=1 go vet ./cmd/bd/` to compile the `//go:build cgo` e2e tests) |
| `gofmt` / `scripts/ci/fmt-check.sh` | pass |
| `golangci-lint run --config=.golangci.yml --build-tags=gms_pure_go ./cmd/bd/...` | **0 issues** |
| `go test ./cmd/bd/` | 14 failures, **byte-identical to a pristine `origin/main` baseline run** — all environment (no Dolt binary in the sandbox). Zero new failures. |
| `go test ./internal/... ./issueops/...` | pass |

Skipped, and why: the Dolt-backed and CGO integration tiers (`make test-migration`, `make test-cross-version`, `make test-upgrade`) — this sandbox has no `dolt` binary, which is what the 14 baseline failures are. They are unaffected by this change in any case: the touched symbols are package-private to `cmd/bd` (`grep` confirms no callers outside it), and the only behavior change is the guard's verdict on markers those suites do not write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)