### PR TITLE
test(scripts): resolve Git Bash explicitly on Windows (#5727)

### DIFF
--- a/scripts/check_doc_freshness_test.go
+++ b/scripts/check_doc_freshness_test.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/scripts/internal/testbash"
 )
 
 var freshnessDocuments = []struct {
@@ -158,16 +160,59 @@ func TestDocFreshnessBashProbeIgnoresStartupEnvironment(t *testing.T) {
 		t.Skip("Git Bash discovery is Windows-specific")
 	}
 
-	poison := filepath.Join(t.TempDir(), "poison.sh")
-	if err := os.WriteFile(poison, []byte("exit 97\n"), 0o600); err != nil {
-		t.Fatalf("write startup poison: %v", err)
-	}
-	t.Setenv("BASH_ENV", poison)
-	t.Setenv("ENV", poison)
+	t.Run("startup and option controls", func(t *testing.T) {
+		poison := filepath.Join(t.TempDir(), "poison.sh")
+		if err := os.WriteFile(poison, []byte("exit 97\n"), 0o600); err != nil {
+			t.Fatalf("write startup poison: %v", err)
+		}
+		t.Setenv("BASH_ENV", poison)
+		t.Setenv("ENV", poison)
+		t.Setenv("SHELLOPTS", "noexec")
+		t.Setenv("BASHOPTS", "failglob")
+		t.Setenv("BASH_FUNC_uname%%", "() { builtin printf 'Linux\\n'; }")
 
-	if bash := docFreshnessBash(t); bash == "" {
-		t.Fatal("docFreshnessBash returned an empty executable")
-	}
+		if bash := docFreshnessBash(t); bash == "" {
+			t.Fatal("docFreshnessBash returned an empty executable")
+		}
+	})
+
+	t.Run("valid explicit override", func(t *testing.T) {
+		t.Setenv(testbash.OverrideEnv, "")
+		resolved := docFreshnessBash(t)
+		t.Setenv(testbash.OverrideEnv, resolved)
+		if got := docFreshnessBash(t); !strings.EqualFold(filepath.Clean(got), filepath.Clean(resolved)) {
+			t.Fatalf("resolved override = %q, want %q", got, resolved)
+		}
+	})
+
+	t.Run("invalid explicit override is configuration", func(t *testing.T) {
+		t.Setenv(testbash.OverrideEnv, "bash.exe")
+		if _, err := testbash.Resolve(); err == nil {
+			t.Fatal("relative Git Bash override unexpectedly succeeded")
+		} else if !testbash.IsConfigurationError(err) {
+			t.Fatalf("relative override error was not classified as configuration: %v", err)
+		}
+	})
+
+	t.Run("poisoned Git exec path", func(t *testing.T) {
+		t.Setenv(testbash.OverrideEnv, "")
+		t.Setenv("GIT_EXEC_PATH", t.TempDir())
+		if bash := docFreshnessBash(t); bash == "" {
+			t.Fatal("docFreshnessBash returned an empty executable")
+		}
+	})
+
+	t.Run("success without execution sentinel", func(t *testing.T) {
+		t.Setenv(testbash.OverrideEnv, "")
+		bash := docFreshnessBash(t)
+		err := testbash.Probe(bash, "early exit", "exit 0", os.Environ())
+		if err == nil {
+			t.Fatal("early successful exit unexpectedly passed without the execution sentinel")
+		}
+		if !strings.Contains(err.Error(), "without the exact execution sentinel") {
+			t.Fatalf("early-exit error = %v", err)
+		}
+	})
 }
 
 func TestDocFreshnessPreservesDateDiagnostics(t *testing.T) {
@@ -428,59 +473,23 @@ func runDocFreshnessProcess(t *testing.T, reviewed string, today, maxAge *string
 func docFreshnessBash(t *testing.T) string {
 	t.Helper()
 
+	bash, err := testbash.Resolve()
+	if err != nil {
+		t.Fatalf("bash is required to exercise check-doc-freshness.sh: %v", err)
+	}
 	if runtime.GOOS != "windows" {
-		bash, err := exec.LookPath("bash")
-		if err != nil {
-			t.Fatalf("bash is required to exercise check-doc-freshness.sh: %v", err)
-		}
 		return bash
 	}
 
-	git, err := exec.LookPath("git.exe")
-	if err != nil {
-		t.Fatalf("Git for Windows is required to exercise check-doc-freshness.sh: %v", err)
-	}
-	execPathCommand := exec.Command(git, "--exec-path")
-	execPathCommand.Env = docFreshnessProbeEnv()
-	execPathOutput, err := execPathCommand.CombinedOutput()
-	if err != nil {
-		t.Fatalf("locate the Git for Windows installation: %v: %s", err, strings.TrimSpace(string(execPathOutput)))
-	}
-	execPath := filepath.Clean(strings.TrimSpace(string(execPathOutput)))
-	if !filepath.IsAbs(execPath) {
-		t.Fatalf("Git for Windows returned a non-absolute exec path: %q", execPath)
-	}
-	gitRoot := filepath.Clean(filepath.Join(execPath, "..", "..", ".."))
-	candidates := []string{
-		filepath.Join(gitRoot, "bin", "bash.exe"),
-		filepath.Join(gitRoot, "usr", "bin", "bash.exe"),
-	}
-	var diagnostics []string
-	for _, candidate := range candidates {
-		if _, err := os.Stat(candidate); err != nil {
-			diagnostics = append(diagnostics, fmt.Sprintf("%s: %v", candidate, err))
-			continue
-		}
-		probe := exec.Command(candidate, "--noprofile", "--norc", "-c", `
-export BASH_ENV=
-export ENV=
+	err = testbash.Probe(bash, "Git Bash date environment", `set -eu
 PATH=/usr/bin:/bin
 export PATH
-case "$(uname -s)" in
-    MINGW*|MSYS*) command -v date >/dev/null ;;
-    *) exit 1 ;;
-esac
-`)
-		probe.Env = docFreshnessProbeEnv()
-		if output, err := probe.CombinedOutput(); err == nil {
-			return candidate
-		} else {
-			diagnostics = append(diagnostics, fmt.Sprintf("%s: %v: %s", candidate, err, strings.TrimSpace(string(output))))
-		}
+command -v date >/dev/null
+`, docFreshnessProbeEnv())
+	if err != nil {
+		t.Fatalf("a working Git Bash date environment is required: %v", err)
 	}
-
-	t.Fatalf("a working Git Bash date environment is required: %s", strings.Join(diagnostics, "; "))
-	return ""
+	return bash
 }
 
 func docFreshnessMarkerExists(t *testing.T, path string) bool {

--- a/scripts/internal/testbash/resolver.go
+++ b/scripts/internal/testbash/resolver.go
@@ -1,0 +1,129 @@
+// Package testbash resolves the Bash interpreter used by repository script
+// tests. On Windows, callers receive a positively identified Git Bash rather
+// than whichever bash launcher happens to appear first on PATH.
+package testbash
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// OverrideEnv names the optional absolute Git Bash override used on Windows.
+const OverrideEnv = "BEADS_TEST_GIT_BASH"
+
+const probeSuccess = "BEADS_TEST_BASH_PROBE_SUCCESS_7B75D507"
+
+// ConfigurationError reports an invalid explicit test configuration. Callers
+// may distinguish it from an unavailable optional prerequisite.
+type ConfigurationError struct {
+	err error
+}
+
+func (e *ConfigurationError) Error() string {
+	return e.err.Error()
+}
+
+func (e *ConfigurationError) Unwrap() error {
+	return e.err
+}
+
+// IsConfigurationError reports whether err was caused by an invalid explicit
+// test configuration.
+func IsConfigurationError(err error) bool {
+	var configurationError *ConfigurationError
+	return errors.As(err, &configurationError)
+}
+
+func configurationErrorf(format string, args ...any) error {
+	return &ConfigurationError{err: fmt.Errorf(format, args...)}
+}
+
+// Resolve returns the Bash interpreter for a repository script test.
+func Resolve() (string, error) {
+	return resolve()
+}
+
+// Probe verifies a caller-specific Bash capability under an environment
+// derived from the supplied entries. Bash startup, option, and
+// exported-function controls are removed before the probe runs.
+func Probe(path, capability, script string, environment []string) error {
+	return runProbe(path, capability, script, sanitizedEnvironment(environment))
+}
+
+func runProbe(path, capability, script string, environment []string) error {
+	probeScript := script + `
+beads_testbash_probe_status=$?
+if [ "$beads_testbash_probe_status" -eq 0 ]; then
+  builtin printf '%s' '` + probeSuccess + `'
+fi
+exit "$beads_testbash_probe_status"
+`
+	//nolint:gosec // G702: this test-only API intentionally executes its caller-selected Bash interpreter.
+	cmd := exec.Command(path, "--noprofile", "--norc", "-c", probeScript)
+	cmd.Env = environment
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s probe: %w: %s", capability, err, strings.TrimSpace(string(output)))
+	}
+	if string(output) != probeSuccess {
+		return fmt.Errorf(
+			"%s probe exited successfully without the exact execution sentinel: %q",
+			capability,
+			string(output),
+		)
+	}
+	return nil
+}
+
+func sanitizedEnvironment(entries []string, overrides ...string) []string {
+	overrideKeys := make(map[string]struct{}, len(overrides))
+	safeOverrides := make([]string, 0, len(overrides))
+	for _, entry := range overrides {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		normalizedKey := environmentKey(key)
+		if isBashAuthorityControl(normalizedKey) {
+			continue
+		}
+		overrideKeys[normalizedKey] = struct{}{}
+		safeOverrides = append(safeOverrides, entry)
+	}
+
+	environment := make([]string, 0, len(entries)+len(safeOverrides))
+	for _, entry := range entries {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		normalizedKey := environmentKey(key)
+		if isBashAuthorityControl(normalizedKey) {
+			continue
+		}
+		if _, overridden := overrideKeys[normalizedKey]; overridden {
+			continue
+		}
+		environment = append(environment, entry)
+	}
+	return append(environment, safeOverrides...)
+}
+
+func isBashAuthorityControl(normalizedKey string) bool {
+	return normalizedKey == environmentKey("BASH_ENV") ||
+		normalizedKey == environmentKey("ENV") ||
+		normalizedKey == environmentKey("SHELLOPTS") ||
+		normalizedKey == environmentKey("BASHOPTS") ||
+		normalizedKey == environmentKey("GIT_EXEC_PATH") ||
+		strings.HasPrefix(normalizedKey, environmentKey("BASH_FUNC_"))
+}
+
+func environmentKey(key string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToUpper(key)
+	}
+	return key
+}

