### PR TITLE
Strengthen test observations

### DIFF
--- a/beads_test.go
+++ b/beads_test.go
@@ -82,21 +82,22 @@ func TestFindDatabasePath(t *testing.T) {
 }
 
 func TestFindBeadsDir(t *testing.T) {
-	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	root := t.TempDir()
+	beadsDir := filepath.Join(root, "real", ".beads")
 	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
 		t.Fatalf("create beads directory: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"backend":"dolt"}`), 0o600); err != nil {
 		t.Fatalf("write metadata: %v", err)
 	}
-	t.Setenv("BEADS_DIR", beadsDir)
-
-	want, err := filepath.EvalSymlinks(beadsDir)
-	if err != nil {
-		t.Fatalf("canonicalize BEADS_DIR: %v", err)
+	beadsDirLink := filepath.Join(root, "beads-link")
+	if err := os.Symlink(beadsDir, beadsDirLink); err != nil {
+		t.Fatalf("link beads directory: %v", err)
 	}
-	if got := beads.FindBeadsDir(); got != want {
-		t.Errorf("FindBeadsDir() = %q, want canonical BEADS_DIR %q", got, want)
+	t.Setenv("BEADS_DIR", beadsDirLink)
+
+	if got := beads.FindBeadsDir(); got != beadsDir {
+		t.Errorf("FindBeadsDir() = %q, want canonical BEADS_DIR %q", got, beadsDir)
 	}
 }
 

--- a/beads_test.go
+++ b/beads_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -98,6 +99,9 @@ func TestFindBeadsDir(t *testing.T) {
 	}
 	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"backend":"dolt"}`), 0o600); err != nil {
 		t.Fatalf("write metadata: %v", err)
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("BEADS_DIR canonicalization test requires symlink support")
 	}
 	beadsDirLink := filepath.Join(root, "beads-link")
 	if err := os.Symlink(beadsDir, beadsDirLink); err != nil {

--- a/beads_test.go
+++ b/beads_test.go
@@ -72,12 +72,18 @@ func TestOpen(t *testing.T) {
 }
 
 func TestFindDatabasePath(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "beads.db")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "beads.db")
 	t.Setenv("BEADS_DIR", "")
 	t.Setenv("BEADS_DB", path)
 
-	if got := beads.FindDatabasePath(); got != path {
-		t.Errorf("FindDatabasePath() = %q, want BEADS_DB path %q", got, path)
+	canonicalDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("canonicalize BEADS_DB parent: %v", err)
+	}
+	want := filepath.Join(canonicalDir, "beads.db")
+	if got := beads.FindDatabasePath(); got != want {
+		t.Errorf("FindDatabasePath() = %q, want canonical BEADS_DB path %q", got, want)
 	}
 }
 
@@ -96,8 +102,12 @@ func TestFindBeadsDir(t *testing.T) {
 	}
 	t.Setenv("BEADS_DIR", beadsDirLink)
 
-	if got := beads.FindBeadsDir(); got != beadsDir {
-		t.Errorf("FindBeadsDir() = %q, want canonical BEADS_DIR %q", got, beadsDir)
+	want, err := filepath.EvalSymlinks(beadsDir)
+	if err != nil {
+		t.Fatalf("canonicalize real BEADS_DIR: %v", err)
+	}
+	if got := beads.FindBeadsDir(); got != want {
+		t.Errorf("FindBeadsDir() = %q, want canonical BEADS_DIR %q", got, want)
 	}
 }
 

--- a/beads_test.go
+++ b/beads_test.go
@@ -91,8 +91,12 @@ func TestFindBeadsDir(t *testing.T) {
 	}
 	t.Setenv("BEADS_DIR", beadsDir)
 
-	if got := beads.FindBeadsDir(); got != beadsDir {
-		t.Errorf("FindBeadsDir() = %q, want BEADS_DIR %q", got, beadsDir)
+	want, err := filepath.EvalSymlinks(beadsDir)
+	if err != nil {
+		t.Fatalf("canonicalize BEADS_DIR: %v", err)
+	}
+	if got := beads.FindBeadsDir(); got != want {
+		t.Errorf("FindBeadsDir() = %q, want canonical BEADS_DIR %q", got, want)
 	}
 }
 

--- a/beads_test.go
+++ b/beads_test.go
@@ -72,17 +72,28 @@ func TestOpen(t *testing.T) {
 }
 
 func TestFindDatabasePath(t *testing.T) {
-	// This will return empty string in test environment without a database
-	path := beads.FindDatabasePath()
-	// Just verify it doesn't panic
-	_ = path
+	path := filepath.Join(t.TempDir(), "beads.db")
+	t.Setenv("BEADS_DIR", "")
+	t.Setenv("BEADS_DB", path)
+
+	if got := beads.FindDatabasePath(); got != path {
+		t.Errorf("FindDatabasePath() = %q, want BEADS_DB path %q", got, path)
+	}
 }
 
 func TestFindBeadsDir(t *testing.T) {
-	// This will return empty string or a valid path
-	dir := beads.FindBeadsDir()
-	// Just verify it doesn't panic
-	_ = dir
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("create beads directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"backend":"dolt"}`), 0o600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+
+	if got := beads.FindBeadsDir(); got != beadsDir {
+		t.Errorf("FindBeadsDir() = %q, want BEADS_DIR %q", got, beadsDir)
+	}
 }
 
 func TestOpenFromConfig_Embedded(t *testing.T) {

--- a/beads_test.go
+++ b/beads_test.go
@@ -74,6 +74,9 @@ func TestOpen(t *testing.T) {
 func TestFindDatabasePath(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "beads.db")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("create BEADS_DB path: %v", err)
+	}
 	t.Setenv("BEADS_DIR", "")
 	t.Setenv("BEADS_DB", path)
 

--- a/cmd/bd/config_apply_test.go
+++ b/cmd/bd/config_apply_test.go
@@ -334,7 +334,6 @@ func TestRemoteApplyResultUsesSuccessfulRemoteRecheck(t *testing.T) {
 }
 
 func TestPrintApplyResults(t *testing.T) {
-	// Smoke test — just ensure no panic
 	results := []ApplyResult{
 		{Check: "hooks", Action: "none", Status: applyStatusOK, Message: "up to date"},
 		{Check: "remote", Action: "add_remote", Status: applyStatusApplied, Message: "added"},
@@ -342,12 +341,31 @@ func TestPrintApplyResults(t *testing.T) {
 		{Check: "hooks", Action: "reinstall", Status: applyStatusDryRun, Message: "would reinstall"},
 		{Check: "remote", Action: "none", Status: applyStatusSkipped, Message: "skipped"},
 	}
-	// Redirect stdout to avoid test noise
-	old := os.Stdout
-	os.Stdout, _ = os.Open(os.DevNull)
-	defer func() { os.Stdout = old }()
-	printApplyResults(results)
-	printApplyResults(nil)
+
+	output := captureStdout(t, func() error {
+		printApplyResults(results)
+		return nil
+	})
+	for _, want := range []string{
+		"✓ hooks: up to date",
+		"✓ remote: added",
+		"✗ server: failed",
+		"error: no dolt",
+		"~ hooks: would reinstall",
+		"– remote: skipped",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("printApplyResults() output = %q, want substring %q", output, want)
+		}
+	}
+
+	emptyOutput := captureStdout(t, func() error {
+		printApplyResults(nil)
+		return nil
+	})
+	if emptyOutput != "No actions to apply\n" {
+		t.Errorf("printApplyResults(nil) = %q, want %q", emptyOutput, "No actions to apply\\n")
+	}
 }
 
 // fakeOriginRemoteEvidence simulates the two evidence sources

--- a/cmd/bd/config_side_effects_test.go
+++ b/cmd/bd/config_side_effects_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"os"
+	"strings"
 	"testing"
 )
 
