### PR TITLE
fix(wisp): gc --closed preview skips live-gating candidates instead of failing the batch

### DIFF
--- a/cmd/bd/wisp.go
+++ b/cmd/bd/wisp.go
@@ -956,20 +956,50 @@ func runWispPurgeClosed(ctx context.Context, dryRun bool, force bool, excludeTyp
 		ids[i] = issue.ID
 	}
 
+	// Non-force paths (count preview and --dry-run) skip-with-notice candidates
+	// that still gate live work instead of failing the whole batch; --force is
+	// unchanged (purges every closed wisp, orphans the live dependents).
+	deletable := ids
+	if !force {
+		safe, protected, err := partitionClosedWispsByLiveDependents(ctx, ids)
+		if err != nil {
+			return HandleError("checking live dependents of closed wisps: %v", err)
+		}
+		reportSkippedProtectedWisps(protected)
+		deletable = safe
+	}
+
 	if !force && !dryRun {
 		if jsonOutput {
 			return outputJSON(map[string]interface{}{
-				"candidates": len(ids),
+				"candidates": len(deletable),
+				"skipped":    len(ids) - len(deletable),
 				"dry_run":    true,
 			})
 		}
-		fmt.Printf("Found %d closed wisp(s) to delete\n", len(ids))
+		if len(deletable) == 0 {
+			fmt.Println("No deletable closed wisps — all have live dependents outside the batch")
+			return nil
+		}
+		fmt.Printf("Found %d closed wisp(s) to delete\n", len(deletable))
 		fmt.Printf("\nUse --force to proceed, or --dry-run for detailed preview.\n")
 		return nil
 	}
 