--- a/scripts/internal/testbash/resolver_other.go
+++ b/scripts/internal/testbash/resolver_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package testbash
+
+import "os/exec"
+
+func resolve() (string, error) {
+	return exec.LookPath("bash")
+}

--- a/scripts/internal/testbash/resolver_other_test.go
+++ b/scripts/internal/testbash/resolver_other_test.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package testbash
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveUsesPATH(t *testing.T) {
+	bin := t.TempDir()
+	bash := filepath.Join(bin, "bash")
+	if err := os.WriteFile(bash, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write PATH Bash: %v", err)
+	}
+	t.Setenv("PATH", bin)
+
+	resolved, err := Resolve()
+	if err != nil {
+		t.Fatalf("resolve PATH Bash: %v", err)
+	}
+	if resolved != bash {
+		t.Fatalf("resolved Bash = %q, want PATH result %q", resolved, bash)
+	}
+}

--- a/scripts/internal/testbash/resolver_test.go
+++ b/scripts/internal/testbash/resolver_test.go
@@ -1,0 +1,80 @@
+package testbash
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSanitizedEnvironmentRemovesBashAuthorityControls(t *testing.T) {
+	controls := []string{
+		"BASH_ENV",
+		"ENV",
+		"SHELLOPTS",
+		"BASHOPTS",
+		"GIT_EXEC_PATH",
+		"BASH_FUNC_beads_testbash%%",
+	}
+	for _, key := range controls {
+		t.Setenv(key, "inherited-poison")
+	}
+
+	overrides := make([]string, 0, len(controls)+1)
+	for _, key := range controls {
+		overrides = append(overrides, key+"=override-poison")
+	}
+	overrides = append(overrides, "BEADS_TEST_SAFE=override")
+
+	environment := sanitizedEnvironment(os.Environ(), overrides...)
+	for _, entry := range environment {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if isBashAuthorityControl(environmentKey(key)) {
+			t.Fatalf("sanitized environment retained Bash authority control %q", key)
+		}
+	}
+	if !containsEnvironmentEntry(environment, "BEADS_TEST_SAFE=override") {
+		t.Fatalf("sanitized environment did not retain benign override: %q", environment)
+	}
+}
+
+func TestProbeRejectsSuccessWithoutSentinel(t *testing.T) {
+	bash, err := Resolve()
+	if err != nil {
+		t.Skipf("bash is required to exercise probe execution: %v", err)
+	}
+
+	err = runProbe(bash, "early exit", "exit 0", sanitizedEnvironment(os.Environ()))
+	if err == nil {
+		t.Fatal("early successful exit unexpectedly passed without the execution sentinel")
+	}
+	if !strings.Contains(err.Error(), "without the exact execution sentinel") {
+		t.Fatalf("early-exit error = %v", err)
+	}
+}
+
+func TestProbePreservesFailure(t *testing.T) {
+	bash, err := Resolve()
+	if err != nil {
+		t.Skipf("bash is required to exercise probe execution: %v", err)
+	}
+
+	err = Probe(bash, "failing capability", "exit 73", os.Environ())
+	if err == nil {
+		t.Fatal("failing capability unexpectedly passed")
+	}
+	if !strings.Contains(err.Error(), "exit status 73") {
+		t.Fatalf("failing-capability error = %v", err)
+	}
+}
+
+func containsEnvironmentEntry(environment []string, want string) bool {
+	for _, entry := range environment {
+		if entry == want {
+			return true
+		}
+	}
+	return false
+}

