### PR TITLE
fix(formula): validate an absent var's own default against enum/pattern

### DIFF
--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -474,7 +474,13 @@ func ValidateProvidedVars(formula *Formula, values map[string]string) error {
 
 	for name, def := range formula.Vars {
 		val, provided := values[name]
-		if !provided {
+		// An absent var with no default is left to the caller's missing-var
+		// path (that is the point of ValidateProvidedVars). But an absent var
+		// with a declared default is applied silently, so its default must be
+		// validated against enum/pattern here — exactly as ValidateVars does —
+		// or an authoring typo (e.g. a default not in the enum) slips through
+		// pour/wisp/mol bond while cook rejects it (#5695).
+		if !provided && def.Default == nil {
 			continue
 		}
 

--- a/internal/formula/validate_provided_defaults_test.go
+++ b/internal/formula/validate_provided_defaults_test.go
@@ -1,0 +1,57 @@
+package formula
+
+import (
+	"errors"
+	"testing"
+)
+
+func varDefault(s string) *string { return &s }
+
+// TestValidateProvidedVarsChecksAbsentDefaultAgainstEnum is a born-failing
+// reproduction for the first gap in #5695: ValidateProvidedVars skipped absent
+// variables entirely, so a var whose own declared default violates its enum
+// (an authoring typo) was silently applied by pour/wisp/mol bond, while cook's
+// ValidateVars rejected the same malformed formula. The two entry points must
+// agree — a bad default is a formula-authoring error regardless of who loads it.
+func TestValidateProvidedVarsChecksAbsentDefaultAgainstEnum(t *testing.T) {
+	f := &Formula{
+		Vars: map[string]*VarDef{
+			"policy": {Enum: []string{"strict", "lax"}, Default: varDefault("loose")},
+		},
+	}
+
+	// Baseline: ValidateVars already rejects the bad default.
+	if err := ValidateVars(f, map[string]string{}); err == nil {
+		t.Fatal("ValidateVars: want error for default not in enum, got nil")
+	}
+
+	// The fix: ValidateProvidedVars must reject it too, even though "policy" is
+	// absent from the provided values.
+	err := ValidateProvidedVars(f, map[string]string{})
+	if err == nil {
+		t.Fatal("ValidateProvidedVars: want error for absent var's bad default, got nil")
+	}
+	if !errors.Is(err, ErrVarValidation) {
+		t.Fatalf("ValidateProvidedVars: want ErrVarValidation, got %v", err)
+	}
+}
+
+// TestValidateProvidedVarsStillSkipsAbsentNoDefault guards that the fix does not
+// over-reach: an absent var with NO default is still skipped (that is the whole
+// purpose of ValidateProvidedVars — callers surface their own missing-var
+// message), and a valid default passes.
+func TestValidateProvidedVarsStillSkipsAbsentNoDefault(t *testing.T) {
+	f := &Formula{
+		Vars: map[string]*VarDef{
+			"needed": {Enum: []string{"a", "b"}}, // no default, absent from values
+		},
+	}
+	if err := ValidateProvidedVars(f, map[string]string{}); err != nil {
+		t.Fatalf("absent no-default var must be skipped, got %v", err)
+	}
+
+	f.Vars["needed"].Default = varDefault("a") // valid default now present
+	if err := ValidateProvidedVars(f, map[string]string{}); err != nil {
+		t.Fatalf("valid absent default must pass, got %v", err)
+	}
+}


### PR DESCRIPTION
## What

`bd cook` and `bd mol pour`/`wisp`/`bond` disagreed on the same malformed
formula. A variable whose own declared `default` violates its `enum`/`pattern`
(an authoring typo) was **rejected** by `bd cook` but **silently applied** by
the pour/wisp/mol-bond path:

```toml
[vars.policy]
enum = ["strict", "lax"]
default = "loose"   # typo, not in the enum
```

## Why

`ValidateProvidedVars` (`internal/formula/parser.go`) skipped every variable
absent from the caller-supplied values:

```go
if !provided {
    continue
}
```

so it never validated a var's own default. `ValidateVars` (the `bd cook` path)
does run defaulted values through `validateVarValue`, so behavior forked purely
on which command loaded the formula — a silent bad default via pour/wisp/bond
vs. a hard rejection via cook.

## Fix

Only skip an absent variable when it has **no** default. An absent variable that
carries a declared default now flows through `validateVarValue` (which already
substitutes `*def.Default` when `!provided`), so the default is checked against
enum/pattern exactly as `ValidateVars` does. Absent vars with no default are
still skipped, preserving the caller-supplied missing-var path that
`ValidateProvidedVars` exists to defer to.

## Scope

This addresses the **first** of the two gaps in #5695 (absent-var defaults skip
enum/pattern checks). The second gap — `bd mol bond --dry-run` validating vars
before `extends` is resolved — lives in `cmd/bd/mol_bond.go` and is filed as a
separate PR per the repo's split-by-layer PR guideline, so this issue stays open
until both land.

## Verification (RED → GREEN)

Pure-Go unit test in `internal/formula`, no store required.

RED — on the unmodified base, only the test applied:

```
=== RUN   TestValidateProvidedVarsChecksAbsentDefaultAgainstEnum
    validate_provided_defaults_test.go:32: ValidateProvidedVars: want error for absent var's bad default, got nil
--- FAIL: TestValidateProvidedVarsChecksAbsentDefaultAgainstEnum (0.00s)
FAIL	github.com/steveyegge/beads/internal/formula
```

GREEN — with the fix (full package, existing `TestValidateProvidedVars` table
still green):

```
ok  	github.com/steveyegge/beads/internal/formula	0.114s
```

`ValidateProvidedVars` shows 100% statement coverage; `gofmt`, `go vet`,
`go build ./...` (all `-tags gms_pure_go`) clean.
