### PR TITLE
fix(schema): verify migration DDL before recording marks

### DIFF
--- a/internal/storage/schema/cli_migrations.go
+++ b/internal/storage/schema/cli_migrations.go
@@ -57,6 +57,10 @@ func cliCompatibleMigrationSQL(name, sqlText string) string {
 		return cliMigration0046AddIsBlocked
 	case "0049_longtext_large_content_columns.up.sql":
 		return cliMigration0049LongtextLargeContentColumns
+	case "0050_dependencies_deterministic_id.up.sql":
+		// Direct DDL: the Dolt CLI batch path can report success while a
+		// prepared ALTER silently no-ops (dolthub/dolt#11345).
+		return cliMigration0050DependenciesDeterministicID
 	case "0051_drop_aux_id_defaults.up.sql":
 		// Direct DDL: the source migration's PREPARE/EXECUTE guards exist for
 		// re-run safety on upgraded databases; a fresh bundle always has the
@@ -171,6 +175,11 @@ SET FOREIGN_KEY_CHECKS = 1;`
 
 const cliMigration0046AddIsBlocked = `ALTER TABLE issues ADD COLUMN is_blocked TINYINT(1) NOT NULL DEFAULT 0;
 CREATE INDEX idx_issues_is_blocked ON issues(is_blocked, status);`
+
+const cliMigration0050DependenciesDeterministicID = `ALTER TABLE dependencies ALTER COLUMN id DROP DEFAULT;
+CREATE UNIQUE INDEX IF NOT EXISTS uk_dep_issue_target ON dependencies (issue_id, depends_on_issue_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uk_dep_wisp_target ON dependencies (issue_id, depends_on_wisp_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uk_dep_external_target ON dependencies (issue_id, depends_on_external);`
 
 const cliMigration0049LongtextLargeContentColumns = `ALTER TABLE issues MODIFY COLUMN description LONGTEXT NOT NULL, MODIFY COLUMN design LONGTEXT NOT NULL, MODIFY COLUMN acceptance_criteria LONGTEXT NOT NULL, MODIFY COLUMN notes LONGTEXT NOT NULL;
 ALTER TABLE issues MODIFY COLUMN close_reason LONGTEXT DEFAULT '';

--- a/internal/storage/schema/content_hash_test.go
+++ b/internal/storage/schema/content_hash_test.go
@@ -146,6 +146,9 @@ func TestMigrationWorkNotNeededWhenContentHashColumnsPresent(t *testing.T) {
 		WillReturnRows(showColumnsRows("content_hash"))
 	mock.ExpectQuery(`SHOW COLUMNS FROM ignored_schema_migrations LIKE 'content_hash'`).
 		WillReturnRows(showColumnsRows("content_hash"))
+	expectNoIDDefaultInvariantRepairSentinel(mock)
+	expectHealthyIDDefaultInvariants(mock, mainIDDefaultInvariantTables)
+	expectHealthyIDDefaultInvariants(mock, ignoredIDDefaultInvariantTables)
 	// No backfill pending (custom tables already populated).
 	expectScalar(mock, "SELECT COUNT(*) FROM custom_types", "count", 1)
 	expectScalar(mock, "SELECT COUNT(*) FROM custom_statuses", "count", 1)

--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"regexp"
 	"strings"
@@ -157,12 +158,16 @@ func TestMigrateUpSeedsIgnorePatternsWhenNoWorkNeeded(t *testing.T) {
 
 	expectIgnorePatternSeed(mock, LatestVersion())
 	// migrationWorkNeeded: both cursors at latest, both content_hash columns
-	// present, no custom backfill pending -> no work, MigrateUp short-circuits.
+	// present, schema invariants hold, and no custom backfill is pending -> no
+	// work, so MigrateUp short-circuits.
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion())
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
 	expectIgnoredSentinelProbes(mock, true)
 	expectContentHashColumnExists(mock)
 	expectContentHashColumnExists(mock)
+	expectNoIDDefaultInvariantRepairSentinel(mock)
+	expectHealthyIDDefaultInvariants(mock, mainIDDefaultInvariantTables)
+	expectHealthyIDDefaultInvariants(mock, ignoredIDDefaultInvariantTables)
 	expectScalar(mock, "SELECT COUNT(*) FROM custom_types", "count", 1)
 	expectScalar(mock, "SELECT COUNT(*) FROM custom_statuses", "count", 1)
 	// The seed inserted rows and no migration pass follows to commit them, so
@@ -202,6 +207,9 @@ func TestMigrateUpSkipsSeedCommitWhenNothingChanged(t *testing.T) {
 	expectIgnoredSentinelProbes(mock, true)
 	expectContentHashColumnExists(mock)
 	expectContentHashColumnExists(mock)
+	expectNoIDDefaultInvariantRepairSentinel(mock)
+	expectHealthyIDDefaultInvariants(mock, mainIDDefaultInvariantTables)
+	expectHealthyIDDefaultInvariants(mock, ignoredIDDefaultInvariantTables)
 	expectScalar(mock, "SELECT COUNT(*) FROM custom_types", "count", 1)
 	expectScalar(mock, "SELECT COUNT(*) FROM custom_statuses", "count", 1)
 
@@ -310,6 +318,9 @@ func expectOnePendingMigration(t *testing.T, mock sqlmock.Sqlmock) {
 	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?)")).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"hash"}))
+	expectNoIDDefaultInvariantRepairSentinel(mock)
+	expectHealthyIDDefaultInvariants(mock, mainIDDefaultInvariantTables)
+	expectHealthyIDDefaultInvariants(mock, mainIDDefaultInvariantTables)
 	expectScalar(mock, "SELECT COUNT(*) FROM custom_types", "count", 1)
 	expectScalar(mock, "SELECT COUNT(*) FROM custom_statuses", "count", 1)
 	// rekeyDependencyIDs probes whether each edge table has an id column; this
@@ -329,6 +340,7 @@ func expectOnePendingMigration(t *testing.T, mock sqlmock.Sqlmock) {
 	// too, not just in migrationWorkNeeded.
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", latestIgnored)
 	expectIgnoredSentinelProbes(mock, true)
+	expectHealthyIDDefaultInvariants(mock, ignoredIDDefaultInvariantTables)
 	expectDoltStatusRows(mock)
 	expectDoltStatusRows(mock)
 	mock.ExpectQuery("(?s)SELECT t\\.TABLE_NAME\\s+FROM INFORMATION_SCHEMA\\.TABLES t").
@@ -360,6 +372,23 @@ func expectColumnExists(mock sqlmock.Sqlmock, present bool) {
 func expectContentHashColumnExists(mock sqlmock.Sqlmock) {
 	mock.ExpectQuery(`SHOW COLUMNS FROM \w+ LIKE 'content_hash'`).
 		WillReturnRows(showColumnsRows("content_hash"))
+}
+
+func expectNoIDDefaultInvariantRepairSentinel(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.TABLES`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+}
+
+func expectHealthyIDDefaultInvariants(mock sqlmock.Sqlmock, tables []string) {
+	args := make([]driver.Value, len(tables))
+	rows := sqlmock.NewRows([]string{"TABLE_NAME", "COLUMN_DEFAULT"})
+	for i, table := range tables {
+		args[i] = table
+		rows.AddRow(table, nil)
+	}
+	mock.ExpectQuery(`(?s)SELECT TABLE_NAME, COLUMN_DEFAULT.*FROM INFORMATION_SCHEMA\.COLUMNS.*TABLE_NAME IN`).
+		WithArgs(args...).
+		WillReturnRows(rows)
 }
 
 func expectScalar(mock sqlmock.Sqlmock, query, column string, value any) {

--- a/internal/storage/schema/migration_invariants.go
+++ b/internal/storage/schema/migration_invariants.go
@@ -1,0 +1,282 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var repairMigrationIDDefaultInvariants = repairIDDefaultInvariants
+
+const idDefaultInvariantRepairSentinel = "schema_id_default_invariant_repair_in_progress"
+
+var uuidDefaultDDLRE = regexp.MustCompile(`(?i)\s+DEFAULT\s+\(UUID\(\)\)`)
+
+var (
+	mainIDDefaultInvariantTables = []string{
+		"dependencies",
+		"events",
+		"comments",
+		"issue_snapshots",
+		"compaction_snapshots",
+	}
+	ignoredIDDefaultInvariantTables = []string{
+		"wisp_events",
+		"wisp_comments",
+		"wisp_dependencies",
+	}
+	// events joined the clone-local ignored plane in migration 0062. The
+	// remaining main-series tables are versioned and must be committed when an
+	// at-latest repair changes their schema.
+	versionedIDDefaultInvariantTables = map[string]struct{}{
+		"dependencies":         {},
+		"comments":             {},
+		"issue_snapshots":      {},
+		"compaction_snapshots": {},
+	}
+)
+
+// migrationIDDefaultTables returns the no-default invariant introduced by one
+// migration. Keeping this keyed to the frozen filename lets runMigrations
+// enforce the DDL before recording that version without mistaking a different
+// migration source that happens to reuse the same numeric version.
+func migrationIDDefaultTables(filename string) []string {
+	switch filename {
+	case "0050_dependencies_deterministic_id.up.sql":
+		return mainIDDefaultInvariantTables[:1]
+	case "0051_drop_aux_id_defaults.up.sql":
+		return mainIDDefaultInvariantTables[1:]
+	case "0010_drop_wisp_id_defaults.up.sql":
+		return ignoredIDDefaultInvariantTables
+	default:
+		return nil
+	}
+}
+
+// idDefaultInvariantNeedsRepair reports whether any current-schema id column
+// still has a default that its recorded migration claims to have dropped.
+func idDefaultInvariantNeedsRepair(ctx context.Context, db DBConn) (bool, error) {
+	resume, err := idDefaultInvariantRepairPending(ctx, db)
+	if err != nil {
+		return false, err
+	}
+	if resume {
+		return true, nil
+	}
+	mainNeeds, err := idDefaultsNeedRepair(ctx, db, mainIDDefaultInvariantTables)
+	if err != nil {
+		return false, err
+	}
+	if mainNeeds {
+		return true, nil
+	}
+	return idDefaultsNeedRepair(ctx, db, ignoredIDDefaultInvariantTables)
+}
+
+func idDefaultsNeedRepair(ctx context.Context, db DBConn, tables []string) (bool, error) {
+	targets, err := idDefaultTablesNeedingRepair(ctx, db, tables)
+	return len(targets) > 0, err
+}
+
+func idDefaultTablesNeedingRepair(ctx context.Context, db DBConn, tables []string) ([]string, error) {
+	defaults, err := readIDColumnDefaults(ctx, db, tables)
+	if err != nil {
+		return nil, err
+	}
+	var targets []string
+	for _, table := range tables {
+		columnDefault, ok := defaults[table]
+		if !ok {
+			return nil, fmt.Errorf("migration invariant: expected current-schema column %s.id is missing", table)
+		}
+		if columnDefault.Valid {
+			targets = append(targets, table)
+		}
+	}
+	return targets, nil
+}
+
+// repairIDDefaultInvariants reasserts the canonical no-default DDL and verifies
+// the result. It is used both immediately after the migration body (before its
+// cursor row is recorded) and on an at-latest database whose cursor contradicts
+// its live DDL. The returned table names are the tables actually altered.
+func repairIDDefaultInvariants(ctx context.Context, db DBConn, tables []string) ([]string, error) {
+	if len(tables) == 0 {
+		return nil, nil
+	}
+	targets, err := idDefaultTablesNeedingRepair(ctx, db, tables)
+	if err != nil {
+		return nil, err
+	}
+	for _, table := range targets {
+		// table is selected only from the hard-coded invariant lists above.
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("ALTER TABLE `%s` ALTER COLUMN id DROP DEFAULT", table)); err != nil {
+			return nil, fmt.Errorf("reasserting migration invariant for %s.id: %w", table, err)
+		}
+	}
+
+	if len(targets) == 0 {
+		return nil, nil
+	}
+	stillNeedsRepair, err := idDefaultsNeedRepair(ctx, db, tables)
+	if err != nil {
+		return nil, err
+	}
+	if stillNeedsRepair {
+		return nil, fmt.Errorf("migration invariant verification failed: id default remains on one of %s", strings.Join(tables, ", "))
+	}
+	return targets, nil
+}
+
+func idDefaultInvariantRepairPending(ctx context.Context, db DBConn) (bool, error) {
+	return auxRekeyResumePending(ctx, db, idDefaultInvariantRepairSentinel)
+}
+
+func setIDDefaultInvariantRepairPending(ctx context.Context, db DBConn) error {
+	return setAuxRekeyInProgress(ctx, db, idDefaultInvariantRepairSentinel)
+}
+
+func clearIDDefaultInvariantRepairPending(ctx context.Context, db DBConn) error {
+	return clearAuxRekeyInProgress(ctx, db, idDefaultInvariantRepairSentinel)
+}
+
+func commitIDDefaultInvariantRepairs(ctx context.Context, db DBConn, changed []string) error {
+	pending, err := pendingVersionedIDDefaultSchemaRepairs(ctx, db)
+	if err != nil {
+		return err
+	}
+	tableSet := make(map[string]struct{}, len(changed)+len(pending))
+	for _, table := range append(changed, pending...) {
+		if _, ok := versionedIDDefaultInvariantTables[table]; ok {
+			tableSet[table] = struct{}{}
+		}
+	}
+	versioned := make([]string, 0, len(tableSet))
+	for table := range tableSet {
+		versioned = append(versioned, table)
+	}
+	if len(versioned) == 0 {
+		return clearIDDefaultInvariantRepairPending(ctx, db)
+	}
+	sort.Strings(versioned)
+	for _, table := range versioned {
+		if err := DrainCall(ctx, db, "CALL DOLT_ADD('-f', ?)", table); err != nil {
+			return fmt.Errorf("staging migration invariant repair for %s: %w", table, err)
+		}
+	}
+	if err := DrainCall(ctx, db, "CALL DOLT_COMMIT('-m', ?)", "schema: repair recorded migration invariants"); err != nil {
+		return fmt.Errorf("committing migration invariant repairs: %w", err)
+	}
+
+	dirty, err := dirtyTables(ctx, db, false)
+	if err != nil {
+		return fmt.Errorf("verifying committed migration invariant repairs: %w", err)
+	}
+	for _, table := range versioned {
+		if _, ok := dirty[table]; ok {
+			return fmt.Errorf("migration invariant repair for %s remains uncommitted", table)
+		}
+	}
+	return clearIDDefaultInvariantRepairPending(ctx, db)
+}
+
+func pendingVersionedIDDefaultSchemaRepairs(ctx context.Context, db DBConn) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT to_table_name, data_change
+FROM dolt_diff_summary('HEAD', 'WORKING')
+WHERE schema_change = 1`)
+	if err != nil {
+		return nil, fmt.Errorf("reading pending migration invariant schema changes: %w", err)
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var table sql.NullString
+		var dataChange bool
+		if err := rows.Scan(&table, &dataChange); err != nil {
+			return nil, fmt.Errorf("scanning pending migration invariant schema change: %w", err)
+		}
+		if _, ok := versionedIDDefaultInvariantTables[table.String]; !table.Valid || !ok {
+			continue
+		}
+		if dataChange {
+			return nil, fmt.Errorf("refusing to commit migration invariant repair for %s: table also has uncommitted row changes", table.String)
+		}
+		tables = append(tables, table.String)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading pending migration invariant schema changes: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("closing pending migration invariant schema changes: %w", err)
+	}
+	for _, table := range tables {
+		if err := verifyOnlyUUIDDefaultWasDropped(ctx, db, table); err != nil {
+			return nil, err
+		}
+	}
+	sort.Strings(tables)
+	return tables, nil
+}
+
+func verifyOnlyUUIDDefaultWasDropped(ctx context.Context, db DBConn, table string) error {
+	rows, err := db.QueryContext(ctx, "SELECT from_create_statement, to_create_statement FROM dolt_schema_diff('HEAD', 'WORKING', ?)", table)
+	if err != nil {
+		return fmt.Errorf("reading migration invariant schema diff for %s: %w", table, err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return fmt.Errorf("migration invariant repair for %s has no schema diff", table)
+	}
+	var fromDDL, toDDL string
+	if err := rows.Scan(&fromDDL, &toDDL); err != nil {
+		return fmt.Errorf("scanning migration invariant schema diff for %s: %w", table, err)
+	}
+	if rows.Next() {
+		return fmt.Errorf("migration invariant repair for %s has multiple schema diffs", table)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("reading migration invariant schema diff for %s: %w", table, err)
+	}
+	if uuidDefaultDDLRE.ReplaceAllString(fromDDL, "") != toDDL {
+		return fmt.Errorf("refusing to commit migration invariant repair for %s: schema diff contains changes beyond dropping DEFAULT (UUID())", table)
+	}
+	return nil
+}
+
+func readIDColumnDefaults(ctx context.Context, db DBConn, tables []string) (map[string]sql.NullString, error) {
+	placeholders := make([]string, len(tables))
+	args := make([]any, len(tables))
+	for i, table := range tables {
+		placeholders[i] = "?"
+		args[i] = table
+	}
+	rows, err := db.QueryContext(ctx, `
+SELECT TABLE_NAME, COLUMN_DEFAULT
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE()
+  AND COLUMN_NAME = 'id'
+  AND TABLE_NAME IN (`+strings.Join(placeholders, ", ")+")", args...)
+	if err != nil {
+		return nil, fmt.Errorf("reading migration id-default invariants: %w", err)
+	}
+	defer rows.Close()
+
+	defaults := make(map[string]sql.NullString, len(tables))
+	for rows.Next() {
+		var table string
+		var columnDefault sql.NullString
+		if err := rows.Scan(&table, &columnDefault); err != nil {
+			return nil, fmt.Errorf("scanning migration id-default invariant: %w", err)
+		}
+		defaults[table] = columnDefault
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading migration id-default invariants: %w", err)
+	}
+	return defaults, nil
+}

--- a/internal/storage/schema/migration_invariants_dolt_test.go
+++ b/internal/storage/schema/migration_invariants_dolt_test.go
@@ -1,0 +1,125 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// TestGH5269MigrationMarkRequiresAppliedDDL reproduces the reported invariant
+// violation against an externally supplied Dolt 2.2.x sql-server. The normal
+// test suite skips it when no external DSN is supplied; unit tests cover the
+// invariant decision and version-recording boundary without Docker.
+func TestGH5269MigrationMarkRequiresAppliedDDL(t *testing.T) {
+	adminDSN := os.Getenv("BEADS_GH5269_ADMIN_DSN")
+	if adminDSN == "" {
+		t.Skip("set BEADS_GH5269_ADMIN_DSN to run the GH#5269 reproduction")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	admin, err := sql.Open("mysql", adminDSN)
+	if err != nil {
+		t.Fatalf("open admin connection: %v", err)
+	}
+	defer admin.Close()
+
+	dbName := fmt.Sprintf("gh5269_%d", time.Now().UnixNano())
+	if _, err := admin.ExecContext(ctx, "CREATE DATABASE `"+dbName+"`"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cleanupCancel()
+		_, _ = admin.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS `"+dbName+"`")
+	})
+
+	dsn := adminDSN + dbName + "?multiStatements=true&parseTime=true"
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	defer db.Close()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin connection: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := MigrateUp(ctx, conn); err != nil {
+		t.Fatalf("construct current schema: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx, "ALTER TABLE dependencies ALTER COLUMN id SET DEFAULT (UUID())"); err != nil {
+		t.Fatalf("construct reported schema drift: %v", err)
+	}
+	if err := DrainCall(ctx, conn, "CALL DOLT_ADD('dependencies')"); err != nil {
+		t.Fatalf("stage reported schema drift: %v", err)
+	}
+	if err := DrainCall(ctx, conn, "CALL DOLT_COMMIT('-m', 'reproduce GH#5269 schema drift')"); err != nil {
+		t.Fatalf("commit reported schema drift: %v", err)
+	}
+
+	// This is the reporter's permanent state: the cursor is current but one of
+	// the DDL effects it claims is absent. A normal migration pass must not
+	// silently accept that contradiction.
+	_, migrateErr := MigrateUp(ctx, conn)
+
+	var version int
+	if err := conn.QueryRowContext(ctx, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations").Scan(&version); err != nil {
+		t.Fatalf("read migration mark: %v", err)
+	}
+	var columnDefault sql.NullString
+	if err := conn.QueryRowContext(ctx, `
+SELECT COLUMN_DEFAULT
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'dependencies' AND COLUMN_NAME = 'id'`).Scan(&columnDefault); err != nil {
+		t.Fatalf("read dependencies.id default: %v", err)
+	}
+	var tableName, createSQL string
+	if err := conn.QueryRowContext(ctx, "SHOW CREATE TABLE dependencies").Scan(&tableName, &createSQL); err != nil {
+		t.Fatalf("show dependencies DDL: %v", err)
+	}
+	if columnDefault.Valid && !strings.Contains(strings.ToLower(createSQL), "default (uuid())") {
+		t.Fatalf("INFORMATION_SCHEMA reports default %q but SHOW CREATE TABLE disagrees: %s", columnDefault.String, createSQL)
+	}
+
+	if migrateErr == nil && version == LatestVersion() && columnDefault.Valid {
+		t.Fatalf("migration reported success at v%d, but dependencies.id default remains %q", version, columnDefault.String)
+	}
+	if migrateErr != nil {
+		t.Fatalf("migration consistency pass returned an error instead of repairing: %v", migrateErr)
+	}
+	if version != LatestVersion() {
+		t.Fatalf("schema version = %d, want %d", version, LatestVersion())
+	}
+	if columnDefault.Valid {
+		t.Fatalf("dependencies.id default = %q, want NULL", columnDefault.String)
+	}
+	var dirtyDependencies int
+	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM dolt_status WHERE table_name = 'dependencies'").Scan(&dirtyDependencies); err != nil {
+		t.Fatalf("read dependencies dolt_status: %v", err)
+	}
+	if dirtyDependencies != 0 {
+		t.Fatalf("dependencies remains dirty after invariant repair: dolt_status count = %d", dirtyDependencies)
+	}
+	if err := DrainCall(ctx, conn, "CALL DOLT_RESET('--hard')"); err != nil {
+		t.Fatalf("reset working set to HEAD: %v", err)
+	}
+	columnDefault = sql.NullString{}
+	if err := conn.QueryRowContext(ctx, `
+SELECT COLUMN_DEFAULT
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'dependencies' AND COLUMN_NAME = 'id'`).Scan(&columnDefault); err != nil {
+		t.Fatalf("read dependencies.id default after hard reset: %v", err)
+	}
+	if columnDefault.Valid {
+		t.Fatalf("dependencies.id default after hard reset = %q, repair was not committed to HEAD", columnDefault.String)
+	}
+}

--- a/internal/storage/schema/migration_invariants_test.go
+++ b/internal/storage/schema/migration_invariants_test.go
@@ -1,0 +1,197 @@
+package schema
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestMigrationWorkNeededWhenRecordedDDLIsAbsent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion())
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
+	expectIgnoredSentinelProbes(mock, true)
+	expectContentHashColumnExists(mock)
+	expectContentHashColumnExists(mock)
+	expectNoIDDefaultInvariantRepairSentinel(mock)
+	expectIDDefaultInvariants(mock, mainIDDefaultInvariantTables, map[string]string{"dependencies": "uuid()"})
+
+	needed, err := migrationWorkNeeded(context.Background(), db)
+	if err != nil {
+		t.Fatalf("migrationWorkNeeded: %v", err)
+	}
+	if !needed {
+		t.Fatal("migrationWorkNeeded = false when v50 is recorded but dependencies.id still has DEFAULT (uuid())")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestRepairIDDefaultInvariantsDropsAndVerifiesDefault(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	expectIDDefaultInvariants(mock, mainIDDefaultInvariantTables, map[string]string{"dependencies": "uuid()"})
+	mock.ExpectExec(regexp.QuoteMeta("ALTER TABLE `dependencies` ALTER COLUMN id DROP DEFAULT")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	expectHealthyIDDefaultInvariants(mock, mainIDDefaultInvariantTables)
+
+	changed, err := repairIDDefaultInvariants(context.Background(), db, mainIDDefaultInvariantTables)
+	if err != nil {
+		t.Fatalf("repairIDDefaultInvariants: %v", err)
+	}
+	if len(changed) != 1 || changed[0] != "dependencies" {
+		t.Fatalf("repairIDDefaultInvariants changed = %v, want [dependencies]", changed)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestCommitIDDefaultInvariantRepairsResumesAfterInterruptedAlter(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM dolt_diff_summary('HEAD', 'WORKING')")).
+		WillReturnRows(sqlmock.NewRows([]string{"to_table_name", "data_change"}).AddRow("dependencies", false))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT from_create_statement, to_create_statement FROM dolt_schema_diff('HEAD', 'WORKING', ?)")).
+		WithArgs("dependencies").
+		WillReturnRows(sqlmock.NewRows([]string{"from_create_statement", "to_create_statement"}).
+			AddRow("CREATE TABLE dependencies (id char(36) DEFAULT (uuid()))", "CREATE TABLE dependencies (id char(36))"))
+	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD('-f', ?)")).
+		WithArgs("dependencies").
+		WillReturnRows(sqlmock.NewRows([]string{"status"}))
+	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?)")).
+		WithArgs("schema: repair recorded migration invariants").
+		WillReturnRows(sqlmock.NewRows([]string{"hash"}))
+	expectDoltStatusRows(mock)
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM local_metadata WHERE `key` = ?")).
+		WithArgs(idDefaultInvariantRepairSentinel).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := commitIDDefaultInvariantRepairs(context.Background(), db, nil); err != nil {
+		t.Fatalf("commitIDDefaultInvariantRepairs: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestRunMigrationsDoesNotRecordVersionWhenInvariantCannotBeApplied(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	originalCounter := issueRowCounter
+	issueRowCounter = func(context.Context, DBConn) (int64, error) { return 0, nil }
+	defer func() { issueRowCounter = originalCounter }()
+
+	mock.ExpectExec("(?s).*Migration 0050.*").WillReturnResult(sqlmock.NewResult(0, 0))
+	expectIDDefaultInvariants(mock, []string{"dependencies"}, map[string]string{"dependencies": "uuid()"})
+	applyErr := errors.New("prepared ALTER did not take effect")
+	mock.ExpectExec(regexp.QuoteMeta("ALTER TABLE `dependencies` ALTER COLUMN id DROP DEFAULT")).
+		WillReturnError(applyErr)
+
+	applied, err := runMigrations(context.Background(), db, mainSource, 49, 50, false)
+	if applied != 0 {
+		t.Fatalf("runMigrations applied = %d, want 0", applied)
+	}
+	if !errors.Is(err, applyErr) {
+		t.Fatalf("runMigrations error = %v, want invariant error", err)
+	}
+	if !strings.Contains(err.Error(), "verifying migration 0050_dependencies_deterministic_id.up.sql") {
+		t.Fatalf("runMigrations error lacks migration context: %v", err)
+	}
+	// No schema_migrations INSERT is expected. sqlmock fails if the runner
+	// records v50 after the invariant repair errors.
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestRunMigrationsDoesNotRecordVersionWhenDDLStillContradictsMark(t *testing.T) {
+	originalCounter := issueRowCounter
+	issueRowCounter = func(context.Context, DBConn) (int64, error) { return 0, nil }
+	defer func() { issueRowCounter = originalCounter }()
+
+	cases := []struct {
+		name          string
+		source        migrationSource
+		minVersion    int
+		upTo          int
+		migrationName string
+		tables        []string
+		stubbornTable string
+	}{
+		{"main 0050", mainSource, 49, 50, "0050_dependencies_deterministic_id.up.sql", mainIDDefaultInvariantTables[:1], "dependencies"},
+		{"main 0051", mainSource, 50, 51, "0051_drop_aux_id_defaults.up.sql", mainIDDefaultInvariantTables[1:], "events"},
+		{"ignored 0010", ignoredSource, 9, 10, "0010_drop_wisp_id_defaults.up.sql", ignoredIDDefaultInvariantTables, "wisp_events"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock.New: %v", err)
+			}
+			defer db.Close()
+
+			mock.ExpectExec("(?s).*").WillReturnResult(sqlmock.NewResult(0, 0))
+			expectIDDefaultInvariants(mock, tc.tables, map[string]string{tc.stubbornTable: "uuid()"})
+			mock.ExpectExec(regexp.QuoteMeta("ALTER TABLE `" + tc.stubbornTable + "` ALTER COLUMN id DROP DEFAULT")).
+				WillReturnResult(sqlmock.NewResult(0, 0))
+			// Model GH#5269's exact silent-success mode: ALTER reports success,
+			// but the live DDL remains unchanged.
+			expectIDDefaultInvariants(mock, tc.tables, map[string]string{tc.stubbornTable: "uuid()"})
+
+			applied, err := runMigrations(context.Background(), db, tc.source, tc.minVersion, tc.upTo, false)
+			if applied != 0 {
+				t.Fatalf("runMigrations applied = %d, want 0", applied)
+			}
+			if err == nil || !strings.Contains(err.Error(), "migration invariant verification failed") {
+				t.Fatalf("runMigrations error = %v, want invariant verification failure", err)
+			}
+			if !strings.Contains(err.Error(), tc.migrationName) {
+				t.Fatalf("runMigrations error lacks migration name %s: %v", tc.migrationName, err)
+			}
+			// No cursor INSERT is expected; sqlmock rejects one.
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet expectations: %v", err)
+			}
+		})
+	}
+}
+
+func expectIDDefaultInvariants(mock sqlmock.Sqlmock, tables []string, defaults map[string]string) {
+	args := make([]driver.Value, len(tables))
+	rows := sqlmock.NewRows([]string{"TABLE_NAME", "COLUMN_DEFAULT"})
+	for i, table := range tables {
+		args[i] = table
+		if columnDefault, ok := defaults[table]; ok {
+			rows.AddRow(table, columnDefault)
+		} else {
+			rows.AddRow(table, nil)
+		}
+	}
+	mock.ExpectQuery(`(?s)SELECT TABLE_NAME, COLUMN_DEFAULT.*FROM INFORMATION_SCHEMA\.COLUMNS.*TABLE_NAME IN`).
+		WithArgs(args...).
+		WillReturnRows(rows)
+}

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -563,10 +563,49 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 		return applied, err
 	}
 
+	if len(dirtyBefore) > 0 {
+		invariantTargets, err := idDefaultTablesNeedingRepair(ctx, db, mainIDDefaultInvariantTables)
+		if err != nil {
+			return applied, fmt.Errorf("check main migration invariants: %w", err)
+		}
+		var dirtyInvariantTargets []string
+		for _, table := range invariantTargets {
+			if _, wasDirty := dirtyBefore[table]; wasDirty {
+				dirtyInvariantTargets = append(dirtyInvariantTargets, table)
+			}
+		}
+		if len(dirtyInvariantTargets) > 0 {
+			return applied, &DirtyTablesError{Tables: dirtyInvariantTargets}
+		}
+	}
+	invariantRepairPending, err := idDefaultInvariantRepairPending(ctx, db)
+	if err != nil {
+		return applied, fmt.Errorf("check migration invariant repair sentinel: %w", err)
+	}
+	invariantTargets, err := idDefaultTablesNeedingRepair(ctx, db, mainIDDefaultInvariantTables)
+	if err != nil {
+		return applied, fmt.Errorf("check main migration invariants: %w", err)
+	}
+	if len(invariantTargets) > 0 && !invariantRepairPending {
+		if err := setIDDefaultInvariantRepairPending(ctx, db); err != nil {
+			return applied, fmt.Errorf("record migration invariant repair sentinel: %w", err)
+		}
+		invariantRepairPending = true
+	}
+	invariantsRepaired, err := repairIDDefaultInvariants(ctx, db, mainIDDefaultInvariantTables)
+	if err != nil {
+		return applied, fmt.Errorf("repair main migration invariants: %w", err)
+	}
+	if invariantRepairPending {
+		if err := commitIDDefaultInvariantRepairs(ctx, db, invariantsRepaired); err != nil {
+			return applied, err
+		}
+	}
 	backfilled, err := ensureBackfilledCustomStatusesCustomTypes(ctx, db)
 	if err != nil {
 		return applied, fmt.Errorf("backfill custom tables: %w", err)
 	}
+	backfilled = backfilled || len(invariantsRepaired) > 0
 
 	// #4259: rewrite any per-clone-random dependency ids (minted by 0043's
 	// DEFAULT (UUID()) before this fix) to the deterministic key, so independently
@@ -618,6 +657,11 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	if err != nil {
 		return applied, fmt.Errorf("ignored migrations: %w", err)
 	}
+	ignoredInvariantsRepaired, err := repairIDDefaultInvariants(ctx, db, ignoredIDDefaultInvariantTables)
+	if err != nil {
+		return applied, fmt.Errorf("repair ignored migration invariants: %w", err)
+	}
+	backfilled = backfilled || len(ignoredInvariantsRepaired) > 0
 	if err := unstageIgnoredTables(ctx, db); err != nil {
 		return applied, fmt.Errorf("unstaging ignored migration tables: %w", err)
 	}
@@ -670,6 +714,13 @@ func migrationWorkNeeded(ctx context.Context, db DBConn) (bool, error) {
 		return false, err
 	}
 	if !hasIgnoredHash {
+		return true, nil
+	}
+	invariantRepairNeeded, err := idDefaultInvariantNeedsRepair(ctx, db)
+	if err != nil {
+		return false, err
+	}
+	if invariantRepairNeeded {
 		return true, nil
 	}
 	return needsBackfilledCustomStatusesCustomTypes(ctx, db)
@@ -1434,11 +1485,15 @@ func runMigrations(ctx context.Context, db DBConn, src migrationSource, minVersi
 		if err := src.preMigrationRepair(ctx, db, mf.version); err != nil {
 			return count, fmt.Errorf("pre-repair for migration %s: %w", mf.name, err)
 		}
+		invariantTables := migrationIDDefaultTables(mf.name)
 
 		fmt.Fprintf(stderr, "Applying migration %04d: %s…\n", mf.version, humanMigrationName(mf.name))
 		start := time.Now()
 		if err := execMigrationBody(ctx, db, string(data)); err != nil {
 			return count, fmt.Errorf("migration %s: %w", mf.name, err)
+		}
+		if _, err := repairMigrationIDDefaultInvariants(ctx, db, invariantTables); err != nil {
+			return count, fmt.Errorf("verifying migration %s: %w", mf.name, err)
 		}
 		sum := sha256.Sum256(data)
 		contentHash := hex.EncodeToString(sum[:])

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -1491,6 +1491,25 @@ func TestCLICompatibleMigration0032UsesDirectDropColumn(t *testing.T) {
 	}
 }
 
+func TestCLICompatibleMigration0050UsesDirectInvariantDDL(t *testing.T) {
+	got := cliCompatibleMigrationSQL("0050_dependencies_deterministic_id.up.sql", "source migration")
+	for _, want := range []string{
+		"ALTER TABLE dependencies ALTER COLUMN id DROP DEFAULT",
+		"CREATE UNIQUE INDEX IF NOT EXISTS uk_dep_issue_target",
+		"CREATE UNIQUE INDEX IF NOT EXISTS uk_dep_wisp_target",
+		"CREATE UNIQUE INDEX IF NOT EXISTS uk_dep_external_target",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("0050 CLI migration missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{"PREPARE", "EXECUTE", "DEALLOCATE"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("0050 CLI migration contains prepared-DDL marker %q", forbidden)
+		}
+	}
+}
+
 func TestCLICompatibleMigration0049UsesDirectLongtextDDL(t *testing.T) {
 	got := cliCompatibleMigrationSQL("0049_longtext_large_content_columns.up.sql", "source migration")
 	for _, want := range []string{
@@ -1534,6 +1553,7 @@ func TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities(t *testing.T)
 		"ALTER TABLE schema_migrations DROP COLUMN applied_at",
 		"ALTER TABLE issues MODIFY COLUMN close_reason LONGTEXT DEFAULT ''",
 		"ALTER TABLE comments MODIFY COLUMN text LONGTEXT NOT NULL",
+		"ALTER TABLE dependencies ALTER COLUMN id DROP DEFAULT",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("AllMigrationsSQL missing direct CLI DDL %q", want)
@@ -1582,6 +1602,18 @@ WHERE table_schema = DATABASE()
   AND table_name = 'schema_migrations'
   AND column_name = 'applied_at'`, "schema_migrations.applied_at")
 	requireDoltFKRules(t, dir, "fk_comments_issue", "CASCADE", "CASCADE")
+	requireDoltNoRows(t, dir, `
+SELECT column_name
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'dependencies'
+  AND column_name = 'id'
+  AND column_default IS NOT NULL`, "dependencies.id default")
+	for _, index := range []string{"uk_dep_issue_target", "uk_dep_wisp_target", "uk_dep_external_target"} {
+		requireDoltCount(t, dir,
+			fmt.Sprintf(`SELECT COUNT(DISTINCT index_name) AS c FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'dependencies' AND index_name = %s`, doltSQLString(index)),
+			"1")
+	}
 	requireDoltColumnShape(t, dir, "comments", "text", "longtext", "NO")
 	requireDoltColumnShape(t, dir, "issues", "description", "longtext", "NO")
 	requireDoltColumnShape(t, dir, "wisps", "description", "longtext", "NO")
@@ -1972,6 +2004,10 @@ func TestRunMigrationsUsesProvidedSource(t *testing.T) {
 	stderr = &bytes.Buffer{}
 	defer func() { stderr = orig }()
 
+	origInvariantRepair := repairMigrationIDDefaultInvariants
+	repairMigrationIDDefaultInvariants = func(context.Context, DBConn, []string) ([]string, error) { return nil, nil }
+	defer func() { repairMigrationIDDefaultInvariants = origInvariantRepair }()
+
 	// Stub the large-rig row counter for the same reason as
 	// TestRunMigrationsStderrOutput: mockDB.QueryRowContext panics.
 	origCounter := issueRowCounter
@@ -2017,9 +2053,12 @@ func TestRunMigrationsLargeRigNoticeOnlyOnMainSource(t *testing.T) {
 	var mainBuf bytes.Buffer
 	orig := stderr
 	stderr = &mainBuf
-	// Bounded below migration 40 for the same reason as
-	// TestRunMigrationsStderrOutput: the panic-stub mock can't answer the
-	// queries versions 40/41/47/53 issue on the pinned connection.
+	origInvariantRepair := repairMigrationIDDefaultInvariants
+	repairMigrationIDDefaultInvariants = func(context.Context, DBConn, []string) ([]string, error) { return nil, nil }
+	defer func() { repairMigrationIDDefaultInvariants = origInvariantRepair }()
+
+	// Main stays bounded below migrations 40/41/47/53, whose repairs query
+	// the pinned connection.
 	if _, err := runMigrations(context.Background(), &mockDB{}, mainSource, 0, 39, false); err != nil {
 		stderr = orig
 		t.Fatalf("runMigrations(mainSource): %v", err)


### PR DESCRIPTION
## What

Fixes gastownhall/beads#5269 by making migration marks conditional on verified schema effects.

- Reasserts and verifies the no-`DEFAULT (UUID())` invariants from migrations 0050, 0051, and ignored migration 0010 before recording their cursor rows.
- Detects already-marked databases whose live DDL contradicts those marks and repairs them with a retry-safe, narrowly scoped schema commit.
- Rejects unrelated row/schema dirt rather than sweeping it into the repair commit.
- Uses direct 0050 DDL in the Dolt CLI migration bundle, where prepared statements can silently no-op.

## Why

A database can currently report the latest migration version while retaining pre-migration UUID defaults. Once the cursor row exists, ordinary migration runs trust it and permanently skip the missing DDL. This leaves clone-random IDs enabled despite the deterministic-ID migration.

The exact historical cause on the reporter's database remains unavailable, but the permanent failure mode is deterministic: current marks plus contradictory live DDL are silently accepted. The fix closes that trust gap at both boundaries—before recording a mark and when opening an already-marked database.

## Diagnosis

Tight Docker reproduction against Dolt 2.2.0:

```bash
BEADS_GH5269_ADMIN_DSN='root:@tcp(127.0.0.1:<port>)/' \
  ./scripts/test.sh -run '^TestGH5269MigrationMarkRequiresAppliedDDL$' \
  ./internal/storage/schema/...
```

Before the fix it failed 3/3 with:

```text
migration reported success at v65, but dependencies.id default remains "uuid()"
```

The container was resource-capped throughout diagnosis. The final run passed and additionally proved the repair was committed by checking a clean `dolt_status` and hard-resetting to `HEAD` before re-reading the DDL.

Twenty repeated v1.1.2 applications of migration 0050 against Dolt 2.2.0 succeeded, including the prepared ALTER. This falsified the simple claim that the driver path always skips prepared DDL; the confirmed defect is trusting the cursor without verifying schema reality.

## Testing

- `./scripts/test.sh ./internal/storage/schema/...`
- `./scripts/test.sh ./internal/storage/...`
- `make test`
- Docker Dolt 2.2.0 reproduction above
- `BD_LINT_NEW_FROM_MERGE_BASE=upstream/main make ci-pr-lint`
- `git diff --check`

## Safety

This touches protected schema/migration behavior but does not modify frozen migration files. It requires substantive human review before merge.