--- a/scripts/internal/testbash/resolver_windows.go
+++ b/scripts/internal/testbash/resolver_windows.go
@@ -1,0 +1,93 @@
+//go:build windows
+
+package testbash
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func resolve() (string, error) {
+	if override := os.Getenv(OverrideEnv); override != "" {
+		if !filepath.IsAbs(override) {
+			return "", configurationErrorf("%s must be an absolute path: %q", OverrideEnv, override)
+		}
+		override = filepath.Clean(override)
+		if err := validateCandidate(override); err != nil {
+			return "", configurationErrorf("%s=%s: %v", OverrideEnv, override, err)
+		}
+		return override, nil
+	}
+
+	git, err := exec.LookPath("git.exe")
+	if err != nil {
+		return "", fmt.Errorf("Git for Windows is required: %w", err)
+	}
+	gitInfo, err := os.Stat(git)
+	if err != nil {
+		return "", fmt.Errorf("inspect Git for Windows executable %s: %w", git, err)
+	}
+	if !gitInfo.Mode().IsRegular() {
+		return "", fmt.Errorf("Git for Windows executable %s is not an ordinary file", git)
+	}
+
+	execPathCommand := exec.Command(git, "--exec-path")
+	execPathCommand.Env = sanitizedEnvironment(os.Environ())
+	execPathOutput, err := execPathCommand.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf(
+			"locate the Git for Windows installation through %s: %w: %s",
+			git,
+			err,
+			strings.TrimSpace(string(execPathOutput)),
+		)
+	}
+	execPath := filepath.Clean(strings.TrimSpace(string(execPathOutput)))
+	if !filepath.IsAbs(execPath) {
+		return "", fmt.Errorf("Git for Windows returned a non-absolute exec path: %q", execPath)
+	}
+
+	gitRoot := filepath.Clean(filepath.Join(execPath, "..", "..", ".."))
+	candidates := []string{
+		filepath.Join(gitRoot, "bin", "bash.exe"),
+		filepath.Join(gitRoot, "usr", "bin", "bash.exe"),
+	}
+	diagnostics := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidateErr := validateCandidate(candidate); candidateErr != nil {
+			diagnostics = append(diagnostics, fmt.Sprintf("%s: %v", candidate, candidateErr))
+			continue
+		}
+		return candidate, nil
+	}
+
+	return "", fmt.Errorf("no working Git Bash candidate: %s", strings.Join(diagnostics, "; "))
+}
+
+func validateCandidate(candidate string) error {
+	info, err := os.Stat(candidate)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("is not an ordinary file")
+	}
+
+	return runProbe(
+		candidate,
+		"Git Bash identity",
+		`set -eu
+test -n "${BASH_VERSION:-}"
+case "$(uname -s)" in
+  MINGW*|MSYS*) ;;
+  *) printf 'expected Git Bash, found %s\n' "$(uname -s)" >&2; exit 69 ;;
+esac
+pwd -W >/dev/null
+`,
+		sanitizedEnvironment(os.Environ(), "PATH=/usr/bin:/bin", "LC_ALL=C", "LANG=C"),
+	)
+}