@@ -137,20 +137,23 @@ func TestCheckConfigUnsetSideEffects_UnknownKey(t *testing.T) {
 }
 
 func TestPrintConfigSideEffects(t *testing.T) {
-	// Redirect stderr to avoid test noise
-	old := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	defer func() { w.Close(); r.Close(); os.Stderr = old }()
+	if output := captureStderr(t, func() { printConfigSideEffects(nil) }); output != "" {
+		t.Errorf("printConfigSideEffects(nil) = %q, want no output", output)
+	}
 
-	// Should not panic with empty, single, or multiple effects
-	printConfigSideEffects(nil)
-	printConfigSideEffects([]configSideEffect{})
-	printConfigSideEffects([]configSideEffect{
-		{Message: "test hint", Command: "bd test"},
+	output := captureStderr(t, func() {
+		printConfigSideEffects([]configSideEffect{
+			{Message: "no command hint"},
+			{Message: "with command", Command: "bd apply"},
+		})
 	})
-	printConfigSideEffects([]configSideEffect{
-		{Message: "no command hint"},
-		{Message: "with command", Command: "bd apply"},
-	})
+	for _, want := range []string{
+		"Hint: no command hint",
+		"Hint: with command",
+		"→ bd apply",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("printConfigSideEffects() output = %q, want substring %q", output, want)
+		}
+	}
 }

--- a/cmd/bd/helpers_test.go
+++ b/cmd/bd/helpers_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"os/exec"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/utils"
 )
 
