### PR TITLE
fix(cli): document that bd list --format exports the dependency graph

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -411,7 +411,7 @@ func init() {
 	listCmd.Flags().String("id", "", "Filter by specific issue IDs (comma-separated, e.g., bd-1,bd-5,bd-10)")
 	listCmd.Flags().IntP("limit", "n", workapi.DefaultListLimit, "Limit results (default 50, use 0 for unlimited)")
 	listCmd.Flags().Int("offset", 0, "Skip the first N matching results (0-based). Only supported under --proxied-server.")
-	listCmd.Flags().String("format", "", "Export the dependency graph of the listed issues: 'digraph' (edge list for golang.org/x/tools/cmd/digraph), 'dot' (Graphviz), or a Go template rendered once per edge over .IssueID, .DependsOnID, .Type, .Issue, .Dependency. 'digraph' and templates print nothing when no listed issue depends on another; 'dot' still prints the nodes")
+	listCmd.Flags().String("format", "", "Export the dependency graph of the listed issues: 'digraph' (edge list for golang.org/x/tools/cmd/digraph), 'dot' (Graphviz), or a Go template rendered once per edge over .IssueID, .DependsOnID, .Type, .Issue, .Dependency. 'json' is the exception and does not export the graph: it is equivalent to --json, which also wins when both flags are given. 'digraph' and templates print nothing when no listed issue depends on another; 'dot' still prints the nodes")
 	listCmd.Flags().Bool("all", false, "Show all issues including closed (overrides default filter)")
 	listCmd.Flags().Bool("long", false, "Show detailed multi-line output for each issue")
 	listCmd.Flags().String("sort", "", "Sort by field: priority, created, updated, closed, status, id, title, type, assignee")

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -411,7 +411,7 @@ func init() {
 	listCmd.Flags().String("id", "", "Filter by specific issue IDs (comma-separated, e.g., bd-1,bd-5,bd-10)")
 	listCmd.Flags().IntP("limit", "n", workapi.DefaultListLimit, "Limit results (default 50, use 0 for unlimited)")
 	listCmd.Flags().Int("offset", 0, "Skip the first N matching results (0-based). Only supported under --proxied-server.")
-	listCmd.Flags().String("format", "", "Output format: 'digraph' (for golang.org/x/tools/cmd/digraph), 'dot' (Graphviz), or Go template")
+	listCmd.Flags().String("format", "", "Export the dependency graph of the listed issues: 'digraph' (edge list for golang.org/x/tools/cmd/digraph), 'dot' (Graphviz), or a Go template rendered once per edge over .IssueID, .DependsOnID, .Type, .Issue, .Dependency. 'digraph' and templates print nothing when no listed issue depends on another; 'dot' still prints the nodes")
 	listCmd.Flags().Bool("all", false, "Show all issues including closed (overrides default filter)")
 	listCmd.Flags().Bool("long", false, "Show detailed multi-line output for each issue")
 	listCmd.Flags().String("sort", "", "Sort by field: priority, created, updated, closed, status, id, title, type, assignee")

--- a/cmd/bd/list_output_test.go
+++ b/cmd/bd/list_output_test.go
@@ -88,6 +88,57 @@ func TestOutputFormattedListExactBytes(t *testing.T) {
 	}
 }
 
+// TestOutputFormattedListEdgeScope pins what --format's help now states: every
+// non-dot format renders the dependency edges BETWEEN the listed issues, so it
+// prints nothing both when there are no dependencies and when the only
+// dependency leaves the listed set. The second case is what covers the
+// endpoint-membership guard; without it, a listing would spill edges to issues
+// the caller filtered out. Only 'dot' declares nodes, which is why it alone
+// still prints on an edgeless listing.
+func TestOutputFormattedListEdgeScope(t *testing.T) {
+	t.Parallel()
+	issues, _ := listOutputFixture()
+
+	for _, tc := range []struct {
+		name string
+		deps map[string][]*types.Dependency
+	}{
+		{name: "no dependencies", deps: nil},
+		{
+			name: "dependency leaves the listed set",
+			deps: map[string][]*types.Dependency{
+				"list-a": {{IssueID: "list-a", DependsOnID: "list-unlisted", Type: types.DepBlocks}},
+			},
+		},
+	} {
+		for _, format := range []string{"digraph", "{{.IssueID}} -> {{.DependsOnID}}"} {
+			t.Run(tc.name+"/"+format, func(t *testing.T) {
+				t.Parallel()
+				var out bytes.Buffer
+				if err := outputFormattedList(&out, issues, tc.deps, format); err != nil {
+					t.Fatalf("outputFormattedList: %v", err)
+				}
+				if got := out.String(); got != "" {
+					t.Fatalf("format %q wrote %q, want no output", format, got)
+				}
+			})
+		}
+	}
+
+	t.Run("dot declares nodes without edges", func(t *testing.T) {
+		t.Parallel()
+		var out bytes.Buffer
+		if err := outputFormattedList(&out, issues, nil, "dot"); err != nil {
+			t.Fatalf("outputFormattedList: %v", err)
+		}
+		for _, id := range []string{"list-a", "list-b"} {
+			if !strings.Contains(out.String(), id) {
+				t.Fatalf("dot output with no dependencies omitted node %q:\n%s", id, out.String())
+			}
+		}
+	})
+}
+
 func TestOutputFormattedListWriterErrors(t *testing.T) {
 	t.Parallel()
 	issues, deps := listOutputFixture()


### PR DESCRIPTION
Fixes #5722.

## What

Corrects the `--format` help on `bd list`. No behavior change. Adds a test that pins the scope the help now describes.

## Why

`--format` reads like a per-issue rendering knob: "Output format: 'digraph' ..., 'dot' ..., or Go template". It is not one. Every non-dot value walks the dependency EDGES between the issues in the listing and prints one line per edge whose two endpoints are both in that listing. When nothing in the listing depends on anything else in it, there are no edges, so `bd list --format digraph` and `bd list --format '<template>'` print nothing and exit 0. That is correct for an edge exporter, but the help gives a user no way to know it, and `--format dot` muddies it further because dot declares nodes as well as edges and therefore always prints something. The result is two of the three advertised values looking broken.

The template context is the edge too. The fields are `.IssueID`, `.DependsOnID`, `.Type`, `.Issue`, `.Dependency`. There is no top-level `.ID`, so the natural first guess, `--format '{{.ID}}'`, renders `<no value>` even when edges exist. The new help names the fields so that guess does not happen.

Fixing the help rather than the behavior is deliberate. Making templates iterate per issue would break the `digraph` preset, which is an edge list by definition, and it is a design call that belongs to you rather than to a drive-by contributor.

## Verification

- `go build -tags gms_pure_go ./...`
- `./scripts/test.sh -run '^TestOutputFormattedList' ./cmd/bd/...` and the full `./cmd/bd/...`
- `make test` passes
- `./scripts/check-cli-docs-drift.sh --base main`: PASS, generated CLI docs are fresh. `docs/CLI_REFERENCE.md` and `docs/cli-reference/` are deliberately untouched; they build from the v1.2.2 tag in `docs/cli-docs.pin`, not from HEAD.
- Behavior confirmed by hand on a scrubbed temp DB before and after: two issues, no dependencies gives empty output at exit 0 for digraph and templates while dot prints both nodes. Adding one dependency makes digraph print `t-7kz t-l4j`, the same template print the edge, dot print nodes plus the edge, and `'{{.ID}}'` print `<no value>`.

The test covers the endpoint-membership guard as well as the happy path: a dependency whose other endpoint is outside the listing must not be emitted. Removing that guard fails the test, so it is discriminating rather than decorative.

One note on the local lint gate: `make ci-pr-lint` reports 2 gosec findings for me, in `internal/config/permissions_open_nonlinux.go` (G304) and `internal/utils/path_case_darwin.go` (G103). Both are pre-existing on a clean `main` and sit in darwin/non-linux build-constrained files, so I do not think CI's Linux runners lint them. Neither is touched by this PR.

