### PR TITLE
fix: make row_lock an aggregate revision

### DIFF
--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -1149,7 +1149,7 @@ type DeleteIssuesRequest struct {
 	//
 	// NEITHER `cascade` NOR `force` BYPASSES IT. Both bypass POLICY — the dependents guard — and never a precondition. Under `cascade` the guard still covers only the NAMED bead: the closure is resolved inside the deleting transaction, so a matching token promises the row is the one you read and promises nothing about how far the closure has grown since. A caller that needs the closure itself pinned wants `dry_run` first.
 	//
-	// IT GUARDS LIFECYCLE STATE, NOT THE GRAPH. The token is reminted by status, assignee and started-at writes and deliberately not by label, dependency or rename writes, so a match does not promise the bead's edges are the ones you saw.
+	// IT GUARDS THE NAMED AGGREGATE, NOT ITS TRANSITIVE CLOSURE. The token is reminted by every supported user-authored mutation, including outgoing dependency edits. Inbound edges belong to their source aggregates and derived blocked-state recomputation is excluded, so a match does not promise the cascade closure is unchanged.
 	//
 	// The token is the `revision` a lifecycle write answers with, and the one `GET /v0/beads/issues/{id}` publishes — which is where a delete guard should seed itself, since reading the bead before erasing it is the only way to be sure it is the bead you meant. DECODE IT AS A 64-BIT INTEGER, for the reason `UpdateIssueRequest.expected_version` spells out.
 	ExpectedVersion *int64 `json:"expected_version,omitempty"`

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -7368,10 +7368,11 @@ components:
             pinned wants `dry_run` first.
 
 
-            IT GUARDS LIFECYCLE STATE, NOT THE GRAPH. The token is reminted by
-            status, assignee and started-at writes and deliberately not by
-            label, dependency or rename writes, so a match does not promise the
-            bead's edges are the ones you saw.
+            IT GUARDS THE NAMED AGGREGATE, NOT ITS TRANSITIVE CLOSURE. The token
+            is reminted by every supported user-authored mutation, including
+            outgoing dependency edits. Inbound edges belong to their source
+            aggregates and derived blocked-state recomputation is excluded, so
+            a match does not promise the cascade closure is unchanged.
 
 
             The token is the `revision` a lifecycle write answers with, and the

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -54,7 +54,7 @@ func (s *DoltStore) addDependencyWithOptions(ctx context.Context, dep *types.Dep
 		}
 	}
 
-	var eventWritten bool
+	var result issueops.DependencyWriteResult
 	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
 		opts := issueops.AddDependencyOpts{
 			SourceTable:   "issues",
@@ -65,18 +65,21 @@ func (s *DoltStore) addDependencyWithOptions(ctx context.Context, dep *types.Dep
 			EmitEvent:     addOpts.EmitEvent,
 		}
 		var e error
-		eventWritten, e = issueops.AddDependencyInTx(ctx, tx, dep, actor, opts)
+		result, e = issueops.AddDependencyInTxWithResult(ctx, tx, dep, actor, opts)
 		return e
 	}); err != nil {
 		return err
+	}
+	if !result.Changed {
+		return nil
 	}
 	// GH#2455: Use explicit DOLT_ADD to avoid sweeping up stale config changes.
 	// Stage events only when AddDependencyInTx actually recorded a
 	// dependency_added event (explicit verb + genuine new edge). A structural or
 	// idempotent add writes no event, so staging events would sweep unrelated
 	// pending event rows into this dependency commit.
-	tables := []string{"dependencies"}
-	if eventWritten {
+	tables := []string{"issues", "dependencies"}
+	if result.EventWritten {
 		tables = append(tables, "events")
 	}
 	return s.doltAddAndCommit(ctx, tables, "dependency: add "+string(dep.Type)+" "+dep.IssueID+" -> "+dep.DependsOnID)
@@ -122,7 +125,7 @@ func (s *DoltStore) RemoveDependencyWithOptions(ctx context.Context, issueID, de
 		clearJournalScope := s.scopeEventsJournalTransaction(tx)
 		defer clearJournalScope()
 
-		eventWritten, err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID, actor, rmOpts.EmitEvent)
+		result, err := issueops.RemoveDependencyInTxWithResult(ctx, tx, issueID, dependsOnID, actor, rmOpts.EmitEvent)
 		if err != nil {
 			return err
 		}
@@ -130,13 +133,16 @@ func (s *DoltStore) RemoveDependencyWithOptions(ctx context.Context, issueID, de
 		if err := s.commitSQLTx(ctx, "sql commit", tx); err != nil {
 			return err
 		}
+		if !result.Changed {
+			return nil
+		}
 		// GH#2455: Use explicit DOLT_ADD to avoid sweeping up stale config changes.
 		// Stage events only when RemoveDependencyInTx actually recorded a
 		// dependency_removed event (explicit verb + genuine edge removal). A
 		// structural or missing-edge remove writes no event, so staging events would
 		// sweep unrelated pending event rows into this dependency commit.
-		tables := []string{"dependencies"}
-		if eventWritten {
+		tables := []string{"issues", "dependencies"}
+		if result.EventWritten {
 			tables = append(tables, "events")
 		}
 		return s.doltAddAndCommit(ctx, tables, "dependency: remove "+issueID+" -> "+dependsOnID)

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -33,7 +33,7 @@ func (s *DoltStore) AddComment(ctx context.Context, issueID, actor, comment stri
 		if isWisp {
 			return nil
 		}
-		return s.doltAddAndCommit(ctx, []string{"events"}, fmt.Sprintf("bd: comment %s", issueID))
+		return s.doltAddAndCommit(ctx, []string{"issues", "events"}, fmt.Sprintf("bd: comment %s", issueID))
 	})
 }
 
@@ -80,36 +80,38 @@ func (s *DoltStore) EventsSince(ctx context.Context, cursor storage.EventCursor,
 // comment so a burst of comments still reads back in the order it was written
 // (see issueops.NextLiveCommentTime).
 func (s *DoltStore) AddIssueComment(ctx context.Context, issueID, author, text string) (*types.Comment, error) {
-	return s.addOrImportComment(ctx, issueID, func(tx *sql.Tx) (*types.Comment, error) {
-		return issueops.AddIssueCommentInTx(ctx, tx, issueID, author, text)
+	return s.addOrImportComment(ctx, issueID, func(tx *sql.Tx) (*types.Comment, bool, error) {
+		comment, err := issueops.AddIssueCommentInTx(ctx, tx, issueID, author, text)
+		return comment, err == nil, err
 	})
 }
 
 // ImportIssueComment adds a comment during import, preserving the original timestamp.
 // This prevents comment timestamp drift across import/export cycles.
 func (s *DoltStore) ImportIssueComment(ctx context.Context, issueID, author, text string, createdAt time.Time) (*types.Comment, error) {
-	return s.addOrImportComment(ctx, issueID, func(tx *sql.Tx) (*types.Comment, error) {
-		return issueops.ImportIssueCommentInTx(ctx, tx, issueID, author, text, createdAt)
+	return s.addOrImportComment(ctx, issueID, func(tx *sql.Tx) (*types.Comment, bool, error) {
+		return issueops.ImportIssueCommentInTxWithResult(ctx, tx, issueID, author, text, createdAt)
 	})
 }
 
 // addOrImportComment is the shared wisp-routing / retry / dolt-commit tail
 // around either comment insert; insert does the write inside the transaction.
-func (s *DoltStore) addOrImportComment(ctx context.Context, issueID string, insert func(*sql.Tx) (*types.Comment, error)) (*types.Comment, error) {
+func (s *DoltStore) addOrImportComment(ctx context.Context, issueID string, insert func(*sql.Tx) (*types.Comment, bool, error)) (*types.Comment, error) {
 	var result *types.Comment
+	var changed bool
 	err := s.withCircuitWrite(ctx, func(ctx context.Context) error {
 		isWisp := s.isActiveWisp(ctx, issueID)
 		if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
 			var err error
-			result, err = insert(tx)
+			result, changed, err = insert(tx)
 			return err
 		}); err != nil {
 			return err
 		}
-		if isWisp {
+		if isWisp || !changed {
 			return nil
 		}
-		return s.doltAddAndCommit(ctx, []string{"comments"}, fmt.Sprintf("bd: comment %s", issueID))
+		return s.doltAddAndCommit(ctx, []string{"issues", "comments"}, fmt.Sprintf("bd: comment %s", issueID))
 	})
 	if err != nil {
 		return nil, err

--- a/internal/storage/dolt/labels.go
+++ b/internal/storage/dolt/labels.go
@@ -21,10 +21,14 @@ func (s *DoltStore) AddLabel(ctx context.Context, issueID, label, actor string) 
 		}); err != nil {
 			return err
 		}
-		if isWisp || !changed {
+		if isWisp {
 			return nil
 		}
-		return s.doltAddAndCommit(ctx, []string{"issues", "events", "labels"}, fmt.Sprintf("bd: label add %s", issueID))
+		tables := []string{"events"}
+		if changed {
+			tables = []string{"issues", "events", "labels"}
+		}
+		return s.doltAddAndCommit(ctx, tables, fmt.Sprintf("bd: label add %s", issueID))
 	})
 }
 
@@ -41,10 +45,14 @@ func (s *DoltStore) RemoveLabel(ctx context.Context, issueID, label, actor strin
 		}); err != nil {
 			return err
 		}
-		if isWisp || !changed {
+		if isWisp {
 			return nil
 		}
-		return s.doltAddAndCommit(ctx, []string{"issues", "events", "labels"}, fmt.Sprintf("bd: label remove %s", issueID))
+		tables := []string{"events"}
+		if changed {
+			tables = []string{"issues", "events", "labels"}
+		}
+		return s.doltAddAndCommit(ctx, tables, fmt.Sprintf("bd: label remove %s", issueID))
 	})
 }
 

--- a/internal/storage/dolt/labels.go
+++ b/internal/storage/dolt/labels.go
@@ -13,15 +13,18 @@ import (
 func (s *DoltStore) AddLabel(ctx context.Context, issueID, label, actor string) error {
 	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
 		isWisp := s.isActiveWisp(ctx, issueID)
+		changed := false
 		if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-			return issueops.AddLabelInTx(ctx, tx, "", "", issueID, label, actor)
+			var err error
+			changed, err = issueops.AddLabelInTx(ctx, tx, "", "", issueID, label, actor)
+			return err
 		}); err != nil {
 			return err
 		}
-		if isWisp {
+		if isWisp || !changed {
 			return nil
 		}
-		return s.doltAddAndCommit(ctx, []string{"events", "labels"}, fmt.Sprintf("bd: label add %s", issueID))
+		return s.doltAddAndCommit(ctx, []string{"issues", "events", "labels"}, fmt.Sprintf("bd: label add %s", issueID))
 	})
 }
 
@@ -30,15 +33,18 @@ func (s *DoltStore) AddLabel(ctx context.Context, issueID, label, actor string) 
 func (s *DoltStore) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
 	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
 		isWisp := s.isActiveWisp(ctx, issueID)
+		changed := false
 		if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-			return issueops.RemoveLabelInTx(ctx, tx, "", "", issueID, label, actor)
+			var err error
+			changed, err = issueops.RemoveLabelInTx(ctx, tx, "", "", issueID, label, actor)
+			return err
 		}); err != nil {
 			return err
 		}
-		if isWisp {
+		if isWisp || !changed {
 			return nil
 		}
-		return s.doltAddAndCommit(ctx, []string{"events", "labels"}, fmt.Sprintf("bd: label remove %s", issueID))
+		return s.doltAddAndCommit(ctx, []string{"issues", "events", "labels"}, fmt.Sprintf("bd: label remove %s", issueID))
 	})
 }
 

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -1040,22 +1040,26 @@ func (t *doltTransaction) AddDependencyWithOptions(ctx context.Context, dep *typ
 	}
 
 	var addErr error
-	var eventWritten bool
+	var result issueops.DependencyWriteResult
 	if opts.PrecheckedTarget != nil && table == "wisp_dependencies" && kind == issueops.DepTargetIssue {
-		eventWritten, addErr = t.addWispDepSuspendingIssueTargetFK(ctx, dep, actor, opts)
+		result, addErr = t.addWispDepSuspendingIssueTargetFK(ctx, dep, actor, opts)
 	} else {
-		eventWritten, addErr = issueops.AddDependencyInTx(ctx, t.txFor(table), dep, actor, opts)
+		result, addErr = issueops.AddDependencyInTxWithResult(ctx, t.txFor(table), dep, actor, opts)
 	}
 	if addErr != nil {
 		return addErr
 	}
+	if !result.Changed {
+		return nil
+	}
 	t.dirty.MarkDirty(table)
+	t.dirty.MarkDirty(opts.SourceTable)
 	// AddDependencyInTx records a dependency_added event on the source's event
 	// table only for a genuine emit (explicit verb + new edge); stage that table
 	// so StageAndCommit commits the event with the edge (a torn write otherwise
 	// leaves the event in the working set, dropped on reset). A structural or
 	// idempotent add writes no event, so leave eventTable unstaged.