@@ -27,10 +29,30 @@ func TestIsNumericID_EdgeCases(t *testing.T) {
 	}
 }
 
-func TestGetWorktreeGitDir(_ *testing.T) {
-	gitDir := getWorktreeGitDir()
-	// Just verify it doesn't panic and returns a string
-	_ = gitDir
+func TestGetWorktreeGitDir(t *testing.T) {
+	git.ResetCaches()
+	t.Cleanup(git.ResetCaches)
+	t.Chdir(t.TempDir())
+
+	if got := getWorktreeGitDir(); got != "" {
+		t.Errorf("getWorktreeGitDir() = %q outside a git repository, want empty", got)
+	}
+}
+
+func TestGetWorktreeGitDirInRepository(t *testing.T) {
+	git.ResetCaches()
+	t.Cleanup(git.ResetCaches)
+	repo := t.TempDir()
+	cmd := exec.Command("git", "init", "-q")
+	cmd.Dir = repo
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, output)
+	}
+	t.Chdir(repo)
+
+	if got := getWorktreeGitDir(); got != ".git" {
+		t.Errorf("getWorktreeGitDir() = %q, want .git", got)
+	}
 }
 
 func TestExtractPrefix(t *testing.T) {

--- a/cmd/bd/helpers_test.go
+++ b/cmd/bd/helpers_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/git"
@@ -39,25 +42,40 @@ func TestGetWorktreeGitDir(t *testing.T) {
 	}
 }
 
-func TestGetWorktreeGitDirInRepository(t *testing.T) {
+func TestGetWorktreeGitDirInWorktree(t *testing.T) {
 	git.ResetCaches()
 	t.Cleanup(git.ResetCaches)
-	repo := t.TempDir()
-	cmd := exec.Command("git", "init", "-q")
-	cmd.Dir = repo
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git init: %v\n%s", err, output)
-	}
-	cmd = exec.Command("git", "config", "core.hooksPath", ".git/hooks")
-	cmd.Dir = repo
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("configure repository-local hooks: %v\n%s", err, output)
-	}
-	t.Chdir(repo)
 
-	if got := getWorktreeGitDir(); got != ".git" {
-		t.Errorf("getWorktreeGitDir() = %q, want .git", got)
+	repo := t.TempDir()
+	runGitInDir(t, repo, "init", "-q")
+	runGitInDir(t, repo, "config", "core.hooksPath", ".git/hooks")
+	runGitInDir(t, repo, "config", "user.email", "test@example.com")
+	runGitInDir(t, repo, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repo, "README"), []byte("test\n"), 0o600); err != nil {
+		t.Fatalf("write initial worktree file: %v", err)
 	}
