### PR TITLE
fix(ci): require direct workflow build tags

### DIFF
--- a/.github/workflows/ci-measurements.yml
+++ b/.github/workflows/ci-measurements.yml
@@ -128,7 +128,7 @@ jobs:
           source scripts/ci/lib/timing.sh
           source ./.buildflags
 
-          ci_time "macos short go test" -- go test -v -race -short -skip '^TestEmbedded' ./...
+          ci_time "macos short go test" -- go test -tags=gms_pure_go -v -race -short -skip '^TestEmbedded' ./...
 
   macos-candidates:
     name: Measure macOS no-short candidates
@@ -493,7 +493,7 @@ jobs:
           source scripts/ci/lib/timing.sh
           source ./.buildflags
 
-          ci_time "build cmd/bd subprocess binary" -- go build -tags "$BEADS_BUILD_TAGS" -o artifacts/bd ./cmd/bd
+          ci_time "build cmd/bd subprocess binary" -- go build -tags gms_pure_go -o artifacts/bd ./cmd/bd
 
       - name: Upload prebuilt bd
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -661,7 +661,7 @@ jobs:
           source scripts/ci/lib/timing.sh
           source ./.buildflags
 
-          ci_time "build candidate binary" -- go build -o /tmp/bd-candidate ./cmd/bd
+          ci_time "build candidate binary" -- go build -tags gms_pure_go -o /tmp/bd-candidate ./cmd/bd
           export CANDIDATE_BIN=/tmp/bd-candidate
           if [[ -z "$SMOKE_VERSION" ]]; then
             SMOKE_VERSION="$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1 --json tagName --jq '.[0].tagName')"
@@ -757,4 +757,3 @@ jobs:
           path: artifacts/
           retention-days: 7
           if-no-files-found: ignore
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,9 +93,9 @@ jobs:
           source ./.buildflags
           go_version="$(go version)"
           commit="$(git rev-parse HEAD)"
-          go build -tags "$BEADS_BUILD_TAGS" -o artifacts/bd-linux-gms-pure ./cmd/bd
+          go build -tags gms_pure_go -o artifacts/bd-linux-gms-pure ./cmd/bd
           chmod +x artifacts/bd-linux-gms-pure
