### PR TITLE
Beads 1.2 remediation: migration-consent gate — bd never migrates an existing database without explicit consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `bd migrate --force`, or `BD_ALLOW_MIGRATE=1` for scripts/CI
   (`BD_ALLOW_REMOTE_MIGRATE=1` is honored as an alias). Fresh databases
   (`bd init`) still migrate to latest — creating a database is consent for its
-  schema — and a database already at this binary's latest version never
-  consults the gate, so already-migrated (v65) workspaces see no change. The
+  schema — and the same creation principle covers a workspace the invocation
+  just cloned into existence (`bd init --remote`, `bd bootstrap` sync), so the
+  #4259 behind-remote flows keep their exact behavior. A database already at
+  this binary's latest version never consults the gate, so already-migrated
+  (v65) workspaces see no change. The
   remote-backed case keeps all of the #4259 remote-migrate gate's additional
   protections (smart gate, adopt fast-forward, fork-skew analysis) unchanged.
   JSON consumers: the refusal renders as a structured error carrying a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING (fail-closed): bd no longer migrates an existing database without
+  explicit consent** (Beads 1.2 release remediation). The 1.2.0/1.2.1 releases
+  applied migrations 54–65 at store open on ANY command — including pure reads
+  like `bd list` — with no prompt, and older binaries then refuse the migrated
+  database (schema-skew guard). Every command against an existing database with
+  pending main-sequence migrations now refuses with guidance instead of
+  migrating, and the refused open performs ZERO writes (dolt_ignore seeding and
+  clone-local migrations included). Consent is any of: the explicit verbs
+  `bd migrate` / `bd migrate schema` (a preview flag withholds it),
+  `bd migrate --force`, or `BD_ALLOW_MIGRATE=1` for scripts/CI
+  (`BD_ALLOW_REMOTE_MIGRATE=1` is honored as an alias). Fresh databases
+  (`bd init`) still migrate to latest — creating a database is consent for its
+  schema — and a database already at this binary's latest version never
+  consults the gate, so already-migrated (v65) workspaces see no change. The
+  remote-backed case keeps all of the #4259 remote-migrate gate's additional
+  protections (smart gate, adopt fast-forward, fork-skew analysis) unchanged.
+  JSON consumers: the refusal renders as a structured error carrying a
+  `migrate_consent` object (`current_version`, `required_version`, `pending`).
+- **Shipped migrations are frozen by CI** (same remediation): the content hash
+  of every released up-migration (main 0001–0065, ignored 0001–0024) is pinned
+  by `TestShippedMigrationsAreFrozen`. Schema v65 is de-facto shipped; any
+  amendment to a released migration must land as a new migration (0066+) so
+  installed schemas and freshly-migrated ones cannot fork.
+- **go.mod retracts v1.2.0 and v1.2.1** so Go-module consumers are steered off
+  the escaped releases.
+
 - **`bd reclaim` summarizes the leases its replica guard declined instead of
   naming every one, every run** (wy-sp2l4). A lease granted by another replica
   is by construction never reclaimed here, so the audit was not a one-off: it

--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -740,6 +740,15 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 		return err
 	}
 
+	// Creation-consent for the migration-consent gate
+	// (schema/migrate_consent.go): this sync action just CLONED the database
+	// fresh, so the operator's explicit bootstrap is consent for its schema —
+	// the same principle that exempts a fresh `bd init`. The #4259
+	// remote-migrate gate below is unaffected (consent is not its
+	// designated-migrator override), so the behind-remote refusal keeps its
+	// exact bd-6dnrw.31 behavior.
+	schema.SetLocalMigrateConsent(true)
+
 	// Open and close the store to ensure dolt_ignore'd wisp tables are
 	// created in the working set. Clone does not include these tables
 	// (they are never committed), so they must be recreated after clone.

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1335,6 +1335,15 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				syncFromRemote = false
 			} else {
 				bootstrappedFromRemote = true
+				// Creation-consent for the migration-consent gate
+				// (schema/migrate_consent.go): this invocation just CLONED the
+				// database into a workspace that did not exist before, so the
+				// operator's `bd init --remote` is consent for its schema —
+				// the same principle that exempts a fresh `bd init`. The
+				// #4259 remote-migrate gate is unaffected (consent is not its
+				// designated-migrator override), so the smart-gate /
+				// designated-migrator flows keep their exact behavior.
+				schema.SetLocalMigrateConsent(true)
 				if !quiet {
 					fmt.Printf("  %s Bootstrapped from remote: %s\n", ui.RenderPass("✓"), syncURL)
 				}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -318,6 +318,19 @@ func isForcedMigrate(cmd *cobra.Command) bool {
 	return force
 }
 
+// isMigrateConsentCommand reports whether cmd is one of the explicit
+// migration verbs (`bd migrate`, `bd migrate schema`) invoked for real:
+// typing the verb IS the operator consenting to apply pending schema
+// migrations (migrate_consent.go), no --force required. Preview flags
+// withhold the consent — a --dry-run/--inspect must not consent to the work
+// it only inspects.
+func isMigrateConsentCommand(cmd *cobra.Command) bool {
+	if cmd != migrateCmd && cmd != migrateSchemaCmd {
+		return false
+	}
+	return forcedMigratePreviewFlag(cmd) == ""
+}
+
 // forcedMigratePreviewFlag returns the name of a preview flag (--dry-run,
 // --inspect) that conflicts with --force on a forced migrate invocation, or ""
 // when there is no conflict. The combination must be rejected BEFORE the store
@@ -1406,6 +1419,12 @@ var rootCmd = &cobra.Command{
 		// root command ever be re-run in-process (tests, a future server mode).
 		schema.SetForceAllowRemoteMigrate(forcedMigrate)
 
+		// The explicit migration verbs carry migration consent on their own
+		// (migrate_consent.go): every other command refuses to apply pending
+		// schema migrations to an existing database. Same unconditional
+		// set-or-clear discipline as the gate override above.
+		schema.SetLocalMigrateConsent(isMigrateConsentCommand(cmd))
+
 		// Auto-migrate database on version bump (bd-jgxi).
 		// Runs for ALL non-preview commands (including read-only ones) because
 		// the migration opens its own store connection, writes the version
@@ -1634,6 +1653,18 @@ var rootCmd = &cobra.Command{
 					handleRemoteMigrateGateJSON(gateErr)
 				} else {
 					fmt.Fprint(os.Stderr, gateErr.UserMessage())
+				}
+				return SilentExit()
+			}
+			// The migration-consent gate blocks silent in-place migration of
+			// ANY existing database (1.2 release remediation) and tells the
+			// operator how to consent.
+			var consentErr *schema.MigrateConsentError
+			if errors.As(err, &consentErr) {
+				if jsonOutput {
+					handleMigrateConsentJSON(consentErr)
+				} else {
+					fmt.Fprint(os.Stderr, consentErr.UserMessage())
 				}
 				return SilentExit()
 			}

--- a/cmd/bd/migrate_consent.go
+++ b/cmd/bd/migrate_consent.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+func handleMigrateConsentJSON(e *schema.MigrateConsentError) {
+	outer := buildJSONError(e.Error(), "bd migrate schema  or  "+schema.AllowMigrateEnv+"=1 bd <command>")
+	if m, ok := outer.(map[string]interface{}); ok {
+		m["migrate_consent"] = map[string]interface{}{
+			"current_version":  e.CurrentVersion,
+			"required_version": e.LatestVersion,
+			"pending":          e.Pending,
+		}
+	}
+	encoder := json.NewEncoder(os.Stderr)
+	encoder.SetIndent("", "  ")
+	_ = encoder.Encode(outer)
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -275,6 +275,7 @@
           "recovery/circular-dependencies",
           "recovery/sync-failures",
           "recovery/history-squash",
+          "recovery/unmigrate-schema-v65",
           "recovery/uninstalling"
         ]
       },

