### PR TITLE
docs(cli): say which direction --reverse reverses from

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -415,7 +415,7 @@ func init() {
 	listCmd.Flags().Bool("all", false, "Show all issues including closed (overrides default filter)")
 	listCmd.Flags().Bool("long", false, "Show detailed multi-line output for each issue")
 	listCmd.Flags().String("sort", "", "Sort by field: priority, created, updated, closed, status, id, title, type, assignee")
-	listCmd.Flags().BoolP("reverse", "r", false, "Reverse sort order")
+	listCmd.Flags().BoolP("reverse", "r", false, "Invert the sort field's default direction (created/updated/closed default to newest-first, so --sort updated --reverse is oldest-first)")
 
 	// Pattern matching
 	listCmd.Flags().String("title-contains", "", "Filter by title substring (case-insensitive)")

--- a/cmd/bd/query.go
+++ b/cmd/bd/query.go
@@ -290,7 +290,7 @@ func init() {
 	queryCmd.Flags().BoolP("all", "a", false, "Include closed issues (default: exclude closed)")
 	queryCmd.Flags().Bool("long", false, "Show detailed multi-line output for each issue")
 	queryCmd.Flags().String("sort", "", "Sort by field: priority, created, updated, closed, status, id, title, type, assignee")
-	queryCmd.Flags().BoolP("reverse", "r", false, "Reverse sort order")
+	queryCmd.Flags().BoolP("reverse", "r", false, "Invert the sort field's default direction (created/updated/closed default to newest-first, so --sort updated --reverse is oldest-first)")
 	queryCmd.Flags().Bool("parse-only", false, "Only parse the query and show the AST (for debugging)")
 
 	rootCmd.AddCommand(queryCmd)

--- a/cmd/bd/search.go
+++ b/cmd/bd/search.go
@@ -366,7 +366,7 @@ func init() {
 	searchCmd.Flags().IntP("limit", "n", 50, "Limit results (default: 50)")
 	searchCmd.Flags().Bool("long", false, "Show detailed multi-line output for each issue")
 	searchCmd.Flags().String("sort", "", "Sort by field: priority, created, updated, closed, status, id, title, type, assignee")
-	searchCmd.Flags().BoolP("reverse", "r", false, "Reverse sort order")
+	searchCmd.Flags().BoolP("reverse", "r", false, "Invert the sort field's default direction (created/updated/closed default to newest-first, so --sort updated --reverse is oldest-first)")
 
 	// Date range flags
 	searchCmd.Flags().String("created-after", "", "Filter issues created after date (YYYY-MM-DD or RFC3339)")


### PR DESCRIPTION
## What

Spells out, in the `--reverse` help on `bd list`, `bd search`, and `bd query`, which direction the flag reverses from. Help text only, no behavior change.

## Why

The date sort fields already default to newest-first (`created`, `updated`, `closed` in `sqlbuild.SortDefs`), and `--reverse` inverts whatever that field's default is. The help said only "Reverse sort order", which reads as "give me newest first" and returns the opposite.

Concretely, `bd list --sort updated --reverse` returns oldest-first. I hit this in daily use and spent a while assuming the sort was broken before reading `internal/storage/sqlbuild/sort.go`.

Before:

```
-r, --reverse   Reverse sort order
```

After:

```
-r, --reverse   Invert the sort field's default direction (created/updated/closed default to newest-first, so --sort updated --reverse is oldest-first)
```

The behavior itself looks like settled semantics, so this changes only the description.

## Verification

Ordering confirmed unchanged, on a scratch workspace with stock bd and no orchestrator:

```
bd list --sort updated --json           -> 01:12:15, 01:12:13, 01:12:11   (newest first)
bd list --sort updated --reverse --json -> 01:12:11, 01:12:13, 01:12:15   (oldest first)
```

Gates run:

- `go build -tags gms_pure_go ./...`
- `./scripts/test.sh -run 'Help|Flag|Usage|Sort|Reverse' ./cmd/bd/...`
- `make test`, 92 packages ok, no failures
- `./scripts/check-cli-docs-drift.sh --base main` reports "generated CLI docs are fresh"

Two notes for the reviewer:

1. I deliberately did not regenerate `docs/CLI_REFERENCE.md` or `docs/cli-reference/`. Those build from the tag pinned in `docs/cli-docs.pin` (v1.1.0), not from HEAD, so they should pick this up at the next release pin bump. The drift check passes as-is.
2. `make ci-pr-lint` fails locally for me with 2 gosec findings, in `internal/config/permissions_open_nonlinux.go` (G304) and `internal/utils/path_case_darwin.go` (G103). Both are pre-existing on a clean `main` (confirmed by stashing this change and rerunning) and sit in darwin/non-linux build-constrained files, so I do not think CI's Linux runners lint them. Untouched by this PR.