+	runGitInDir(t, repo, "add", "README")
+	runGitInDir(t, repo, "commit", "-qm", "initial")
+
+	worktree := filepath.Join(t.TempDir(), "linked")
+	runGitInDir(t, repo, "worktree", "add", "-q", "-b", "test-worktree", worktree)
+	t.Chdir(worktree)
+
+	want := runGitInDir(t, worktree, "rev-parse", "--git-dir")
+	if got := getWorktreeGitDir(); got != want {
+		t.Errorf("getWorktreeGitDir() = %q, want git worktree directory %q", got, want)
+	}
+}
+
+func runGitInDir(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+	return strings.TrimSpace(string(output))
 }
 
 func TestExtractPrefix(t *testing.T) {

--- a/cmd/bd/helpers_test.go
+++ b/cmd/bd/helpers_test.go
@@ -48,6 +48,11 @@ func TestGetWorktreeGitDirInRepository(t *testing.T) {
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init: %v\n%s", err, output)
 	}
+	cmd = exec.Command("git", "config", "core.hooksPath", ".git/hooks")
+	cmd.Dir = repo
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("configure repository-local hooks: %v\n%s", err, output)
+	}
 	t.Chdir(repo)
 
 	if got := getWorktreeGitDir(); got != ".git" {

--- a/cmd/bd/linear_test.go
+++ b/cmd/bd/linear_test.go
@@ -1780,6 +1780,15 @@ func (f fakeLinearConfigReader) GetConfig(_ context.Context, key string) (string
 	return f[key], nil
 }
 
+type countingLinearConfigReader struct {
+	calls int
+}
+
+func (f *countingLinearConfigReader) GetConfig(context.Context, string) (string, error) {
+	f.calls++
+	return "", nil
+}
+
 // TestApplyLinearExcludeIDConfig covers the bd-ee0 config-read path that
 // wires linear.exclude_id_prefix / linear.exclude_id_patterns into
 // SyncOptions. The engine-side filter behavior (applying the rules to
@@ -1851,16 +1860,27 @@ func TestApplyLinearExcludeIDConfig(t *testing.T) {
 
 // TestApplyLinearExcludeIDConfig_NilSafe verifies nil inputs are no-ops.
 func TestApplyLinearExcludeIDConfig_NilSafe(t *testing.T) {
-	opts := tracker.SyncOptions{
-		ExcludeIDPrefix:   "existing-",
-		ExcludeIDPatterns: []string{"existing-pattern"},
-	}
-	applyLinearExcludeIDConfig(context.Background(), nil, &opts)
+	t.Run("nil reader preserves options", func(t *testing.T) {
+		opts := tracker.SyncOptions{
+			ExcludeIDPrefix:   "existing-",
+			ExcludeIDPatterns: []string{"existing-pattern"},
+		}
+		applyLinearExcludeIDConfig(context.Background(), nil, &opts)
 
-	if opts.ExcludeIDPrefix != "existing-" {
-		t.Errorf("nil reader changed ExcludeIDPrefix to %q", opts.ExcludeIDPrefix)
-	}
-	if !reflect.DeepEqual(opts.ExcludeIDPatterns, []string{"existing-pattern"}) {
-		t.Errorf("nil reader changed ExcludeIDPatterns to %v", opts.ExcludeIDPatterns)
-	}
+		if opts.ExcludeIDPrefix != "existing-" {
+			t.Errorf("nil reader changed ExcludeIDPrefix to %q", opts.ExcludeIDPrefix)
+		}
+		if !reflect.DeepEqual(opts.ExcludeIDPatterns, []string{"existing-pattern"}) {
+			t.Errorf("nil reader changed ExcludeIDPatterns to %v", opts.ExcludeIDPatterns)
+		}
+	})
+
+	t.Run("nil options do not query reader", func(t *testing.T) {
+		reader := &countingLinearConfigReader{}
+		applyLinearExcludeIDConfig(context.Background(), reader, nil)
+
+		if reader.calls != 0 {
+			t.Errorf("nil options queried config reader %d times, want 0", reader.calls)
+		}
+	})
 }

--- a/cmd/bd/linear_test.go
+++ b/cmd/bd/linear_test.go
@@ -1849,10 +1849,18 @@ func TestApplyLinearExcludeIDConfig(t *testing.T) {
 	}
 }
 
-// TestApplyLinearExcludeIDConfig_NilSafe verifies the helper is safe to
-// call with nil reader or nil opts (defensive guards).
+// TestApplyLinearExcludeIDConfig_NilSafe verifies nil inputs are no-ops.
 func TestApplyLinearExcludeIDConfig_NilSafe(t *testing.T) {
-	var opts tracker.SyncOptions
-	applyLinearExcludeIDConfig(context.Background(), nil, &opts)                    // must not panic
-	applyLinearExcludeIDConfig(context.Background(), fakeLinearConfigReader{}, nil) // must not panic
+	opts := tracker.SyncOptions{
+		ExcludeIDPrefix:   "existing-",
+		ExcludeIDPatterns: []string{"existing-pattern"},
+	}
+	applyLinearExcludeIDConfig(context.Background(), nil, &opts)
+
+	if opts.ExcludeIDPrefix != "existing-" {
+		t.Errorf("nil reader changed ExcludeIDPrefix to %q", opts.ExcludeIDPrefix)
+	}
+	if !reflect.DeepEqual(opts.ExcludeIDPatterns, []string{"existing-pattern"}) {
+		t.Errorf("nil reader changed ExcludeIDPatterns to %v", opts.ExcludeIDPatterns)
+	}
 }

--- a/cmd/bd/workspace_identity_test.go
+++ b/cmd/bd/workspace_identity_test.go
@@ -1,25 +1,27 @@
 package main
 
 import (
+	"context"
+	"path/filepath"
 	"testing"
 )
 
 func TestValidateWorkspaceIdentity_NilStore(t *testing.T) {
-	// When store is nil, validateWorkspaceIdentity should be a no-op
-	// (no panic, no os.Exit)
 	origStore := store
 	store = nil
-	defer func() { store = nil; store = origStore }()
+	t.Cleanup(func() { store = origStore })
 
-	validateWorkspaceIdentity(nil, "/nonexistent")
-	// If we got here, no os.Exit was called — pass
+	if err := validateWorkspaceIdentity(context.Background(), filepath.Join(t.TempDir(), ".beads")); err != nil {
+		t.Errorf("validateWorkspaceIdentity() with nil store = %v, want nil", err)
+	}
 }
 
 func TestValidateWorkspaceIdentity_NonexistentDir(t *testing.T) {
-	// When beadsDir doesn't exist, configfile.Load fails and we skip validation
 	origStore := store
 	store = nil
-	defer func() { store = origStore }()
+	t.Cleanup(func() { store = origStore })
 
-	validateWorkspaceIdentity(nil, "/nonexistent/path/that/does/not/exist")
+	if err := validateWorkspaceIdentity(context.Background(), filepath.Join(t.TempDir(), "missing", ".beads")); err != nil {
+		t.Errorf("validateWorkspaceIdentity() with no config = %v, want nil", err)
+	}
 }

--- a/cmd/bd/workspace_identity_test.go
+++ b/cmd/bd/workspace_identity_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
 )
 
 func TestValidateWorkspaceIdentity_NilStore(t *testing.T) {
@@ -16,12 +18,26 @@ func TestValidateWorkspaceIdentity_NilStore(t *testing.T) {
 	}
 }
 