--- a/scripts/internal/testbash/resolver_windows_test.go
+++ b/scripts/internal/testbash/resolver_windows_test.go
@@ -1,0 +1,118 @@
+//go:build windows
+
+package testbash
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveIgnoresEarlierBashLauncher(t *testing.T) {
+	t.Setenv(OverrideEnv, "")
+
+	shadowDir := t.TempDir()
+	shadowBash := filepath.Join(shadowDir, "bash.cmd")
+	if err := os.WriteFile(shadowBash, []byte("@echo off\r\nexit /b 97\r\n"), 0o600); err != nil {
+		t.Fatalf("write PATH-first Bash launcher: %v", err)
+	}
+	t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+	t.Setenv("PATH", shadowDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GIT_EXEC_PATH", t.TempDir())
+
+	ambient, err := exec.LookPath("bash")
+	if err != nil {
+		t.Fatalf("locate PATH-first Bash launcher: %v", err)
+	}
+	if !strings.EqualFold(filepath.Clean(ambient), filepath.Clean(shadowBash)) {
+		t.Fatalf("ambient bash = %q, want PATH-first launcher %q", ambient, shadowBash)
+	}
+
+	resolved, err := Resolve()
+	if err != nil {
+		t.Fatalf("resolve Git Bash with another launcher first on PATH: %v", err)
+	}
+	if strings.EqualFold(filepath.Clean(resolved), filepath.Clean(ambient)) {
+		t.Fatalf("resolver selected PATH-first launcher %q", resolved)
+	}
+	if err := validateCandidate(resolved); err != nil {
+		t.Fatalf("resolved interpreter is not Git Bash: %v", err)
+	}
+}
+
+func TestResolveOverride(t *testing.T) {
+	t.Setenv(OverrideEnv, "")
+	resolved, err := Resolve()
+	if err != nil {
+		t.Fatalf("resolve default Git Bash: %v", err)
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		t.Setenv(OverrideEnv, resolved)
+		got, err := Resolve()
+		if err != nil {
+			t.Fatalf("resolve explicit Git Bash: %v", err)
+		}
+		if !strings.EqualFold(filepath.Clean(got), filepath.Clean(resolved)) {
+			t.Fatalf("resolved override = %q, want %q", got, resolved)
+		}
+	})
+
+	t.Run("relative", func(t *testing.T) {
+		t.Setenv(OverrideEnv, "bash.exe")
+		if _, err := Resolve(); err == nil {
+			t.Fatal("relative override unexpectedly succeeded")
+		} else if !IsConfigurationError(err) {
+			t.Fatalf("relative override error was not classified as configuration: %v", err)
+		} else if !strings.Contains(err.Error(), "must be an absolute path") {
+			t.Fatalf("relative override error = %v", err)
+		}
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		t.Setenv(OverrideEnv, t.TempDir())
+		if _, err := Resolve(); err == nil {
+			t.Fatal("directory override unexpectedly succeeded")
+		} else if !IsConfigurationError(err) {
+			t.Fatalf("directory override error was not classified as configuration: %v", err)
+		} else if !strings.Contains(err.Error(), "is not an ordinary file") {
+			t.Fatalf("directory override error = %v", err)
+		}
+	})
+}
+
+func TestResolveIgnoresBashAuthorityControls(t *testing.T) {
+	t.Setenv(OverrideEnv, "")
+	poison := filepath.Join(t.TempDir(), "startup.sh")
+	if err := os.WriteFile(poison, []byte("exit 97\n"), 0o600); err != nil {
+		t.Fatalf("write startup poison: %v", err)
+	}
+	t.Setenv("BASH_ENV", poison)
+	t.Setenv("ENV", poison)
+	t.Setenv("SHELLOPTS", "noexec")
+	t.Setenv("BASHOPTS", "failglob")
+	t.Setenv("BASH_FUNC_uname%%", "() { builtin printf 'Linux\\n'; }")
+
+	if _, err := Resolve(); err != nil {
+		t.Fatalf("resolve Git Bash with poisoned Bash authority controls: %v", err)
+	}
+}
+
+func TestProbeRejectsNoExecFalseSuccess(t *testing.T) {
+	t.Setenv(OverrideEnv, "")
+	bash, err := Resolve()
+	if err != nil {
+		t.Fatalf("resolve default Git Bash: %v", err)
+	}
+	t.Setenv("SHELLOPTS", "noexec")
+
+	err = runProbe(bash, "noexec falsifier", "exit 73", os.Environ())
+	if err == nil {
+		t.Fatal("probe accepted exit zero without executing its body")
+	}
+	if !strings.Contains(err.Error(), "without the exact execution sentinel") {
+		t.Fatalf("noexec false-success error = %v", err)
+	}
+}