-	if eventWritten {
+	if result.EventWritten {
 		t.dirty.MarkDirty(eventTable)
 	}
 	t.recordDepTierWrite(table)
@@ -1094,15 +1098,15 @@ func (t *doltTransaction) recordDepTierWrite(writeTable string) {
 // target's existence was just validated on the regular tx. The regular tx
 // commits before the ignored tx, so the committed end-state always satisfies
 // the FK; suspend the session's FK checks around this one statement scope.
-func (t *doltTransaction) addWispDepSuspendingIssueTargetFK(ctx context.Context, dep *types.Dependency, actor string, opts issueops.AddDependencyOpts) (bool, error) {
+func (t *doltTransaction) addWispDepSuspendingIssueTargetFK(ctx context.Context, dep *types.Dependency, actor string, opts issueops.AddDependencyOpts) (issueops.DependencyWriteResult, error) {
 	if _, err := t.ignoredTx.ExecContext(ctx, "SET foreign_key_checks = 0"); err != nil {
-		return false, fmt.Errorf("suspend foreign key checks for cross-tier dependency: %w", err)
+		return issueops.DependencyWriteResult{}, fmt.Errorf("suspend foreign key checks for cross-tier dependency: %w", err)
 	}
-	eventWritten, addErr := issueops.AddDependencyInTx(ctx, t.ignoredTx, dep, actor, opts)
+	result, addErr := issueops.AddDependencyInTxWithResult(ctx, t.ignoredTx, dep, actor, opts)
 	if _, err := t.ignoredTx.ExecContext(ctx, "SET foreign_key_checks = 1"); err != nil && addErr == nil {
 		addErr = fmt.Errorf("restore foreign key checks after cross-tier dependency: %w", err)
 	}
-	return eventWritten, addErr
+	return result, addErr
 }
 
 // readDepTargetForPrecheck validates a dependency target on the transaction
@@ -1209,16 +1213,22 @@ func (t *doltTransaction) RemoveDependencyWithOptions(ctx context.Context, issue
 		table = "wisp_dependencies"
 		eventTable = "wisp_events"
 	}
-	eventWritten, err := issueops.RemoveDependencyInTx(ctx, t.txFor(table), issueID, dependsOnID, actor, rmOpts.EmitEvent)
+	result, err := issueops.RemoveDependencyInTxWithResult(ctx, t.txFor(table), issueID, dependsOnID, actor, rmOpts.EmitEvent)
 	if err != nil {
 		return wrapExecError("remove dependency in tx", err)
 	}
+	if !result.Changed {
+		return nil
+	}
 	t.dirty.MarkDirty(table)
+	if table == "dependencies" {
+		t.dirty.MarkDirty("issues")
+	}
 	// RemoveDependencyInTx records a dependency_removed event on the source's
 	// event table only for a genuine emit (explicit verb + edge removal); stage
 	// that table so it commits with the edge. A structural or missing-edge remove
 	// writes no event, so leave eventTable unstaged.
-	if eventWritten {
+	if result.EventWritten {
 		t.dirty.MarkDirty(eventTable)
 	}
 	return nil
@@ -1233,11 +1243,18 @@ func (t *doltTransaction) AddLabel(ctx context.Context, issueID, label, actor st
 		eventTable = "wisp_events"
 	}
 
-	if err := issueops.AddLabelInTx(ctx, t.txFor(table), table, eventTable, issueID, label, actor); err != nil {
+	changed, err := issueops.AddLabelInTx(ctx, t.txFor(table), table, eventTable, issueID, label, actor)
+	if err != nil {
 		return wrapExecError("add label in tx", err)
+	}
+	if !changed {
+		return nil
 	}
 	t.dirty.MarkDirty(table)
 	t.dirty.MarkDirty(eventTable)
+	if table == "labels" {
+		t.dirty.MarkDirty("issues")
+	}
 	return nil
 }
 
@@ -1273,11 +1290,18 @@ func (t *doltTransaction) RemoveLabel(ctx context.Context, issueID, label, actor
 		eventTable = "wisp_events"
 	}
 
-	if err := issueops.RemoveLabelInTx(ctx, t.txFor(table), table, eventTable, issueID, label, actor); err != nil {
+	changed, err := issueops.RemoveLabelInTx(ctx, t.txFor(table), table, eventTable, issueID, label, actor)
+	if err != nil {
 		return wrapExecError("remove label in tx", err)
+	}
+	if !changed {
+		return nil
 	}
 	t.dirty.MarkDirty(table)
 	t.dirty.MarkDirty(eventTable)
+	if table == "labels" {
+		t.dirty.MarkDirty("issues")
+	}
 	return nil
 }
 
@@ -1371,11 +1395,25 @@ func (t *doltTransaction) ImportIssueComment(ctx context.Context, issueID, autho
 	}
 
 	createdAtText := issueops.FormatAuxTime(createdAt)
-	id, _, err := issueops.InsertDerivedComment(ctx, t.txFor(table), table, issueID, author, text, createdAtText)
+	id, existed, err := issueops.InsertDerivedComment(ctx, t.txFor(table), table, issueID, author, text, createdAtText)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add comment: %w", err)
 	}
-	t.dirty.MarkDirty(table)
+	if !existed {
+		t.dirty.MarkDirty(table)
+		issueTable := "issues"
+		if table == "wisp_comments" {
+			issueTable = "wisps"
+		}
+		if err := issueops.TouchRowVersionInTx(ctx, t.txFor(table), issueTable, issueID); err != nil {
+			return nil, fmt.Errorf("failed to add comment: %w", err)
+		}
+		if table == "wisp_comments" {
+			t.dirty.MarkDirty("wisps")
+		} else {
+			t.dirty.MarkDirty("issues")
+		}
+	}
 
 	stored, err := issueops.ParseAuxTime(createdAtText)
 	if err != nil {
@@ -1438,7 +1476,19 @@ func (t *doltTransaction) AddComment(ctx context.Context, issueID, actor, commen
 	if err != nil {
 		return wrapExecError("add comment in tx", err)
 	}
+	issueTable := "issues"
+	if table == "wisp_events" {
+		issueTable = "wisps"
+	}
+	if err := issueops.TouchRowVersionInTx(ctx, t.txFor(table), issueTable, issueID); err != nil {
+		return wrapExecError("add comment in tx", err)
+	}
 	t.dirty.MarkDirty(table)
+	if table == "wisp_events" {
+		t.dirty.MarkDirty("wisps")
+	} else {
+		t.dirty.MarkDirty("issues")
+	}
 	stored, err := issueops.ParseAuxTime(createdAt)
 	if err != nil {
 		return wrapExecError("add comment in tx", err)

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -1247,13 +1247,12 @@ func (t *doltTransaction) AddLabel(ctx context.Context, issueID, label, actor st
 	if err != nil {
 		return wrapExecError("add label in tx", err)
 	}
-	if !changed {
-		return nil
-	}
-	t.dirty.MarkDirty(table)
 	t.dirty.MarkDirty(eventTable)
-	if table == "labels" {
-		t.dirty.MarkDirty("issues")
+	if changed {
+		t.dirty.MarkDirty(table)
+		if table == "labels" {
+			t.dirty.MarkDirty("issues")
+		}
 	}
 	return nil
 }
@@ -1294,13 +1293,12 @@ func (t *doltTransaction) RemoveLabel(ctx context.Context, issueID, label, actor
 	if err != nil {
 		return wrapExecError("remove label in tx", err)
 	}
-	if !changed {
-		return nil
-	}
-	t.dirty.MarkDirty(table)
 	t.dirty.MarkDirty(eventTable)
-	if table == "labels" {
-		t.dirty.MarkDirty("issues")
+	if changed {
+		t.dirty.MarkDirty(table)
+		if table == "labels" {
+			t.dirty.MarkDirty("issues")
+		}
 	}
 	return nil
 }

--- a/internal/storage/domain/db/comment.go
+++ b/internal/storage/domain/db/comment.go
@@ -152,18 +152,25 @@ func (r *commentSQLRepositoryImpl) InsertRecord(ctx context.Context, comment *ty
 	}
 	createdAtText := issueops.FormatAuxTime(copy.CreatedAt)
 	commentTable := pickCommentTable(opts.UseWispsTable)
+	inserted := true
 	if copy.ID == "" {
-		id, _, err := issueops.InsertDerivedComment(ctx, r.runner, commentTable, copy.IssueID, copy.Author, copy.Text, createdAtText)
+		id, existed, err := issueops.InsertDerivedComment(ctx, r.runner, commentTable, copy.IssueID, copy.Author, copy.Text, createdAtText)
 		if err != nil {
 			return nil, fmt.Errorf("db: CommentSQLRepository.InsertRecord: %w", err)
 		}
 		copy.ID = id
+		inserted = !existed
 	} else {
 		//nolint:gosec // G201: commentTable is one of two hardcoded constants
 		if _, err := r.runner.ExecContext(ctx, fmt.Sprintf(`
 			INSERT INTO %s (id, issue_id, author, text, created_at)
 			VALUES (?, ?, ?, ?, ?)
 		`, commentTable), copy.ID, copy.IssueID, copy.Author, copy.Text, createdAtText); err != nil {
+			return nil, fmt.Errorf("db: CommentSQLRepository.InsertRecord: %w", err)
+		}
+	}
+	if inserted {
+		if err := issueops.TouchRowVersionInTx(ctx, r.runner, issueTable, copy.IssueID); err != nil {
 			return nil, fmt.Errorf("db: CommentSQLRepository.InsertRecord: %w", err)
 		}
 	}

--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -105,22 +106,34 @@ func (r *dependencySQLRepositoryImpl) Insert(ctx context.Context, dep *types.Dep
 		}
 	}
 	table := pickDepTable(opts.UseWispsTable)
+	issueTable := pickIssueTable(opts.UseWispsTable)
 
-	var existingType string
+	var existingType, existingMetadata string
 	err := r.runner.QueryRowContext(ctx,
 		//nolint:gosec // G201: table and depTargetExpr are hardcoded constants
-		fmt.Sprintf("SELECT type FROM %s WHERE issue_id = ? AND %s = ?", table, depTargetExpr),
+		fmt.Sprintf("SELECT type, COALESCE(metadata, '{}') FROM %s WHERE issue_id = ? AND %s = ?", table, depTargetExpr),
 		dep.IssueID, dep.DependsOnID,
-	).Scan(&existingType)
+	).Scan(&existingType, &existingMetadata)
 	switch {
 	case err == nil:
 		if existingType == string(dep.Type) {
+			existingValue, requestedValue := json.RawMessage(existingMetadata), json.RawMessage(metadata)
+			equal, err := storage.MetadataValuesEqual(&existingValue, &requestedValue)
+			if err != nil {
+				return fmt.Errorf("db: DependencySQLRepository.Insert: compare metadata: %w", err)
+			}
+			if equal {
+				return nil
+			}
 			//nolint:gosec // G201: table and depTargetExpr are hardcoded constants
 			if _, err := r.runner.ExecContext(ctx,
 				fmt.Sprintf("UPDATE %s SET metadata = ? WHERE issue_id = ? AND %s = ?", table, depTargetExpr),
 				metadata, dep.IssueID, dep.DependsOnID,
 			); err != nil {
 				return fmt.Errorf("db: DependencySQLRepository.Insert: refresh metadata: %w", err)
+			}
+			if err := issueops.TouchRowVersionInTx(ctx, r.runner, issueTable, dep.IssueID); err != nil {
+				return fmt.Errorf("db: DependencySQLRepository.Insert: %w", err)
 			}
 			// A same-type add refreshes edge metadata. It is an observable graph
 			// mutation, so emit the complete replacement edge for replay.
@@ -156,6 +169,9 @@ func (r *dependencySQLRepositoryImpl) Insert(ctx context.Context, dep *types.Dep
 		if missing := r.classifyMissingEndpoint(ctx, dep, opts.UseWispsTable, targetCol, err); missing != nil {
 			return missing
 		}
+		return fmt.Errorf("db: DependencySQLRepository.Insert: %w", err)
+	}
+	if err := issueops.TouchRowVersionInTx(ctx, r.runner, issueTable, dep.IssueID); err != nil {
 		return fmt.Errorf("db: DependencySQLRepository.Insert: %w", err)
 	}
 	if dep.Type == types.DepParentChild {
@@ -352,6 +368,10 @@ func (r *dependencySQLRepositoryImpl) Delete(ctx context.Context, issueID, depen
 		issueID, dependsOnID,
 	); err != nil {
 		return domain.DepDeleteResult{}, fmt.Errorf("db: DependencySQLRepository.Delete: %s -> %s: %w", issueID, dependsOnID, err)
+	}
+	issueTable := pickIssueTable(opts.UseWispsTable)
+	if err := issueops.TouchRowVersionInTx(ctx, r.runner, issueTable, issueID); err != nil {
+		return domain.DepDeleteResult{}, fmt.Errorf("db: DependencySQLRepository.Delete: %w", err)
 	}
 
 	// The type lookup above returned Found:false when no edge existed, so reaching

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -760,6 +760,7 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 	// RowVersion CAS token is stale-zero on read — the backend-divergent break
 	// the RowVersion contract (types.Issue.RowVersion) forbids. The duplicate-key
 	// path rewrites it too so an upsert also advances the token.
+	rowVersion := issueops.FreshRowLock()
 	_, err := runner.ExecContext(ctx, fmt.Sprintf(`
 		INSERT INTO %s (
 			id, content_hash, title, description, design, acceptance_criteria, notes,
@@ -814,11 +815,15 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 		issue.EventKind, issue.Actor, issue.Target, issue.Payload,
 		issue.AwaitType, issue.AwaitID, issue.Timeout.Nanoseconds(), formatJSONStringArray(issue.Waiters),
 		issue.DueAt, issue.DeferUntil, jsonMetadata(issue.Metadata),
-		issueops.FreshRowLock(), nullString(string(issue.StorageClass.Normalize())),
+		rowVersion, nullString(string(issue.StorageClass.Normalize())),
 	)
 	if err != nil {
 		return fmt.Errorf("db: insert into %s: %w", table, err)
 	}
+	// This upsert always assigns VALUES(row_lock), so the generated value is the
+	// stored value; unlike the classic stale-guarded import path, no incumbent
+	// token can survive a successful statement.
+	issue.RowVersion = rowVersion
 	return nil
 }
 

--- a/internal/storage/domain/db/label.go
+++ b/internal/storage/domain/db/label.go
@@ -74,6 +74,10 @@ func (r *labelSQLRepositoryImpl) Insert(ctx context.Context, issueID, label, act
 		}
 		return nil
 	}
+	issueTable := pickIssueTable(opts.UseWispsTable)
+	if err := issueops.TouchRowVersionInTx(ctx, r.runner, issueTable, issueID); err != nil {
+		return fmt.Errorf("db: LabelSQLRepository.Insert %s/%s: %w", issueID, label, err)
+	}
 	if err := r.events.Record(ctx, domain.Event{
 		IssueID:  issueID,
 		Type:     types.EventLabelAdded,
@@ -109,6 +113,10 @@ func (r *labelSQLRepositoryImpl) Delete(ctx context.Context, issueID, label, act
 	}
 	if rows == 0 {
 		return nil
+	}
+	issueTable := pickIssueTable(opts.UseWispsTable)
+	if err := issueops.TouchRowVersionInTx(ctx, r.runner, issueTable, issueID); err != nil {
+		return fmt.Errorf("db: LabelSQLRepository.Delete %s/%s: %w", issueID, label, err)
 	}
 	if err := r.events.Record(ctx, domain.Event{
 		IssueID:  issueID,

--- a/internal/storage/embeddeddolt/aggregate_revision_test.go
+++ b/internal/storage/embeddeddolt/aggregate_revision_test.go
@@ -1,0 +1,328 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/types"
+	publicops "github.com/steveyegge/beads/issueops"
+)
+
+// These aggregate-revision cases preserve the source-completeness design and
+// behavioral intent of gastownhall/beads#4682 and #4697 (Julian Knutsen),
+// retargeted to current main's existing row_lock / RowVersion token.
+func TestAggregateRevisionChangesForEveryVisibleAuxiliaryMutation(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "aggregate_revision")
+	ctx := t.Context()
+	ops, err := embeddeddolt.NewIssueOperations(te.store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commenter, err := embeddeddolt.NewCommenter(te.store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dependencies, err := embeddeddolt.NewDependencyEditor(te.store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	create := func(t *testing.T, id string, wisp bool) *types.Issue {
+		t.Helper()
+		result, err := ops.Create(ctx, publicops.CreateRequest{
+			Actor:         "seed",
+			ForceIDPrefix: true,
+			Issue: &types.Issue{ID: id, Title: id, Status: types.StatusOpen,
+				Priority: 2, IssueType: types.TypeTask, Ephemeral: wisp},
+		})
+		if err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+		if result.Issue.RowVersion == 0 {
+			t.Fatalf("create %s returned zero RowVersion", id)
+		}
+		return result.Issue
+	}
+	assertChanged := func(t *testing.T, id string, before int64) int64 {
+		t.Helper()
+		after, err := te.store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("read %s: %v", id, err)
+		}
+		if after.RowVersion == 0 || after.RowVersion == before {
+			t.Fatalf("%s RowVersion = %d after mutation, want non-zero and different from %d", id, after.RowVersion, before)
+		}
+		return after.RowVersion
+	}
+
+	for _, wisp := range []bool{false, true} {
+		plane := "issue"
+		if wisp {
+			plane = "wisp"
+		}
+		t.Run(plane, func(t *testing.T) {
+			label := create(t, "revision-"+plane+"-label", wisp)
+			if err := te.store.AddLabel(ctx, label.ID, "added", "writer"); err != nil {
+				t.Fatal(err)
+			}
+			version := assertChanged(t, label.ID, label.RowVersion)
+			if err := te.store.RemoveLabel(ctx, label.ID, "added", "writer"); err != nil {
+				t.Fatal(err)
+			}
+			assertChanged(t, label.ID, version)
+
+			comment := create(t, "revision-"+plane+"-comment", wisp)
+			if _, err := commenter.AddComment(ctx, publicops.AddCommentRequest{Author: "writer", IssueID: comment.ID, Text: "visible comment"}); err != nil {
+				t.Fatal(err)
+			}
+			assertChanged(t, comment.ID, comment.RowVersion)
+
+			target := create(t, "revision-"+plane+"-target", false)
+			dependency := create(t, "revision-"+plane+"-dependency", wisp)
+			if _, err := dependencies.AddDependencies(ctx, publicops.AddDependenciesRequest{Actor: "writer", Edges: []publicops.DependencyEdge{{IssueID: dependency.ID, DependsOnID: target.ID, Type: publicops.DepRelated}}}); err != nil {
+				t.Fatal(err)
+			}
+			version = assertChanged(t, dependency.ID, dependency.RowVersion)
+			if _, err := dependencies.RemoveDependency(ctx, publicops.RemoveDependencyRequest{Actor: "writer", IssueID: dependency.ID, DependsOnID: target.ID}); err != nil {
+				t.Fatal(err)
+			}
+			assertChanged(t, dependency.ID, version)
+
+			metadata := create(t, "revision-"+plane+"-metadata", wisp)
+			updated, err := ops.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: metadata.ID, Patch: publicops.IssuePatch{Metadata: publicops.MetadataPatch{Set: map[string]json.RawMessage{"decision": json.RawMessage(`"yes"`)}}}})
+			if err != nil || !updated.Changed {
+				t.Fatalf("metadata update: %#v, %v", updated, err)
+			}
+			assertChanged(t, metadata.ID, metadata.RowVersion)
+
+			parent := create(t, "revision-"+plane+"-parent", false)
+			child := create(t, "revision-"+plane+"-child", wisp)
+			updated, err = ops.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: child.ID, Patch: publicops.IssuePatch{ParentID: publicops.Field[string]{Set: true, Value: parent.ID}}})
+			if err != nil || !updated.Changed {
+				t.Fatalf("parent update: %#v, %v", updated, err)
+			}
+			assertChanged(t, child.ID, child.RowVersion)
+		})
+	}
+}
+
+func TestAggregateRevisionAuxiliaryMutationInvalidatesGuard(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "aggregate_revision_stale")
+	ctx := t.Context()
+	ops, err := embeddeddolt.NewIssueOperations(te.store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dependencies, err := embeddeddolt.NewDependencyEditor(te.store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	create := func(t *testing.T, id string) *types.Issue {
+		t.Helper()
+		result, err := ops.Create(ctx, publicops.CreateRequest{Actor: "seed", ForceIDPrefix: true, Issue: &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return result.Issue
+	}
+
+	target := create(t, "stale-target")
+	parent := create(t, "stale-parent-target")
+	for _, tc := range []struct {
+		name   string
+		mutate func(*testing.T, *types.Issue)
+	}{
+		{"label", func(t *testing.T, issue *types.Issue) {
+			t.Helper()
+			mustNoError(t, te.store.AddLabel(ctx, issue.ID, "new", "writer"))
+		}},
+		{"metadata", func(t *testing.T, issue *types.Issue) {
+			t.Helper()
+			_, err := ops.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: issue.ID, Patch: publicops.IssuePatch{Metadata: publicops.MetadataPatch{Set: map[string]json.RawMessage{"x": json.RawMessage(`1`)}}}})
+			mustNoError(t, err)
+		}},
+		{"parent", func(t *testing.T, issue *types.Issue) {
+			t.Helper()
+			_, err := ops.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: issue.ID, Patch: publicops.IssuePatch{ParentID: publicops.Field[string]{Set: true, Value: parent.ID}}})
+			mustNoError(t, err)
+		}},
+		{"dependency", func(t *testing.T, issue *types.Issue) {
+			t.Helper()
+			_, err := dependencies.AddDependencies(ctx, publicops.AddDependenciesRequest{Actor: "writer", Edges: []publicops.DependencyEdge{{IssueID: issue.ID, DependsOnID: target.ID, Type: publicops.DepRelated}}})
+			mustNoError(t, err)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			issue := create(t, "stale-"+tc.name)
+			stale := issue.RowVersion
+			tc.mutate(t, issue)
+			_, err := ops.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: issue.ID, ExpectedVersion: &stale, Patch: publicops.IssuePatch{Title: publicops.Field[string]{Set: true, Value: "must not land"}}})
+			if !errors.Is(err, storage.ErrVersionMismatch) {
+				t.Fatalf("guard after %s mutation = %v, want ErrVersionMismatch", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestAggregateRevisionCreateWritesBackAndNoOpsStayStable(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "aggregate_revision_noop")
+	ctx := t.Context()
+	issue := &types.Issue{ID: "revision-create-readback", Title: "create", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := te.store.CreateIssue(ctx, issue, "writer"); err != nil {
+		t.Fatal(err)
+	}
+	if issue.RowVersion == 0 {
+		t.Fatal("CreateIssue left caller's RowVersion at zero")
+	}
+	if err := te.store.AddLabel(ctx, issue.ID, "same", "writer"); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := te.store.GetIssue(ctx, issue.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eventsBeforeNoOps, err := te.store.GetEvents(ctx, issue.ID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := te.store.AddLabel(ctx, issue.ID, "same", "writer"); err != nil {
+		t.Fatal(err)
+	}
+	if err := te.store.RemoveLabel(ctx, issue.ID, "missing", "writer"); err != nil {
+		t.Fatal(err)
+	}
+	after, err := te.store.GetIssue(ctx, issue.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.RowVersion != stored.RowVersion {
+		t.Fatalf("idempotent label operations changed RowVersion %d -> %d", stored.RowVersion, after.RowVersion)
+	}
+	eventsAfterNoOps, err := te.store.GetEvents(ctx, issue.ID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(eventsAfterNoOps) != len(eventsBeforeNoOps) {
+		t.Fatalf("idempotent label operations emitted events: %d -> %d", len(eventsBeforeNoOps), len(eventsAfterNoOps))
+	}
+
+	target := &types.Issue{ID: "revision-noop-target", Title: "target", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := te.store.CreateIssue(ctx, target, "writer"); err != nil {
+		t.Fatal(err)
+	}
+	dep := &types.Dependency{IssueID: issue.ID, DependsOnID: target.ID, Type: types.DepRelated, Metadata: `{"reason":"same"}`}
+	if err := te.store.AddDependency(ctx, dep, "writer"); err != nil {
+		t.Fatal(err)
+	}
+	stored, err = te.store.GetIssue(ctx, issue.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := te.store.AddDependency(ctx, dep, "writer"); err != nil {
+		t.Fatal(err)
+	}
+	after, err = te.store.GetIssue(ctx, issue.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.RowVersion != stored.RowVersion {
+		t.Fatalf("idempotent dependency assertion changed RowVersion %d -> %d", stored.RowVersion, after.RowVersion)
+	}
+
+	emptySource := &types.Issue{ID: "revision-empty-metadata-source", Title: "source", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := te.store.CreateIssue(ctx, emptySource, "writer"); err != nil {
+		t.Fatal(err)
+	}
+	emptyMetadataDep := &types.Dependency{IssueID: emptySource.ID, DependsOnID: target.ID, Type: types.DepRelated}
+	if err := te.store.AddDependency(ctx, emptyMetadataDep, "writer"); err != nil {
+		t.Fatal(err)
+	}
+	stored, err = te.store.GetIssue(ctx, emptySource.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := te.store.AddDependency(ctx, emptyMetadataDep, "writer"); err != nil {
+		t.Fatal(err)
+	}
+	after, err = te.store.GetIssue(ctx, emptySource.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.RowVersion != stored.RowVersion {
+		t.Fatalf("empty dependency metadata re-assertion changed RowVersion %d -> %d", stored.RowVersion, after.RowVersion)
+	}
+}
+
+func TestAggregateRevisionAuxiliaryUpdatesCommitTheRemintedToken(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "aggregate_revision_commit")
+	ctx := t.Context()
+	ops, err := embeddeddolt.NewIssueOperations(te.store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	create := func(id string) {
+		t.Helper()
+		if err := te.store.CreateIssue(ctx, &types.Issue{
+			ID: id, Title: id, Status: types.StatusOpen,
+			Priority: 2, IssueType: types.TypeTask,
+		}, "seed"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	readVersions := func(id string) (working, head int64) {
+		t.Helper()
+		te.queryScalar(t, ctx, "SELECT row_lock FROM issues WHERE id = ?", []any{id}, &working)
+		te.queryScalar(t, ctx, "SELECT row_lock FROM issues AS OF 'HEAD' WHERE id = ?", []any{id}, &head)
+		return working, head
+	}
+
+	create("revision-commit-label")
+	create("revision-commit-child")
+	create("revision-commit-parent")
+	if err := te.store.CloseIssue(ctx, "revision-commit-parent", "done", "seed", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := te.store.Commit(ctx, "seed"); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ops.Update(ctx, publicops.UpdateRequest{
+		Actor: "writer", IssueID: "revision-commit-label",
+		Patch: publicops.IssuePatch{Labels: publicops.LabelPatch{Add: []string{"fresh"}}},
+	})
+	if err != nil || !result.Changed {
+		t.Fatalf("label-only update = %#v, %v", result, err)
+	}
+	working, head := readVersions("revision-commit-label")
+	if working != head {
+		t.Fatalf("label-only remint was not committed: working=%d HEAD=%d", working, head)
+	}
+
+	result, err = ops.Update(ctx, publicops.UpdateRequest{
+		Actor: "writer", IssueID: "revision-commit-child",
+		Patch: publicops.IssuePatch{ParentID: publicops.Field[string]{Set: true, Value: "revision-commit-parent"}},
+	})
+	if err != nil || !result.Changed {
+		t.Fatalf("parent-only update = %#v, %v", result, err)
+	}
+	working, head = readVersions("revision-commit-child")
+	if working != head {
+		t.Fatalf("parent-only remint was not committed: working=%d HEAD=%d", working, head)
+	}
+}
+
+func mustNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/storage/embeddeddolt/aggregate_revision_test.go
+++ b/internal/storage/embeddeddolt/aggregate_revision_test.go
@@ -210,8 +210,8 @@ func TestAggregateRevisionCreateWritesBackAndNoOpsStayStable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(eventsAfterNoOps) != len(eventsBeforeNoOps) {
-		t.Fatalf("idempotent label operations emitted events: %d -> %d", len(eventsBeforeNoOps), len(eventsAfterNoOps))
+	if len(eventsAfterNoOps) != len(eventsBeforeNoOps)+2 {
+		t.Fatalf("row-idempotent label operations emitted %d new audit events, want 2", len(eventsAfterNoOps)-len(eventsBeforeNoOps))
 	}
 
 	target := &types.Issue{ID: "revision-noop-target", Title: "target", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
@@ -258,6 +258,89 @@ func TestAggregateRevisionCreateWritesBackAndNoOpsStayStable(t *testing.T) {
 	}
 	if after.RowVersion != stored.RowVersion {
 		t.Fatalf("empty dependency metadata re-assertion changed RowVersion %d -> %d", stored.RowVersion, after.RowVersion)
+	}
+}
+
+func TestAggregateRevisionTransactionLabelEventsDoNotRemintNoOps(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "aggregate_revision_tx_labels")
+	ctx := t.Context()
+	issue := &types.Issue{ID: "revision-tx-labels", Title: "transaction labels", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := te.store.CreateIssue(ctx, issue, "writer"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := te.store.RunInTransaction(ctx, "test: add label", func(tx storage.Transaction) error {
+		return tx.AddLabel(ctx, issue.ID, "same", "writer")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	withLabel, err := te.store.GetIssue(ctx, issue.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var committedLabelCount int
+	te.queryScalar(t, ctx, "SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ? AND label = ?", []any{issue.ID, "same"}, &committedLabelCount)
+	if committedLabelCount != 1 {
+		t.Fatalf("committed label count = %d, want 1", committedLabelCount)
+	}
+	var committedRevision int64
+	te.queryScalar(t, ctx, "SELECT row_lock FROM issues AS OF 'HEAD' WHERE id = ?", []any{issue.ID}, &committedRevision)
+	if committedRevision != withLabel.RowVersion {
+		t.Fatalf("committed revision = %d, working revision = %d", committedRevision, withLabel.RowVersion)
+	}
+
+	if err := te.store.RunInTransaction(ctx, "test: audit row-level label no-ops", func(tx storage.Transaction) error {
+		if err := tx.AddLabel(ctx, issue.ID, "same", "writer"); err != nil {
+			return err
+		}
+		return tx.RemoveLabel(ctx, issue.ID, "missing", "writer")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	afterNoOps, err := te.store.GetIssue(ctx, issue.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterNoOps.RowVersion != withLabel.RowVersion {
+		t.Fatalf("transactional label no-ops changed RowVersion %d -> %d", withLabel.RowVersion, afterNoOps.RowVersion)
+	}
+	events, err := te.store.GetEvents(ctx, issue.ID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var added, removed int
+	for _, event := range events {
+		switch event.EventType {
+		case types.EventLabelAdded:
+			added++
+		case types.EventLabelRemoved:
+			removed++
+		}
+	}
+	if added != 2 || removed != 1 {
+		t.Fatalf("transactional label audit events: added=%d removed=%d, want added=2 removed=1", added, removed)
+	}
+
+	if err := te.store.RunInTransaction(ctx, "test: remove label", func(tx storage.Transaction) error {
+		return tx.RemoveLabel(ctx, issue.ID, "same", "writer")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	afterRemove, err := te.store.GetIssue(ctx, issue.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterRemove.RowVersion == afterNoOps.RowVersion {
+		t.Fatalf("genuine transactional label removal preserved RowVersion %d", afterRemove.RowVersion)
+	}
+	te.queryScalar(t, ctx, "SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ? AND label = ?", []any{issue.ID, "same"}, &committedLabelCount)
+	if committedLabelCount != 0 {
+		t.Fatalf("committed label count after removal = %d, want 0", committedLabelCount)
+	}
+	te.queryScalar(t, ctx, "SELECT row_lock FROM issues AS OF 'HEAD' WHERE id = ?", []any{issue.ID}, &committedRevision)
+	if committedRevision != afterRemove.RowVersion {
+		t.Fatalf("committed revision after removal = %d, working revision = %d", committedRevision, afterRemove.RowVersion)
 	}
 }
 

--- a/internal/storage/embeddeddolt/labels.go
+++ b/internal/storage/embeddeddolt/labels.go
@@ -21,13 +21,15 @@ func (s *EmbeddedDoltStore) GetLabels(ctx context.Context, issueID string) ([]st
 
 func (s *EmbeddedDoltStore) AddLabel(ctx context.Context, issueID, label, actor string) error {
 	return s.withConn(ctx, true, func(tx *sql.Tx) error {
-		return issueops.AddLabelInTx(ctx, tx, "", "", issueID, label, actor)
+		_, err := issueops.AddLabelInTx(ctx, tx, "", "", issueID, label, actor)
+		return err
 	})
 }
 
 // RemoveLabel removes a label from an issue.
 func (s *EmbeddedDoltStore) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
 	return s.withConn(ctx, true, func(tx *sql.Tx) error {
-		return issueops.RemoveLabelInTx(ctx, tx, "", "", issueID, label, actor)
+		_, err := issueops.RemoveLabelInTx(ctx, tx, "", "", issueID, label, actor)
+		return err
 	})
 }

--- a/internal/storage/embeddeddolt/migrate_aggregate_revision_test.go
+++ b/internal/storage/embeddeddolt/migrate_aggregate_revision_test.go
@@ -1,0 +1,37 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+func TestAggregateRevisionMigrationBackfillsIssuesAndWisps(t *testing.T) {
+	requireEmbedded(t)
+	ctx := t.Context()
+	dir := seedMainSchemaAt(t, ctx, 65)
+	conn, closeConn := openPinnedConn(t, ctx, dir)
+	defer closeConn()
+
+	for _, table := range []string{"issues", "wisps"} {
+		execFrozenGuard(t, ctx, conn,
+			fmt.Sprintf("INSERT INTO %s (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type, row_lock) VALUES ('backfill-%s', 'legacy', '', '', '', '', 'open', 2, 'task', 0)", table, table))
+	}
+	mustDrain(t, ctx, conn, "CALL DOLT_ADD('-A')")
+	mustDrain(t, ctx, conn, "CALL DOLT_COMMIT('-m', 'test: seed legacy aggregate revisions')")
+	if _, err := schema.MigrateUp(ctx, conn); err != nil {
+		t.Fatalf("MigrateUp: %v", err)
+	}
+	for _, table := range []string{"issues", "wisps"} {
+		var rowLock int64
+		if err := conn.QueryRowContext(ctx, "SELECT row_lock FROM "+table+" WHERE id = ?", "backfill-"+table).Scan(&rowLock); err != nil {
+			t.Fatalf("read %s row_lock: %v", table, err)
+		}
+		if rowLock == 0 {
+			t.Fatalf("%s legacy row_lock remained zero", table)
+		}
+	}
+}

--- a/internal/storage/embeddeddolt/transaction.go
+++ b/internal/storage/embeddeddolt/transaction.go
@@ -248,12 +248,11 @@ func (t *embeddedTransaction) AddLabel(ctx context.Context, issueID, label, acto
 	if err != nil {
 		return err
 	}
-	if !changed {
-		return nil
-	}
-	t.dirty.MarkDirty(issueTableForLabelTable(labelTable))
-	t.dirty.MarkDirty(labelTable)
 	t.dirty.MarkDirty(eventTable)
+	if changed {
+		t.dirty.MarkDirty(issueTableForLabelTable(labelTable))
+		t.dirty.MarkDirty(labelTable)
+	}
 	return nil
 }
 
@@ -263,12 +262,11 @@ func (t *embeddedTransaction) RemoveLabel(ctx context.Context, issueID, label, a
 	if err != nil {
 		return err
 	}
-	if !changed {
-		return nil
-	}
-	t.dirty.MarkDirty(issueTableForLabelTable(labelTable))
-	t.dirty.MarkDirty(labelTable)
 	t.dirty.MarkDirty(eventTable)
+	if changed {
+		t.dirty.MarkDirty(issueTableForLabelTable(labelTable))
+		t.dirty.MarkDirty(labelTable)
+	}
 	return nil
 }
 

--- a/internal/storage/embeddeddolt/transaction.go
+++ b/internal/storage/embeddeddolt/transaction.go
@@ -173,8 +173,8 @@ func (t *embeddedTransaction) AddDependency(ctx context.Context, dep *types.Depe
 }
 
 func (t *embeddedTransaction) AddDependencyWithOptions(ctx context.Context, dep *types.Dependency, actor string, addOpts storage.DependencyAddOptions) error {
-	_, _, eventTable, depTable := issueops.WispTableRouting(issueops.IsActiveWispInTx(ctx, t.tx, dep.IssueID))
-	eventWritten, err := issueops.AddDependencyInTx(ctx, t.tx, dep, actor, issueops.AddDependencyOpts{
+	issueTable, _, eventTable, depTable := issueops.WispTableRouting(issueops.IsActiveWispInTx(ctx, t.tx, dep.IssueID))
+	result, err := issueops.AddDependencyInTxWithResult(ctx, t.tx, dep, actor, issueops.AddDependencyOpts{
 		IsCrossPrefix:  types.ExtractPrefix(dep.IssueID) != types.ExtractPrefix(dep.DependsOnID),
 		SkipCycleCheck: addOpts.SkipCycleCheck,
 		EmitEvent:      addOpts.EmitEvent,
@@ -182,11 +182,15 @@ func (t *embeddedTransaction) AddDependencyWithOptions(ctx context.Context, dep 
 	if err != nil {
 		return err
 	}
+	if !result.Changed {
+		return nil
+	}
+	t.dirty.MarkDirty(issueTable)
 	t.dirty.MarkDirty(depTable)
 	// AddDependencyInTx records a dependency_added event on the source's event
 	// table only for a genuine emit (explicit verb + new edge); stage it so the
 	// event commits with the edge. A structural or idempotent add writes no event.
-	if eventWritten {
+	if result.EventWritten {
 		t.dirty.MarkDirty(eventTable)
 	}
 	return nil
@@ -210,17 +214,21 @@ func (t *embeddedTransaction) RemoveDependency(ctx context.Context, issueID, dep
 func (t *embeddedTransaction) RemoveDependencyWithOptions(ctx context.Context, issueID, dependsOnID string, actor string, rmOpts storage.DependencyRemoveOptions) error {
 	// Route dirty marking on the source's wisp status: a wisp-source remove
 	// stages wisp_dependencies/wisp_events, a permanent one dependencies/events.
-	_, _, eventTable, depTable := issueops.WispTableRouting(issueops.IsActiveWispInTx(ctx, t.tx, issueID))
-	eventWritten, err := issueops.RemoveDependencyInTx(ctx, t.tx, issueID, dependsOnID, actor, rmOpts.EmitEvent)
+	issueTable, _, eventTable, depTable := issueops.WispTableRouting(issueops.IsActiveWispInTx(ctx, t.tx, issueID))
+	result, err := issueops.RemoveDependencyInTxWithResult(ctx, t.tx, issueID, dependsOnID, actor, rmOpts.EmitEvent)
 	if err != nil {
 		return err
 	}
+	if !result.Changed {
+		return nil
+	}
+	t.dirty.MarkDirty(issueTable)
 	t.dirty.MarkDirty(depTable)
 	// RemoveDependencyInTx records a dependency_removed event on the source's
 	// event table only for a genuine emit (explicit verb + edge removal); stage
 	// it so it commits with the edge. A structural or missing-edge remove writes
 	// no event.
-	if eventWritten {
+	if result.EventWritten {
 		t.dirty.MarkDirty(eventTable)
 	}
 	return nil
@@ -236,9 +244,14 @@ func (t *embeddedTransaction) GetDependencyRecords(ctx context.Context, issueID 
 
 func (t *embeddedTransaction) AddLabel(ctx context.Context, issueID, label, actor string) error {
 	_, labelTable, eventTable, _ := issueops.WispTableRouting(issueops.IsActiveWispInTx(ctx, t.tx, issueID))
-	if err := issueops.AddLabelInTx(ctx, t.tx, labelTable, eventTable, issueID, label, actor); err != nil {
+	changed, err := issueops.AddLabelInTx(ctx, t.tx, labelTable, eventTable, issueID, label, actor)
+	if err != nil {
 		return err
 	}
+	if !changed {
+		return nil
+	}
+	t.dirty.MarkDirty(issueTableForLabelTable(labelTable))
 	t.dirty.MarkDirty(labelTable)
 	t.dirty.MarkDirty(eventTable)
 	return nil
@@ -246,12 +259,24 @@ func (t *embeddedTransaction) AddLabel(ctx context.Context, issueID, label, acto
 
 func (t *embeddedTransaction) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
 	_, labelTable, eventTable, _ := issueops.WispTableRouting(issueops.IsActiveWispInTx(ctx, t.tx, issueID))
-	if err := issueops.RemoveLabelInTx(ctx, t.tx, labelTable, eventTable, issueID, label, actor); err != nil {
+	changed, err := issueops.RemoveLabelInTx(ctx, t.tx, labelTable, eventTable, issueID, label, actor)
+	if err != nil {
 		return err
 	}
+	if !changed {
+		return nil
+	}
+	t.dirty.MarkDirty(issueTableForLabelTable(labelTable))
 	t.dirty.MarkDirty(labelTable)
 	t.dirty.MarkDirty(eventTable)
 	return nil
+}
+
+func issueTableForLabelTable(labelTable string) string {
+	if labelTable == "wisp_labels" {
+		return "wisps"
+	}
+	return "issues"
 }
 
 func (t *embeddedTransaction) GetLabels(ctx context.Context, issueID string) ([]string, error) {

--- a/internal/storage/issueops/aggregate.go
+++ b/internal/storage/issueops/aggregate.go
@@ -334,12 +334,12 @@ func ApplyLabelPatch(ctx context.Context, tx DBTX, current *types.Issue, patch p
 		return false, fmt.Errorf("apply labels: transaction must be *sql.Tx")
 	}
 	for _, label := range stringSetDifference(existing, target) {
-		if err := RemoveLabelInTx(ctx, sqlTx, "", "", current.ID, label, actor); err != nil {
+		if _, err := RemoveLabelInTx(ctx, sqlTx, "", "", current.ID, label, actor); err != nil {
 			return false, err
 		}
 	}
 	for _, label := range stringSetDifference(target, existing) {
-		if err := AddLabelInTx(ctx, sqlTx, "", "", current.ID, label, actor); err != nil {
+		if _, err := AddLabelInTx(ctx, sqlTx, "", "", current.ID, label, actor); err != nil {
 			return false, err
 		}
 	}
@@ -381,12 +381,12 @@ func ApplyParentPatch(ctx context.Context, tx DBTX, current *types.Issue, parent
 	}
 	var recomputed RecomputeIsBlockedResult
 	for _, parentID := range stringSetDifference(existing, target) {
-		if _, err := removeDependencyInTx(ctx, sqlTx, current.ID, parentID, actor, false, &recomputed); err != nil {
+		if _, err := removeDependencyInTx(ctx, sqlTx, current.ID, parentID, actor, false, &recomputed, nil); err != nil {
 			return ParentPatchResult{}, err
 		}
 	}
 	for _, parentID := range stringSetDifference(target, existing) {
-		if _, err := addDependencyInTx(ctx, sqlTx, &types.Dependency{IssueID: current.ID, DependsOnID: parentID, Type: types.DepParentChild}, actor, AddDependencyOpts{}, &recomputed); err != nil {
+		if _, err := addDependencyInTx(ctx, sqlTx, &types.Dependency{IssueID: current.ID, DependsOnID: parentID, Type: types.DepParentChild}, actor, AddDependencyOpts{}, &recomputed, nil); err != nil {
 			return ParentPatchResult{}, err
 		}
 	}

--- a/internal/storage/issueops/bulk_ops.go
+++ b/internal/storage/issueops/bulk_ops.go
@@ -293,9 +293,9 @@ func updateIssueIDInTx(ctx context.Context, tx *sql.Tx, oldID, newID string, iss
 	now := time.Now().UTC()
 	result, err := tx.ExecContext(ctx, `
 		UPDATE issues
-		SET id = ?, title = ?, description = ?, design = ?, acceptance_criteria = ?, notes = ?, updated_at = ?
+		SET id = ?, title = ?, description = ?, design = ?, acceptance_criteria = ?, notes = ?, updated_at = ?, row_lock = ?
 		WHERE id = ?
-	`, newID, issue.Title, issue.Description, issue.Design, issue.AcceptanceCriteria, issue.Notes, now, oldID)
+	`, newID, issue.Title, issue.Description, issue.Design, issue.AcceptanceCriteria, issue.Notes, now, freshRowLock(), oldID)
 	if err != nil {
 		return fmt.Errorf("update issue ID: %w", err)
 	}
@@ -326,9 +326,9 @@ func updateWispIDInTx(ctx context.Context, tx *sql.Tx, oldID, newID string, issu
 	now := time.Now().UTC()
 	result, err := tx.ExecContext(ctx, `
 		UPDATE wisps
-		SET id = ?, title = ?, description = ?, design = ?, acceptance_criteria = ?, notes = ?, updated_at = ?
+		SET id = ?, title = ?, description = ?, design = ?, acceptance_criteria = ?, notes = ?, updated_at = ?, row_lock = ?
 		WHERE id = ?
-	`, newID, issue.Title, issue.Description, issue.Design, issue.AcceptanceCriteria, issue.Notes, now, oldID)
+	`, newID, issue.Title, issue.Description, issue.Design, issue.AcceptanceCriteria, issue.Notes, now, freshRowLock(), oldID)
 	if err != nil {
 		return fmt.Errorf("update wisp ID: %w", err)
 	}

--- a/internal/storage/issueops/close.go
+++ b/internal/storage/issueops/close.go
@@ -60,10 +60,9 @@ func CloseIssueWithoutEventInTx(ctx context.Context, tx DBTX, id string, reason,
 // so force bypasses the child and blocker policies, never the version check. Because
 // the read shares this transaction, a mismatch returns before any write and the
 // transaction rolls back with the issue unchanged (a true compare-and-swap).
-// row_lock only tracks lifecycle/ownership writes (status, assignee, started_at),
-// so this guards against a concurrent lifecycle change — not against concurrent
-// label, dependency, rename, or is_blocked writes that leave row_lock untouched
-// (see the freshRowLock invariant in lease.go).
+// row_lock tracks every supported user-authored aggregate mutation. Exact
+// no-ops and derived is_blocked recomputation are excluded (see the
+// freshRowLock invariant in lease.go).
 func CloseIssueCheckedInTx(ctx context.Context, tx DBTX, id, reason, actor, session string, force bool, expectedVersion *int64) (*CloseResult, error) {
 	if expectedVersion != nil {
 		if err := CheckVersionInTx(ctx, tx, id, *expectedVersion); err != nil {

--- a/internal/storage/issueops/commenter.go
+++ b/internal/storage/issueops/commenter.go
@@ -55,6 +55,9 @@ func ExecuteAddComment(ctx context.Context, tx *sql.Tx, request publicops.AddCom
 	}
 	tables := ChangedTables{}
 	tables.Add(commentTable)
+	if commentTable == "comments" {
+		tables.Add("issues")
+	}
 	return publicops.AddCommentResult{Comment: comment}, tables, nil
 }
 

--- a/internal/storage/issueops/comments.go
+++ b/internal/storage/issueops/comments.go
@@ -228,18 +228,24 @@ func GetCommentCountsInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) (m
 //
 //nolint:gosec // G201: table names come from hardcoded constants
 func AddIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, text string) (*types.Comment, error) {
-	return addIssueCommentInTx(ctx, tx, issueID, author, text, time.Now().UTC().Truncate(time.Second), true)
+	comment, _, err := addIssueCommentInTx(ctx, tx, issueID, author, text, time.Now().UTC().Truncate(time.Second), true)
+	return comment, err
 }
 
 // ImportIssueCommentInTx adds a comment preserving the original timestamp.
 //
 //nolint:gosec // G201: table names come from hardcoded constants
 func ImportIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, text string, createdAt time.Time) (*types.Comment, error) {
+	comment, _, err := ImportIssueCommentInTxWithResult(ctx, tx, issueID, author, text, createdAt)
+	return comment, err
+}
+
+func ImportIssueCommentInTxWithResult(ctx context.Context, tx *sql.Tx, issueID, author, text string, createdAt time.Time) (*types.Comment, bool, error) {
 	return addIssueCommentInTx(ctx, tx, issueID, author, text, createdAt, false)
 }
 
 //nolint:gosec // G201: table names come from hardcoded constants
-func addIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, text string, createdAt time.Time, live bool) (*types.Comment, error) {
+func addIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, text string, createdAt time.Time, live bool) (*types.Comment, bool, error) {
 	isWisp := IsActiveWispInTx(ctx, tx, issueID)
 	issueTable, _, _, _ := WispTableRouting(isWisp)
 	commentTable := "comments"
@@ -251,28 +257,33 @@ func addIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, text 
 	var exists bool
 	if err := tx.QueryRowContext(ctx, fmt.Sprintf(
 		`SELECT EXISTS(SELECT 1 FROM %s WHERE id = ?)`, issueTable), issueID).Scan(&exists); err != nil {
-		return nil, fmt.Errorf("check issue existence: %w", err)
+		return nil, false, fmt.Errorf("check issue existence: %w", err)
 	}
 	if !exists {
-		return nil, fmt.Errorf("issue %s not found", issueID)
+		return nil, false, fmt.Errorf("issue %s not found", issueID)
 	}
 
 	if live {
 		advanced, err := NextLiveCommentTime(ctx, tx, commentTable, issueID, createdAt)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		createdAt = advanced
 	}
 
 	createdAtText := FormatAuxTime(createdAt)
-	id, _, err := InsertDerivedComment(ctx, tx, commentTable, issueID, author, text, createdAtText)
+	id, existed, err := InsertDerivedComment(ctx, tx, commentTable, issueID, author, text, createdAtText)
 	if err != nil {
-		return nil, err
+		return nil, false, err
+	}
+	if !existed {
+		if err := TouchRowVersionInTx(ctx, tx, issueTable, issueID); err != nil {
+			return nil, false, err
+		}
 	}
 	stored, err := ParseAuxTime(createdAtText)
 	if err != nil {
-		return nil, fmt.Errorf("add comment to %s: %w", commentTable, err)
+		return nil, false, fmt.Errorf("add comment to %s: %w", commentTable, err)
 	}
 
 	comment := &types.Comment{
@@ -285,9 +296,9 @@ func addIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, text 
 	if err := RecordCommentEventInTx(ctx, tx, issueID, &EventComment{
 		ID: id, Author: author, Text: text, CreatedAt: stored, Source: CommentSourceStructured,
 	}); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return comment, nil
+	return comment, !existed, nil
 }
 
 // AddCommentEventInTx adds a comment as an event to an issue within a transaction.
@@ -296,7 +307,7 @@ func addIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, text 
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
 func AddCommentEventInTx(ctx context.Context, tx DBTX, issueID, actor, comment string) error {
 	isWisp := IsActiveWispInTx(ctx, tx, issueID)
-	_, _, eventTable, _ := WispTableRouting(isWisp)
+	issueTable, _, eventTable, _ := WispTableRouting(isWisp)
 
 	createdAt := NowAuxTime()
 	id, err := InsertDerivedEventReturningID(ctx, tx, eventTable, AuxEvent{
@@ -307,6 +318,9 @@ func AddCommentEventInTx(ctx context.Context, tx DBTX, issueID, actor, comment s
 		CreatedAt: createdAt,
 	})
 	if err != nil {
+		return fmt.Errorf("add comment event to %s: %w", eventTable, err)
+	}
+	if err := TouchRowVersionInTx(ctx, tx, issueTable, issueID); err != nil {
 		return fmt.Errorf("add comment event to %s: %w", eventTable, err)
 	}
 	stored, err := ParseAuxTime(createdAt)

--- a/internal/storage/issueops/compaction.go
+++ b/internal/storage/issueops/compaction.go
@@ -90,8 +90,8 @@ func CheckEligibilityInTx(ctx context.Context, tx *sql.Tx, issueID string, tier 
 func ApplyCompactionInTx(ctx context.Context, tx *sql.Tx, issueID string, tier int, originalSize int, commitHash string) error {
 	now := time.Now().UTC()
 	_, err := tx.ExecContext(ctx,
-		`UPDATE issues SET compaction_level = ?, compacted_at = ?, compacted_at_commit = ?, original_size = ?, updated_at = ? WHERE id = ?`,
-		tier, now, commitHash, originalSize, now, issueID)
+		`UPDATE issues SET compaction_level = ?, compacted_at = ?, compacted_at_commit = ?, original_size = ?, updated_at = ?, row_lock = ? WHERE id = ?`,
+		tier, now, commitHash, originalSize, now, freshRowLock(), issueID)
 	if err != nil {
 		return fmt.Errorf("apply compaction: %w", err)
 	}
@@ -173,16 +173,16 @@ func RestoreFromSnapshotInTx(ctx context.Context, tx *sql.Tx, issueID string) (*
 			UPDATE issues
 			SET description = ?, design = ?, notes = ?, acceptance_criteria = ?,
 			    compaction_level = 0, compacted_at = NULL, compacted_at_commit = '', original_size = 0,
-			    updated_at = ?
+			    updated_at = ?, row_lock = ?
 			WHERE id = ?`,
-			snap.Description, snap.Design, snap.Notes, snap.AcceptanceCriteria, now, issueID)
+			snap.Description, snap.Design, snap.Notes, snap.AcceptanceCriteria, now, freshRowLock(), issueID)
 	} else {
 		_, err = tx.ExecContext(ctx, `
 			UPDATE issues
 			SET description = ?, design = ?, notes = ?, acceptance_criteria = ?,
-			    compaction_level = ?, updated_at = ?
+			    compaction_level = ?, updated_at = ?, row_lock = ?
 			WHERE id = ?`,
-			snap.Description, snap.Design, snap.Notes, snap.AcceptanceCriteria, newLevel, now, issueID)
+			snap.Description, snap.Design, snap.Notes, snap.AcceptanceCriteria, newLevel, now, freshRowLock(), issueID)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("restore issue %s: %w", issueID, err)

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -31,6 +31,9 @@ type BatchContext struct {
 	// issue for a result the caller discards. Singular creates leave this
 	// false so they keep reconciling immediately, per-issue.
 	SkipChildCounterReconcile bool
+	// SkipRowVersionReadback lets the batch entry point defer each issue's
+	// readback until all cross-issue dependencies have been persisted.
+	SkipRowVersionReadback bool
 }
 
 // NewBatchContext reads config from the database and returns a BatchContext.
@@ -204,6 +207,11 @@ func CreateIssueInTxWithResult(ctx context.Context, tx DBTX, bc *BatchContext, i
 			return result, err
 		}
 	}
+	if !bc.SkipRowVersionReadback {
+		if err := tx.QueryRowContext(ctx, fmt.Sprintf("SELECT row_lock FROM %s WHERE id = ?", issueTable), issue.ID).Scan(&issue.RowVersion); err != nil {
+			return result, fmt.Errorf("read final row version for %s: %w", issue.ID, err)
+		}
+	}
 	return result, nil
 }
 
@@ -288,6 +296,7 @@ func CreateIssuesInTxWithContext(ctx context.Context, tx DBTX, bc *BatchContext,
 	// reconcile behavior.
 	batch := *bc
 	batch.SkipChildCounterReconcile = true
+	batch.SkipRowVersionReadback = true
 
 	result := CreateIssuesResult{}
 	accepted := issues[:0:0]
@@ -331,6 +340,19 @@ func CreateIssuesInTxWithContext(ctx context.Context, tx DBTX, bc *BatchContext,
 	}
 	if recomputed.WispRowsChanged {
 		result.markChanged("wisps")
+	}
+	// Auxiliary aggregate writes (notably dependency creation) may remint the
+	// token after the row insert. Return the final in-transaction token on each
+	// caller-owned Issue so an immediate guarded mutation does not start stale.
+	for _, issue := range issues {
+		if issue == nil {
+			continue
+		}
+		table, _ := TableRouting(issue)
+		//nolint:gosec // G201: table comes from TableRouting.
+		if err := tx.QueryRowContext(ctx, fmt.Sprintf("SELECT row_lock FROM %s WHERE id = ?", table), issue.ID).Scan(&issue.RowVersion); err != nil {
+			return CreateIssuesResult{}, fmt.Errorf("read final row version for %s: %w", issue.ID, err)
+		}
 	}
 	return result, nil
 }

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -3,10 +3,12 @@ package issueops
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/depid"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/sqlbuild"
@@ -170,11 +172,24 @@ type DepTargetPrecheck struct {
 // same-type re-add or a silent structural add. Callers that stage tables for a
 // Dolt commit stage the events table only when an event row exists, so a
 // no-event add cannot sweep unrelated pending rows into the commit (GH#2455).
-func AddDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, actor string, opts AddDependencyOpts) (bool, error) {
-	return addDependencyInTx(ctx, tx, dep, actor, opts, nil)
+type DependencyWriteResult struct {
+	Changed      bool
+	EventWritten bool
 }
 
-func addDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, actor string, opts AddDependencyOpts, recomputeResult *RecomputeIsBlockedResult) (bool, error) {
+func AddDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, actor string, opts AddDependencyOpts) (bool, error) {
+	result, err := AddDependencyInTxWithResult(ctx, tx, dep, actor, opts)
+	return result.EventWritten, err
+}
+
+func AddDependencyInTxWithResult(ctx context.Context, tx *sql.Tx, dep *types.Dependency, actor string, opts AddDependencyOpts) (DependencyWriteResult, error) {
+	var result DependencyWriteResult
+	eventWritten, err := addDependencyInTx(ctx, tx, dep, actor, opts, nil, &result)
+	result.EventWritten = eventWritten
+	return result, err
+}
+
+func addDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, actor string, opts AddDependencyOpts, recomputeResult *RecomputeIsBlockedResult, result *DependencyWriteResult) (bool, error) {
 	// Auto-detect source routing if not provided.
 	sourceTable := opts.SourceTable
 	writeTable := opts.WriteTable
@@ -258,18 +273,32 @@ func addDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 	// Check for existing dependency between the same pair. Use the resolved
 	// target expression defensively so stale/reclassified rows in another typed
 	// target column cannot bypass the idempotency/conflict check.
-	var existingType string
+	var existingType, existingMetadata string
 	//nolint:gosec // G201: writeTable from WispTableRouting; depTargetEquals has no user input.
-	err := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT type FROM %s WHERE issue_id = ? AND %s`, writeTable, depTargetEquals("")),
-		dep.IssueID, dep.DependsOnID).Scan(&existingType)
+	err := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT type, COALESCE(metadata, '{}') FROM %s WHERE issue_id = ? AND %s`, writeTable, depTargetEquals("")),
+		dep.IssueID, dep.DependsOnID).Scan(&existingType, &existingMetadata)
 	if err == nil {
 		if existingType == string(dep.Type) {
+			existingValue, requestedValue := json.RawMessage(existingMetadata), json.RawMessage(metadata)
+			equal, err := storage.MetadataValuesEqual(&existingValue, &requestedValue)
+			if err != nil {
+				return false, fmt.Errorf("compare dependency metadata: %w", err)
+			}
+			if equal {
+				return false, nil
+			}
 			// Same type — idempotent; update metadata. No event is written, so the
 			// caller must not stage the events table for this re-add.
 			//nolint:gosec // G201: writeTable from WispTableRouting; depTargetEquals has no user input.
 			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET metadata = ? WHERE issue_id = ? AND %s`, writeTable, depTargetEquals("")),
 				metadata, dep.IssueID, dep.DependsOnID); err != nil {
 				return false, fmt.Errorf("failed to update dependency metadata: %w", err)
+			}
+			if err := TouchRowVersionInTx(ctx, tx, sourceTable, dep.IssueID); err != nil {
+				return false, fmt.Errorf("touch dependency row versions: %w", err)
+			}
+			if result != nil {
+				result.Changed = true
 			}
 			// A same-type add refreshes edge metadata. It is an observable graph
 			// mutation, so emit the complete replacement edge for replay even
@@ -296,6 +325,12 @@ func addDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 		VALUES (?, ?, ?, ?, UTC_TIMESTAMP(), ?, ?, ?)
 	`, writeTable, targetCol), depid.New(dep.IssueID, dep.DependsOnID), dep.IssueID, dep.DependsOnID, dep.Type, actor, metadata, dep.ThreadID); err != nil {
 		return false, fmt.Errorf("failed to add dependency: %w", err)
+	}
+	if err := TouchRowVersionInTx(ctx, tx, sourceTable, dep.IssueID); err != nil {
+		return false, fmt.Errorf("touch dependency row versions: %w", err)
+	}
+	if result != nil {
+		result.Changed = true
 	}
 	if dep.Type == types.DepParentChild {
 		if err := TouchDependencyCoordinationTableInTx(ctx, tx, dep.DependsOnID, writeTable); err != nil {
@@ -918,12 +953,20 @@ func checkRenameTargetCollision(ctx context.Context, tx DBTX, table, typedCol, n
 //
 //nolint:gosec // G201: depTable from WispTableRouting (hardcoded constants)
 func RemoveDependencyInTx(ctx context.Context, tx *sql.Tx, issueID, dependsOnID, actor string, emitEvent bool) (bool, error) {
-	return removeDependencyInTx(ctx, tx, issueID, dependsOnID, actor, emitEvent, nil)
+	result, err := RemoveDependencyInTxWithResult(ctx, tx, issueID, dependsOnID, actor, emitEvent)
+	return result.EventWritten, err
 }
 
-func removeDependencyInTx(ctx context.Context, tx *sql.Tx, issueID, dependsOnID, actor string, emitEvent bool, recomputeResult *RecomputeIsBlockedResult) (bool, error) {
+func RemoveDependencyInTxWithResult(ctx context.Context, tx *sql.Tx, issueID, dependsOnID, actor string, emitEvent bool) (DependencyWriteResult, error) {
+	var result DependencyWriteResult
+	eventWritten, err := removeDependencyInTx(ctx, tx, issueID, dependsOnID, actor, emitEvent, nil, &result)
+	result.EventWritten = eventWritten
+	return result, err
+}
+
+func removeDependencyInTx(ctx context.Context, tx *sql.Tx, issueID, dependsOnID, actor string, emitEvent bool, recomputeResult *RecomputeIsBlockedResult, result *DependencyWriteResult) (bool, error) {
 	isWisp := IsActiveWispInTx(ctx, tx, issueID)
-	_, _, eventTable, depTable := WispTableRouting(isWisp)
+	issueTable, _, eventTable, depTable := WispTableRouting(isWisp)
 
 	// Capture the row's type before deleting so we can dispatch the right
 	// affected-set helper. If no row matches, treat as a no-op.
@@ -942,6 +985,12 @@ func removeDependencyInTx(ctx context.Context, tx *sql.Tx, issueID, dependsOnID,
 		`DELETE FROM %s WHERE issue_id = ? AND %s = ?`, depTable, DepTargetExpr),
 		issueID, dependsOnID); err != nil {
 		return false, fmt.Errorf("remove dependency: %w", err)
+	}
+	if err := TouchRowVersionInTx(ctx, tx, issueTable, issueID); err != nil {
+		return false, fmt.Errorf("touch dependency row versions: %w", err)
+	}
+	if result != nil {
+		result.Changed = true
 	}
 
 	// The lookup above returned early when no row matched, so reaching here means

--- a/internal/storage/issueops/dependency_editor.go
+++ b/internal/storage/issueops/dependency_editor.go
@@ -183,20 +183,11 @@ func addDependencyEdgeInTx(ctx context.Context, tx *sql.Tx, request publicops.Ad
 	// commits nothing, which is right — the wisp plane is dolt-ignored and has
 	// no version history to write.
 	//
-	// This is NOT every table the edge wrote. A blocking edge also flips the
-	// source's is_blocked (markDirectBlockingDependencySourceInTx, then
-	// MarkIsBlockedInTx over the affected ids), and neither `issues` nor any
-	// other issue-plane table is ever staged here. On an issue-sourced
-	// blocking add the flip therefore stays in the working set and is swept up
-	// by whatever command auto-commits next — including one that was REFUSED,
-	// which then shows up in history having changed nothing of its own. That
-	// predates this role: origin/main's dolt.AddDependencyWithOptions staged
-	// the same {dependencies, events} pair. Tracked as bd-2y9ke; fixing it
-	// changes what every dep-add commit contains and belongs in its own change
-	// with its own tests, so do not widen the set here without reading that
-	// bead first.
+	// Stage sourceTable as well as the edge. This closes bd-2y9ke's pre-existing
+	// torn-commit hole for derived is_blocked changes and is now mandatory because
+	// the aggregate row_lock is reminted with every genuine edge mutation.
 	tables := ChangedTables{}
-	tables.Add(depTable)
+	tables.Add(sourceTable, depTable)
 	if eventWritten {
 		tables.Add(eventTable)
 	}
@@ -246,7 +237,7 @@ func ExecuteRemoveDependency(ctx context.Context, tx *sql.Tx, request publicops.
 	// the delete actually touched or the commit sweeps rows it never wrote
 	// (GH#2455). ChangedTables drops the wisp tables itself.
 	sourceIsWisp := IsActiveWispInTx(ctx, tx, request.IssueID)
-	_, _, eventTable, depTable := WispTableRouting(sourceIsWisp)
+	sourceTable, _, eventTable, depTable := WispTableRouting(sourceIsWisp)
 
 	// RemoveDependencyInTx reports whether it recorded an event, which on the
 	// explicit-verb path is exactly "an edge was there and is gone" — it
@@ -259,6 +250,6 @@ func ExecuteRemoveDependency(ctx context.Context, tx *sql.Tx, request publicops.
 		return publicops.RemoveDependencyResult{Removed: false}, nil, nil
 	}
 	tables := ChangedTables{}
-	tables.Add(depTable, eventTable)
+	tables.Add(sourceTable, depTable, eventTable)
 	return publicops.RemoveDependencyResult{Removed: true}, tables, nil
 }

--- a/internal/storage/issueops/execution.go
+++ b/internal/storage/issueops/execution.go
@@ -220,8 +220,8 @@ func ExecuteUpdate(ctx context.Context, tx *sql.Tx, request publicops.UpdateRequ
 	}
 	if labelsChanged {
 		changedAny = true
-		_, labelTable, eventTable, _ := WispTableRouting(IsActiveWispInTx(ctx, tx, attempt.IssueID))
-		tables.Add(labelTable, eventTable)
+		issueTable, labelTable, eventTable, _ := WispTableRouting(IsActiveWispInTx(ctx, tx, attempt.IssueID))
+		tables.Add(issueTable, labelTable, eventTable)
 	}
 	parentResult, err := ApplyParentPatch(ctx, tx, current, attempt.Patch.ParentID, attempt.Actor)
 	if err != nil {
@@ -229,8 +229,8 @@ func ExecuteUpdate(ctx context.Context, tx *sql.Tx, request publicops.UpdateRequ
 	}
 	if parentResult.Changed {
 		changedAny = true
-		_, _, _, dependencyTable := WispTableRouting(IsActiveWispInTx(ctx, tx, attempt.IssueID))
-		tables.Add(dependencyTable)
+		issueTable, _, _, dependencyTable := WispTableRouting(IsActiveWispInTx(ctx, tx, attempt.IssueID))
+		tables.Add(issueTable, dependencyTable)
 		if parentResult.IssueRowsChanged {
 			tables.Add("issues")
 		}

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -116,6 +116,7 @@ func insertIssueCreateOnly(ctx context.Context, tx DBTX, table string, issue *ty
 
 //nolint:gosec // G201: table is a hardcoded constant ("issues" or "wisps")
 func executeIssueInsert(ctx context.Context, tx DBTX, table string, issue *types.Issue, suffix string) error {
+	rowVersion := freshRowLock()
 	_, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		INSERT INTO %s (
 			id, content_hash, title, description, design, acceptance_criteria, notes,
@@ -151,10 +152,13 @@ func executeIssueInsert(ctx context.Context, tx DBTX, table string, issue *types
 		issue.EventKind, issue.Actor, issue.Target, issue.Payload,
 		issue.AwaitType, issue.AwaitID, issue.Timeout.Nanoseconds(), FormatJSONStringArray(issue.Waiters),
 		issue.DueAt, issue.DeferUntil, JSONMetadata(issue.Metadata),
-		freshRowLock(), NullString(string(issue.StorageClass.Normalize())),
+		rowVersion, NullString(string(issue.StorageClass.Normalize())),
 	)
 	if err != nil {
 		return fmt.Errorf("insert issue into %s: %w", table, err)
+	}
+	if suffix == "" {
+		issue.RowVersion = rowVersion
 	}
 	return nil
 }

--- a/internal/storage/issueops/journal_completeness_test.go
+++ b/internal/storage/issueops/journal_completeness_test.go
@@ -170,6 +170,7 @@ var beadDMLExemptions = map[string]string{
 	"RetargetInboundDependenciesToIssueInTx": "rewrites dep rows during promote; PromoteFromEphemeralInTx journals it",
 	"DeleteWispFromDependenciesInTx":         "cleans up dep rows during a delete that journals the delete",
 	"DeleteWispsFromDependenciesInTx":        "cleans up dep rows during a delete that journals the delete",
+	"TouchRowVersionInTx":                    "constituent aggregate-token write; the calling label/comment/dependency entry point journals the mutation",
 
 	// (4) compaction maintenance — a lossy content rewrite outside the
 	// create/update/close/delete/dep/label op vocabulary. Carried from the

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -151,11 +151,11 @@ func AddLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID,
 	if err != nil {
 		return false, fmt.Errorf("add label: rows affected: %w", err)
 	}
-	if rows == 0 {
-		return false, nil
-	}
-	if err := TouchRowVersionInTx(ctx, tx, issueTable, issueID); err != nil {
-		return false, fmt.Errorf("add label: %w", err)
+	changed := rows > 0
+	if changed {
+		if err := TouchRowVersionInTx(ctx, tx, issueTable, issueID); err != nil {
+			return false, fmt.Errorf("add label: %w", err)
+		}
 	}
 	comment := "Added label: " + label
 	if err := InsertDerivedEvent(ctx, tx, eventTable, AuxEvent{
@@ -171,7 +171,7 @@ func AddLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID,
 	if err := RecordEventInTx(ctx, tx, EventUpdate, issueID); err != nil {
 		return false, err
 	}
-	return true, nil
+	return changed, nil
 }
 
 // RemoveLabelInTx removes a label from an issue and records an event within
@@ -192,11 +192,11 @@ func RemoveLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issue
 	if err != nil {
 		return false, fmt.Errorf("remove label: rows affected: %w", err)
 	}
-	if rows == 0 {
-		return false, nil
-	}
-	if err := TouchRowVersionInTx(ctx, tx, issueTable, issueID); err != nil {
-		return false, fmt.Errorf("remove label: %w", err)
+	changed := rows > 0
+	if changed {
+		if err := TouchRowVersionInTx(ctx, tx, issueTable, issueID); err != nil {
+			return false, fmt.Errorf("remove label: %w", err)
+		}
 	}
 	comment := "Removed label: " + label
 	if err := InsertDerivedEvent(ctx, tx, eventTable, AuxEvent{
@@ -210,7 +210,7 @@ func RemoveLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issue
 	if err := RecordEventInTx(ctx, tx, EventUpdate, issueID); err != nil {
 		return false, err
 	}
-	return true, nil
+	return changed, nil
 }
 
 func resolveLabelTables(ctx context.Context, tx DBTX, labelTable, eventTable, issueID string) (string, string, string, error) {

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -131,26 +131,31 @@ func getLabelsIntoFromTable(ctx context.Context, tx DBTX, labelTable string, ids
 // AddLabelInTx adds a label to an issue and records an event within an existing
 // transaction. Automatically routes to wisp tables if the ID is an active wisp.
 // Uses INSERT IGNORE for idempotency.
-func AddLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID, label, actor string) error {
+func AddLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID, label, actor string) (bool, error) {
 	// Reject an over-length label up front. The INSERT IGNORE below would
 	// otherwise silently truncate it to the VARCHAR(255) column, storing a label
 	// the caller never sent; a typed ErrFieldTooLong is the clean rejection.
 	if err := types.CheckFieldLen("label", label); err != nil {
-		return err
+		return false, err
 	}
-	if labelTable == "" || eventTable == "" {
-		isWisp := IsActiveWispInTx(ctx, tx, issueID)
-		_, lt, et, _ := WispTableRouting(isWisp)
-		if labelTable == "" {
-			labelTable = lt
-		}
-		if eventTable == "" {
-			eventTable = et
-		}
+	issueTable, labelTable, eventTable, err := resolveLabelTables(ctx, tx, labelTable, eventTable, issueID)
+	if err != nil {
+		return false, err
 	}
 	//nolint:gosec // G201: labelTable is from WispTableRouting ("labels" or "wisp_labels")
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`INSERT IGNORE INTO %s (issue_id, label) VALUES (?, ?)`, labelTable), issueID, label); err != nil {
-		return fmt.Errorf("add label: %w", err)
+	result, err := tx.ExecContext(ctx, fmt.Sprintf(`INSERT IGNORE INTO %s (issue_id, label) VALUES (?, ?)`, labelTable), issueID, label)
+	if err != nil {
+		return false, fmt.Errorf("add label: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("add label: rows affected: %w", err)
+	}
+	if rows == 0 {
+		return false, nil
+	}
+	if err := TouchRowVersionInTx(ctx, tx, issueTable, issueID); err != nil {
+		return false, fmt.Errorf("add label: %w", err)
 	}
 	comment := "Added label: " + label
 	if err := InsertDerivedEvent(ctx, tx, eventTable, AuxEvent{
@@ -159,11 +164,14 @@ func AddLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID,
 		Actor:     actor,
 		Comment:   str(comment),
 	}); err != nil {
-		return fmt.Errorf("add label: record event: %w", err)
+		return false, fmt.Errorf("add label: record event: %w", err)
 	}
 	// A label is part of the bead snapshot, so a label write journals as an
 	// update carrying the complete post-mutation set.
-	return RecordEventInTx(ctx, tx, EventUpdate, issueID)
+	if err := RecordEventInTx(ctx, tx, EventUpdate, issueID); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // RemoveLabelInTx removes a label from an issue and records an event within
@@ -171,19 +179,24 @@ func AddLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID,
 // an active wisp.
 //
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
-func RemoveLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID, label, actor string) error {
-	if labelTable == "" || eventTable == "" {
-		isWisp := IsActiveWispInTx(ctx, tx, issueID)
-		_, lt, et, _ := WispTableRouting(isWisp)
-		if labelTable == "" {
-			labelTable = lt
-		}
-		if eventTable == "" {
-			eventTable = et
-		}
+func RemoveLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID, label, actor string) (bool, error) {
+	issueTable, labelTable, eventTable, err := resolveLabelTables(ctx, tx, labelTable, eventTable, issueID)
+	if err != nil {
+		return false, err
 	}
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE issue_id = ? AND label = ?`, labelTable), issueID, label); err != nil {
-		return fmt.Errorf("remove label: %w", err)
+	result, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE issue_id = ? AND label = ?`, labelTable), issueID, label)
+	if err != nil {
+		return false, fmt.Errorf("remove label: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("remove label: rows affected: %w", err)
+	}
+	if rows == 0 {
+		return false, nil
+	}
+	if err := TouchRowVersionInTx(ctx, tx, issueTable, issueID); err != nil {
+		return false, fmt.Errorf("remove label: %w", err)
 	}
 	comment := "Removed label: " + label
 	if err := InsertDerivedEvent(ctx, tx, eventTable, AuxEvent{
@@ -192,7 +205,28 @@ func RemoveLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issue
 		Actor:     actor,
 		Comment:   str(comment),
 	}); err != nil {
-		return fmt.Errorf("remove label: record event: %w", err)
+		return false, fmt.Errorf("remove label: record event: %w", err)
 	}
-	return RecordEventInTx(ctx, tx, EventUpdate, issueID)
+	if err := RecordEventInTx(ctx, tx, EventUpdate, issueID); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func resolveLabelTables(ctx context.Context, tx DBTX, labelTable, eventTable, issueID string) (string, string, string, error) {
+	if (labelTable == "labels" && eventTable == "wisp_events") || (labelTable == "wisp_labels" && eventTable == "events") {
+		return "", "", "", fmt.Errorf("label tables disagree: %s and %s", labelTable, eventTable)
+	}
+	isWisp := labelTable == "wisp_labels" || eventTable == "wisp_events"
+	if labelTable == "" && eventTable == "" {
+		isWisp = IsActiveWispInTx(ctx, tx, issueID)
+	}
+	issueTable, resolvedLabel, resolvedEvent, _ := WispTableRouting(isWisp)
+	if labelTable == "" {
+		labelTable = resolvedLabel
+	}
+	if eventTable == "" {
+		eventTable = resolvedEvent
+	}
+	return issueTable, labelTable, eventTable, nil
 }

--- a/internal/storage/issueops/lease.go
+++ b/internal/storage/issueops/lease.go
@@ -44,7 +44,8 @@ func leaseTTL(ctx context.Context) time.Duration {
 
 // freshRowLock returns a random non-zero int64 for the row_lock cell.
 //
-// row_lock is the keystone of dead-worker recovery on Dolt. Dolt has no real
+// row_lock is the aggregate revision and the keystone of dead-worker recovery
+// on Dolt. Dolt has no real
 // row locking and merges concurrent commits cell-by-cell, so two transactions
 // that touch DIFFERENT cells of the same issue row (a reclaim writing status,
 // a close writing closed_at) merge silently instead of conflicting — which
@@ -57,12 +58,14 @@ func leaseTTL(ctx context.Context) time.Duration {
 // column default) so a freshly-claimed row is always distinguishable from a
 // never-touched one.
 //
-// INVARIANT: any path that mutates status, assignee, or started_at on an
-// in_progress issue MUST rewrite row_lock — that is the set the reclaim/close
-// races care about (claim, close, updateIssueInTx, reclaim, unclaim all do).
-// Paths that touch only orthogonal cells (is_blocked, compaction_level,
-// dependency metadata, rename, or reopen — which acts on closed rows) are safe
-// to merge with a reclaim and intentionally do NOT rewrite it. Heartbeats no
+// INVARIANT: every supported write that changes the user-authored issue
+// aggregate MUST rewrite row_lock. That includes scalar and lifecycle fields,
+// labels, comments, dependency edges, compaction/restoration and rename. Exact
+// no-ops do not rewrite it. The derived is_blocked projection is deliberately
+// excluded: it is recomputed from other rows, is not authored issue state, and
+// bumping it would make an otherwise stable issue token depend on graph-cache
+// maintenance. The dependency mutation that caused a recompute still rewrites
+// its source aggregate's token. Heartbeats no
 // longer touch the issues row at all (bd-lrgn1): the lease lives in the
 // ephemeral leases table, where a racing heartbeat and reclaim contend on the
 // SAME lease row and conflict without any help. Adding a new path that sets
@@ -116,6 +119,30 @@ func RowLockClause() (string, []interface{}) {
 // like the classic insert (see the freshRowLock invariant and types.Issue.RowVersion).
 func FreshRowLock() int64 {
 	return freshRowLock()
+}
+
+// TouchRowVersionInTx remints the aggregate revision for issueID in the same
+// transaction as an auxiliary-table mutation. issueTable is the already
+// resolved "issues" or "wisps" plane that owns the auxiliary row; resolving it
+// again on another Dolt session can route a wisp mutation to the durable plane.
+// Call it only after a genuine mutation; no-ops keep the token stable.
+func TouchRowVersionInTx(ctx context.Context, tx DBTX, issueTable, issueID string) error {
+	if issueTable != "issues" && issueTable != "wisps" {
+		return fmt.Errorf("touch row version for %s: invalid issue table %q", issueID, issueTable)
+	}
+	//nolint:gosec // G201: issueTable is validated above.
+	result, err := tx.ExecContext(ctx, fmt.Sprintf("UPDATE %s SET row_lock = ?, updated_at = updated_at WHERE id = ?", issueTable), freshRowLock(), issueID)
+	if err != nil {
+		return fmt.Errorf("touch row version for %s: %w", issueID, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("touch row version for %s: rows affected: %w", issueID, err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("%w: issue %s", storage.ErrNotFound, issueID)
+	}
+	return nil
 }
 
 // LeaseTTL is the exported form of leaseTTL: it resolves the lease TTL for the

--- a/internal/storage/issueops/row_lock_guard_test.go
+++ b/internal/storage/issueops/row_lock_guard_test.go
@@ -59,8 +59,7 @@ var sqlWriteKeywordRe = regexp.MustCompile(`(?i)\b(?:SET|VALUES|SELECT)\b`)
 
 // auxOrExemptMarkers identify a matched write that legitimately does NOT stamp
 // row_lock. The exemption set is main's freshRowLock invariant (lease.go):
-// row_lock guards status/assignee/started_at against the reclaim/close races,
-// and paths touching only orthogonal cells are safe to merge with a reclaim.
+// row_lock guards the complete user-authored aggregate against stale writes.
 //
 //   - is_blocked: the denormalized is_blocked recompute deliberately preserves
 //     updated_at (blocked_state.go x4, dependencies.go, domain/db/dependency.go)
@@ -70,14 +69,6 @@ var sqlWriteKeywordRe = regexp.MustCompile(`(?i)\b(?:SET|VALUES|SELECT)\b`)
 //     (The PR's other exemption, the lease heartbeat, is moot on main: since
 //     bd-lrgn1 heartbeats live entirely in the ephemeral leases table and never
 //     touch the issues row.)
-//   - "compaction_level = ": compaction apply/restore rewrites bookkeeping and
-//     compacted body text only — cells the reclaim/close races don't care
-//     about, exempted by name in the freshRowLock invariant. The assignment
-//     form (not the bare column name) keeps the create INSERT, whose column
-//     list also names compaction_level, checkable.
-//   - "SET id = ?": rename (updateIssueIDInTx/updateWispIDInTx) is the only
-//     writer of the primary key, exempted by name in the freshRowLock
-//     invariant.
 //   - "SELECT %s FROM": the persistence move's fully-templated aux-table copy
 //     (INSERT INTO %s (%s) SELECT %s FROM %s ...) — it copies snapshot/event
 //     side tables verbatim; the issues/wisps row itself is re-inserted through
@@ -100,15 +91,13 @@ var sqlWriteKeywordRe = regexp.MustCompile(`(?i)\b(?:SET|VALUES|SELECT)\b`)
 // status in the same statement as an is_blocked-marked WHERE predicate must
 // still stamp. See setClauseAssignsLifecycleField.
 var auxOrExemptMarkers = []string{
-	"is_blocked",          // is_blocked recompute (exempt by design)
-	"compaction_level = ", // compaction bookkeeping/restore (exempt by design)
-	"SET id = ?",          // rename: primary-key rewrite (exempt by design)
-	"SELECT %s FROM",      // persistence move's verbatim aux-table copy
-	"issue_id",            // events / dependencies / comments / snapshots FK
-	"depends_on",          // dependency edge + retarget writes
-	"parent_id",           // child_counters
-	"last_child",          // child_counters
-	"event_type",          // events / wisp_events
+	"is_blocked",     // is_blocked recompute (exempt by design)
+	"SELECT %s FROM", // persistence move's verbatim aux-table copy
+	"issue_id",       // events / dependencies / comments / snapshots FK
+	"depends_on",     // dependency edge + retarget writes
+	"parent_id",      // child_counters
+	"last_child",     // child_counters
+	"event_type",     // events / wisp_events
 }
 
 // funcNameExemptions are functions whose issues/wisps write is deliberately
@@ -141,22 +130,14 @@ var funcNameExemptions = map[string]string{
 	"resolveOneConflictRow": "whole-row `theirs` adoption: the adopted row_lock already vouches for the (identical) adopted content",
 }
 
-// TestAllIssueRowWritesStampRowLock is the load-bearing completeness guard for
-// the freshRowLock invariant: it proves, at build time, that EVERY issues/wisps
-// row write across both whole-row write stacks (issueops and the proxied
-// internal/storage/domain/db) either stamps a fresh row_lock or matches a
-// documented exemption. A forgotten write path is a test failure, catching an
-// accidental reintroduction of the zombie-merge bug before it ships.
+// TestAllIssueRowWritesStampRowLock is the source-completeness guard for the
+// packages it inventories: every issues/wisps SQL write in issueops,
+// domain/db, and versioncontrolops either stamps row_lock or matches the single
+// reviewed whole-row-adoption exemption below. Behavioral backend tests cover
+// orchestration outside these SQL-owning packages.
 //
-// This does not mean every documented exemption is itself free of a stale-CAS
-// hole in RowVersion — two of them knowingly are one: compaction rewrites
-// bookkeeping and compacted body text while deliberately preserving row_lock
-// (documented at storage.go:319-325, the same "lifecycle/ownership only"
-// contract this guard enforces), and a rename (updateIssueIDInTx) changes the
-// primary key without reminting the old row's token — but that is safe by
-// construction: the CAS predicate is keyed on id, so a stale ExpectedVersion
-// read against the pre-rename id matches no row at all rather than winning
-// against renamed content.
+// Auxiliary-table writers are covered behaviorally by the aggregate revision
+// mutation matrix because their SQL does not target issues/wisps directly.
 func TestAllIssueRowWritesStampRowLock(t *testing.T) {
 	// versioncontrolops is included alongside issueops and the proxied
 	// domain/db: it writes issues/wisps rows too, both from automerge's
@@ -194,6 +175,62 @@ func TestAllIssueRowWritesStampRowLock(t *testing.T) {
 		t.Fatal("guard verified zero issue-table writes — the scan regex or directory set is wrong")
 	}
 	t.Logf("verified %d issues/wisps row writes across both stacks stamp row_lock", checked)
+}
+
+// TestAllAuxiliaryAggregateWritersTouchRowVersion complements the SQL-row scan
+// above by pinning the known SQL-owning chokepoints for labels, comments and
+// dependency edges. It is an explicit inventory, not discovery of future
+// writers; the real-backend mutation matrix provides the supported-surface
+// check. Design adapted from Julian Knutsen's completeness guards in
+// gastownhall/beads#4682 and #4697.
+func TestAllAuxiliaryAggregateWritersTouchRowVersion(t *testing.T) {
+	writers := map[string][]string{
+		"labels.go":       {"AddLabelInTx", "RemoveLabelInTx"},
+		"comments.go":     {"addIssueCommentInTx", "AddCommentEventInTx"},
+		"dependencies.go": {"addDependencyInTx", "removeDependencyInTx"},
+		filepath.Join("..", "domain", "db", "label.go"):      {"Insert", "Delete"},
+		filepath.Join("..", "domain", "db", "comment.go"):    {"InsertRecord"},
+		filepath.Join("..", "domain", "db", "dependency.go"): {"Insert", "Delete"},
+	}
+	for path, names := range writers {
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, src, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, name := range names {
+			var found, touched bool
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Name.Name != name || fn.Body == nil {
+					continue
+				}
+				found = true
+				ast.Inspect(fn.Body, func(node ast.Node) bool {
+					call, ok := node.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+					switch callee := call.Fun.(type) {
+					case *ast.Ident:
+						touched = callee.Name == "TouchRowVersionInTx" || touched
+					case *ast.SelectorExpr:
+						touched = callee.Sel.Name == "TouchRowVersionInTx" || touched
+					}
+					return true
+				})
+			}
+			if !found {
+				t.Errorf("%s: aggregate writer %s not found; update the completeness inventory", path, name)
+			} else if !touched {
+				t.Errorf("%s: aggregate writer %s does not touch RowVersion", path, name)
+			}
+		}
+	}
 }
 
 // scanIssueWriteRowLockStamps parses one Go source file and returns the number
@@ -258,8 +295,14 @@ func scanIssueWriteRowLockStamps(t *testing.T, path string, src []byte) (checked
 				continue
 			}
 
-			if hasAnyMarker(stmt, auxOrExemptMarkers) && !setClauseAssignsLifecycleField(stmt) {
-				continue // auxiliary table or documented exemption: no stamp
+			if hasAnyMarker(stmt, auxOrExemptMarkers) {
+				// Auxiliary-table markers are definitive because issues/wisps do
+				// not have those columns. is_blocked is different: it exists on the
+				// aggregate row and exempts only derived-cache-only SET clauses.
+				isBlockedMarker := strings.Contains(strings.ToLower(stmt), "is_blocked")
+				if !isBlockedMarker || !setClauseAssignsLifecycleField(stmt) {
+					continue
+				}
 			}
 			checked++
 
@@ -310,20 +353,14 @@ func setClause(stmt string) string {
 	return clause
 }
 
-// lifecycleFieldAssignRe matches an assignment to one of the three columns
-// the freshRowLock invariant (lease.go) exists to guard: status, assignee,
-// started_at (see storage.go's ExpectedVersion doc). A write assigning any of
-// these must stamp row_lock regardless of an aux/exempt marker matched
-// elsewhere in the statement.
-var lifecycleFieldAssignRe = regexp.MustCompile(`(?i)\b(?:status|assignee|started_at)\s*=`)
+// lifecycleFieldAssignRe includes scalar aggregate columns that could otherwise
+// hide behind an is_blocked marker in the WHERE clause. The historical name is
+// retained to keep this adversarial guard's helper churn small.
+var lifecycleFieldAssignRe = regexp.MustCompile(`(?i)\b(?:title|description|design|acceptance_criteria|notes|status|priority|issue_type|assignee|owner|estimated_minutes|created_at|closed_at|close_reason|closed_by_session|due_at|defer_until|started_at|external_ref|source_repo|metadata|parent_id|compaction_level|compacted_at|compacted_at_commit|original_size|id)\s*=`)
 
 // setClauseAssignsLifecycleField reports whether stmt's SET clause (not its
-// WHERE predicate) assigns status, assignee, or started_at. Used to refuse an
-// aux/exempt marker match outright when the write is really a lifecycle
-// write that merely happens to share a marker word — e.g. a hypothetical
-// `UPDATE issues SET status = ?, assignee = NULL WHERE is_blocked = 0` must
-// not be waved through by the is_blocked marker just because that word
-// appears in WHERE.
+// WHERE predicate) assigns user-authored aggregate content. Used to refuse an
+// is_blocked exemption when that marker merely occurs in a WHERE predicate.
 func setClauseAssignsLifecycleField(stmt string) bool {
 	return lifecycleFieldAssignRe.MatchString(setClause(stmt))
 }
@@ -557,6 +594,14 @@ func w(tx T, id, s string) {
 }`)
 	if n, v := scanIssueWriteRowLockStamps(t, "lifecycle.go", lifecycleEscapeAttempt); n != 1 || len(v) != 1 {
 		t.Errorf("lifecycle write behind an is_blocked WHERE marker: got checked=%d violations=%d; want checked=1 violations=1 (a marker in WHERE must not exempt a SET that assigns status/assignee/started_at)", n, len(v))
+	}
+
+	contentEscapeAttempt := []byte(`package p
+func w(tx T, id, title string) {
+	tx.ExecContext(ctx, "UPDATE issues SET title = ? WHERE is_blocked = 0", title, id)
+}`)
+	if n, v := scanIssueWriteRowLockStamps(t, "content.go", contentEscapeAttempt); n != 1 || len(v) != 1 {
+		t.Errorf("content write behind an is_blocked WHERE marker: got checked=%d violations=%d; want checked=1 violations=1", n, len(v))
 	}
 
 	// finding 3: the stamp check used to be computed once per FUNCTION, so an

--- a/internal/storage/issueops/row_version_touch_test.go
+++ b/internal/storage/issueops/row_version_touch_test.go
@@ -1,0 +1,40 @@
+package issueops
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestTouchRowVersionUsesResolvedPlaneWithoutRediscovery(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE wisps SET row_lock = ?, updated_at = updated_at WHERE id = ?")).
+		WithArgs(sqlmock.AnyArg(), "shared-id").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := TouchRowVersionInTx(context.Background(), db, "wisps", "shared-id"); err != nil {
+		t.Fatal(err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTouchRowVersionRejectsUnknownPlane(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if err := TouchRowVersionInTx(context.Background(), db, "labels", "id"); err == nil {
+		t.Fatal("expected invalid plane error")
+	}
+}

--- a/internal/storage/schema/migrations/0066_backfill_aggregate_row_lock.down.sql
+++ b/internal/storage/schema/migrations/0066_backfill_aggregate_row_lock.down.sql
@@ -1,0 +1,3 @@
+-- The aggregate revision backfill is intentionally irreversible: restoring 0
+-- would make legacy and genuinely never-written states indistinguishable.
+SELECT 1;

--- a/internal/storage/schema/migrations/0066_backfill_aggregate_row_lock.up.sql
+++ b/internal/storage/schema/migrations/0066_backfill_aggregate_row_lock.up.sql
@@ -1,0 +1,4 @@
+-- Migration 0066: make every durable aggregate revision immediately usable.
+-- row_lock is equality-only, so legacy zero rows may share the same non-zero
+-- backfill token; the next supported mutation remints a random token.
+UPDATE issues SET row_lock = 1 WHERE row_lock = 0;

--- a/internal/storage/schema/migrations/ignored/0025_backfill_wisp_aggregate_row_lock.up.sql
+++ b/internal/storage/schema/migrations/ignored/0025_backfill_wisp_aggregate_row_lock.up.sql
@@ -1,0 +1,3 @@
+-- Ignored migration 0025: give clone-local wisps a usable aggregate revision.
+-- This is the ignored-plane twin of synced migration 0066.
+UPDATE wisps SET row_lock = 1 WHERE row_lock = 0;

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -568,13 +568,10 @@ type CloseIssueOptions struct {
 	// requires version 0. Force bypasses child and blocker policy, not this
 	// version check.
 	//
-	// RowVersion tracks lifecycle/ownership writes only — it is rewritten by
-	// status, assignee, and started_at changes (claim, close, reclaim, unclaim,
-	// updateIssueInTx). So this is a "close only if the issue's lifecycle state
-	// is unchanged" guard, NOT an all-columns check: concurrent label, dependency,
-	// rename, is_blocked, or compaction-only writes intentionally do not bump
-	// row_lock and are not caught here (see the freshRowLock invariant in
-	// internal/storage/issueops/lease.go).
+	// RowVersion tracks every supported user-authored aggregate mutation,
+	// including labels, comments and dependency edges. Exact no-ops and derived
+	// is_blocked cache recomputation preserve it (see the freshRowLock invariant
+	// in internal/storage/issueops/lease.go).
 	ExpectedVersion *int64
 }
 

--- a/internal/storage/versioncontrolops/automerge.go
+++ b/internal/storage/versioncontrolops/automerge.go
@@ -477,18 +477,9 @@ func mergeIssuesConflictRow(row rawConflictRow) (issuesRowMerge, bool) {
 		// holder read and it is correct — and convergence-critical (see the
 		// exclusion comment above) — to leave it alone.
 		//
-		// This reminting on ANY settled write (not just a status/assignee/
-		// started_at change) is wider than RowVersion's documented contract
-		// (storage.go's CloseIssueOptions.ExpectedVersion doc, ~319-325):
-		// RowVersion is meant to track lifecycle/ownership writes only, and a
-		// merge that only touched e.g. title or description is not one of
-		// those. The widening is accepted as fail-safe rather than tightened
-		// to the lifecycle columns: the failure mode is a spurious
-		// ExpectedVersion mismatch on a non-lifecycle-only merge, and a caller
-		// that hits it simply re-reads and retries (types.Issue.RowVersion),
-		// never a missed conflict. Narrowing this to match the documented
-		// contract exactly is a separate, deliberate change, not implied by
-		// this fix.
+		// Any settled write changes the user-authored aggregate, so reminting is
+		// the same equality-only contract ordinary writers uphold. A caller that
+		// held either parent's token must re-read the merged aggregate.
 		//
 		// Gated on the column actually existing in the conflict table: a
 		// pre-0054 schema (before row_lock was added) has no

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -74,7 +74,7 @@ type Issue struct {
 	// ===== Concurrency (generic Issue JSON/JSONL omits this field) =====
 	// RowVersion is an opaque optimistic-concurrency token for the library's own
 	// Go call sites: the issues/wisps row_lock cell, a random non-zero value the
-	// engine rewrites on every status/ownership-mutating write. It is
+	// engine rewrites on every supported user-authored aggregate mutation. It is
 	// EQUALITY-ONLY — compare it, never order or interpret it — and a change
 	// signals the row was mutated since you read it. It is json:"-" on purpose:
 	// row_lock is random per write, so generic Issue serialization would break
@@ -83,16 +83,14 @@ type Issue struct {
 	// NewIssueDetails, and on the wire at GET /v0/beads/issues/{id}); Go
 	// consumers read RowVersion directly.
 	//
-	// Coverage is deliberately partial: it changes on claim/close/unclaim and the
-	// generic update path, but NOT on direct-UPDATE paths that rewrite text
-	// without touching row_lock (RestoreFromSnapshotInTx, the compaction
-	// text-truncation path). For a complete change-detection key, combine it with
-	// updated_at (which those paths DO bump), status, and the label set
-	// (label-only and reopen writes change those, not row_lock).
+	// Exact no-ops preserve the token. The derived is_blocked projection is the
+	// sole visible exception: recomputation is cache maintenance driven by other
+	// rows, not a user-authored mutation of this aggregate. The dependency edit
+	// that triggered it still remints its source token; inbound edges remain a
+	// graph query on the target.
 	//
-	// 0 appears only on legacy rows backfilled by migration 0054 (DEFAULT 0) that
-	// have not been mutated since; any issue created by the current code path is
-	// non-zero (create stamps freshRowLock()).
+	// Migration 0066 (ignored/0025 for wisps) replaces legacy 0 tokens with a
+	// non-zero equality sentinel; current creates stamp a fresh random token.
 	RowVersion int64 `json:"-"`
 
 	// ===== Time-Based Scheduling (GH#820) =====

--- a/issueops/deleter.go
+++ b/issueops/deleter.go
@@ -85,11 +85,11 @@ type DeleteRequest struct {
 	// be doing the irreversible half of the operation on a row it no longer
 	// recognizes.
 	//
-	// IT GUARDS THE NAMED ROW'S LIFECYCLE STATE, NOT ITS GRAPH AND NOT ITS
-	// CLOSURE. RowVersion is reminted by status, assignee and started_at
-	// writes and deliberately not by label, dependency, rename or is_blocked
-	// writes, so a matching token does NOT promise that the row's edges are the
-	// ones the caller saw. Under Cascade that has a consequence worth saying
+	// IT GUARDS THE NAMED AGGREGATE, NOT ITS TRANSITIVE CLOSURE. RowVersion is
+	// reminted by every supported user-authored mutation, including outgoing
+	// dependency edits, but an inbound edge is authored on its source aggregate
+	// and derived is_blocked recomputation is excluded. A matching token therefore
+	// does not promise the cascade closure is unchanged. Under Cascade that has a consequence worth saying
 	// out loud: the closure is resolved inside the deleting transaction, so a
 	// caller whose named row is unchanged deletes the closure the graph has
 	// NOW, which an edge added since its read may have grown. A caller that

--- a/issueops/issueops.go
+++ b/issueops/issueops.go
@@ -264,10 +264,10 @@ type UpdateRequest struct {
 	//   - THE TOKEN IS OPAQUE AND COMPARED FOR EQUALITY ONLY. RowVersion is
 	//     minted afresh on every lifecycle write rather than incremented, so
 	//     "newer" and "older" are not questions a version guard can answer.
-	//   - IT GUARDS THE ROW'S LIFECYCLE STATE, NOT ITS GRAPH. RowVersion is
-	//     reminted by status, assignee and started_at writes and deliberately
-	//     not by label, dependency, rename or is_blocked writes, so a matching
-	//     token does not promise the row's edges are the ones the caller saw.
+	//   - IT GUARDS THE USER-AUTHORED AGGREGATE, INCLUDING labels, comments and
+	//     dependency edges. Exact no-ops preserve it. Derived is_blocked cache
+	//     recomputation is excluded; the graph edit that caused it remints its
+	//     source aggregate instead.
 	//   - nil DISABLES THE CHECK. Each is a pointer so that "do not check" is
 	//     distinct from a caller requiring the never-written version 0, or the
 	//     empty assignee, which is a real guard meaning "expected unassigned".


### PR DESCRIPTION
## Summary

- widen the existing equality-only `row_lock` token into an aggregate revision for supported user-authored issue and wisp mutations
- preserve tokens across exact no-ops, derived `is_blocked` recomputation, and inbound dependency changes
- return final stored revisions from create paths and backfill legacy zero tokens on both storage planes
- add behavioral aggregate, durability, migration, routing, and source-completeness coverage

This adapts useful design and tests from #4682 and #4697 by Julian Knutsen while keeping the change scoped to the current-main `row_lock` model.

## Validation

- `BEADS_TEST_EMBEDDED_DOLT=1 ./scripts/test.sh -run '^(TestAggregateRevision|TestAggregateRevisionMigrationBackfillsIssuesAndWisps)' ./internal/storage/embeddeddolt/...`
- `./scripts/test.sh ./internal/storage/issueops/... ./internal/storage/domain/db/... ./internal/storage/dolt/... ./internal/storage/embeddeddolt/... ./internal/storage/schema/... ./internal/storage/versioncontrolops/... ./issueops/...`
- `BASE_SHA=d1e725d9f35b scripts/check-migration-hygiene.sh`
- `make api-check`
- affected-package `go build` and `go vet`
- `git diff --check`

## Review

Independent review found and drove fixes for timestamp preservation during token-only remints and durable staging of label/parent token changes. Residual future-guard/doc wording findings are recorded on `gc-yfkxj`; no CRITICAL or HIGH issue remains at `f55210dbb`.