+type metadataRecordingStore struct {
+	storage.DoltStorage
+	metadataCalls int
+}
+
+func (s *metadataRecordingStore) GetMetadata(context.Context, string) (string, error) {
+	s.metadataCalls++
+	return "unexpected", nil
+}
+
 func TestValidateWorkspaceIdentity_NonexistentDir(t *testing.T) {
 	origStore := store
-	store = nil
+	fakeStore := &metadataRecordingStore{}
+	store = fakeStore
 	t.Cleanup(func() { store = origStore })
 
 	if err := validateWorkspaceIdentity(context.Background(), filepath.Join(t.TempDir(), "missing", ".beads")); err != nil {
 		t.Errorf("validateWorkspaceIdentity() with no config = %v, want nil", err)
+	}
+	if fakeStore.metadataCalls != 0 {
+		t.Errorf("validateWorkspaceIdentity() queried metadata %d times without config, want 0", fakeStore.metadataCalls)
 	}
 }

--- a/examples/library-usage/main_test.go
+++ b/examples/library-usage/main_test.go
@@ -121,24 +121,45 @@ func TestExampleCompiles(t *testing.T) {
 	t.Log("✅ All example operations work correctly")
 }
 
-// TestDependencyConstants ensures all constants are accessible
+// TestDependencyConstants ensures the example's public constants retain their
+// documented wire values.
 func TestDependencyConstants(t *testing.T) {
-	// Test that all constants from the example are accessible
-	_ = beads.StatusOpen
-	_ = beads.StatusInProgress
-	_ = beads.StatusClosed
-	_ = beads.StatusBlocked
+	statuses := map[beads.Status]string{
+		beads.StatusOpen:       "open",
+		beads.StatusInProgress: "in_progress",
+		beads.StatusClosed:     "closed",
+		beads.StatusBlocked:    "blocked",
+	}
+	for got, want := range statuses {
+		if string(got) != want {
+			t.Errorf("status constant = %q, want %q", got, want)
+		}
+	}
 
-	_ = beads.TypeBug
-	_ = beads.TypeFeature
-	_ = beads.TypeTask
-	_ = beads.TypeEpic
-	_ = beads.TypeChore
+	issueTypes := map[beads.IssueType]string{
+		beads.TypeBug:     "bug",
+		beads.TypeFeature: "feature",
+		beads.TypeTask:    "task",
+		beads.TypeEpic:    "epic",
+		beads.TypeChore:   "chore",
+	}
+	for got, want := range issueTypes {
+		if string(got) != want {
+			t.Errorf("issue type constant = %q, want %q", got, want)
+		}
+	}
 
-	_ = beads.DepBlocks
-	_ = beads.DepRelated
-	_ = beads.DepParentChild
-	_ = beads.DepDiscoveredFrom
+	dependencyTypes := map[beads.DependencyType]string{
+		beads.DepBlocks:         "blocks",
+		beads.DepRelated:        "related",
+		beads.DepParentChild:    "parent-child",
+		beads.DepDiscoveredFrom: "discovered-from",
+	}
+	for got, want := range dependencyTypes {
+		if string(got) != want {
+			t.Errorf("dependency type constant = %q, want %q", got, want)
+		}
+	}
 }
 
 // TestFindDatabasePath tests database discovery