--- a/scripts/pr_preflight_test.go
+++ b/scripts/pr_preflight_test.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/scripts/internal/testbash"
 )
 
 const (
@@ -244,6 +246,26 @@ func TestPRPreflightSupportsGitHubCLIWithoutClosingIssuesReferences(t *testing.T
 
 func TestPRPreflightFixtureIgnoresHostShellAndGitHubState(t *testing.T) {
 	hostState := t.TempDir()
+	var pathShadowMarker string
+	if runtime.GOOS == "windows" {
+		shadowDir := t.TempDir()
+		shadowBash := filepath.Join(shadowDir, "bash.cmd")
+		pathShadowMarker = filepath.Join(shadowDir, "invoked")
+		body := "@echo off\r\n> \"%~dp0invoked\" echo invoked\r\nexit /b 97\r\n"
+		if err := os.WriteFile(shadowBash, []byte(body), 0o600); err != nil {
+			t.Fatalf("write PATH-first Bash launcher: %v", err)
+		}
+		t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+		t.Setenv("PATH", shadowDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+		ambient, err := exec.LookPath("bash")
+		if err != nil {
+			t.Fatalf("locate PATH-first Bash launcher: %v", err)
+		}
+		if !strings.EqualFold(filepath.Clean(ambient), filepath.Clean(shadowBash)) {
+			t.Fatalf("ambient bash = %q, want PATH-first launcher %q", ambient, shadowBash)
+		}
+	}
+
 	startupMarker := filepath.Join(hostState, "startup-invoked")
 	hostStartup := filepath.Join(hostState, "host-startup.sh")
 	if err := os.WriteFile(
@@ -273,6 +295,13 @@ func TestPRPreflightFixtureIgnoresHostShellAndGitHubState(t *testing.T) {
 	}
 	if len(run.calls) == 0 {
 		t.Fatal("controlled gh function did not intercept any calls")
+	}
+	if pathShadowMarker != "" {
+		if _, err := os.Stat(pathShadowMarker); err == nil {
+			t.Fatal("preflight fixture executed the PATH-first Bash launcher")
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("inspect PATH-first Bash launcher marker: %v", err)
+		}
 	}
 }
 
@@ -601,7 +630,7 @@ func runPRPreflightWithFakeGH(t *testing.T, fixture preflightFixture) preflightR
 func prPreflightProcessTools(t *testing.T) (string, string) {
 	t.Helper()
 
-	bash, err := exec.LookPath("bash")
+	bash, err := testbash.Resolve()
 	if err != nil {
 		t.Fatalf("bash is required to exercise pr-preflight.sh: %v", err)
 	}
@@ -633,8 +662,7 @@ command -v jq >/dev/null
 esac
 `
 	}
-	probe := exec.Command(bash, "--noprofile", "--norc", "-c", probeScript)
-	probe.Env = append(prPreflightWindowsRuntimeEnv(),
+	probeEnvironment := append(prPreflightWindowsRuntimeEnv(),
 		"PATH="+path,
 		"HOME="+msysPath(t.TempDir()),
 		"LC_ALL=C",
@@ -645,8 +673,8 @@ esac
 		"GIT_CONFIG_GLOBAL=/dev/null",
 		"GIT_CONFIG_SYSTEM=/dev/null",
 	)
-	if output, err := probe.CombinedOutput(); err != nil {
-		t.Fatalf("selected Bash cannot provide the required preflight boundary: %v\n%s", err, output)
+	if err := testbash.Probe(bash, "preflight process boundary", probeScript, probeEnvironment); err != nil {
+		t.Fatalf("selected Bash cannot provide the required preflight boundary: %v", err)
 	}
 	return bash, path
 }


### PR DESCRIPTION
Native Windows script fixtures can select the WSL launcher before Git Bash and fail before their controlled test runs. Add the shared test-only `scripts/internal/testbash` resolver and use it in the doc-freshness and PR-preflight fixtures. Part of #5727.

On Windows, the resolver locates Git for Windows through `git.exe --exec-path` and checks the interpreter's MINGW/MSYS identity, `pwd -W` support, and exact execution sentinel. `BEADS_TEST_GIT_BASH` remains an absolute validated override. Other hosts retain PATH-based Bash lookup. Each fixture owns its existing capability checks.

Probes remove inherited Bash startup, option, and exported-function controls. Their documented contract requires no stdout or stderr and no shell exit, including `exit 0`, so success reaches the sentinel epilogue. The PR-preflight fixture relies on that shared sanitization instead of adding redundant empty `BASH_ENV` and `ENV` entries. The scoped G702 suppression preserves the intentionally caller-selected, test-only execution boundary.

All ten `TestDocFreshness*` names are preserved. The separate missing zero/partial-selection guard is already tracked by #5726 and implemented in open #5729; it is not part of this PR. The two changes remain compatible in either merge order, with normal current-base reconciliation. This update does not claim protection against a future filtered command selecting no tests.

Validation on current main f56632ad: native Windows Go 1.26.5 / Git for Windows Bash passed the resolver suite (7 parents, 3 children), all ten doc-freshness parents (29 children), and five PR-preflight selector parents (26 children, including the existing workflow contract). The ordinary scripts wrapper, native vet, diff check, and full ci-pr-lint also passed. Focused tests and the scripts wrapper used CGO_ENABLED=0. No tests skipped or failed in the three selected suites; no full Go suite, race, hosted Windows placement, or future zero-selection immunity claim is made. Fresh hosted evidence is required for the updated head. Production Bash discovery and the issue's other fixtures retain their existing scope.

_codex-unknown-model-unknown-reasoning on behalf of Ewen Cuthiell_