--- a/docs/recovery/unmigrate-schema-v65.md
+++ b/docs/recovery/unmigrate-schema-v65.md
@@ -1,0 +1,88 @@
+---
+title: Un-migrate from Schema v65
+description: Move a database that bd 1.2.x auto-migrated back to a 1.1.2-compatible workspace, keeping all data
+---
+
+The 1.2.0/1.2.1 releases migrated existing databases to schema v65
+automatically, on any command — including reads. If your database was
+migrated and you want to go back to bd 1.1.2 (whose binaries refuse a v65
+database with `schema version mismatch: database is at v65, binary knows up
+to v53`), this runbook rebuilds a 1.1.2-compatible workspace from a full
+export. It is written to be executable by an agent as-is.
+
+There is no in-place down-migration. The procedure is export → set aside →
+fresh init → import.
+
+**What survives** (verified): issues with statuses and close reasons,
+dependencies, comments, notes, labels, memories, and wisps (with
+`--all`).
+**What does not**: Dolt commit history and the events/telemetry audit
+tables. Both remain readable in the set-aside `.beads.v65.bak` directory —
+nothing is deleted.
+
+<Warning>
+Run every step with the binaries it names: the EXPORT runs under the 1.2.x
+binary that matches the database; the INIT and IMPORT run under the 1.1.2
+binary you are returning to. Mixing them up fails closed (schema-skew guard),
+but re-running the whole sequence from the top is the only supported retry.
+</Warning>
+
+## Preconditions
+
+1. **Stop anything that writes to this workspace** — supervisors, watchers,
+   hooks on a timer.
+2. **Server mode: stop the dolt sql-server** serving this database
+   (`bd dolt stop`, or stop the process that owns it). For a SHARED server
+   database, coordinate with the other clients first — after this procedure
+   they must re-clone or run it too; do not un-migrate a shared database
+   unilaterally.
+3. Install (or locate) a **bd 1.1.2 binary** alongside the current one. GitHub
+   releases: tag `v1.1.2`. Keep both paths handy; the steps name which one to
+   use.
+4. Run from the directory that CONTAINS `.beads/`.
+
+## Procedure
+
+```bash
+# 1. Full export, with the 1.2.x binary the database currently matches.
+bd export --all -o snapshot.jsonl
+#    Sanity: the file is non-empty and its line count is plausible for
+#    your workspace.
+wc -l snapshot.jsonl
+
+# 2. Set the migrated workspace aside. Salvage-first: rename, never delete.
+mv .beads .beads.v65.bak
+
+# 3. Fresh init under the 1.1.2 binary (creates a v53-schema workspace).
+#    Use the same issue prefix as before.
+bd-1.1.2 init --prefix <your-prefix>
+
+# 4. Import the snapshot under the 1.1.2 binary.
+bd-1.1.2 import snapshot.jsonl
+```
+
+## Verify
+
+```bash
+# Counts match your expectations (compare against the export):
+bd-1.1.2 list -n 0 --status all | tail -3
+# A known issue round-trips with its comments/labels/deps:
+bd-1.1.2 show <some-known-id>
+# Memories survived:
+bd-1.1.2 memories | head
+```
+
+If anything is missing, the migrated original is intact in `.beads.v65.bak`:
+restore it with `mv .beads .beads.failed && mv .beads.v65.bak .beads` and use
+a 1.2.x binary with it while you retry.
+
+## Afterwards
+
+- Keep `.beads.v65.bak` until you are confident; it holds the Dolt history
+  and audit tables the import does not carry.
+- Pin your install to 1.1.2 until a release whose default does not migrate
+  your database is available; see the release notes of the version that sent
+  you here.
+- If this workspace had a Dolt remote, the remote still holds the MIGRATED
+  history. Do not push the rebuilt workspace over it without deciding which
+  side is canonical; a fresh remote is the simple safe choice.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module github.com/steveyegge/beads
 
 go 1.26.5
 
+// v1.2.0 and v1.2.1 auto-migrated existing databases to schema v65 without
+// consent on any command, including reads; older binaries then refuse the
+// migrated database. Superseded by the migration-consent release (see
+// CHANGELOG "Beads 1.2 release remediation").
+retract [v1.2.0, v1.2.1]
+
 require (
 	charm.land/glamour/v2 v2.0.1
 	charm.land/huh/v2 v2.0.3

--- a/internal/storage/dolt/testmain_test.go
+++ b/internal/storage/dolt/testmain_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/testutil"
 )
 