--- a/examples/library-usage/main_test.go
+++ b/examples/library-usage/main_test.go
@@ -124,41 +124,31 @@ func TestExampleCompiles(t *testing.T) {
 // TestDependencyConstants ensures the example's public constants retain their
 // documented wire values.
 func TestDependencyConstants(t *testing.T) {
-	statuses := map[beads.Status]string{
-		beads.StatusOpen:       "open",
-		beads.StatusInProgress: "in_progress",
-		beads.StatusClosed:     "closed",
-		beads.StatusBlocked:    "blocked",
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"StatusOpen", string(beads.StatusOpen), "open"},
+		{"StatusInProgress", string(beads.StatusInProgress), "in_progress"},
+		{"StatusClosed", string(beads.StatusClosed), "closed"},
+		{"StatusBlocked", string(beads.StatusBlocked), "blocked"},
+		{"TypeBug", string(beads.TypeBug), "bug"},
+		{"TypeFeature", string(beads.TypeFeature), "feature"},
+		{"TypeTask", string(beads.TypeTask), "task"},
+		{"TypeEpic", string(beads.TypeEpic), "epic"},
+		{"TypeChore", string(beads.TypeChore), "chore"},
+		{"DepBlocks", string(beads.DepBlocks), "blocks"},
+		{"DepRelated", string(beads.DepRelated), "related"},
+		{"DepParentChild", string(beads.DepParentChild), "parent-child"},
+		{"DepDiscoveredFrom", string(beads.DepDiscoveredFrom), "discovered-from"},
 	}
-	for got, want := range statuses {
-		if string(got) != want {
-			t.Errorf("status constant = %q, want %q", got, want)
-		}
-	}
-
-	issueTypes := map[beads.IssueType]string{
-		beads.TypeBug:     "bug",
-		beads.TypeFeature: "feature",
-		beads.TypeTask:    "task",
-		beads.TypeEpic:    "epic",
-		beads.TypeChore:   "chore",
-	}
-	for got, want := range issueTypes {
-		if string(got) != want {
-			t.Errorf("issue type constant = %q, want %q", got, want)
-		}
-	}
-
-	dependencyTypes := map[beads.DependencyType]string{
-		beads.DepBlocks:         "blocks",
-		beads.DepRelated:        "related",
-		beads.DepParentChild:    "parent-child",
-		beads.DepDiscoveredFrom: "discovered-from",
-	}
-	for got, want := range dependencyTypes {
-		if string(got) != want {
-			t.Errorf("dependency type constant = %q, want %q", got, want)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("constant = %q, want %q", tt.got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/storage/hook_decorator_test.go
+++ b/internal/storage/hook_decorator_test.go
@@ -1,6 +1,7 @@
 package storage_test
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -52,6 +53,37 @@ func TestNewHookFiringStoreNilRunnerPreservesWrappedStore(t *testing.T) {
 	}
 	if got := wrapped.Unwrap(); got != raw {
 		t.Errorf("NewHookFiringStore(...).Unwrap() = %T, want original store %T", got, raw)
+	}
+}
+
+type transactionRecordingStore struct {
+	storage.DoltStorage
+	commitMessage string
+	callbackRan   bool
+}
+
+func (s *transactionRecordingStore) RunInTransaction(_ context.Context, commitMessage string, fn func(storage.Transaction) error) error {
+	s.commitMessage = commitMessage
+	s.callbackRan = true
+	return fn(nil)
+}
+
+func TestHookFiringStoreNilRunnerDelegatesTransaction(t *testing.T) {
+	raw := &transactionRecordingStore{}
+	wrapped := storage.NewHookFiringStore(raw, nil)
+
+	callbackRan := false
+	if err := wrapped.RunInTransaction(context.Background(), "test transaction", func(storage.Transaction) error {
+		callbackRan = true
+		return nil
+	}); err != nil {
+		t.Fatalf("RunInTransaction() = %v", err)
+	}
+	if !raw.callbackRan || !callbackRan {
+		t.Error("RunInTransaction() did not invoke the wrapped store and callback")
+	}
+	if raw.commitMessage != "test transaction" {
+		t.Errorf("wrapped transaction message = %q, want %q", raw.commitMessage, "test transaction")
 	}
 }
 

--- a/internal/storage/hook_decorator_test.go
+++ b/internal/storage/hook_decorator_test.go
@@ -1,12 +1,9 @@
 package storage_test
 
 import (
-	"context"
-	"errors"
 	"sync"
 	"testing"
 
-	"github.com/steveyegge/beads/internal/hooks"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -40,45 +37,22 @@ func (m *mockHookRunner) get(i int) hookInvocation {
 	return m.invoked[i]
 }
 
-// Unfortunately hooks.Runner uses concrete methods, not an interface.
-// The HookFiringStore takes *hooks.Runner which calls shell scripts.
-// For unit testing, we need to verify the decorator logic without
-// actually running hook scripts. We'll test via the transaction
-// tracking mechanism and verify the overall architecture works.
-
 func TestHookFiringStoreCompileTimeChecks(t *testing.T) {
 	// Verify the decorator satisfies DoltStorage at compile time.
 	// This is also checked via var _ declarations in the source.
 	var _ storage.DoltStorage = (*storage.HookFiringStore)(nil)
 }
 
-func TestHookTrackingTransactionAccumulatesEvents(t *testing.T) {
-	// This test verifies the transaction tracking logic by checking
-	// that RunInTransaction with a nil runner doesn't panic and the
-	// decorator properly wraps the transaction.
-	//
-	// Full integration tests require a real DoltStore + hook scripts,
-	// which are covered by the bd CLI integration test suite.
-	t.Log("Transaction tracking is tested via integration tests in cmd/bd/")
-}
+func TestNewHookFiringStoreNilRunnerPreservesWrappedStore(t *testing.T) {
+	raw := &stubDoltStore{}
+	wrapped := storage.NewHookFiringStore(raw, nil)
 
-func TestNewHookFiringStoreNilRunnerSafe(t *testing.T) {
-	// Verify that a nil runner doesn't cause panics.
-	// We can't easily mock DoltStorage (it's a massive interface),
-	// so we verify the constructor doesn't panic.
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("NewHookFiringStore with nil runner panicked: %v", r)
-		}
-	}()
-	// Can't pass nil for DoltStorage without a mock, but we can verify
-	// the nil runner path in fireHook.
-	_ = hooks.EventCreate
-	_ = hooks.EventUpdate
-	_ = hooks.EventClose
-	_ = context.Background()
-	_ = errors.New("test")
-	_ = types.Issue{}
+	if wrapped == nil {
+		t.Fatal("NewHookFiringStore() returned nil")
+	}
+	if got := wrapped.Unwrap(); got != raw {
+		t.Errorf("NewHookFiringStore(...).Unwrap() = %T, want original store %T", got, raw)
+	}
 }
 
 // stubDoltStore is a typed stand-in for a concrete DoltStorage implementation.


### PR DESCRIPTION
## What
Replace the test-evidence audit's no-observation tests with assertions on production results, rendered output, delegated calls, and explicit no-op effects.

## Why
A test that only reaches the end does not establish that the system under test produced the expected result. These changes make the audited tests sensitive to regressions while retaining their original scope.

## Validation
- Focused changed-test packages: passed in a capped Docker container.
- `make test`: exercised in a capped Docker container; unrelated existing failures remained in `cmd/bd`, `cmd/bd/setup`, and `internal/doltserver` (permission/process-diagnostic assumptions).
- `make ci-pr-lint`: gofmt passed; the container image lacks the required `golangci-lint` binary.

_Agent-pi-unknown-model-unknown-reasoning on behalf of Jonathan Baldie_
