### PR TITLE
test(ci): make doc-freshness selection fail closed

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -470,7 +470,7 @@ jobs:
           restore-keys: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-
 
       - name: Exercise native date and Bash process boundary
-        run: go test '-tags=integration,gms_pure_go' -count=1 -run '^TestDocFreshness' ./scripts
+        run: go test '-tags=integration,gms_pure_go' -count=1 -run '^(TestDocFreshness.*|TestRequiredSuiteContract)$' ./scripts -args -required-suite=doc-freshness
 
       - name: Exercise repository text EOL policy boundary
         run: go test '-tags=integration,gms_pure_go' -count=1 ./scripts/gitattributespolicy -args -required-host -expected-goos '${{ matrix.expected_goos }}'

--- a/scripts/check_doc_freshness_test.go
+++ b/scripts/check_doc_freshness_test.go
@@ -62,6 +62,7 @@ date() {
 }
 `
 
+// Register every TestDocFreshness* test in requiredSuiteDefinitions in required_suite_test.go.
 func TestDocFreshnessDoesNotRequirePython(t *testing.T) {
 	run := runDocFreshness(t, "2026-01-15", "2026-01-31", "90")
 	if run.err != nil {

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -436,9 +436,12 @@ func TestRepositoryTextEOLPolicyWorkflow(t *testing.T) {
 	}
 
 	docStep := job.step(t, "Exercise native date and Bash process boundary")
-	const wantDocCommand = "go test '-tags=integration,gms_pure_go' -count=1 -run '^TestDocFreshness' ./scripts"
+	const (
+		requiredSuiteSelector = "-required-suite=doc-freshness"
+		wantDocCommand        = "go test '-tags=integration,gms_pure_go' -count=1 -run '^(TestDocFreshness.*|TestRequiredSuiteContract)$' ./scripts -args " + requiredSuiteSelector
+	)
 	if docStep.Run != wantDocCommand {
-		t.Errorf("doc-freshness command = %q, want exact original %q", docStep.Run, wantDocCommand)
+		t.Errorf("doc-freshness command = %q, want required-suite execution %q", docStep.Run, wantDocCommand)
 	}
 
 	eolStep := job.step(t, "Exercise repository text EOL policy boundary")

--- a/scripts/required_suite_test.go
+++ b/scripts/required_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -119,9 +120,19 @@ func TestRequiredSuiteContract(t *testing.T) {
 		}
 	})
 
-	if actual, err := listCompiledTopLevelTests(); err != nil {
-		t.Fatal(err)
-	} else if validateRequiredSuiteInventory(suite, actual) == nil {
+	t.Run("compiled suite", func(t *testing.T) {
+		actual, err := listCompiledTopLevelTests()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !slices.ContainsFunc(actual, func(name string) bool {
+			return strings.HasPrefix(name, suite.memberPrefix)
+		}) {
+			t.Skip("doc-freshness tests are not compiled without the integration build tag")
+		}
+		if err := validateRequiredSuiteInventory(suite, actual); err != nil {
+			t.Fatal(err)
+		}
 		for _, run := range []string{"^$", "^TestDocFreshnessDoesNotRequirePython$", "^TestDocFreshness"} {
 			t.Run("TestMain rejects "+run, func(t *testing.T) {
 				output, exitCode := runSuiteTestProcess(t, run, docFreshnessRequiredSuite)
@@ -130,7 +141,7 @@ func TestRequiredSuiteContract(t *testing.T) {
 				}
 			})
 		}
-	}
+	})
 
 	t.Run("Unicode inventory is retained", func(t *testing.T) {
 		parsed := parseCompiledTopLevelTests("TestDocFreshnessΔ\nok\texample/scripts\t0.1s\n")

--- a/scripts/required_suite_test.go
+++ b/scripts/required_suite_test.go
@@ -1,0 +1,349 @@
+package scripts_test
+
+import (
+	"flag"
+	"fmt"
+	"go/token"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	docFreshnessRequiredSuite = "doc-freshness"
+	requiredSuiteContractTest = "TestRequiredSuiteContract"
+)
+
+var requiredSuite = flag.String(
+	"required-suite",
+	"",
+	"require the named CI test suite to have its exact compiled inventory selected",
+)
+
+type requiredSuiteDefinition struct {
+	memberPrefix string
+	tests        []string
+}
+
+var requiredSuiteDefinitions = map[string]requiredSuiteDefinition{
+	docFreshnessRequiredSuite: {
+		memberPrefix: "TestDocFreshness",
+		tests: []string{
+			"TestDocFreshnessDoesNotRequirePython",
+			"TestDocFreshnessValidatesMaxAge",
+			"TestDocFreshnessBashProbeIgnoresStartupEnvironment",
+			"TestDocFreshnessPreservesDateDiagnostics",
+			"TestDocFreshnessPreservesISODateBoundaries",
+			"TestDocFreshnessUsesProlepticGregorianLeapRules",
+			"TestDocFreshnessUsesNativeDefaultTodayProvider",
+			"TestDocFreshnessReportsUnavailableTodayProvider",
+			"TestDocFreshnessReportsInvalidTodayProviderOutput",
+			"TestDocFreshnessReportsInvalidTodayOverride",
+		},
+	},
+}
+
+type requiredSuiteFlags struct {
+	run, skip, list, count, cpu string
+	short                       bool
+}
+
+// Required mode owns only compiled top-level inventory and selection. m.Run
+// remains authoritative for runtime failures, skips, and subtest dispositions.
+func TestMain(m *testing.M) {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+	if *requiredSuite == "" {
+		os.Exit(m.Run())
+	}
+	tests, err := listCompiledTopLevelTests()
+	if err == nil {
+		err = validateRequiredSuite(*requiredSuite, tests, currentRequiredSuiteFlags())
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "required test suite contract failed: %v\n", err)
+		os.Exit(2)
+	}
+	os.Exit(m.Run())
+}
+
+func TestRequiredSuiteContract(t *testing.T) {
+	suite := requiredSuiteDefinitions[docFreshnessRequiredSuite]
+	compiled := append([]string{requiredSuiteContractTest, "TestUnrelated"}, suite.tests...)
+	valid := requiredSuiteFlags{run: "^(TestDocFreshness.*|TestRequiredSuiteContract)$", count: "1"}
+
+	withoutLast := append([]string(nil), compiled[:len(compiled)-1]...)
+	withExtra := append(append([]string(nil), compiled...), "TestDocFreshnessNewBehavior")
+	withDuplicate := append(append([]string(nil), compiled...), suite.tests[0])
+	for _, test := range []struct {
+		name     string
+		active   string
+		compiled []string
+		flags    requiredSuiteFlags
+		wantErr  bool
+	}{
+		{name: "inactive focused use", compiled: withExtra, flags: requiredSuiteFlags{run: "[", skip: ".", count: "0", short: true}},
+		{name: "exact inventory and selection", active: docFreshnessRequiredSuite, compiled: compiled, flags: valid},
+		{name: "unknown suite", active: "unknown", compiled: compiled, flags: valid, wantErr: true},
+		{name: "zero selected", active: docFreshnessRequiredSuite, compiled: compiled, flags: withRun(valid, "^$"), wantErr: true},
+		{name: "partial selection", active: docFreshnessRequiredSuite, compiled: compiled, flags: withRun(valid, "^TestDocFreshnessDoesNotRequirePython$"), wantErr: true},
+		{name: "authority omitted", active: docFreshnessRequiredSuite, compiled: compiled, flags: withRun(valid, "^TestDocFreshness"), wantErr: true},
+		{name: "unrelated selected", active: docFreshnessRequiredSuite, compiled: compiled, flags: withRun(valid, "^Test"), wantErr: true},
+		{name: "missing inventory", active: docFreshnessRequiredSuite, compiled: withoutLast, flags: valid, wantErr: true},
+		{name: "extra inventory", active: docFreshnessRequiredSuite, compiled: withExtra, flags: valid, wantErr: true},
+		{name: "duplicate inventory", active: docFreshnessRequiredSuite, compiled: withDuplicate, flags: valid, wantErr: true},
+		{name: "skip", active: docFreshnessRequiredSuite, compiled: compiled, flags: withFlag(valid, "skip"), wantErr: true},
+		{name: "count", active: docFreshnessRequiredSuite, compiled: compiled, flags: withFlag(valid, "count"), wantErr: true},
+		{name: "cpu", active: docFreshnessRequiredSuite, compiled: compiled, flags: withFlag(valid, "cpu"), wantErr: true},
+		{name: "list", active: docFreshnessRequiredSuite, compiled: compiled, flags: withFlag(valid, "list"), wantErr: true},
+		{name: "short", active: docFreshnessRequiredSuite, compiled: compiled, flags: withFlag(valid, "short"), wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateRequiredSuite(test.active, test.compiled, test.flags)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("validateRequiredSuite() error = %v, wantErr %t", err, test.wantErr)
+			}
+		})
+	}
+
+	t.Run("inactive TestMain preserves zero-selection success", func(t *testing.T) {
+		output, exitCode := runSuiteTestProcess(t, "^$", "")
+		if exitCode != 0 {
+			t.Fatalf("inactive focused child exit = %d, want 0:\n%s", exitCode, output)
+		}
+	})
+
+	if actual, err := listCompiledTopLevelTests(); err != nil {
+		t.Fatal(err)
+	} else if validateRequiredSuiteInventory(suite, actual) == nil {
+		for _, run := range []string{"^$", "^TestDocFreshnessDoesNotRequirePython$", "^TestDocFreshness"} {
+			t.Run("TestMain rejects "+run, func(t *testing.T) {
+				output, exitCode := runSuiteTestProcess(t, run, docFreshnessRequiredSuite)
+				if exitCode == 0 || !strings.Contains(output, "required test suite contract failed:") {
+					t.Fatalf("exit = %d, want nonzero required-suite diagnostic:\n%s", exitCode, output)
+				}
+			})
+		}
+	}
+
+	t.Run("Unicode inventory is retained", func(t *testing.T) {
+		parsed := parseCompiledTopLevelTests("TestDocFreshnessΔ\nok\texample/scripts\t0.1s\n")
+		if len(parsed) != 1 || parsed[0] != "TestDocFreshnessΔ" ||
+			validateRequiredSuiteInventory(suite, append(compiled, parsed...)) == nil {
+			t.Fatalf("Unicode test was dropped or accepted: parsed=%v", parsed)
+		}
+	})
+
+	for _, test := range []struct {
+		name string
+		want bool
+	}{
+		{name: "TestDocFreshnessΔ", want: true},
+		{name: "TestdocFreshness"},
+		{name: "Testδ"},
+		{name: "Test", want: true},
+		{name: "Benchmark", want: true},
+		{name: "Example", want: true},
+		{name: "Fuzz", want: true},
+		{name: "Example_doc", want: true},
+		{name: "Exampledoc"},
+	} {
+		if got := isTopLevelListCandidate(test.name); got != test.want {
+			t.Errorf("isTopLevelListCandidate(%q) = %t, want %t", test.name, got, test.want)
+		}
+	}
+}
+
+func withRun(flags requiredSuiteFlags, run string) requiredSuiteFlags {
+	flags.run = run
+	return flags
+}
+
+func withFlag(flags requiredSuiteFlags, name string) requiredSuiteFlags {
+	switch name {
+	case "skip":
+		flags.skip = "."
+	case "count":
+		flags.count = "2"
+	case "cpu":
+		flags.cpu = "1,2"
+	case "list":
+		flags.list = "."
+	case "short":
+		flags.short = true
+	}
+	return flags
+}
+
+func validateRequiredSuite(name string, compiled []string, flags requiredSuiteFlags) error {
+	if name == "" {
+		return nil
+	}
+	suite, ok := requiredSuiteDefinitions[name]
+	if !ok {
+		return fmt.Errorf("unknown suite %q", name)
+	}
+	switch {
+	case flags.run == "":
+		return fmt.Errorf("suite %q requires an explicit -test.run selection", name)
+	case strings.Contains(flags.run, "/"):
+		return fmt.Errorf("suite %q requires top-level-only -test.run=%q", name, flags.run)
+	case flags.skip != "":
+		return fmt.Errorf("suite %q forbids -test.skip=%q", name, flags.skip)
+	case flags.count != "1":
+		return fmt.Errorf("suite %q requires -test.count=1, got %q", name, flags.count)
+	case flags.cpu != "":
+		return fmt.Errorf("suite %q forbids -test.cpu=%q", name, flags.cpu)
+	case flags.list != "":
+		return fmt.Errorf("suite %q forbids -test.list=%q", name, flags.list)
+	case flags.short:
+		return fmt.Errorf("suite %q forbids -test.short", name)
+	}
+	if err := validateRequiredSuiteInventory(suite, compiled); err != nil {
+		return fmt.Errorf("suite %q inventory: %w", name, err)
+	}
+	pattern, err := regexp.Compile(flags.run)
+	if err != nil {
+		return fmt.Errorf("suite %q has invalid -test.run=%q: %w", name, flags.run, err)
+	}
+	var selected []string
+	for _, testName := range compiled {
+		if isTopLevelRunCandidate(testName) && pattern.MatchString(testName) {
+			selected = append(selected, testName)
+		}
+	}
+	want := append(append([]string(nil), suite.tests...), requiredSuiteContractTest)
+	return exactInventory("-test.run="+flags.run, want, selected)
+}
+
+func validateRequiredSuiteInventory(suite requiredSuiteDefinition, compiled []string) error {
+	var members []string
+	for _, name := range compiled {
+		if strings.HasPrefix(name, suite.memberPrefix) {
+			members = append(members, name)
+		}
+	}
+	return exactInventory("compiled", suite.tests, members)
+}
+
+func exactInventory(label string, want, got []string) error {
+	wantCounts, gotCounts := make(map[string]int), make(map[string]int)
+	for _, name := range want {
+		wantCounts[name]++
+	}
+	for _, name := range got {
+		gotCounts[name]++
+	}
+	var missing, extra, duplicate []string
+	for name, count := range wantCounts {
+		if gotCounts[name] == 0 {
+			missing = append(missing, name)
+		}
+		if count > 1 {
+			duplicate = append(duplicate, name)
+		}
+	}
+	for name, count := range gotCounts {
+		if wantCounts[name] == 0 {
+			extra = append(extra, name)
+		}
+		if count > 1 {
+			duplicate = append(duplicate, name)
+		}
+	}
+	if len(missing)+len(extra)+len(duplicate) == 0 {
+		return nil
+	}
+	for _, names := range [][]string{missing, extra, duplicate} {
+		sort.Strings(names)
+	}
+	return fmt.Errorf("%s inventory missing=%v extra=%v duplicate=%v", label, missing, extra, duplicate)
+}
+
+func isTopLevelRunCandidate(name string) bool {
+	return isGoTestName(name, "Test") || isGoTestName(name, "Example") || isGoTestName(name, "Fuzz")
+}
+
+func listCompiledTopLevelTests() ([]string, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("locate current test executable: %w", err)
+	}
+	output, err := exec.Command(executable, "-test.list=.").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("list compiled top-level tests: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	tests := parseCompiledTopLevelTests(string(output))
+	if len(tests) == 0 {
+		return nil, fmt.Errorf("test executable reported no compiled top-level tests")
+	}
+	return tests, nil
+}
+
+func parseCompiledTopLevelTests(output string) []string {
+	var tests []string
+	for _, line := range strings.Split(output, "\n") {
+		name := strings.TrimSpace(line)
+		if token.IsIdentifier(name) && isTopLevelListCandidate(name) {
+			tests = append(tests, name)
+		}
+	}
+	return tests
+}
+
+func isTopLevelListCandidate(name string) bool {
+	return isTopLevelRunCandidate(name) || isGoTestName(name, "Benchmark")
+}
+
+func isGoTestName(name, prefix string) bool {
+	if !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	if len(name) == len(prefix) {
+		return true
+	}
+	next, _ := utf8.DecodeRuneInString(name[len(prefix):])
+	return !unicode.IsLower(next)
+}
+
+func runSuiteTestProcess(t *testing.T, run, suite string) (string, int) {
+	t.Helper()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"-test.count=1", "-test.run=" + run}
+	if suite != "" {
+		args = append(args, "-required-suite="+suite)
+	}
+	output, runErr := exec.Command(executable, args...).CombinedOutput()
+	if runErr == nil {
+		return string(output), 0
+	}
+	if exitErr, ok := runErr.(*exec.ExitError); ok {
+		return string(output), exitErr.ExitCode()
+	}
+	t.Fatal(runErr)
+	return "", -1
+}
+
+func currentRequiredSuiteFlags() requiredSuiteFlags {
+	return requiredSuiteFlags{
+		run: testFlagValue("test.run"), skip: testFlagValue("test.skip"),
+		list: testFlagValue("test.list"), count: testFlagValue("test.count"),
+		cpu: testFlagValue("test.cpu"), short: testFlagValue("test.short") == "true",
+	}
+}
+
+func testFlagValue(name string) string {
+	if testFlag := flag.Lookup(name); testFlag != nil {
+		return testFlag.Value.String()
+	}
+	return ""
+}


### PR DESCRIPTION
## What

Make the existing required doc-freshness jobs reject an incomplete compiled
test inventory or selector, instead of accepting Go's zero-test success.

The untagged `scripts/required_suite_test.go` introduces the package's first
`TestMain`: it fronts every `go test ./scripts` invocation, with or without
the integration build tag. Without `-required-suite`, it delegates to
`m.Run()` and preserves ordinary focused testing.

With `-args -required-suite=doc-freshness`, it checks the ten maintained
`TestDocFreshness*` tests and requires the effective selector to include
exactly those tests plus `TestRequiredSuiteContract`. The existing three-host
workflow and YAML-aware workflow test activate and protect that invocation.

The review follow-up also makes the contract test itself fail on compiled
inventory drift. Only its compiled-suite subtest skips when no suite members
are compiled, as in an untagged build; its other checks still run. A pointer
beside the doc-freshness tests documents where new members must be registered.

The complete PR touches four files:

```text
.github/workflows/pr.yml
scripts/ci_workflow_test.go
scripts/required_suite_test.go
scripts/check_doc_freshness_test.go
```

Fixes #5726.

## Why

`go test -run` succeeds when it selects nothing. A renamed test, omitted
member, or narrower selector could therefore leave the required Linux, macOS,
and Windows job green without exercising its intended contract.

The registry and exact selection check catch that drift. The contract test
must report the same registry mismatch locally, not silently stop exercising
its three process-level selector-rejection checks.

## Boundary

This checks compiled top-level inventory and selection; it is not another
test runner or result parser.

- `m.Run()` owns runtime failures, skips, subtest results, and the final exit
  status. A selected test's intentional platform skip remains ordinary Go
  behavior.
- Required mode rejects selection-affecting skip, repeat, list-only, short,
  and subtest-selector modes. Ordinary non-required focused use stays usable.
- No new job, freshness policy, external prerequisite, or runner-layout pin
  is introduced.

## Validation

Review-response base: `c0d8da42de5fd15c95adac85e342ba4a121da0fb`.
Review-response head: `62621ffbce1e87ebe6a5acfeb4d4e5259db8a9c6`.
The original one-commit patch rebased without a patch change, and the local
attribute-hydration check passed with no attribute changes.

Native Windows amd64, Go 1.26.5, Git for Windows Bash:

- PASS: untagged and integration-tagged `TestRequiredSuiteContract`.
- PASS: all three process-level selector-rejection subtests in the tagged
  contract; only the integration-only subtest skips in the untagged build.
- PASS: the exact required command below.
- PASS: `scripts/test.sh ./scripts`, including current-base workflow policy.
- PASS: the same Go overlay adding an unregistered
  `TestDocFreshnessNewBehaviorDriftProbe` passed the contract before the repair
  and fails with the precise extra-member diagnostic after it.
- PASS: the same drift overlay is also rejected by required mode before the
  suite can run.
- PASS: gofmt and `git diff --check`.
- PASS: `mingw32-make ci-pr-lint` scoped to the base above, with zero findings
  in both the native and non-CGO Windows passes. The first attempt timed out
  loading packages; the single warm-cache retry passed with the unchanged
  five-minute limit.
- FAIL, outside the changed package: the one final `mingw32-make test` run
  reported 48 top-level failures across 12 packages. The scripts package
  passed again. Failures include native-Windows path/permission fixtures,
  metrics/Prime fixtures, and untagged `internal/testutil` tests referring to
  `checkDolt`/`doltReady`, which are only defined under `!windows`.
  No `cmd/` or `internal/` file differs from the base in this PR. These
  failures are tracked separately; the full local baseline is not green.

```text
go test '-tags=integration,gms_pure_go' -count=1 -run '^(TestDocFreshness.*|TestRequiredSuiteContract)$' ./scripts -args -required-suite=doc-freshness
```

Fresh hosted doc-freshness jobs on Linux, macOS and Windows, plus PR Core
(wrapper timing), passed at the review-response head above in PR workflow run
33971750583. The required aggregate and remaining overall CI jobs are still
pending at this update; the old head's successful checks are not reused.

## Coordination

#5730 preserves all ten doc-freshness names and remains independent.
#5614 changes the separate version-consistency job. Whichever overlapping
workflow PR lands second must preserve the first change on current main.

---

_Codex-unknown-model-unknown-reasoning on behalf of Ewen Cuthiell_
