### PR TITLE
fix(cli): --until, --defer and --due rejections name the supported unit set

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -244,7 +244,7 @@ var createCmd = &cobra.Command{
 		if dueStr != "" {
 			t, err := timeparsing.ParseRelativeTime(dueStr, time.Now())
 			if err != nil {
-				return HandleError("invalid --due format %q. Examples: +6h, tomorrow, next monday, 2025-01-15", dueStr)
+				return HandleError("invalid --due format %q. %s", dueStr, deferUntilFormatHint)
 			}
 			dueAt = &t
 		}
@@ -254,7 +254,7 @@ var createCmd = &cobra.Command{
 		if deferStr != "" {
 			t, err := timeparsing.ParseRelativeTime(deferStr, time.Now())
 			if err != nil {
-				return HandleError("invalid --defer format %q. Examples: +1h, tomorrow, next monday, 2025-01-15", deferStr)
+				return HandleError("invalid --defer format %q. %s", deferStr, deferUntilFormatHint)
 			}
 			// Warn if defer date is in the past (user probably meant future)
 			if t.Before(time.Now()) && !silent && !debug.IsQuiet() {

--- a/cmd/bd/create_input.go
+++ b/cmd/bd/create_input.go
@@ -235,7 +235,7 @@ func gatherCreateInput(cmd *cobra.Command, args []string) (createInput, error) {
 	if dueStr, _ := cmd.Flags().GetString("due"); dueStr != "" {
 		t, err := timeparsing.ParseRelativeTime(dueStr, time.Now())
 		if err != nil {
-			return in, HandleError("invalid --due format %q. Examples: +6h, tomorrow, next monday, 2025-01-15", dueStr)
+			return in, HandleError("invalid --due format %q. %s", dueStr, deferUntilFormatHint)
 		}
 		in.dueAt = &t
 	}
@@ -243,7 +243,7 @@ func gatherCreateInput(cmd *cobra.Command, args []string) (createInput, error) {
 	if deferStr, _ := cmd.Flags().GetString("defer"); deferStr != "" {
 		t, err := timeparsing.ParseRelativeTime(deferStr, time.Now())
 		if err != nil {
-			return in, HandleError("invalid --defer format %q. Examples: +1h, tomorrow, next monday, 2025-01-15", deferStr)
+			return in, HandleError("invalid --defer format %q. %s", deferStr, deferUntilFormatHint)
 		}
 		if t.Before(time.Now()) && !in.silent && !debug.IsQuiet() {
 			fmt.Fprintf(os.Stderr, "%s Defer date %q is in the past. Issue will appear in bd ready immediately.\n",

--- a/cmd/bd/defer.go
+++ b/cmd/bd/defer.go
@@ -14,6 +14,8 @@ import (
 	"github.com/steveyegge/beads/internal/utils"
 )
 
+const deferUntilFormatHint = "Use a relative offset [+-]<n><unit> with unit h=hours, d=days, w=weeks, m=months, y=years (+1h, +3m), natural language (tomorrow, next monday), or a date (2025-01-15)"
+
 var deferCmd = &cobra.Command{
 	Use:   "defer [id...]",
 	Short: "Defer one or more issues for later",
@@ -52,7 +54,7 @@ Examples:
 		if untilStr != "" {
 			t, err := timeparsing.ParseRelativeTime(untilStr, time.Now())
 			if err != nil {
-				return HandleError("invalid --until format %q. Examples: +1h, tomorrow, next monday, 2025-01-15", untilStr)
+				return HandleError("invalid --until format %q. %s", untilStr, deferUntilFormatHint)
 			}
 			if t.Before(time.Now()) && !jsonOutput {
 				fmt.Fprintf(os.Stderr, "%s Defer date %q is in the past. Issue will appear in bd ready immediately.\n",

--- a/cmd/bd/defer_until_hint_test.go
+++ b/cmd/bd/defer_until_hint_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/timeparsing"
 )
 
@@ -62,5 +66,102 @@ func TestDeferUntilRejectionNamesUnitSet(t *testing.T) {
 		if !strings.Contains(output, unit) {
 			t.Errorf("expected the error to name %q, got: %s", unit, output)
 		}
+	}
+}
+
+// TestRelativeTimeRejectionsShareTheHint guards the half of this fix that no
+// behavioural test can reach cheaply. --defer and --due land on the same
+// parser as --until, through the direct create and update paths and through
+// their proxied-input twins, so a caller who mistypes any of them deserves the
+// same unit set. A site that re-inlines its own example list still passes every
+// call-level test while sending that caller back on the hunt, which is why the
+// uniformity is pinned at the source. Blunt line matching, in the style of
+// TestCobraParallelPolicyGuard.
+func TestRelativeTimeRejectionsShareTheHint(t *testing.T) {
+	sources, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+
+	rejection := regexp.MustCompile(`invalid --(?:until|defer|due) format`)
+	found := 0
+
+	for _, file := range sources {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		for i, line := range strings.Split(string(data), "\n") {
+			if !rejection.MatchString(line) {
+				continue
+			}
+			found++
+			if !strings.Contains(line, "deferUntilFormatHint") {
+				t.Errorf("%s:%d rejects a relative-time flag without the shared hint: %s",
+					file, i+1, strings.TrimSpace(line))
+			}
+		}
+	}
+
+	if found == 0 {
+		t.Fatal("found no relative-time rejection sites; the guard is matching nothing")
+	}
+}
+
+// TestGatherInputRejectionsNameUnitSet exercises the proxied-input paths for
+// both flags that share the hint, so the unit set is proven to reach a real
+// caller rather than only to be present in the constant.
+func TestGatherInputRejectionsNameUnitSet(t *testing.T) {
+	prevJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = prevJSON })
+
+	units := []string{"h=hours", "d=days", "w=weeks", "m=months", "y=years"}
+
+	assertNamesUnits := func(t *testing.T, flag, output string) {
+		t.Helper()
+		if !strings.Contains(output, `invalid `+flag+` format "+3mo"`) {
+			t.Fatalf("expected the rejected %s value in the error, got: %s", flag, output)
+		}
+		for _, unit := range units {
+			if !strings.Contains(output, unit) {
+				t.Errorf("expected the %s error to name %q, got: %s", flag, unit, output)
+			}
+		}
+	}
+
+	for _, flag := range []string{"--due", "--defer"} {
+		t.Run("create "+flag, func(t *testing.T) {
+			cmd := newCreateFlagsCommand(t, flag, "+3mo")
+			var err error
+			output := captureStderr(t, func() {
+				_, err = gatherCreateInput(cmd, []string{"title"})
+			})
+			if err == nil {
+				t.Fatalf("expected %s=+3mo to fail", flag)
+			}
+			assertNamesUnits(t, flag, output)
+		})
+
+		t.Run("update "+flag, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "update"}
+			cmd.Flags().String("due", "", "Due date")
+			cmd.Flags().String("defer", "", "Defer until")
+			cmd.Flags().Bool("json", false, "JSON output")
+			if err := cmd.ParseFlags([]string{flag, "+3mo"}); err != nil {
+				t.Fatalf("parse update flags: %v", err)
+			}
+			var err error
+			output := captureStderr(t, func() {
+				_, err = gatherUpdateInput(t.Context(), cmd)
+			})
+			if err == nil {
+				t.Fatalf("expected %s=+3mo to fail", flag)
+			}
+			assertNamesUnits(t, flag, output)
+		})
 	}
 }

--- a/cmd/bd/defer_until_hint_test.go
+++ b/cmd/bd/defer_until_hint_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/timeparsing"
+)
+
+// TestDeferUntilFormatHintCoversCompactUnits keeps the --until failure message
+// and the parser it describes in step. "+3mo" is rejected while "+3m" is three
+// months, so a message naming one example leaves the caller trying units one at
+// a time to find the boundary.
+func TestDeferUntilFormatHintCoversCompactUnits(t *testing.T) {
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	for _, unit := range []string{"h", "d", "w", "m", "y"} {
+		value := "+3" + unit
+		if _, err := timeparsing.ParseRelativeTime(value, now); err != nil {
+			t.Errorf("parser rejected %q, which the --until hint names as supported: %v", value, err)
+		}
+		if !strings.Contains(deferUntilFormatHint, unit+"=") {
+			t.Errorf("--until hint does not name unit %q: %s", unit, deferUntilFormatHint)
+		}
+	}
+
+	if _, err := timeparsing.ParseRelativeTime("+3mo", now); err == nil {
+		t.Fatal("expected +3mo to be rejected; the hint exists to send that caller to +3m")
+	}
+	if !strings.Contains(deferUntilFormatHint, "+3m") {
+		t.Errorf("--until hint should show the month form +3m: %s", deferUntilFormatHint)
+	}
+}
+
+// TestDeferUntilRejectionNamesUnitSet exercises the real --until failure path
+// and asserts the unit set reaches stderr, so dropping the hint from the error
+// fails here rather than only degrading the message.
+func TestDeferUntilRejectionNamesUnitSet(t *testing.T) {
+	if err := deferCmd.Flags().Set("until", "+3mo"); err != nil {
+		t.Fatalf("setting --until: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := deferCmd.Flags().Set("until", ""); err != nil {
+			t.Fatalf("resetting --until: %v", err)
+		}
+		deferCmd.Flags().Lookup("until").Changed = false
+	})
+
+	var err error
+	output := captureStderr(t, func() {
+		err = deferCmd.RunE(deferCmd, []string{"t-1"})
+	})
+
+	if err == nil {
+		t.Fatal("expected --until=+3mo to fail")
+	}
+	if !strings.Contains(output, `invalid --until format "+3mo"`) {
+		t.Fatalf("expected the rejected value in the error, got: %s", output)
+	}
+	for _, unit := range []string{"h=hours", "d=days", "w=weeks", "m=months", "y=years"} {
+		if !strings.Contains(output, unit) {
+			t.Errorf("expected the error to name %q, got: %s", unit, output)
+		}
+	}
+}

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -285,7 +285,7 @@ pointless).`,
 			} else {
 				t, err := timeparsing.ParseRelativeTime(dueStr, time.Now())
 				if err != nil {
-					return HandleErrorRespectJSON("invalid --due format %q. Examples: +6h, tomorrow, next monday, 2025-01-15", dueStr)
+					return HandleErrorRespectJSON("invalid --due format %q. %s", dueStr, deferUntilFormatHint)
 				}
 				updates["due_at"] = t
 			}
@@ -302,7 +302,7 @@ pointless).`,
 			} else {
 				t, err := timeparsing.ParseRelativeTime(deferStr, time.Now())
 				if err != nil {
-					return HandleErrorRespectJSON("invalid --defer format %q. Examples: +1h, tomorrow, next monday, 2025-01-15", deferStr)
+					return HandleErrorRespectJSON("invalid --defer format %q. %s", deferStr, deferUntilFormatHint)
 				}
 				// Warn if defer date is in the past (user probably meant future)
 				inPast := t.Before(time.Now())

--- a/cmd/bd/update_input.go
+++ b/cmd/bd/update_input.go
@@ -176,7 +176,7 @@ func gatherUpdateInput(ctx context.Context, cmd *cobra.Command) (*updateInput, e
 		} else {
 			t, err := timeparsing.ParseRelativeTime(dueStr, time.Now())
 			if err != nil {
-				return nil, HandleErrorRespectJSON("invalid --due format %q. Examples: +6h, tomorrow, next monday, 2025-01-15", dueStr)
+				return nil, HandleErrorRespectJSON("invalid --due format %q. %s", dueStr, deferUntilFormatHint)
 			}
 			in.fields["due_at"] = t
 		}
@@ -192,7 +192,7 @@ func gatherUpdateInput(ctx context.Context, cmd *cobra.Command) (*updateInput, e
 		} else {
 			t, err := timeparsing.ParseRelativeTime(deferStr, time.Now())
 			if err != nil {
-				return nil, HandleErrorRespectJSON("invalid --defer format %q. Examples: +1h, tomorrow, next monday, 2025-01-15", deferStr)
+				return nil, HandleErrorRespectJSON("invalid --defer format %q. %s", deferStr, deferUntilFormatHint)
 			}
 			inPast := t.Before(time.Now())
 			if inPast && !jsonOut {


### PR DESCRIPTION
## What

Makes the relative-time rejection messages name the unit set the parser actually accepts, across every flag that reaches that parser: `bd defer --until`, and `--defer` and `--due` on both `bd create` and `bd update`. Message only, parsing behavior untouched.

## Why

`bd defer <id> --until "+3mo"` fails with:

```
invalid --until format "+3mo". Examples: +1h, tomorrow, next monday, 2025-01-15
```

The examples jump from a single hours case straight to absolute dates and never state which units exist, so the boundary has to be found by trial. What makes it costly is that the feature is already there: the compact-duration parser accepts `h`, `d`, `w`, `m` and `y`, so months work fine spelled `+3m`. We assumed months were unsupported and used absolute dates for a while before reading `internal/timeparsing`.

After:

```
invalid --until format "+3mo". Use a relative offset [+-]<n><unit> with unit
h=hours, d=days, w=weeks, m=months, y=years (+1h, +3m), natural language
(tomorrow, next monday), or a date (2025-01-15)
```

`--until` was only one door onto that parser. The same message sat at eight other sites, so `bd create --defer +3mo` and `bd update --defer +3mo` sent the caller on the same hunt. All of them now share one constant:

- `cmd/bd/create.go` (`--due`, `--defer`) and `cmd/bd/create_input.go` (the proxied-server input path)
- `cmd/bd/update.go` (`--due`, `--defer`) and `cmd/bd/update_input.go` (same, proxied)

`--due` is included because it lands on the same `timeparsing.ParseRelativeTime`, so the hint is equally true there.

## Verification

Months already work and are genuinely calendar months, not day approximations, on a scratch workspace with stock bd and no orchestrator:

```
--until +3m   -> defer_until 2026-11-12
--until +90d  -> defer_until 2026-11-11
```

Different results, so `m` is `AddDate(0, n, 0)` rather than a day count.

Gates:

- `go build -tags gms_pure_go ./...`
- `./scripts/test.sh ./cmd/bd/...` passes
- `make test` passes
- `./scripts/check-cli-docs-drift.sh --base main` reports the generated CLI docs are fresh. I did not regenerate `docs/CLI_REFERENCE.md` or `docs/cli-reference/`, since they build from the tag pinned in `docs/cli-docs.pin` rather than from HEAD.

Three tests cover this. The existing pin keeps the hint and the parser in step: every unit the hint names must actually parse, and `+3mo` must still be rejected. A source guard then fails if any rejection site stops using the shared constant, which is the only way to catch a site that re-inlines its own example list while still passing every call-level test. A behavioural test drives the two proxied-input paths for both flags and asserts the unit set reaches the caller. Reverting any single site fails at least one of them.

Two notes on the local gates, both pre-existing and untouched by this PR:

- `golangci-lint` reports 2 gosec findings, in `internal/config/permissions_open_nonlinux.go` (G304) and `internal/utils/path_case_darwin.go` (G103). Both sit in darwin/non-linux build-constrained files. Scoped the way the PR workflow scopes it (`--new-from-merge-base`), this branch reports 0 issues.
- `make ci-pr-lint`'s gofmt step currently fails on three files that are already unformatted on `main`: `internal/storage/{dolt,embeddeddolt,uow}/role_fixture_kit_test.go`. Not mine, but you may want to know the gate is red on main.

## Follow-up I deliberately left out

The `--until` flag's own help string has the same gap:

```go
deferCmd.Flags().String("until", "", "Defer until specific time (e.g., +1h, tomorrow, next monday)")
```

That is where a user looks first, so it is arguably the more valuable half. I kept it out to hold this PR to one concern. Happy to send it separately, or fold it in here.
