### PR TITLE
fix(list): union repeated --status/--state/--id; refuse repeated --type/--assignee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`bd list` no longer silently drops all but the last repeated filter flag.**
+  `--status`, `--state`, and `--id` were plain string flags, so
+  `bd list --status open --status closed --status pinned` kept only `pinned` —
+  a census over 477 issues quietly answered over 3, with nothing in the output
+  to distinguish the narrowed answer from a correct one. Repeats of those three
+  flags now union with the comma form (`--status open --status closed` ≡
+  `--status open,closed`). `--type` and `--assignee` are single-valued all the
+  way down — unioning would fail type validation or exact-match nobody — so a
+  repeat of either now refuses loudly instead of silently keeping the last
+  value: `--type given more than once (already "bug"); pass a single value`.
+  Single-flag and comma-form spellings behave exactly as before.
+
 ### Changed
 
 - **`bd reclaim` summarizes the leases its replica guard declined instead of

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -395,12 +395,12 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 }
 
 func init() {
-	listCmd.Flags().StringP("status", "s", "", "Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress. Note: repeating -s/--status silently overwrites the previous value — always use the comma-separated form for multi-status filters.")
-	listCmd.Flags().String("state", "", "Alias for --status")
+	listCmd.Flags().VarP(&listStatusFlag, "status", "s", "Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated or repeated for multiple: --status open,in_progress")
+	listCmd.Flags().Var(&listStateFlag, "state", "Alias for --status")
 	_ = listCmd.Flags().MarkHidden("state")
 	registerPriorityFlag(listCmd, "")
-	listCmd.Flags().StringP("assignee", "a", "", "Filter by assignee")
-	listCmd.Flags().StringP("type", "t", "", "Filter by type (bug, feature, task, epic, chore, decision, merge-request, molecule, gate, convoy). Aliases: mr→merge-request, feat→feature, mol→molecule, dec/adr→decision")
+	listCmd.Flags().VarP(&listAssigneeFlag, "assignee", "a", "Filter by assignee")
+	listCmd.Flags().VarP(&listTypeFlag, "type", "t", "Filter by type (bug, feature, task, epic, chore, decision, merge-request, molecule, gate, convoy). Aliases: mr→merge-request, feat→feature, mol→molecule, dec/adr→decision")
 	listCmd.Flags().StringSliceP("label", "l", []string{}, "Filter by labels (AND: must have ALL). Can combine with --label-any")
 	listCmd.Flags().StringSlice("label-any", []string{}, "Filter by labels (OR: must have AT LEAST ONE). Can combine with --label")
 	listCmd.Flags().StringSlice("exclude-label", []string{}, "Exclude issues that have ANY of these labels")
@@ -408,7 +408,7 @@ func init() {
 	listCmd.Flags().String("label-regex", "", "Filter by label regex pattern (e.g., 'tech-(debt|legacy)')")
 	listCmd.Flags().String("title", "", "Filter by title text (case-insensitive substring match)")
 	listCmd.Flags().String("spec", "", "Filter by spec_id prefix")
-	listCmd.Flags().String("id", "", "Filter by specific issue IDs (comma-separated, e.g., bd-1,bd-5,bd-10)")
+	listCmd.Flags().Var(&listIDFlag, "id", "Filter by specific issue IDs (comma-separated or repeated, e.g., bd-1,bd-5,bd-10)")
 	listCmd.Flags().IntP("limit", "n", workapi.DefaultListLimit, "Limit results (default 50, use 0 for unlimited)")
 	listCmd.Flags().Int("offset", 0, "Skip the first N matching results (0-based). Only supported under --proxied-server.")
 	listCmd.Flags().String("format", "", "Output format: 'digraph' (for golang.org/x/tools/cmd/digraph), 'dot' (Graphviz), or Go template")

--- a/cmd/bd/list_filter_flags.go
+++ b/cmd/bd/list_filter_flags.go
@@ -1,0 +1,76 @@
+package main
+
+import "fmt"
+
+// unionStringFlag accumulates repeated flag occurrences into a comma-joined
+// set: `--status open --status closed` means the same union as
+// `--status open,closed`. Setting the empty string clears it — `bd children`
+// resets listCmd's flags that way after borrowing them, and gatherListInput
+// resets after each read so in-process callers that Execute() more than once
+// do not inherit the previous command's filter.
+type unionStringFlag struct {
+	value string
+}
+
+func (f *unionStringFlag) Set(s string) error {
+	switch {
+	case s == "":
+		f.value = ""
+	case f.value == "":
+		f.value = s
+	default:
+		f.value += "," + s
+	}
+	return nil
+}
+
+func (f *unionStringFlag) String() string { return f.value }
+
+// Type reports "string" so cmd.Flags().GetString keeps working on flags
+// registered with this value.
+func (f *unionStringFlag) Type() string { return "string" }
+
+// onceStringFlag refuses a repeated occurrence outright. It belongs on
+// filters that are single-valued all the way down (--type, --assignee),
+// where comma-joining would either fail type validation on the joined value
+// or exact-match nothing and return an empty result that reads as a clean
+// answer. Empty-string reset semantics match unionStringFlag.
+type onceStringFlag struct {
+	name  string
+	value string
+	set   bool
+}
+
+func (f *onceStringFlag) Set(s string) error {
+	if s == "" {
+		f.value = ""
+		f.set = false
+		return nil
+	}
+	if f.set {
+		return fmt.Errorf("--%s given more than once (already %q); pass a single value", f.name, f.value)
+	}
+	f.set = true
+	f.value = s
+	return nil
+}
+
+func (f *onceStringFlag) String() string { return f.value }
+
+func (f *onceStringFlag) Type() string { return "string" }
+
+var (
+	listStatusFlag   unionStringFlag
+	listStateFlag    unionStringFlag
+	listIDFlag       unionStringFlag
+	listTypeFlag     = onceStringFlag{name: "type"}
+	listAssigneeFlag = onceStringFlag{name: "assignee"}
+)
+
+func resetListFilterFlags() {
+	_ = listStatusFlag.Set("")
+	_ = listStateFlag.Set("")
+	_ = listIDFlag.Set("")
+	_ = listTypeFlag.Set("")
+	_ = listAssigneeFlag.Set("")
+}

--- a/cmd/bd/list_filter_flags_test.go
+++ b/cmd/bd/list_filter_flags_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// resetListFilterFlagState restores listCmd's filter flags to their unparsed
+// state so these tests leave nothing behind for the rest of the package.
+func resetListFilterFlagState(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		resetListFilterFlags()
+		for _, name := range []string{"status", "state", "type", "assignee", "id"} {
+			if fl := listCmd.Flags().Lookup(name); fl != nil {
+				fl.Changed = false
+			}
+		}
+	})
+}
+
+func TestListRepeatedStatusUnions(t *testing.T) {
+	resetListFilterFlagState(t)
+
+	if err := listCmd.ParseFlags([]string{"--status", "open", "--status", "closed", "-s", "pinned"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	got, err := listCmd.Flags().GetString("status")
+	if err != nil {
+		t.Fatalf("GetString(status): %v", err)
+	}
+	if got != "open,closed,pinned" {
+		t.Fatalf("repeated --status = %q, want union %q", got, "open,closed,pinned")
+	}
+}
+
+func TestListSingleAndCommaStatusUnchanged(t *testing.T) {
+	resetListFilterFlagState(t)
+
+	if err := listCmd.ParseFlags([]string{"--status", "open"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if got, _ := listCmd.Flags().GetString("status"); got != "open" {
+		t.Fatalf("single --status = %q, want %q", got, "open")
+	}
+
+	resetListFilterFlags()
+	if err := listCmd.ParseFlags([]string{"--status", "open,in_progress"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if got, _ := listCmd.Flags().GetString("status"); got != "open,in_progress" {
+		t.Fatalf("comma --status = %q, want %q", got, "open,in_progress")
+	}
+}
+
+func TestListRepeatedIDUnions(t *testing.T) {
+	resetListFilterFlagState(t)
+
+	if err := listCmd.ParseFlags([]string{"--id", "bd-1", "--id", "bd-2,bd-3"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if got, _ := listCmd.Flags().GetString("id"); got != "bd-1,bd-2,bd-3" {
+		t.Fatalf("repeated --id = %q, want %q", got, "bd-1,bd-2,bd-3")
+	}
+}
+
+func TestListRepeatedTypeRefused(t *testing.T) {
+	resetListFilterFlagState(t)
+
+	for _, args := range [][]string{
+		{"--type", "bug", "--type", "epic"},
+		{"-t", "bug", "-t", "epic"},
+	} {
+		resetListFilterFlags()
+		err := listCmd.ParseFlags(args)
+		if err == nil {
+			t.Fatalf("ParseFlags(%v) accepted a repeated --type", args)
+		}
+		if !strings.Contains(err.Error(), "type") || !strings.Contains(err.Error(), "more than once") {
+			t.Fatalf("ParseFlags(%v) error %q does not name the repeated flag", args, err)
+		}
+	}
+}
+
+func TestListRepeatedAssigneeRefused(t *testing.T) {
+	resetListFilterFlagState(t)
+
+	err := listCmd.ParseFlags([]string{"--assignee", "alice", "--assignee", "bob"})
+	if err == nil {
+		t.Fatal("ParseFlags accepted a repeated --assignee")
+	}
+	if !strings.Contains(err.Error(), "assignee") || !strings.Contains(err.Error(), "more than once") {
+		t.Fatalf("error %q does not name the repeated flag", err)
+	}
+}
+
+func TestListSingleTypeAndAssigneeUnchanged(t *testing.T) {
+	resetListFilterFlagState(t)
+
+	if err := listCmd.ParseFlags([]string{"--type", "bug", "--assignee", "alice"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if got, _ := listCmd.Flags().GetString("type"); got != "bug" {
+		t.Fatalf("single --type = %q, want %q", got, "bug")
+	}
+	if got, _ := listCmd.Flags().GetString("assignee"); got != "alice" {
+		t.Fatalf("single --assignee = %q, want %q", got, "alice")
+	}
+}
+
+// bd children borrows listCmd's status flag with Set("all") and a deferred
+// Set(""); an empty Set must fully reset both value kinds.
+func TestEmptySetResetsFilterFlags(t *testing.T) {
+	resetListFilterFlagState(t)
+
+	fl := listCmd.Flags()
+	_ = fl.Set("status", "all")
+	_ = fl.Set("status", "")
+	_ = fl.Set("status", "open")
+	if got, _ := fl.GetString("status"); got != "open" {
+		t.Fatalf("status after reset = %q, want %q", got, "open")
+	}
+
+	_ = fl.Set("type", "bug")
+	_ = fl.Set("type", "")
+	if err := fl.Set("type", "epic"); err != nil {
+		t.Fatalf("Set(type) after reset refused: %v", err)
+	}
+	if got, _ := fl.GetString("type"); got != "epic" {
+		t.Fatalf("type after reset = %q, want %q", got, "epic")
+	}
+}
+
+// Two parses in one process must not bleed into each other once
+// resetListFilterFlags has run between them, the way gatherListInput does.
+func TestFilterFlagsDoNotLeakAcrossParses(t *testing.T) {
+	resetListFilterFlagState(t)
+
+	if err := listCmd.ParseFlags([]string{"--status", "open", "--status", "closed"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	resetListFilterFlags()
+	if err := listCmd.ParseFlags([]string{"--status", "pinned"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if got, _ := listCmd.Flags().GetString("status"); got != "pinned" {
+		t.Fatalf("status after second parse = %q, want %q (leaked prior parse)", got, "pinned")
+	}
+}

--- a/cmd/bd/list_input.go
+++ b/cmd/bd/list_input.go
@@ -43,6 +43,10 @@ type listInput struct {
 func gatherListInput(cmd *cobra.Command) (listInput, error) {
 	in := listInput{}
 
+	// The custom filter values persist across in-process Execute() calls;
+	// clear them once this read has copied them out.
+	defer resetListFilterFlags()
+
 	in.Status, _ = cmd.Flags().GetString("status")
 	if in.Status == "" {
 		in.Status, _ = cmd.Flags().GetString("state")


### PR DESCRIPTION
## The bug, reproduced with stock beads

`bd list`'s filter flags are plain pflag strings, so a repeated flag silently keeps only the last value:

```
bd list --status open        --json | jq length   # 165
bd list --status closed      --json | jq length   # 303
bd list --status pinned      --json | jq length   # 3
bd list --status open --status closed --status pinned --json | jq length
# 3  — exactly the pinned count. The first two flags were discarded with no
#      warning, and the output is indistinguishable from a correct answer.
```

This is worse for scripts than for humans: a human eyeballing 3 rows where they expected hundreds may notice; a script pipes the clean-looking count onward. A session-closeout audit built on this reported "1 bead filed today" when the truth was 5. The `--status` help text warns about the overwrite today, but a doc note does not reach a script that already ran.

`TestListRepeatedStatusUnions` / `TestListRepeatedIDUnions` / `TestListRepeatedTypeRefused` / `TestListRepeatedAssigneeRefused` in this PR are the minimal repro — all four fail against the current flag registrations (verified by reverting `list.go` alone) and pass with the fix. No orchestrator involved anywhere; this is pure pflag semantics.

## The fix — shaped by what each filter's downstream accepts

- **`--status`, `--state`, `--id` union on repeat.** Their `ListRequest` fields are already documented comma-separated OR sets, so repeats now build exactly the comma form: `--status open --status closed` ≡ `--status open,closed`. Single values and the comma form parse byte-identically to before (covered by tests).
- **`--type`, `--assignee` refuse on repeat.** Both are single-valued all the way down. Joining `--type` would surface as `invalid issue type: "bug,epic"` — loud but misdirected; joining `--assignee` would exact-match nobody and return an empty result that reads as a clean answer, i.e. the same defect in a new spelling. A repeat now fails at parse time naming the flag: `invalid argument "epic" for "-t, --type" flag: --type given more than once (already "bug"); pass a single value`. (Precedent: `singleWorktreeStringFlag` in `worktree_remove_cmd.go` already refuses repeats this way.)

## Two invariants the value types carry

- **`Set("")` fully resets them.** `bd children` borrows `listCmd`'s status flag with `Set("all")` and a deferred `Set("")`; an accumulating value that treated `""` as one more element would break that reuse.
- **`gatherListInput` clears them after copying values out.** pflag values persist across in-process `Execute()` calls (the cmd/bd test binary, library embedders — the hazard `main.go`'s PersistentPostRunE comment documents), and an accumulating value would otherwise leak one command's filter into the next. `TestFilterFlagsDoNotLeakAcrossParses` covers this.

## Scope

One layer: `cmd/bd` only — no issueops/storage change, since the union spelling is one the storage layer already accepts. `Type()` reports `"string"` so every existing `GetString` read keeps working; the diff to `list.go`/`list_input.go` is 5 registration lines plus one deferred reset.

The same last-win wart exists on other commands' string filters (`count`, `search`, `human list`, `stale`, `dep tree`, `find-duplicates` at least — any plain `String` flag read as a filter). The two value types here are reusable as-is; I kept this PR to `bd list`, the surface the defect was measured on, rather than sweep every command in one diff.

## Verification

- `CGO_ENABLED=0 go build ./cmd/bd/` and `go vet ./cmd/bd/` clean.
- New tests: 8/8 pass; the four repeated-flag tests go red with the fix's registrations reverted.
- Full `CGO_ENABLED=0 go test ./cmd/bd/`: the failure set is byte-identical (17 test names) with and without this change on my machine — all 17 are pre-existing environment failures (nocgo build without the embedded Dolt backend), none list-related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)