### PR TITLE
fix(cli): accept --flat on bd ready as an alias for --plain

### DIFF
--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -732,6 +732,7 @@ func init() {
 	readyCmd.Flags().String("mol-type", "", "Filter by molecule type: swarm, patrol, or work")
 	readyCmd.Flags().Bool("pretty", true, "Display issues in a tree format with status/priority symbols")
 	readyCmd.Flags().Bool("plain", false, "Display issues as a plain numbered list")
+	readyCmd.Flags().Bool("flat", false, "Alias for --plain, spelled the way bd list spells it")
 	readyCmd.Flags().Bool("include-deferred", false, "Include issues with future defer_until timestamps")
 	readyCmd.Flags().Bool("include-ephemeral", false, "Include ephemeral issues (wisps) in results")
 	readyCmd.Flags().Bool("gated", false, "Find molecules ready for gate-resume dispatch")

--- a/cmd/bd/ready_input.go
+++ b/cmd/bd/ready_input.go
@@ -63,6 +63,9 @@ func gatherReadyInput(cmd *cobra.Command, resolveCap func(*cobra.Command) (int, 
 	in.Brief, _ = cmd.Flags().GetBool("brief")
 	in.prettyFormat, _ = cmd.Flags().GetBool("pretty")
 	in.plainFormat, _ = cmd.Flags().GetBool("plain")
+	if flat, _ := cmd.Flags().GetBool("flat"); flat {
+		in.plainFormat = true
+	}
 	in.jsonOut = jsonOutput
 
 	limit, _ := cmd.Flags().GetInt("limit")

--- a/cmd/bd/ready_input_test.go
+++ b/cmd/bd/ready_input_test.go
@@ -469,6 +469,33 @@ func TestGatherReadyInputIgnoresNegativeOffset(t *testing.T) {
 	}
 }
 
+// TestGatherReadyInputFlatAliasesPlain pins the flag-name parity with
+// `bd list --flat`. Both spellings have to land on plainFormat, because that
+// one field is where the direct route and the proxied route each build their
+// usePlain choice.
+func TestGatherReadyInputFlatAliasesPlain(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "neither", args: nil, want: false},
+		{name: "plain", args: []string{"--plain"}, want: true},
+		{name: "flat", args: []string{"--flat"}, want: true},
+		{name: "both", args: []string{"--plain", "--flat"}, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runGatherReadyInput(t, newReadyFlagsCommand(t, tc.args...), nil)
+			if got.err != nil {
+				t.Fatalf("gatherReadyInput(%v) = %v, want no error", tc.args, got.err)
+			}
+			if got.in.plainFormat != tc.want {
+				t.Errorf("plainFormat = %v, want %v", got.in.plainFormat, tc.want)
+			}
+		})
+	}
+}
+
 // TestGatherReadyInputKeepsDirectoryLabelVerbatim pins GH#541's label against
 // the collapse into workapi. The configured label is not user input: `bd ready`
 // has always put it on the filter exactly as configured, so it must not be


### PR DESCRIPTION
Part of #5680 (covers the `bd ready --flat` half only; the `bd count --metadata-field` half needs storage-layer plumbing and is not in this PR).

## What

`bd ready` now accepts `--flat` as an alias for its existing `--plain`. One flag registration plus three lines in the shared input gatherer, and a table test.

## Why

`bd list --flat` turns off the tree view. `bd ready --plain` does the same job under a different name. Someone who picks up `--flat` from `bd list` and tries it on `bd ready` gets `unknown flag: --flat` and exit 1, and the error does not point at `--plain`. It is a naming inconsistency between two neighbouring commands, not a missing capability.

That distinction is why this is an alias rather than new behavior: the capability already exists and only the spelling is missing.

The alias folds into `gatherReadyInput`, which is the single place `bd ready` parses its flags for both the direct route and the proxied one, so both listings pick it up from one edit. `--plain` stays the canonical spelling and behaves exactly as before.

## Verification

- `go build -tags gms_pure_go ./...`
- `./scripts/test.sh -run '^TestGatherReadyInputFlatAliasesPlain$' ./cmd/bd/...` and the full `./cmd/bd/...`
- `make test` passes
- Red/green: with the two source hunks reverted and the test kept, the flat and both cases fail with `parse [--flat]: unknown flag: --flat`.
- `./scripts/check-cli-docs-drift.sh --base main` and `./scripts/check-doc-flags.sh` both pass. Generated CLI docs are untouched on purpose, per `docs/cli-docs.pin`.
- By hand on a scrubbed temp DB: `bd ready --flat` and `bd ready --plain` print the same numbered list, and bare `bd ready` still prints the tree.

One note on the local lint gate: `make ci-pr-lint` reports 2 gosec findings for me, in `internal/config/permissions_open_nonlinux.go` (G304) and `internal/utils/path_case_darwin.go` (G103). Both are pre-existing on a clean `main` and sit in darwin/non-linux build-constrained files, so I do not think CI's Linux runners lint them. Neither is touched by this PR.