-          go test -tags "$BEADS_BUILD_TAGS" -c -o artifacts/bd-cmd-test ./cmd/bd
+          go test -tags gms_pure_go -c -o artifacts/bd-cmd-test ./cmd/bd
           chmod +x artifacts/bd-cmd-test
           (
             cd artifacts
@@ -130,9 +130,8 @@ jobs:
           path: ${{ runner.temp }}/go-cache/non-race
           key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-${{ github.sha }}
 
-  # Fast check: every `go build|test|run|generate|install` invocation in
-  # tracked scripts/hooks/CI carries -tags=gms_pure_go. Prevents ICU-linkage
-  # regressions from re-entering the build (see engdocs/ICU-POLICY.md).
+  # Fast shell/Make guard for direct source-time build-tag declarations.
+  # Workflow `run` steps are checked structurally in the required policy wrapper.
   check-build-tags:
     name: Check build-tag policy
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,7 +53,7 @@ jobs:
           source ./.buildflags
           go_version="$(go version)"
           commit="$(git rev-parse HEAD)"
-          go build -tags "$BEADS_BUILD_TAGS" -o artifacts/bd-linux-gms-pure ./cmd/bd
+          go build -tags gms_pure_go -o artifacts/bd-linux-gms-pure ./cmd/bd
           chmod +x artifacts/bd-linux-gms-pure
           (
             cd artifacts
@@ -151,9 +151,8 @@ jobs:
         run: |
           echo "::warning title=Example build check skipped::checkout or Go setup failed, so examples/ could not be checked this run (checkout: ${{ steps.checkout.outcome }}, setup-go: ${{ steps.setup-go.outcome }}). Advisory only; this does not block the merge."
 
-  # Fast check: every `go build|test|run|generate|install` invocation in
-  # tracked scripts/hooks/CI carries -tags=gms_pure_go. Prevents ICU-linkage
-  # regressions from re-entering the build (see engdocs/ICU-POLICY.md).
+  # Fast shell/Make guard for direct source-time build-tag declarations.
+  # Workflow `run` steps are checked structurally in the required policy wrapper.
   check-build-tags:
     name: Check build-tag policy
     runs-on: ubuntu-latest

--- a/engdocs/ICU-POLICY.md
+++ b/engdocs/ICU-POLICY.md
@@ -86,7 +86,7 @@ passes the tag inline (`-tags gms_pure_go`).
 
 CI runs `scripts/check-build-tags.sh` on every PR (see the `Check build-tag
 policy` job in `.github/workflows/pr.yml`). It fails if any tracked shell script,
-CI workflow, git hook, or the Makefile contains a
+git hook, or the Makefile contains a
 `go build|test|run|generate|install` invocation that:
 
 - does not carry `-tags=...gms_pure_go`, AND
@@ -95,8 +95,19 @@ CI workflow, git hook, or the Makefile contains a
   value contains `gms_pure_go`, AND
 - is not a third-party tool install (`go install X@version` / `go run X@version`).
 
-This is the source-time companion to `scripts/verify-cgo.sh` (runtime).
-Between the two, an ICU regression cannot reach a release binary.
+The required policy wrapper separately parses GitHub Actions YAML and checks
+the first recognizable direct first-party Go command on each logical line in
+`jobs.*.steps[*].run`. Each such command declares the literal `gms_pure_go` tag
+in its own `-tags` argument;
+sources and variables elsewhere in a workflow do not establish that source
+convention. This is deliberately not shell control-flow analysis: dynamic
+payloads, later compound-command segments, command substitutions, and
+sourced-script internals are outside the check's contract. The pinned-tool
+exception covers the repository's simple `go install path@version` and
+`go run path@version` source forms.
+
+These source-time guards complement `scripts/verify-cgo.sh`, which checks the
+release binary at runtime.
 
 To intentionally opt a file out (e.g. because it tests the ICU path),
 add `# build-tags: allow-bare` within the first five lines of the file.

--- a/scripts/check-build-tags.sh
+++ b/scripts/check-build-tags.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # check-build-tags.sh — source-time guard for ICU regression.
 #
-# Scans tracked scripts, CI workflows, and git hooks. Fails when a
+# Scans tracked shell scripts, git hooks, and the Makefile. Fails when a
 # `go build|test|run|generate|install` invocation neither:
 #   (a) carries -tags=...gms_pure_go itself, nor
 #   (b) appears in a file that sources .buildflags beforehand, nor
 #   (c) is an exempt third-party tool install (go install X@version).
 #
-# This is the source-time companion to scripts/verify-cgo.sh (which is a
-# runtime check on release binaries). See engdocs/ICU-POLICY.md.
+# GitHub Actions `run` steps are checked structurally by
+# scripts/checkworkflowtags. See engdocs/ICU-POLICY.md.
 
 set -euo pipefail
 
@@ -16,12 +16,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-# Candidate files: shell scripts, workflows, git hooks, the Makefile.
+# Candidate files: shell scripts, git hooks, and the Makefile. Workflow `run`
+# steps are checked structurally by scripts/checkworkflowtags.
 mapfile -t candidates < <(
     git ls-files \
         '*.sh' \
-        '.github/workflows/*.yml' \
-        '.github/workflows/*.yaml' \
         '.github/scripts/*' \
         '.githooks/*' \
         'Makefile' 2>/dev/null || true

--- a/scripts/checkworkflowtags/main.go
+++ b/scripts/checkworkflowtags/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/steveyegge/beads/scripts/workflowtags"
+)
+
+func main() {
+	violations, err := workflowtags.CheckDir(filepath.Join(".github", "workflows"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	for _, violation := range violations {
+		fmt.Fprintf(os.Stderr, "%s job %q step %q run line %d: %s\n", violation.Path, violation.Job, violation.Step, violation.Line, violation.Message)
+	}
+	if len(violations) != 0 {
+		os.Exit(1)
+	}
+	fmt.Println("workflow build-tag declarations: all direct commands clear")
+}

--- a/scripts/ci/pr-policy.sh
+++ b/scripts/ci/pr-policy.sh
@@ -103,6 +103,8 @@ build_docs_binary() {
 }
 
 ci_time "check build-tag policy" -- ./scripts/check-build-tags.sh
+ci_time "check workflow build-tag declarations" -- \
+    go run -tags=gms_pure_go ./scripts/checkworkflowtags
 ci_time "check go install guidance" -- ./scripts/check-go-install-guidance.sh
 ci_time "check version consistency" -- ./scripts/check-versions.sh
 ci_time "build bd for docs checks" -- build_docs_binary

--- a/scripts/workflowtags/workflowtags.go
+++ b/scripts/workflowtags/workflowtags.go
@@ -1,0 +1,292 @@
+// Package workflowtags checks the repository's source convention for direct Go
+// commands in GitHub Actions run steps. It recognizes only the first simple
+// command on each logical line and deliberately does not interpret arbitrary
+// shell control flow, substitutions, or sourced scripts.
+package workflowtags
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode"
+
+	"gopkg.in/yaml.v3"
+)
+
+var assignment = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*=`)
+
+// Violation identifies a direct workflow Go command missing the required tag.
+type Violation struct {
+	Path    string
+	Job     string
+	Step    string
+	Line    int
+	Message string
+}
+
+// CheckDir checks every workflow YAML file immediately under dir.
+func CheckDir(dir string) ([]Violation, error) {
+	paths, err := filepath.Glob(filepath.Join(dir, "*.y*ml"))
+	if err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no GitHub Actions workflows found under %s", dir)
+	}
+	sort.Strings(paths)
+
+	var violations []Violation
+	for _, path := range paths {
+		// #nosec G304 -- path is emitted by the bounded workflow glob above.
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		var workflow workflow
+		if err := yaml.Unmarshal(data, &workflow); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		jobNames := make([]string, 0, len(workflow.Jobs))
+		for jobName := range workflow.Jobs {
+			jobNames = append(jobNames, jobName)
+		}
+		sort.Strings(jobNames)
+		for _, jobName := range jobNames {
+			job := workflow.Jobs[jobName]
+			for stepIndex, step := range job.Steps {
+				stepName := step.Name
+				if stepName == "" {
+					stepName = fmt.Sprintf("step %d", stepIndex+1)
+				}
+				for _, runViolation := range CheckRun(step.Run) {
+					runViolation.Path = path
+					runViolation.Job = jobName
+					runViolation.Step = stepName
+					violations = append(violations, runViolation)
+				}
+			}
+		}
+	}
+	return violations, nil
+}
+
+type workflow struct {
+	Jobs map[string]workflowJob `yaml:"jobs"`
+}
+
+type workflowJob struct {
+	Steps []workflowStep `yaml:"steps"`
+}
+
+type workflowStep struct {
+	Name string `yaml:"name"`
+	Run  string `yaml:"run"`
+}
+
+// CheckRun checks recognizable direct commands in one decoded run scalar.
+func CheckRun(run string) []Violation {
+	lines := strings.Split(strings.ReplaceAll(run, "\r\n", "\n"), "\n")
+	var violations []Violation
+	for i := 0; i < len(lines); i++ {
+		lineNumber := i + 1
+		logical := lines[i]
+		for trailingUnquotedBackslash(logical) && i+1 < len(lines) {
+			logical = strings.TrimSpace(strings.TrimSuffix(strings.TrimRightFunc(logical, unicode.IsSpace), "\\")) + " " + strings.TrimSpace(lines[i+1])
+			i++
+		}
+
+		words, err := tokenize(logical)
+		if err != nil {
+			// Malformed or complex shell syntax is outside this bounded source check.
+			continue
+		}
+		goArgs, ok := directGoArgs(words)
+		if !ok || exemptVersionedTool(goArgs) || hasRequiredTag(goArgs) {
+			continue
+		}
+		violations = append(violations, Violation{
+			Line:    lineNumber,
+			Message: fmt.Sprintf("direct `go %s` must declare literal gms_pure_go in -tags", goArgs[0]),
+		})
+	}
+	return violations
+}
+
+func directGoArgs(words []string) ([]string, bool) {
+	words = skipEnvPrefix(words)
+	if len(words) > 0 && words[0] == "ci_time" {
+		separator := -1
+		for i, word := range words[1:] {
+			if word == "--" {
+				separator = i + 1
+				break
+			}
+		}
+		if separator < 0 {
+			return nil, false
+		}
+		words = skipEnvPrefix(words[separator+1:])
+	}
+	if len(words) < 2 || words[0] != "go" {
+		return nil, false
+	}
+	switch words[1] {
+	case "build", "test", "run", "generate", "install":
+		return words[1:], true
+	default:
+		return nil, false
+	}
+}
+
+func skipEnvPrefix(words []string) []string {
+	if len(words) > 0 && words[0] == "env" {
+		words = words[1:]
+		for len(words) > 0 {
+			switch {
+			case words[0] == "--":
+				words = words[1:]
+				goto assignments
+			case words[0] == "-i" || words[0] == "--ignore-environment":
+				words = words[1:]
+			case words[0] == "-u" || words[0] == "--unset" || words[0] == "-C" || words[0] == "--chdir":
+				if len(words) < 2 {
+					return nil
+				}
+				words = words[2:]
+			case strings.HasPrefix(words[0], "--unset=") || strings.HasPrefix(words[0], "--chdir="):
+				words = words[1:]
+			default:
+				goto assignments
+			}
+		}
+	}
+assignments:
+	for len(words) > 0 && assignment.MatchString(words[0]) {
+		words = words[1:]
+	}
+	return words
+}
+
+func hasRequiredTag(goArgs []string) bool {
+	lastTags := ""
+	found := false
+	for i := 1; i < len(goArgs); i++ {
+		arg := goArgs[i]
+		if arg == "--" || (goArgs[0] == "test" && arg == "-args") {
+			break
+		}
+		switch {
+		case arg == "-tags":
+			if i+1 >= len(goArgs) {
+				lastTags = ""
+				found = true
+				break
+			}
+			i++
+			lastTags = goArgs[i]
+			found = true
+		case strings.HasPrefix(arg, "-tags="):
+			lastTags = strings.TrimPrefix(arg, "-tags=")
+			found = true
+		}
+	}
+	if !found {
+		return false
+	}
+	for _, tag := range strings.FieldsFunc(lastTags, func(r rune) bool { return r == ',' || unicode.IsSpace(r) }) {
+		if tag == "gms_pure_go" {
+			return true
+		}
+	}
+	return false
+}
+
+// The repository's pinned-tool convention is intentionally narrow: unflagged
+// external package operands with versions. For go run, later words are program
+// arguments; for go install, every package operand must qualify.
+func exemptVersionedTool(goArgs []string) bool {
+	if len(goArgs) < 2 || (goArgs[0] != "run" && goArgs[0] != "install") {
+		return false
+	}
+	packages := goArgs[1:]
+	if goArgs[0] == "run" {
+		packages = packages[:1]
+	}
+	for _, pkg := range packages {
+		at := strings.LastIndexByte(pkg, '@')
+		if at <= 0 || at == len(pkg)-1 || strings.HasPrefix(pkg, ".") || strings.HasPrefix(pkg, "/") || !strings.Contains(pkg[:at], "/") {
+			return false
+		}
+	}
+	return true
+}
+
+func trailingUnquotedBackslash(line string) bool {
+	trimmed := strings.TrimRightFunc(line, unicode.IsSpace)
+	if !strings.HasSuffix(trimmed, "\\") {
+		return false
+	}
+	backslashes := 0
+	for i := len(trimmed) - 1; i >= 0 && trimmed[i] == '\\'; i-- {
+		backslashes++
+	}
+	return backslashes%2 == 1
+}
+
+// tokenize covers only the simple command source forms owned by this check.
+// At the first unquoted shell operator it returns the first simple command.
+func tokenize(line string) ([]string, error) {
+	var words []string
+	var word strings.Builder
+	var quote rune
+	escaped := false
+	flush := func() {
+		if word.Len() > 0 {
+			words = append(words, word.String())
+			word.Reset()
+		}
+	}
+
+	for _, r := range strings.TrimSpace(line) {
+		if escaped {
+			word.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			} else if r == '\\' && quote == '"' {
+				escaped = true
+			} else {
+				word.WriteRune(r)
+			}
+			continue
+		}
+		switch {
+		case r == '\\':
+			escaped = true
+		case r == '\'' || r == '"':
+			quote = r
+		case unicode.IsSpace(r):
+			flush()
+		case r == '#' && word.Len() == 0:
+			return words, nil
+		case r == '#':
+			word.WriteRune(r)
+		case r == ';' || r == '|' || r == '&':
+			flush()
+			return words, nil
+		default:
+			word.WriteRune(r)
+		}
+	}
+	if escaped || quote != 0 {
+		return nil, fmt.Errorf("unterminated quote or escape")
+	}
+	flush()
+	return words, nil
+}

--- a/scripts/workflowtags/workflowtags_test.go
+++ b/scripts/workflowtags/workflowtags_test.go
@@ -1,0 +1,119 @@
+package workflowtags
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		run        string
+		violations int
+	}{
+		{name: "direct tagged", run: `go test -tags=gms_pure_go ./...`},
+		{name: "assignment prefix", run: `CGO_ENABLED=0 go build -tags "netgo,gms_pure_go" ./cmd/bd`},
+		{name: "env prefix", run: `env CGO_ENABLED=0 go test '-tags=integration,gms_pure_go' ./...`},
+		{name: "env unset", run: `env -u GOFLAGS go test ./...`, violations: 1},
+		{name: "env long unset operand", run: `env --unset GOFLAGS go test ./...`, violations: 1},
+		{name: "env long unset", run: `env --unset=GOFLAGS go test ./...`, violations: 1},
+		{name: "env chdir", run: `env -C /tmp go build ./cmd/bd`, violations: 1},
+		{name: "env long chdir", run: `env --chdir /tmp go build ./cmd/bd`, violations: 1},
+		{name: "env ignore environment tagged", run: `env -i go test -tags=gms_pure_go ./...`},
+		{name: "env double dash", run: `env -- go test ./...`, violations: 1},
+		{name: "timed command", run: `ci_time "label mentions go test" -- go test -tags gms_pure_go ./...`},
+		{name: "quoted hash", run: `go test -tags=gms_pure_go -run 'Test#Case' ./...`},
+		{name: "continuation", run: "go test \\\n  -tags=gms_pure_go \\\n  ./..."},
+		{name: "pinned install", run: `go install example.com/tool@v1.2.3`},
+		{name: "multiple pinned installs", run: `go install example.com/tool@v1.2.3 example.com/other@latest`},
+		{name: "pinned run", run: `go run example.com/tool@latest`},
+		{name: "pinned run arguments", run: `go run example.com/tool@latest --help`},
+		{name: "pinned tool with flags is outside exemption", run: `go install -pgo off example.com/tool@v1.2.3`, violations: 1},
+		{name: "bare", run: `go test ./...`, violations: 1},
+		{name: "source is not workflow authority", run: "source ./.buildflags\ngo test ./...", violations: 1},
+		{name: "variable tag", run: `go build -tags "$BEADS_BUILD_TAGS" ./cmd/bd`, violations: 1},
+		{name: "tag substring prefix", run: `go test -tags=notgms_pure_go ./...`, violations: 1},
+		{name: "tag substring suffix", run: `go test -tags=gms_pure_go_extra ./...`, violations: 1},
+		{name: "last tag wins negative", run: `go test -tags=gms_pure_go -tags=integration ./...`, violations: 1},
+		{name: "last tag wins positive", run: `go test -tags=integration -tags=gms_pure_go ./...`},
+		{name: "tag after separator", run: `go test ./... -- -tags=gms_pure_go`, violations: 1},
+		{name: "tag after test args", run: `go test ./... -args -tags=gms_pure_go`, violations: 1},
+		{name: "missing tag value", run: `go test -tags ./...`, violations: 1},
+		{name: "unrelated version text", run: `go run ./cmd/bd --label @v1`, violations: 1},
+		{name: "unquoted hash is argument text", run: `go test -run Test#Case -tags=gms_pure_go ./...`},
+		{name: "compound suffix outside bounded command", run: `go test -tags=gms_pure_go ./... && go test ./...`},
+		{name: "compound suffix cannot authorize first command", run: `go test ./... && go test -tags=gms_pure_go ./...`, violations: 1},
+		{name: "dynamic shell excluded", run: `bash -c 'go test ./...'`},
+		{name: "eval excluded", run: `eval 'go test ./...'`},
+		{name: "substitution excluded", run: `out="$(go test ./...)"`},
+		{name: "wrapper excluded", run: `gotestsum -- -tags=gms_pure_go ./...`},
+		{name: "comment ignored", run: `# explain go test behavior`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CheckRun(tt.run)
+			if len(got) != tt.violations {
+				t.Fatalf("got %d violation(s), want %d: %#v", len(got), tt.violations, got)
+			}
+		})
+	}
+}
+
+func TestCheckDirParsesOnlyRunScalars(t *testing.T) {
+	dir := t.TempDir()
+	fixture := `name: Explain go test behavior
+jobs:
+  check:
+    steps:
+      - name: Inline
+        run: go test -tags=gms_pure_go ./...
+      - name: Literal
+        run: |
+          go build -tags gms_pure_go ./cmd/bd
+      - name: Folded
+        run: >-
+          go test
+          -tags=gms_pure_go
+          ./...
+`
+	if err := os.WriteFile(filepath.Join(dir, "fixture.yml"), []byte(fixture), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	violations, err := CheckDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("unexpected violations: %#v", violations)
+	}
+}
+
+func TestCheckDirRejectsCrossStepSourceAuthority(t *testing.T) {
+	dir := t.TempDir()
+	fixture := `jobs:
+  check:
+    steps:
+      - name: Source flags
+        run: source ./.buildflags
+      - name: Bare command
+        run: go test ./...
+`
+	if err := os.WriteFile(filepath.Join(dir, "fixture.yml"), []byte(fixture), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	violations, err := CheckDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(violations) != 1 || violations[0].Step != "Bare command" {
+		t.Fatalf("violations = %#v, want one in Bare command", violations)
+	}
+}
+
+func TestCheckDirRejectsEmptyInventory(t *testing.T) {
+	if _, err := CheckDir(t.TempDir()); err == nil {
+		t.Fatal("CheckDir succeeded without workflow files")
+	}
+}


### PR DESCRIPTION
## What

Parse GitHub Actions workflow `run` scalars structurally and require the first recognizable direct first-party Go command on each logical line to declare the literal `gms_pure_go` tag.

The fast Bash checker keeps its existing shell, hook, and Make contracts. Workflow source validation moves into a small Go command in the already Go-enabled required policy wrapper.

The review nit also recognizes Go's `--tags=value` and `--tags value` spellings, preserves mixed-alias last-value-wins behavior, and stops scanning at `--args` as well as the existing argument cutoffs. The existing regression table covers those cases.

## Why

The Bash checker treated one `.buildflags` source or tag variable anywhere in a workflow file as authority for every Go command in that file. GitHub Actions steps use separate shells, so this could make the required gate report success for a bare command in another step.

Parsing YAML avoids treating workflow names and other metadata as commands, and it handles inline, literal, and folded `run` scalars without a YAML parser written in Bash. The recognizer is intentionally a source convention rather than shell control-flow analysis; its exact limits are documented in the issue and ICU policy.

Fixes #5527.

## Validation

Current local results are for head `271172bf66e12480ea4cce7a9353d698f9df9efc`, merged with base `f56632adcfabed7da6ed0aabe4e760066b472c46`, on native Windows. These replace the earlier-head results.

Passed:

- `CGO_ENABLED=0 go test -tags=gms_pure_go -count=1 ./scripts/workflowtags`: all 4 parent tests and 51 table cases passed; no skips.
- `CGO_ENABLED=0 go test -tags=integration,gms_pure_go -count=1 ./scripts`: 124 passed outcomes and 36 explicit skips. All 16 required CI structural tests and 10 doc-freshness parent tests passed.
- `CGO_ENABLED=0 go test -tags=gms_pure_go -count=1 ./test/docsync`: all 6 tests passed.
- The complete workflow checker, direct `scripts/check-build-tags.sh` (82 files), and actionlint on all three changed workflows.
- The actual `mingw32-make ci-pr-lint` wrapper, with no merge-base lint restriction: formatting and both the native and Windows/non-CGO lint passes completed with zero findings.
- `git diff --check`.

The aggregate native baseline remains failing:

- `mingw32-make ci-pr-policy` passed its preceding checks and API regeneration, then failed in `internal/httpapi` at `TestNewTokenFileAuthRefusesAnUnusableFile/missing`: the unchanged test expects Unix `no such file` wording, while Windows returns `The system cannot find the file specified.` This existing token-file diagnostic mismatch is tracked in #6543.
- One normal `mingw32-make test` run completed with failures in 12 packages: `cmd/bd`, `cmd/bd/doctor`, `cmd/bd/setup`, `internal/atomicfile`, `internal/beads`, `internal/config`, `internal/configfile`, `internal/hooks`, `internal/httpapi`, `internal/metrics`, `internal/testutil`, and `internal/workspacegate`. The run reports 76 failed test leaves plus the `internal/testutil` Windows compile failure (`checkDolt`/`doltReady` are unavailable). It also identifies existing native path, permission, executable-fixture, and HOME/USERPROFILE mismatches, including a path-boundary guard gap. Worktree/config discovery, file lifetime, prime override, and some error/config behavior remain unlocalized.

This PR changes no cmd/ or internal/ source. Unchanged blobs alone do not establish environment causality. The failing policy and normal-suite results are retained as failures; they are not a clean-baseline claim.

_codex-unknown-model-unknown-reasoning on behalf of Ewen Cuthiell_