+	if len(deletable) == 0 {
+		if jsonOutput {
+			return outputJSON(map[string]interface{}{
+				"candidates": 0,
+				"skipped":    len(ids),
+				"dry_run":    dryRun,
+			})
+		}
+		fmt.Println("No deletable closed wisps — all have live dependents outside the batch")
+		return nil
+	}
+
 	if !jsonOutput {
-		fmt.Printf("Found %d closed wisp(s)\n", len(ids))
+		fmt.Printf("Found %d closed wisp(s)\n", len(deletable))
 		if dryRun {
 			fmt.Println(ui.RenderWarn("DRY RUN - no changes will be made"))
 		}
@@ -985,7 +1015,7 @@ func runWispPurgeClosed(ctx context.Context, dryRun bool, force bool, excludeTyp
 	// Without cascade, closed wisps are deleted and live dependents are
 	// orphaned (edges dropped, is_blocked recomputed) — the same semantics as
 	// a plain `bd delete`.
-	if err := deleteBatch(nil, ids, force, dryRun, false, jsonOutput, false, "wisp gc --closed"); err != nil {
+	if err := deleteBatch(nil, deletable, force, dryRun, false, jsonOutput, false, "wisp gc --closed"); err != nil {
 		return HandleError("%v", err)
 	}
 
@@ -993,6 +1023,97 @@ func runWispPurgeClosed(ctx context.Context, dryRun bool, force bool, excludeTyp
 		fmt.Printf("\nHint: Run 'bd compact --dolt' to reclaim disk space\n")
 	}
 	return nil
+}
+
+// partitionClosedWispsByLiveDependents splits closed-wisp GC candidates into
+// the set that is safe to purge and the set that still gates work outside the
+// deletion. A candidate is safe only when every issue that depends on it is
+// also being deleted; purging one whose dependent survives would orphan that
+// dependent, which is exactly what the non-force DeleteIssues guard rejects.
+//
+// Dropping one candidate can make an earlier one unsafe — a chained closed
+// molecule prefix (step 1 closed, step 2 closed but gating a live step 3) has
+// step 2 protected, which in turn leaves step 1 gating the surviving step 2 —
+// so the safe set is computed as a fixed point over the candidate set, not a
+// single pass. The protected map is keyed by candidate id and holds its sorted
+// dependents that are not in the final safe set. Computing it against that
+// final set is what keeps the returned safe set from tripping
+// DependentsOutsideRequestError.
+func partitionClosedWispsByLiveDependents(ctx context.Context, ids []string) (safe []string, protected map[string][]string, err error) {
+	records, err := store.GetDependentRecordsForIssues(ctx, ids)
+	if err != nil {
+		return nil, nil, err
+	}
+	dependents := make(map[string][]string, len(ids))
+	for _, id := range ids {
+		seen := make(map[string]bool)
+		for _, dep := range records[id] {
+			if seen[dep.IssueID] {
+				continue
+			}
+			seen[dep.IssueID] = true
+			dependents[id] = append(dependents[id], dep.IssueID)
+		}
+	}
+
+	safeSet := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		safeSet[id] = true
+	}
+	for {
+		changed := false
+		for _, id := range ids {
+			if !safeSet[id] {
+				continue
+			}
+			for _, dep := range dependents[id] {
+				if !safeSet[dep] {
+					delete(safeSet, id)
+					changed = true
+					break
+				}
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+
+	protected = make(map[string][]string)
+	for _, id := range ids {
+		if safeSet[id] {
+			safe = append(safe, id)
+			continue
+		}
+		var blockers []string
+		for _, dep := range dependents[id] {
+			if !safeSet[dep] {
+				blockers = append(blockers, dep)
+			}
+		}
+		slices.Sort(blockers)
+		protected[id] = blockers
+	}
+	return safe, protected, nil
+}
+
+// reportSkippedProtectedWisps prints the skip-with-notice for closed wisps that
+// were withheld because a dependent survives outside the deletion, naming those
+// dependents and how to override.
+func reportSkippedProtectedWisps(protected map[string][]string) {
+	if len(protected) == 0 || jsonOutput {
+		return
+	}
+	ids := make([]string, 0, len(protected))
+	for id := range protected {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	fmt.Printf("Skipping %d closed wisp(s) that still gate work outside the batch:\n", len(ids))
+	for _, id := range ids {
+		fmt.Printf("  %s (blocked by: %s)\n", id, strings.Join(protected[id], ", "))
+	}
+	fmt.Println("Use --force to delete them anyway (orphans the dependents: edges dropped, is_blocked recomputed).")
 }
 
 func init() {

--- a/cmd/bd/wisp_gc_purge_closed_preview_embedded_test.go
+++ b/cmd/bd/wisp_gc_purge_closed_preview_embedded_test.go
@@ -1,0 +1,60 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestWispGCPurgeClosedPreviewSkipsLiveDependents is the regression test for
+// #5753: `bd mol wisp gc --closed --dry-run` hard-failed the whole batch with
+// DependentsOutsideRequestError the moment a single closed candidate still had
+// a live dependent outside the batch. One live molecule step therefore blocked
+// the preview of every other eligible closed wisp. The non-force preview must
+// skip-with-notice the protected candidates and preview the rest, exiting 0.
+func TestWispGCPurgeClosedPreviewSkipsLiveDependents(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "pcs")
+
+	// A live molecule prefix: step1 <- step2 <- step3, where step1 and step2 are
+	// closed but step3 (open) still depends on step2. step2 has a live dependent
+	// (step3) and step1 gates the surviving step2 — so BOTH closed steps must be
+	// skipped. This chained shape is why the safe set has to be a fixed point:
+	// dropping step2 makes step1 unsafe too, and a single pass would wrongly mark
+	// step1 deletable and re-trip DependentsOutsideRequestError.
+	step1 := bdCreate(t, bd, dir, "closed chain root", "--ephemeral").ID
+	step2 := bdCreate(t, bd, dir, "closed step gating live work", "--ephemeral").ID
+	step3 := bdCreate(t, bd, dir, "live step", "--ephemeral").ID
+	bdDepAdd(t, bd, dir, step2, step1) // step2 depends on step1
+	bdDepAdd(t, bd, dir, step3, step2) // step3 depends on step2
+	bdClose(t, bd, dir, step1)
+	bdClose(t, bd, dir, step2)
+
+	// A standalone closed wisp with no dependents — safe to purge.
+	safeWisp := bdCreate(t, bd, dir, "standalone closed wisp", "--ephemeral").ID
+	bdClose(t, bd, dir, safeWisp)
+
+	out, err := bdRunWithFlockRetry(t, bd, dir, "mol", "wisp", "gc", "--closed", "--dry-run")
+	if err != nil {
+		t.Fatalf("gc --closed --dry-run must not fail the whole batch over per-candidate hazards; got error: %v\n%s", err, out)
+	}
+	got := string(out)
+	if !strings.Contains(got, safeWisp) {
+		t.Errorf("preview should list the safe closed wisp %s as deletable; output:\n%s", safeWisp, got)
+	}
+	for _, id := range []string{step1, step2} {
+		if !strings.Contains(got, id) {
+			t.Errorf("preview should report the protected closed wisp %s as skipped; output:\n%s", id, got)
+		}
+	}
+	if !strings.Contains(got, step3) {
+		t.Errorf("skip notice should name the live dependent %s that protected the chain; output:\n%s", step3, got)
+	}
+}


### PR DESCRIPTION
## What

Make the non-force `bd mol wisp gc --closed` preview (and `--dry-run`) partition
its candidates and skip-with-notice the closed wisps that still gate work outside
the batch, instead of aborting the whole batch. Protected candidates are listed
with the dependents that withheld them. `--force` is unchanged — it still purges
every closed wisp and orphans the live dependents.

## Why

Refs #5753 (follow-up to #5735). On current `main`,
`bd mol wisp gc --closed --dry-run` exits 1 with `DependentsOutsideRequestError`
the moment a single closed candidate still has a dependent outside the batch, so
one live molecule step blocks the preview of every other eligible closed wisp.
Failing the whole batch over a per-candidate hazard is the wrong granularity for
a GC preview.

Root cause: the preview handed the full closed set to `deleteBatch`, whose
non-force `DeleteIssues` guard rejects the batch if any member has a dependent
not in the deletion set. Fix: partition on the non-force path — a closed wisp is
safe only when every issue depending on it is also being deleted. Dropping one
candidate can make an earlier one unsafe (a chained closed prefix: step 1 gates a
still-closed step 2 that gates a live step 3), so the safe set is computed as a
fixed point, mirroring the guard applied to the final deletion set. The previewed
set therefore never re-trips the error.

Scope note: this fixes the whole-batch **preview/`--dry-run`** failure. Making
non-force actually *delete* the safe subset (rather than staying preview-only),
and the proxied-server twin, are left as separate follow-ups pending your
direction on whether non-force should delete without `--force`.

## Verification

Embedded Dolt integration test (`BEADS_TEST_EMBEDDED_DOLT=1`), added as
`cmd/bd/wisp_gc_purge_closed_preview_embedded_test.go`, covering a chained closed
prefix (step1←step2 both closed, step2 gating a live step3) plus a standalone
safe closed wisp.

RED — unmodified `main`, test only, `gc --closed --dry-run` aborts the batch:

```
gc --closed --dry-run must not fail the whole batch over a per-candidate hazard; got error: exit status 1
  issue pcs-wisp-4j6 has dependents not in deletion set; use --cascade to delete them or --force to orphan them
  Error: issue pcs-wisp-4j6 has dependents not in deletion set; ...
--- FAIL: TestWispGCPurgeClosedPreviewSkipsLiveDependents
```

GREEN — with the fix; the two #5735 regression tests still pass:

```
--- PASS: TestWispGCPurgeClosedPreviewSkipsLiveDependents
--- PASS: TestWispGCPurgeClosedStillPurgesFullyClosedMolecules
--- PASS: TestWispGCPurgeClosedDoesNotCascadeIntoLiveSteps
ok  github.com/steveyegge/beads/cmd/bd
```

Manual check on the chained shape — both closed steps skipped, only the
standalone previewed, exit 0:

```
$ bd mol wisp gc --closed --dry-run
Skipping 2 closed wisp(s) that still gate work outside the batch:
  pc-wisp-430 (blocked by: pc-wisp-366)
  pc-wisp-vg1 (blocked by: pc-wisp-430)
Use --force to delete them anyway (orphans the dependents: ...).
Found 1 closed wisp(s)
...
Issues to delete (1):
  pc-wisp-5xa: standalone
```

Also run: `make ci-pr-lint` (gofmt + golangci-lint + Windows cross-lint) — 0 issues.

## Full local validation

Ran the full local validation for the affected package against both the
unmodified base (`main` @ 185b339b) and the final commit — iso-or-better, no new
failures, the added test green on final and red on base:

- `go test -tags "cgo gms_pure_go" -run 'Wisp|Delete|Purge' ./cmd/bd/` (embedded Dolt) — `ok`
- `make ci-pr-lint` — 0 issues

The change is isolated to `cmd/bd` `runWispPurgeClosed` plus two new helpers with
no edits to shared code, so the wisp/delete package suite is the affected surface;
the complete repository suite runs in CI on the pushed commit.