@@ -28,6 +29,11 @@ func TestMain(m *testing.M) {
 }
 
 func testMainInner(m *testing.M) int {
+	// Package-wide migration consent: these tests exercise the machinery that
+	// runs BELOW the consent gate (migrate_consent.go), exactly as production
+	// does once an operator has consented. Gate-behavior tests manage the
+	// consent state themselves.
+	schema.SetLocalMigrateConsent(true)
 	os.Setenv("BEADS_TEST_MODE", "1")
 	// BEADS_TEST_PDEATHSIG=1 protects TestMultiProcessSchemaInit_DoltVerify
 	// (initschema_multiprocess_test.go), which calls doltserver.Start

--- a/internal/storage/embeddeddolt/test_fixture_test.go
+++ b/internal/storage/embeddeddolt/test_fixture_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -48,6 +49,12 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	embeddedDoltFixtureRoot = root
+
+	// Package-wide migration consent: these tests exercise the machinery that
+	// runs BELOW the consent gate (migrate_consent.go), exactly as production
+	// does once an operator has consented. Gate-behavior tests manage the
+	// consent state themselves.
+	schema.SetLocalMigrateConsent(true)
 
 	code := m.Run()
 	if err := os.RemoveAll(root); err != nil && code == 0 {

--- a/internal/storage/schema/migrate_consent.go
+++ b/internal/storage/schema/migrate_consent.go
@@ -28,7 +28,10 @@ import (
 //     honored as an alias for continuity with the remote gate's hatch).
 //
 // Fresh databases (no schema_migrations table, version 0) are exempt: creating
-// a database is consent for its schema. Databases already at this binary's
+// a database is consent for its schema. The same creation principle covers a
+// workspace this invocation just CLONED into existence (`bd init --remote`,
+// `bd bootstrap` sync) — those paths record the consent explicitly, and the
+// #4259 remote-migrate gate still applies to them unchanged. Databases already at this binary's
 // latest version never consult the gate. The ignored (clone-local, dolt_ignored)
 // migration sequence is deliberately NOT gated on its own: it only materializes
 // per-clone bookkeeping tables and runs on every fresh clone — but when the

--- a/internal/storage/schema/migrate_consent.go
+++ b/internal/storage/schema/migrate_consent.go
@@ -1,0 +1,163 @@
+package schema
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// Migration consent (gastownhall Beads 1.2 release remediation).
+//
+// bd used to auto-apply pending schema migrations the first time a new binary
+// opened an existing database — on ANY command, including reads. The 1.2.x
+// releases turned that into a trap: users upgraded by a package manager had
+// their databases migrated in place with no prompt, and older binaries then
+// refuse the migrated database (schema-skew guard). The remote-migrate gate
+// (#4259) already refuses the silent migration for remote-backed databases;
+// this gate extends the same contract to EVERY existing database: bd never
+// initiates a schema migration without explicit operator consent.
+//
+// Consent is any of:
+//   - `bd migrate` / `bd migrate schema` (the explicit migration verbs; the
+//     root command records the intent via SetLocalMigrateConsent before the
+//     store opens),
+//   - `bd migrate --force` (the remote-gate override, a strict superset), or
+//   - BD_ALLOW_MIGRATE=1 (scripted/CI form; BD_ALLOW_REMOTE_MIGRATE=1 is
+//     honored as an alias for continuity with the remote gate's hatch).
+//
+// Fresh databases (no schema_migrations table, version 0) are exempt: creating
+// a database is consent for its schema. Databases already at this binary's
+// latest version never consult the gate. The ignored (clone-local, dolt_ignored)
+// migration sequence is deliberately NOT gated on its own: it only materializes
+// per-clone bookkeeping tables and runs on every fresh clone — but when the
+// MAIN sequence is pending and unconsented, MigrateUp refuses before ANY write,
+// ignored sequence and dolt_ignore seeding included.
+
+// AllowMigrateEnv, when set to a boolean true ("1", "true", ...), consents to
+// applying pending schema migrations to an existing database. It is consulted
+// only when migrations are actually pending, so exporting it permanently does
+// not warn on every store open.
+const AllowMigrateEnv = "BD_ALLOW_MIGRATE"
+
+// localMigrateConsent is the programmatic consent recorded by the explicit
+// migration verbs (`bd migrate`, `bd migrate schema`). Process-local by
+// design, like forceAllowRemoteMigrate: it cannot leak into child processes.
+var localMigrateConsent bool
+
+// SetLocalMigrateConsent records (or clears) the in-process consent to apply
+// pending schema migrations to an existing database. Set by the root command
+// when the invoked command is one of the explicit migration verbs, before both
+// autoMigrateOnVersionBump and the main store open. External test packages may
+// reset it to false after each test case.
+func SetLocalMigrateConsent(v bool) { localMigrateConsent = v }
+
+// MigrateConsentError is returned when bd would apply pending schema
+// migrations to an existing database without operator consent.
+type MigrateConsentError struct {
+	CurrentVersion int
+	LatestVersion  int
+	Pending        int
+	// UnrecognizedEnv carries a BD_ALLOW_MIGRATE value that was set but not
+	// understood (only boolean values consent), so a typo'd hatch fails with
+	// a hint instead of silently staying locked (0054-gate precedent,
+	// bd-6dnrw.34).
+	UnrecognizedEnv string
+}
+
+func (e *MigrateConsentError) Error() string {
+	return fmt.Sprintf(
+		"database schema is at v%d; this bd requires v%d (%d pending migration(s)), and bd no longer migrates a database without explicit consent — run `bd migrate schema`, or keep using a bd release that matches schema v%d",
+		e.CurrentVersion, e.LatestVersion, e.Pending, e.CurrentVersion)
+}
+
+// UserMessage renders the full operator-facing refusal.
+func (e *MigrateConsentError) UserMessage() string {
+	msg := fmt.Sprintf(
+		"This database is at schema v%d; this bd release uses schema v%d.\n"+
+			"bd no longer upgrades a database automatically (see the release notes).\n"+
+			"\n"+
+			"  To upgrade this database (one-way; older bd releases cannot read it):\n"+
+			"      bd migrate schema\n"+
+			"\n"+
+			"  To keep the current schema, keep using the bd release that created it.\n"+
+			"\n"+
+			"  Scripted/CI consent: BD_ALLOW_MIGRATE=1 bd <command>\n",
+		e.CurrentVersion, e.LatestVersion)
+	if e.UnrecognizedEnv != "" {
+		msg += fmt.Sprintf(
+			"\nNote: %s=%q was set but not understood (use a boolean value, e.g. \"1\" or \"true\"), so it did not consent.\n",
+			AllowMigrateEnv, e.UnrecognizedEnv)
+	}
+	return msg
+}
+
+// IsMigrateConsentError reports whether err (or any error it wraps) is a
+// *MigrateConsentError.
+func IsMigrateConsentError(err error) bool {
+	var e *MigrateConsentError
+	return errors.As(err, &e)
+}
+
+// checkMigrateConsent refuses an unconsented migration of an existing
+// database. Called at the top of MigrateUp, before any write (dolt_ignore
+// seeding included). Returns nil for a fresh database (version 0), a database
+// with no pending main-sequence migrations, or when consent was given.
+func checkMigrateConsent(ctx context.Context, db DBConn) error {
+	if localMigrateConsent || forceAllowRemoteMigrate {
+		return nil // programmatic consent — skip the version reads entirely
+	}
+	current, err := mainSource.currentVersion(ctx, db)
+	if err != nil {
+		return fmt.Errorf("migrate consent: read current version: %w", err)
+	}
+	if current == 0 {
+		return nil // fresh database — creating it is consent for its schema
+	}
+	pending, err := mainSource.pendingVersions(ctx, db)
+	if err != nil {
+		return fmt.Errorf("migrate consent: read pending versions: %w", err)
+	}
+	return migrateConsentDecision(current, len(pending))
+}
+
+// migrateConsentDecision is checkMigrateConsent's pure decision core: nil when
+// nothing is pending or consent was given (programmatic or env), a typed
+// *MigrateConsentError otherwise. current is known to be > 0 here except when
+// callers short-circuit earlier; a zero current is still treated as consent
+// (fresh database).
+func migrateConsentDecision(current, pending int) error {
+	if current == 0 || pending == 0 {
+		return nil
+	}
+	if localMigrateConsent || forceAllowRemoteMigrate {
+		return nil
+	}
+	unrecognized := ""
+	for _, env := range []string{AllowMigrateEnv, AllowRemoteMigrateEnv} {
+		v := os.Getenv(env)
+		if v == "" {
+			continue
+		}
+		allowed, perr := strconv.ParseBool(v)
+		if perr != nil {
+			if env == AllowMigrateEnv {
+				unrecognized = v
+			}
+			continue
+		}
+		if allowed {
+			fmt.Fprintf(defaultStderr(),
+				"Applying %d pending schema migration(s) (%s=%s): v%d -> v%d\n",
+				pending, env, v, current, LatestVersion())
+			return nil
+		}
+	}
+	return &MigrateConsentError{
+		CurrentVersion:  current,
+		LatestVersion:   LatestVersion(),
+		Pending:         pending,
+		UnrecognizedEnv: unrecognized,
+	}
+}

--- a/internal/storage/schema/migrate_consent_test.go
+++ b/internal/storage/schema/migrate_consent_test.go
@@ -1,0 +1,121 @@
+package schema
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestMain grants migration consent for the whole package: the MigrateUp
+// machinery tests exercise what runs BELOW the consent gate, exactly as
+// production does once an operator has consented. The consent tests below
+// clear the grant themselves via resetConsentState.
+func TestMain(m *testing.M) {
+	SetLocalMigrateConsent(true)
+	os.Exit(m.Run())
+}
+
+// resetConsentState clears every consent source for one test case (undoing
+// TestMain's package-wide grant) and restores it afterwards, so consent tests
+// see a clean slate and machinery tests keep their grant.
+func resetConsentState(t *testing.T) {
+	t.Helper()
+	SetLocalMigrateConsent(false)
+	SetForceAllowRemoteMigrate(false)
+	t.Cleanup(func() {
+		SetLocalMigrateConsent(true)
+		SetForceAllowRemoteMigrate(false)
+	})
+	t.Setenv(AllowMigrateEnv, "")
+	t.Setenv(AllowRemoteMigrateEnv, "")
+}
+
+func TestMigrateConsentDecision_FreshDB_Allows(t *testing.T) {
+	resetConsentState(t)
+	if err := migrateConsentDecision(0, 12); err != nil {
+		t.Fatalf("decision = %v, want nil for fresh database (current=0)", err)
+	}
+}
+
+func TestMigrateConsentDecision_NothingPending_Allows(t *testing.T) {
+	resetConsentState(t)
+	if err := migrateConsentDecision(LatestVersion(), 0); err != nil {
+		t.Fatalf("decision = %v, want nil when nothing is pending", err)
+	}
+}
+
+func TestMigrateConsentDecision_PendingNoConsent_Refuses(t *testing.T) {
+	resetConsentState(t)
+	err := migrateConsentDecision(53, 12)
+	var consentErr *MigrateConsentError
+	if !errors.As(err, &consentErr) {
+		t.Fatalf("decision = %v, want *MigrateConsentError", err)
+	}
+	if consentErr.CurrentVersion != 53 || consentErr.Pending != 12 {
+		t.Fatalf("error fields = v%d/%d pending, want v53/12", consentErr.CurrentVersion, consentErr.Pending)
+	}
+	if !IsMigrateConsentError(err) {
+		t.Fatalf("IsMigrateConsentError(err) = false, want true")
+	}
+	msg := consentErr.UserMessage()
+	for _, want := range []string{"bd migrate schema", AllowMigrateEnv} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("UserMessage missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func TestMigrateConsentDecision_LocalConsent_Allows(t *testing.T) {
+	resetConsentState(t)
+	SetLocalMigrateConsent(true)
+	if err := migrateConsentDecision(53, 12); err != nil {
+		t.Fatalf("decision = %v, want nil with local consent set", err)
+	}
+}
+
+func TestMigrateConsentDecision_ForceOverride_Allows(t *testing.T) {
+	resetConsentState(t)
+	SetForceAllowRemoteMigrate(true)
+	if err := migrateConsentDecision(53, 12); err != nil {
+		t.Fatalf("decision = %v, want nil with the migrate --force override set", err)
+	}
+}
+
+func TestMigrateConsentDecision_EnvConsent_Allows(t *testing.T) {
+	for _, env := range []string{AllowMigrateEnv, AllowRemoteMigrateEnv} {
+		for _, v := range []string{"1", "true", "TRUE"} {
+			t.Run(env+"="+v, func(t *testing.T) {
+				resetConsentState(t)
+				t.Setenv(env, v)
+				if err := migrateConsentDecision(53, 12); err != nil {
+					t.Fatalf("decision = %v, want nil with %s=%s", err, env, v)
+				}
+			})
+		}
+	}
+}
+
+func TestMigrateConsentDecision_EnvFalse_Refuses(t *testing.T) {
+	resetConsentState(t)
+	t.Setenv(AllowMigrateEnv, "0")
+	if !IsMigrateConsentError(migrateConsentDecision(53, 12)) {
+		t.Fatalf("want refusal with %s=0", AllowMigrateEnv)
+	}
+}
+
+func TestMigrateConsentDecision_UnparseableEnv_RefusesWithHint(t *testing.T) {
+	resetConsentState(t)
+	t.Setenv(AllowMigrateEnv, "yes-please")
+	err := migrateConsentDecision(53, 12)
+	var consentErr *MigrateConsentError
+	if !errors.As(err, &consentErr) {
+		t.Fatalf("decision = %v, want *MigrateConsentError", err)
+	}
+	if consentErr.UnrecognizedEnv != "yes-please" {
+		t.Fatalf("UnrecognizedEnv = %q, want the unparseable value surfaced", consentErr.UnrecognizedEnv)
+	}
+	if !strings.Contains(consentErr.UserMessage(), "yes-please") {
+		t.Fatalf("UserMessage does not surface the unparseable env value:\n%s", consentErr.UserMessage())
+	}
+}

--- a/internal/storage/schema/migration_freeze_test.go
+++ b/internal/storage/schema/migration_freeze_test.go
@@ -1,0 +1,178 @@
+package schema
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
+	"testing"
+)
+
+// Migration freeze (Beads 1.2 release remediation).
+//
+// Migrations 0001–0065 (and ignored/ 0001–0024) are SHIPPED: the 1.2.x
+// releases published schema v65 to thousands of installs, so these files are
+// now the de-facto on-disk contract of every migrated database. Amending a
+// shipped migration forks installed schemas from freshly-migrated ones — the
+// exact skew the smart gate's fork-skew detection exists to catch at runtime.
+// This test catches it in CI instead: the content hash of every shipped
+// up-migration is pinned; any change must land as a NEW migration (0066+ /
+// ignored 0025+) and extend this table in the same commit that ships it.
+//
+// If this test fails because you edited a shipped migration: revert the edit
+// and write a new migration. There is no legitimate reason to update a pinned
+// hash for an already-released version.
+
+const (
+	frozenMainThrough    = 65
+	frozenIgnoredThrough = 24
+)
+
+var frozenMigrationHashes = map[string]string{
+	"0001_create_issues.up.sql":                            "0c9bc4d97e2c5ee5d276c952333b934cd7d7d18210997d6bfd72d17f0fdb14f0",
+	"0002_create_dependencies.up.sql":                      "9ca011fa0b24ddf26f689eebf347cc2f80dc90256b099d91b993ec82c4d74da5",
+	"0003_create_labels.up.sql":                            "1780f0dc941d97b74af53d5603646d05e83d94eee5a02ac68ccf929200deaec0",
+	"0004_create_comments.up.sql":                          "35ac76b3d0b2d6287cad1329c77c8a0562bb6310ba0ac34ae273d72d4bed0e2a",
+	"0005_create_events.up.sql":                            "c8cbe4bebbe0f92c8a0ccc2a1a0d11ad442635811c2dab093c34c9341a8499b2",
+	"0006_create_config.up.sql":                            "435f5ef129dd4999a9b393c98d633038f0e443280a26e63f7d4315bf025dab1f",
+	"0007_create_metadata.up.sql":                          "f92c4d3dd32cae489142de34c4706900736c91cdc53b0d54e87e71656b828dc9",
+	"0008_create_child_counters.up.sql":                    "99db9b4b5a785ddd209dff628364c4c1eff549c3ca5ec48a64c604b15ef95bfb",
+	"0009_create_issue_snapshots.up.sql":                   "269ef83f083766b7f2fd2dfd2814ef36a585ae4aa18bcab0468a713d48595e48",
+	"0010_create_compaction_snapshots.up.sql":              "cb34cbe311fd89a17d72067f449a65089f2fc9a7c4b3774d54448db5ebc3d659",
+	"0011_create_repo_mtimes.up.sql":                       "bde5204466541dddb53a652fe58561c08b6b3c1fa7feb38a0a582d432d76bda6",
+	"0012_create_routes.up.sql":                            "68e8ef1fc336e8ca6973f6b927b09d3206a7ebd96db9c4cdceab52fb8498c431",
+	"0013_create_issue_counter.up.sql":                     "7ddb30dabe32a66197de78f62400f41d000cf43d0ba8ba2a3943536504dddcdb",
+	"0014_create_interactions.up.sql":                      "0e17f1cb9fc5ee5a7c43ca8e02b9fd59814f8fd4372f9ffb17b50c34388614ce",
+	"0015_create_federation_peers.up.sql":                  "6aa04b3f66566b243c9a4fc09136af5c17f0ffe947a489245e3c451b995a59b9",
+	"0016_default_config.up.sql":                           "5d556c01404eb06acfb9df2b20fde36a2e91bd8a7d14462acbd3c0ae928ea286",
+	"0017_create_ready_issues_view.up.sql":                 "4bab7acbe2d8e441f156cc5912f421dcb214b9b08d7958eacc8e3a7318ab5f57",
+	"0018_create_blocked_issues_view.up.sql":               "84dc6a3950a5447e6665e3d98b43f11a7631dc4e53bab1be332d135e51c9511f",
+	"0019_wisps_dolt_ignore.up.sql":                        "3df660feb6b64c84ef74c408fe8f5840a2815936534362ed123122f795a21c26",
+	"0020_create_wisps.up.sql":                             "bca95662441635454b879bb44ca1e607df9c5efd8fd802be3d53a7371a5ced86",
+	"0021_create_wisp_auxiliary.up.sql":                    "d19284a2be70a448db7746ae009cb264dc86dac0d9094aae9fe80a713a08ee70",
+	"0022_wisp_dep_type_index.up.sql":                      "fc1375e64620cd4264516718d8f924d88131881f4c00c51471b7630c11b74a45",
+	"0023_add_no_history_column.up.sql":                    "d11cd7cb462239e49c0b2f9b93ac73771106d5450ebc3422bb7737748c6f967b",
+	"0024_create_custom_status_type_tables.up.sql":         "816da3feeed531ca9787dca8d4b8072dd94b64d573cf4b6751c61f2390c88a68",
+	"0025_update_ready_issues_view.up.sql":                 "09782d195f22d620ba41802856f9eb6e1a10f68bc5bcc8f3616624f8c28b576a",
+	"0026_update_blocked_issues_view.up.sql":               "33daef6b5a07364fc5f59ab59b0f5c677dcf98d9bd0866c7c3bea874f1f01348",
+	"0027_add_started_at.up.sql":                           "dd3b58a8bbed4c49e855a6002981a285f10b6094938534dd3da9b121155f24d6",
+	"0028_local_state_dolt_ignore.up.sql":                  "24a816406a6f40c66db98697869d172b2b4366b107788fdd00f44b99abee45c3",
+	"0029_create_local_metadata.up.sql":                    "b989fc49ab03e06ff6520f150d6958efdbd3f444b69b824f7b4bb283ca6f2b65",
+	"0030_migrate_local_metadata_keys.up.sql":              "8d55135274c1c75e722e802b250911cc574d52a4ba74fbb13edde84f30f9b3a4",
+	"0031_wisp_events_created_at_index.up.sql":             "2d5cf3a6d4245b48c1b893efcc17b9fa25f1ea807e61290cf54064451fc58d93",
+	"0032_drop_schema_migrations_applied_at.up.sql":        "42b86d6b7352f7e158532cc67f4afa142dc2503ce9f780733c06fc9da3478751",
+	"0033_add_wisp_type_column.up.sql":                     "9256746bb0d6ad9ed9afba0f0501259f0a3599b7d7da507dd7d808a13c688c75",
+	"0034_add_spec_id_column.up.sql":                       "7add95ead971c57618cfbc52e5cb6771d872785bfc035bde12cd27a76358848e",
+	"0035_migrate_infra_to_wisps.up.sql":                   "f917fe319540155572f5c51618cbbe20ec8b9b669d5926d68e3a62629c317c5a",
+	"0036_cleanup_autopush_metadata.up.sql":                "e55f1870c2bc031c574b495ebca650365a9c8088d7a8968fb86a19cab81267e8",
+	"0037_uuid_primary_keys.up.sql":                        "7526beadee13aa7d6ee2175e9a543210b07c1a4426c382f251ebd31eebe32745",
+	"0038_drop_hop_columns.up.sql":                         "002dc637d45840487c35a01ce15cee04872baa45c21f8e20170a4339135a38e7",
+	"0039_drop_child_counters_fk.up.sql":                   "db65f241d1e82da41f34b960abc912f78b72e7dc1cb6dd2298974308edf8b768",
+	"0040_ignored_tables_also_nonlocal_tables.up.sql":      "c7068d67ad3e2b4852549e04d97f25814121de83db919e220bdcb9bdd9b61e5e",
+	"0041_split_dependencies_target.up.sql":                "e84ef393576df31550570fd3217579b1880850c0645b7d2b6ad8cf55a18ac1c0",
+	"0042_add_on_update_cascade.up.sql":                    "9d0fbb3d02955d25442c4a628ac518236068a97ecf164edbc814216bd5a55adc",
+	"0043_drop_dependencies_generated_column.up.sql":       "548b8a69ab82179b7ee7ab3cc87ef00b3ae28d5a3a4976f42364f6939e384668",
+	"0044_update_views_drop_depends_on_id.up.sql":          "531524854cc0e2361817d1ad94ba9470b0e81e378a5422ffb8bce71f3500adf9",
+	"0045_update_blocked_view_drop_depends_on_id.up.sql":   "395dcbf186deedb592d8ed144e0b7953455efa0ccf02076d3b63e5e5d05dc241",
+	"0046_add_is_blocked.up.sql":                           "4d6a5a5fc5e386f2c538b4f3574b82fb2ba025176997953a0a4fbd2a91cddf68",
+	"0047_recompute_mixed_is_blocked.up.sql":               "4aff5a7cc2e1e0250ce4cdb911d010c936681871fb627bceee4b2dc4647dd0a1",
+	"0048_widen_event_value_columns.up.sql":                "093c7a41145508879844d16cbe5acfa69baddbb19bf3e05f00bc08720adea657",
+	"0049_longtext_large_content_columns.up.sql":           "3359343efb7c28e5803de07e9088670489615d151843d7f23705f3ca8dd6a1e8",
+	"0050_dependencies_deterministic_id.up.sql":            "96265ff898753f3bb34549fafa18bbaeb67519705b8cf4e32e67f1058df6841a",
+	"0051_drop_aux_id_defaults.up.sql":                     "deb741d5ac5fc1e0cd2e60eb47e84f384ed3455b18d3e2f12cb4e935fe461059",
+	"0052_add_date_indexes.up.sql":                         "60ae32bc26c41da2e743c1172f73930d18482b8a98aea08b9de85f6009f9c01d",
+	"0053_repair_rig_wisps.up.sql":                         "f13909f0db89f48db694a782d1805eee7ee1b2b2e4dcb3d4b12352333cbcb330",
+	"0054_add_lease_columns.up.sql":                        "2e51058ba15be9d87415949bb03c2c7c2f0e0743c5ae0d3e819b617d95f61680",
+	"0055_move_leases_to_table.up.sql":                     "2237ddbe13f5a783c65da3bb1292d9a5d89a5f22fddb0c33d2db57f1492df22c",
+	"0056_add_comments_keyset_index.up.sql":                "acc28e9b1aa7272c16c86fcb9fd4a2038ae47729a60b53bb75f3a9df05cd3a82",
+	"0057_events_value_columns_idempotent_longtext.up.sql": "f86e0f77be2e58affe1c485767b8dd450408d782c0413a41948ca0c0b6d72d06",
+	"0058_heal_wisp_dependencies_split_constraints.up.sql": "9c1c6d557a03e71cf6b49123831c9f5b5f910fcea3ca51e982ec4acce04ea6ec",
+	"0059_recompute_null_gate_is_blocked.up.sql":           "f0186029a1c87d579b67e0540ec22ad0bd0fc59793b07f7d24a24e122b77c394",
+	"0060_add_storage_class.up.sql":                        "40419632ba75d92dfcf08e16e77a780f014172a17068f6021937df9086a24588",
+	"0061_content_derived_aux_ids.up.sql":                  "d2d65b92789f137da8ee586067c862a9c7744921ccac421e1b793f42050b62a2",
+	"0062_events_dolt_ignore.up.sql":                       "c7de6089997344784a71e7d82ea5e417baaf66320b4533d225a4a6bc3c74222a",
+	"0063_create_provenance_events.up.sql":                 "1ef173be07ca58d17cb09ba3b3f5ca0c96edfcace8d52ae3adde2fd27e8248bd",
+	"0064_create_events_journal.up.sql":                    "25ea9ad8e849dc7e32e7c5850631bedc63a5c5da3bdc58ccb2762fd7a6c758fc",
+	"0065_widen_wisp_comments_text.up.sql":                 "c7341bb977daff92e073db2579e63058cef88d43f1e09b13fa153a772caac2a6",
+}
+
+var frozenIgnoredMigrationHashes = map[string]string{
+	"0001_create_local_state_tables.up.sql":               "a73e9a486124f89e90d50f4597fd1d7ad08e5d0d654459ec87b7520b47f1bb5f",
+	"0002_create_wisp_child_counters.up.sql":              "c575c6710169f2e697f3aca60f5f698acc8a64af0edb1e2305b9d377fd845f45",
+	"0003_split_wisp_dependencies_target.up.sql":          "f82947deeafe589598e2a1802eddf17712bd322692f924bb5653b0fbd5c46a0d",
+	"0004_add_wisp_aux_fks.up.sql":                        "12e18a8bdd214d6f96625e78998433ccc9c2d0ef4d1a35307f2653e725c800b9",
+	"0005_drop_wisp_dependencies_generated_column.up.sql": "08780b28ddef6c15f5de558ea08d821b52610f810555739ee1d737779986c607",
+	"0006_add_wisp_is_blocked.up.sql":                     "4746f10d7040d0b7a9e127437356de87765d12d2d27ee37c9800191e6b619d14",
+	"0007_recompute_wisp_is_blocked.up.sql":               "c3c8d92846a54183cc99afc09f779f6f5ba8030c16ce46b3ee750314bf134627",
+	"0008_widen_wisp_event_value_columns.up.sql":          "51375854ec081d2e0b1434b5ff8b6d87092b891636214ebb9f1dbef22438cc1a",
+	"0009_aux_row_id_rekey_marker.up.sql":                 "3d1ee4f9dde3342d110474c8090a30c474edafe2290e4372a3fc4607c1fdc030",
+	"0010_drop_wisp_id_defaults.up.sql":                   "59d6644667b7e34f9d23261cb694d461ddd4953969e75519d370b0cce8afd0e8",
+	"0011_cleanup_orphaned_child_counters.up.sql":         "0efade0ecb620420ee42127d3f67230da108e31f2ff3c4281855a8dc9e187ecd",
+	"0012_create_leases.up.sql":                           "e128a1301a2bcb967f684b09318aa5cf7ed9adb5f6dd7d412de3d67d1de2b28d",
+	"0013_add_wisp_row_lock.up.sql":                       "127a4af7012769e5f016b13b198b7a57ff8386a10f8a68ffb9ff204989564d1b",
+	"0014_add_wisp_comments_keyset_index.up.sql":          "29ad3654218700481b9541331c714ecbbe96dc81c04dc83fba6bf8d35bed7fa4",
+	"0015_recompute_null_gate_wisp_is_blocked.up.sql":     "e761d5c3ceb9610edbb2e1d153e82d235cc7d7f0b87f28a45bec43835e6a4e19",
+	"0016_add_lease_granted_node.up.sql":                  "31a55421b78d8c90db6cfba5bf8e99e87d6123271575282f761aa077e5d36386",
+	"0017_add_wisps_defer_until_index.up.sql":             "1f031aaf2037280e62cbf604748a4157bf25e3a60b3392af7d74835c5059bdd8",
+	"0018_aux_row_id_rekey2_marker.up.sql":                "3c2120bf55d15e71a9f96972007c3d914154d17ea37a2b51b44412e3e3df6ef1",
+	"0019_create_events.up.sql":                           "db072d67a403e60d5bcbe924b84e473adb09f2326d36ede82fcdab17bb1e2a87",
+	"0020_add_wisp_storage_class.up.sql":                  "9ff476e6c73a3a477aec95143d5cbf180517a9484f647447392576f13181a015",
+	"0021_widen_wisp_large_content_columns.up.sql":        "3cfa1e07a3d02eb7f791814d9642a93b9af3bf63728943afa05dcb0e489919c8",
+	"0022_create_events_journal.up.sql":                   "3d0adcb9f5833b4ba70fb48f88e1043250796feb7173abe000ea4de85eb8b3a5",
+	"0023_repair_events_journal_shape.up.sql":             "d0edd83ca4cfbc46bd17799c6497a70c8c011d130d08a00c71daf792ee1dcd51",
+	"0024_widen_wisp_comments_text.up.sql":                "69a96330e00643dfeddc4bf6ae9bf3b743a3cfddd86f16dc7b8912758b1b570d",
+}
+
+func verifyFrozenMigrations(t *testing.T, fsys fs.FS, dir string, frozen map[string]string, frozenThrough int) {
+	t.Helper()
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		t.Fatalf("reading embedded %s: %v", dir, err)
+	}
+	seen := map[string]bool{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		version, err := parseVersion(name)
+		if err != nil {
+			t.Fatalf("unparseable migration filename %q: %v", name, err)
+		}
+		if version > frozenThrough {
+			continue // not yet released — frozen when a release ships it
+		}
+		want, ok := frozen[name]
+		if !ok {
+			t.Errorf("shipped migration %s (v%d <= frozen floor %d) has no pinned hash — a released version was renamed or replaced; restore the original file", name, version, frozenThrough)
+			continue
+		}
+		seen[name] = true
+		content, err := fs.ReadFile(fsys, dir+"/"+name)
+		if err != nil {
+			t.Fatalf("reading embedded %s/%s: %v", dir, name, err)
+		}
+		sum := sha256.Sum256(content)
+		if got := hex.EncodeToString(sum[:]); got != want {
+			t.Errorf("shipped migration %s was AMENDED (hash %s, pinned %s) — shipped migrations are frozen; land the change as a new migration instead", name, got, want)
+		}
+	}
+	for name := range frozen {
+		if !seen[name] {
+			t.Errorf("pinned migration %s is missing from the embedded FS — a released version was deleted or renamed", name)
+		}
+	}
+}
+
+// TestShippedMigrationsAreFrozen pins the content of every up-migration that a
+// release has shipped. See the file comment for the policy.
+func TestShippedMigrationsAreFrozen(t *testing.T) {
+	verifyFrozenMigrations(t, upMigrations, "migrations", frozenMigrationHashes, frozenMainThrough)
+}
+
+// TestShippedIgnoredMigrationsAreFrozen is the ignored-sequence twin. The
+// ignored tables are clone-local, so an amendment does not fork synced
+// history — but it DOES make freshly-materialized clones diverge from
+// long-lived ones, the same class of bug one plane over.
+func TestShippedIgnoredMigrationsAreFrozen(t *testing.T) {
+	verifyFrozenMigrations(t, upIgnoredMigrations, "migrations/ignored", frozenIgnoredMigrationHashes, frozenIgnoredThrough)
+}

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -172,8 +172,8 @@ type SchemaBehindError struct {
 }
 
 func (e *SchemaBehindError) Error() string {
-	return fmt.Sprintf("schema version mismatch: database is at v%d, binary expects v%d, and the read-only open cannot migrate it; run any bd write command in that workspace to migrate, or set BD_IGNORE_SCHEMA_SKEW=1 to read anyway (queries touching newer schema may fail)",
-		e.DBVersion, e.BinaryVersion)
+	return fmt.Sprintf("schema version mismatch: database is at v%d, binary expects v%d; bd does not migrate a database without explicit consent — run `bd migrate schema` in that workspace to migrate, keep using a bd release that matches schema v%d, or set BD_IGNORE_SCHEMA_SKEW=1 to read anyway (queries touching newer schema may fail)",
+		e.DBVersion, e.BinaryVersion, e.DBVersion)
 }
 
 // IsSchemaBehindError reports whether err (or any error it wraps) is a
@@ -468,6 +468,13 @@ func MigrateUpTo(ctx context.Context, db DBConn, maxVersion int) (int, error) {
 }
 
 func MigrateUp(ctx context.Context, db DBConn) (int, error) {
+	// Consent gate first, before ANY write — dolt_ignore seeding included: an
+	// existing database with pending main-sequence migrations must stay
+	// byte-identical when the operator has not consented (see
+	// migrate_consent.go). Fresh and already-current databases pass through.
+	if err := checkMigrateConsent(ctx, db); err != nil {
+		return 0, err
+	}
 	// Re-assert the canonical dolt_ignore patterns before anything else, and
 	// in particular before the migrationWorkNeeded short-circuit: a database
 	// whose migration cursors arrived at-latest without executing the seeding

--- a/internal/storage/uow/migrate_consent_grant_test.go
+++ b/internal/storage/uow/migrate_consent_grant_test.go
@@ -1,0 +1,17 @@
+package uow
+
+import (
+	"os"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// TestMain grants package-wide migration consent: these tests exercise the
+// provider/bootstrap machinery that runs BELOW the consent gate
+// (schema/migrate_consent.go), exactly as production does once an operator
+// has consented.
+func TestMain(m *testing.M) {
+	schema.SetLocalMigrateConsent(true)
+	os.Exit(m.Run())
+}

--- a/scripts/migration-test/historical-dolt-upgrade-test.sh
+++ b/scripts/migration-test/historical-dolt-upgrade-test.sh
@@ -998,6 +998,18 @@ run_embedded_dolt_upgrade() {
     jq -e '.backend == "dolt" and .dolt_mode == "embedded"' "$metadata" >/dev/null ||
         die "$version: source metadata does not select embedded Dolt"
     metadata_sha=$(sha256_file "$metadata") || die "$version: could not fingerprint source metadata"
+    # Migration-consent gate (Beads 1.2 remediation): the candidate no longer
+    # migrates an existing database from ordinary commands, so the explicit
+    # schema migration is now the FIRST candidate step — previously it ran
+    # later and was already a no-op because the first candidate open had
+    # silently migrated. Same effective sequence, now stated. Before
+    # consenting, assert the gate actually refuses an ordinary command.
+    if run_in_workspace "$candidate" list >/dev/null 2>"$workspace/consent-refusal.err"; then
+        die "$version: candidate operated an un-migrated database without consent"
+    fi
+    grep -q 'bd migrate schema' "$workspace/consent-refusal.err" ||
+        die "$version: consent refusal did not carry migration guidance"
+    migrate_schema_current "$version" first
     verify_surviving_fixture "$version" direct
     if [ "$version" = v1.0.0 ]; then
         [ "$(run_in_workspace "$candidate" config get status.custom)" = review:active ] || die "$version: candidate did not preserve custom status config"
@@ -1015,7 +1027,6 @@ run_embedded_dolt_upgrade() {
     blocker=$(sed -n '2p' "$workspace/fixture-ids")
     run_in_workspace "$candidate" show "$blocker" --json > "$workspace/after-first.json"
     jq -S . "$workspace/after-first.json" > "$workspace/after-first-canonical.json"
-    migrate_schema_current "$version" first
     verify_idempotent_migration "$version" direct
     run_in_workspace "$candidate" show "$task" --json --include-comments |
         jq -S . > "$workspace/direct-after-noops.json"

--- a/scripts/upgrade-smoke-test.sh
+++ b/scripts/upgrade-smoke-test.sh
@@ -212,6 +212,17 @@ cand() { (cd "$WS" && "$CAND_BIN" "$@"); }
 prev_init() { prev init --quiet --non-interactive --skip-hooks --skip-agents; }
 cand_init() { cand init --quiet --non-interactive --skip-hooks --skip-agents; }
 
+# Upgrade an existing workspace to the candidate. Since the migration-consent
+# gate (Beads 1.2 release remediation) the candidate never migrates an
+# existing database from ordinary commands — `bd migrate schema` is the
+# consent step every real upgrade now includes, so the smoke upgrade includes
+# it too. Tolerates a workspace the old binary could not initialize (the
+# migrate is a no-op failure there and cand_init creates a fresh database).
+cand_upgrade() {
+    cand migrate schema >/dev/null 2>&1 || true
+    cand_init 2>/dev/null || true
+}
+
 # Create an issue with the previous binary, tolerating missing --silent flag.
 # Older binaries don't have --silent; we just need to know creation succeeded.
 # Sets _CREATED_ID to a non-empty value on success.
@@ -249,8 +260,21 @@ prev_create --title "Pre-upgrade issue" --type task --priority 1 || true
 ID1="${_CREATED_ID}"
 prev_create --title "Another issue" --type bug || true
 
-# Upgrade: run candidate init (simulates upgrade)
-cand_init 2>/dev/null || true
+# Migration-consent gate: before consenting, an ordinary candidate command on
+# the old-schema database must either work as-is (previous release already
+# ships the candidate's schema — nothing pending) or refuse WITH the consent
+# guidance. A failure without the guidance is a regression.
+GATE_OUT=$(cand list 2>&1) && GATE_RC=0 || GATE_RC=$?
+if [ "$GATE_RC" -eq 0 ]; then
+    pass "Candidate operates database directly (schema already current)"
+elif echo "$GATE_OUT" | grep -q "bd migrate schema"; then
+    pass "Candidate refuses un-migrated database with consent guidance"
+else
+    fail "Candidate failed on old database without consent guidance"
+fi
+
+# Upgrade: consent + candidate init (simulates upgrade)
+cand_upgrade
 
 # Verify
 ROLE=$(git -C "$WS" config --get beads.role 2>/dev/null || echo "MISSING")
@@ -296,7 +320,7 @@ prev_init 2>/dev/null || true
 git -C "$WS" config beads.role contributor
 
 # Upgrade
-cand_init 2>/dev/null || true
+cand_upgrade
 
 ROLE=$(git -C "$WS" config --get beads.role 2>/dev/null || echo "MISSING")
 if [ "$ROLE" = "contributor" ]; then
@@ -330,7 +354,7 @@ else
 fi
 
 # Upgrade with candidate (always runs — verifies candidate defaults to embedded)
-cand_init 2>/dev/null || true
+cand_upgrade
 
 # Verify candidate created an embedded DB
 if embedded_db_exists; then
@@ -400,8 +424,8 @@ if [ -z "${MUT_ID:-}" ]; then
 else
     pass "Issue created with previous binary (id: $MUT_ID)"
 
-    # Upgrade: run candidate init
-    cand_init 2>/dev/null || true
+    # Upgrade: consent + candidate init
+    cand_upgrade
 
     # Mutate using the candidate binary
     cand update "$MUT_ID" --notes "smoke test mutation" 2>/dev/null || true
@@ -468,8 +492,8 @@ if ! $DEP_CREATED; then
 else
     pass "Dependency created with previous binary ($BLOCKED_ID depends on $BLOCKER_ID)"
 
-    # Upgrade (runs migrations 0041–0047, including the data-copy).
-    cand_init 2>/dev/null || true
+    # Upgrade (consents to and runs migrations 0041+, including the data-copy).
+    cand_upgrade
 
     # 1. Blocker queries must not error on the migrated dependency rows.
     if cand ready >/dev/null 2>&1; then


### PR DESCRIPTION
## Beads 1.2 release remediation: the migration-consent gate

Remediation for the escaped 1.2.0/1.2.1 releases, per Chris's 8/14 direction
(roll-forward release whose default never touches an existing database;
breaking schema behind explicit opt-in). **For @julianknutsen's gauntlet —
this PR changes no version numbers and touches no release workflows; cutting
the release (suggested: v1.2.2) stays entirely with the release owner.**

### What 1.2.x did

`bd` auto-applied pending schema migrations at store open on ANY command.
Reproduced on a scratch database: create a DB with a real v1.1.2 binary, run
current main's `bd list` — a pure read — and the DB is migrated v53→v65 with
no prompt; the v1.1.2 binary then refuses it (`schema version mismatch:
database is at v65, binary knows up to v53`). The #4259 remote-migrate gate
only covers remote-backed databases, which typical brew/npm installs are not.

### What this PR changes

**bd never migrates an existing database without explicit consent.**

- `MigrateUp` refuses, before ANY write (dolt_ignore seeding and the
  clone-local ignored sequence included), when an existing database
  (main-sequence cursor > 0) has pending main-sequence migrations and no
  consent. Verified end-to-end: after the refusal the database is untouched
  and the old binary still operates it.
- Consent surfaces: the explicit verbs `bd migrate` / `bd migrate schema`
  (typing the verb IS consent; preview flags withhold it), `bd migrate
  --force` (unchanged), or `BD_ALLOW_MIGRATE=1` for scripts/CI
  (`BD_ALLOW_REMOTE_MIGRATE=1` honored as an alias).
- Fresh databases (`bd init`) migrate as today — creating a database is
  consent for its schema — and the same creation principle covers a workspace
  the invocation just CLONED into existence (`bd init --remote`,
  `bd bootstrap` sync): those paths record the consent explicitly, so every
  #4259 behind-remote flow (smart-gate first-mover, designated-migrator
  guidance, finalized-workspace ergonomics) keeps its exact shipped behavior.
  A database already at the binary's latest version never consults the gate,
  so **already-migrated (v65) workspaces see zero change**.
- The remote-backed case keeps every #4259 protection (smart gate, adopt
  fast-forward, fork-skew) unchanged; the consent gate is a superset fence
  one layer below.
- The refusal is a typed `MigrateConsentError` with an operator-facing
  message and a JSON rendering (`migrate_consent` object), mirroring the
  skew/remote-gate errors. The read-only path's `SchemaBehindError` text now
  points at `bd migrate schema` instead of "run any bd write command".

### Migration freeze

Migrations 0001–0065 (+ ignored 0001–0024) are de-facto shipped. New test
`TestShippedMigrationsAreFrozen` pins each file's SHA-256; amending a
released migration now fails CI — changes must land as 0066+.

### Also in this PR

- `go.mod`: `retract [v1.2.0, v1.2.1]`.
- `docs/recovery/unmigrate-schema-v65.md`: agent-executable un-migrate
  runbook for v65-migrated users (recipe verified empirically: export --all →
  set `.beads` aside → fresh init under 1.1.2 → import; dolt history and
  events stay readable in the set-aside copy).
- `scripts/upgrade-smoke-test.sh` and the historical migration harness now
  model the new upgrade contract: explicit `bd migrate schema` as the upgrade
  step, plus assertions that the unconsented candidate refuses WITH the
  guidance text (turning the remediation itself into a release-gate check).
  Note the historical harness's `migrate_schema_current "first"` previously
  asserted a no-op — the silent auto-migrate had already run during the first
  candidate open; the explicit step now does the real migration at the same
  point in the sequence.

### Suggested release-note copy (for the release owner)

> bd no longer upgrades your database automatically. If you upgraded to
> 1.2.0/1.2.1 and later saw `schema version mismatch: database is at v65,
> binary knows up to v53` from an older bd, that is the schema-skew guard
> protecting a database the 1.2.x releases migrated without asking. This
> release ends that behavior: bd asks first (`bd migrate schema` to upgrade;
> `BD_ALLOW_MIGRATE=1` for automation). To return a migrated database to
> 1.1.2, see docs/recovery/unmigrate-schema-v65.md.

### Testing

- `internal/storage/schema`: full package green, including new
  `migrate_consent_test.go` (decision matrix: fresh/current/pending ×
  consent sources × unparseable-env hint) and the freeze tests.
- E2E on real binaries: v1.1.2-created DB → gated binary refuses `bd list`
  (exit 1, guidance text, zero writes — v1.1.2 binary still operates the DB
  afterward) → `bd migrate schema` migrates → normal operation; fresh init
  unaffected.
- `embeddeddolt` (BEADS_TEST_EMBEDDED_DOLT=1), `uow`, `dolt`, `cmd/bd`
  packages green.
- `golangci-lint` clean on touched packages.

Beads: bd-qhn8y (design trail: bd-yixkn on the epic bd-8du2c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
