### PR TITLE
fix(preflight): share checkout lint authority

### DIFF
--- a/cmd/bd/preflight.go
+++ b/cmd/bd/preflight.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -60,6 +61,8 @@ Examples:
 	RunE:          runPreflight,
 }
 
+const beadsPRLintDriverCommand = "go run -mod=readonly -tags=gms_pure_go ./scripts/pr-lint"
+
 func init() {
 	preflightCmd.Flags().Bool("check", false, "Run checks automatically")
 	preflightCmd.Flags().Bool("fix", false, "Auto-fix issues where possible (vendorHash, version sync)")
@@ -92,12 +95,7 @@ func runPreflight(cmd *cobra.Command, args []string) error {
 
 	// Static checklist mode — tailor the checklist to the detected project
 	// stack so non-Go projects don't get a misleading Go/Nix checklist (GH#4364).
-	root := git.GetRepoRoot()
-	if root == "" {
-		if wd, err := os.Getwd(); err == nil {
-			root = wd
-		}
-	}
+	root := preflightProjectRoot()
 
 	fmt.Println("PR Readiness Checklist:")
 	fmt.Println()
@@ -131,7 +129,7 @@ func buildPreflightChecklist(dir string) []string {
 	if isBeadsRepo(dir) {
 		return []string{
 			"Tests pass: go test -tags gms_pure_go -short ./...",
-			"Lint passes: golangci-lint run --build-tags=gms_pure_go ./...",
+			"Lint passes: make ci-pr-lint",
 			"Formatting: gofmt -l .",
 			"No beads pollution: check .beads/issues.jsonl diff",
 			"Nix hash current: go.sum unchanged or vendorHash updated",
@@ -311,9 +309,22 @@ func runTestCheck() CheckResult {
 	}
 }
 
-// runLintCheck runs golangci-lint and returns the result.
+type lintInvocation struct {
+	display    string
+	executable string
+	args       []string
+	dir        string
+	timeout    time.Duration
+}
+
+// runLintCheck runs the checkout-owned Beads lint driver in the Beads source
+// tree and retains a direct, generic golangci-lint check elsewhere.
 func runLintCheck(skipLint bool) CheckResult {
-	command := "golangci-lint run --build-tags=gms_pure_go ./..."
+	return runLintCheckAt(preflightProjectRoot(), skipLint)
+}
+
+func runLintCheckAt(root string, skipLint bool) CheckResult {
+	invocation := lintInvocationForRoot(root)
 	if skipLint {
 		return CheckResult{
 			Name:    "Lint passes",
@@ -321,33 +332,72 @@ func runLintCheck(skipLint bool) CheckResult {
 			Skipped: true,
 			Warning: true,
 			Output:  "lint check explicitly skipped by --skip-lint",
-			Command: command,
+			Command: invocation.display,
 		}
 	}
 
-	// Check if golangci-lint is available
-	if _, err := exec.LookPath("golangci-lint"); err != nil {
+	if _, err := exec.LookPath(invocation.executable); err != nil {
 		return CheckResult{
 			Name:    "Lint passes",
 			Passed:  false,
-			Output:  "golangci-lint not found in PATH (install it or rerun with --skip-lint)",
-			Command: command,
+			Output:  fmt.Sprintf("%s not found in PATH (install it or rerun with --skip-lint)", invocation.executable),
+			Command: invocation.display,
 		}
 	}
 
-	cmd := exec.Command("golangci-lint", "run", "--build-tags=gms_pure_go", "./...")
+	ctx, cancel := context.WithTimeout(context.Background(), invocation.timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, invocation.executable, invocation.args...)
+	cmd.Dir = invocation.dir
 	output, err := cmd.CombinedOutput()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		output = append(output, []byte(fmt.Sprintf("\nlint check exceeded %s", invocation.timeout))...)
+	}
 
 	return CheckResult{
 		Name:    "Lint passes",
 		Passed:  err == nil,
 		Output:  string(output),
-		Command: command,
+		Command: invocation.display,
 	}
+}
+
+func lintInvocationForRoot(root string) lintInvocation {
+	if isBeadsRepo(root) {
+		return lintInvocation{
+			display:    beadsPRLintDriverCommand,
+			executable: "go",
+			args:       []string{"run", "-mod=readonly", "-tags=gms_pure_go", "./scripts/pr-lint"},
+			dir:        root,
+			timeout:    13 * time.Minute,
+		}
+	}
+	return lintInvocation{
+		display:    "golangci-lint run ./...",
+		executable: "golangci-lint",
+		args:       []string{"run", "./..."},
+		dir:        root,
+		timeout:    6 * time.Minute,
+	}
+}
+
+func preflightProjectRoot() string {
+	if root := git.GetRepoRoot(); root != "" {
+		return root
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	return wd
 }
 
 // runFmtCheck runs gofmt -l and fails if any files need formatting.
 func runFmtCheck() CheckResult {
+	return runFmtCheckAt(preflightProjectRoot())
+}
+
+func runFmtCheckAt(root string) CheckResult {
 	command := "gofmt -l ."
 
 	// Check if gofmt is available
@@ -361,6 +411,7 @@ func runFmtCheck() CheckResult {
 	}
 
 	cmd := exec.Command("gofmt", "-l", ".")
+	cmd.Dir = root
 	output, err := cmd.CombinedOutput()
 
 	if err != nil {

--- a/cmd/bd/preflight_test.go
+++ b/cmd/bd/preflight_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -221,43 +224,178 @@ func TestRunLintCheck_SkipLintFlag(t *testing.T) {
 	}
 }
 
-func TestRunFmtCheck_Formatted(t *testing.T) {
-	dir := t.TempDir()
-	// Write a properly formatted Go file
-	err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
-	if err != nil {
-		t.Fatal(err)
+func TestLintInvocationForRootMatchesChecklistAndProjectType(t *testing.T) {
+	beads := writeMarkerDir(t, map[string]string{"go.mod": "module github.com/steveyegge/beads\n"})
+	beadsInvocation := lintInvocationForRoot(beads)
+	if beadsInvocation.display != beadsPRLintDriverCommand {
+		t.Fatalf("Beads command = %q, want %q", beadsInvocation.display, beadsPRLintDriverCommand)
+	}
+	if beadsInvocation.executable != "go" {
+		t.Fatalf("Beads executable = %q, want go", beadsInvocation.executable)
+	}
+	wantBeadsArgs := []string{"run", "-mod=readonly", "-tags=gms_pure_go", "./scripts/pr-lint"}
+	if !reflect.DeepEqual(beadsInvocation.args, wantBeadsArgs) {
+		t.Fatalf("Beads args = %#v, want %#v", beadsInvocation.args, wantBeadsArgs)
+	}
+	if beadsInvocation.dir != beads {
+		t.Fatalf("Beads command dir = %q, want %q", beadsInvocation.dir, beads)
+	}
+	if checklist := strings.Join(buildPreflightChecklist(beads), "\n"); !strings.Contains(checklist, "make ci-pr-lint") {
+		t.Fatalf("Beads checklist does not report supported lint entrypoint:\n%s", checklist)
 	}
 
-	// Run gofmt -l in the temp dir
-	cmd := exec.Command("gofmt", "-l", ".")
-	cmd.Dir = dir
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("gofmt failed: %v: %s", err, output)
+	generic := writeMarkerDir(t, map[string]string{"go.mod": "module example.com/generic\n"})
+	genericInvocation := lintInvocationForRoot(generic)
+	if genericInvocation.display != "golangci-lint run ./..." {
+		t.Fatalf("generic command = %q, want direct lint contract", genericInvocation.display)
 	}
-	if strings.TrimSpace(string(output)) != "" {
-		t.Fatalf("expected no unformatted files, got: %s", output)
+	if genericInvocation.executable != "golangci-lint" {
+		t.Fatalf("generic executable = %q, want golangci-lint", genericInvocation.executable)
+	}
+	if want := []string{"run", "./..."}; !reflect.DeepEqual(genericInvocation.args, want) {
+		t.Fatalf("generic args = %#v, want %#v", genericInvocation.args, want)
+	}
+	if checklist := strings.Join(buildPreflightChecklist(generic), "\n"); !strings.Contains(checklist, genericInvocation.display) {
+		t.Fatalf("generic checklist does not report executable lint command %q:\n%s", genericInvocation.display, checklist)
 	}
 }
 
-func TestRunFmtCheck_Unformatted(t *testing.T) {
-	dir := t.TempDir()
-	// Write a poorly formatted Go file (extra spaces, no newline)
-	err := os.WriteFile(filepath.Join(dir, "bad.go"), []byte("package main\nfunc  main( )  {  }\n"), 0644)
+func TestRunLintCheckAtBeadsExecutesCheckoutDriverAndReportsJSONCommand(t *testing.T) {
+	realGo, err := exec.LookPath("go")
 	if err != nil {
+		t.Fatalf("locate Go toolchain for subprocess fixture: %v", err)
+	}
+	helperDir := t.TempDir()
+	helperSource := filepath.Join(helperDir, "fake-go.go")
+	const source = `package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func main() {
+	dir, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	marker, err := os.Create(os.Getenv("PREFLIGHT_LINT_MARKER"))
+	if err != nil {
+		panic(err)
+	}
+	defer marker.Close()
+	if err := json.NewEncoder(marker).Encode(map[string]any{"args": os.Args[1:], "dir": dir}); err != nil {
+		panic(err)
+	}
+	fmt.Println("synthetic checkout lint success")
+}
+`
+	if err := os.WriteFile(helperSource, []byte(source), 0o600); err != nil {
+		t.Fatalf("write fake Go source: %v", err)
+	}
+	helperName := "go"
+	if runtime.GOOS == "windows" {
+		helperName += ".exe"
+	}
+	helperPath := filepath.Join(helperDir, helperName)
+	build := exec.Command(realGo, "build", "-o", helperPath, helperSource)
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build fake Go executable: %v\n%s", err, output)
+	}
+
+	beads := writeMarkerDir(t, map[string]string{"go.mod": "module github.com/steveyegge/beads\n"})
+	marker := filepath.Join(t.TempDir(), "invocation.json")
+	t.Setenv("PATH", helperDir)
+	t.Setenv("PREFLIGHT_LINT_MARKER", marker)
+	result := runLintCheckAt(beads, false)
+	if !result.Passed {
+		t.Fatalf("checkout lint invocation failed: %s", result.Output)
+	}
+	if result.Command != beadsPRLintDriverCommand {
+		t.Fatalf("reported command = %q, want %q", result.Command, beadsPRLintDriverCommand)
+	}
+	if !strings.Contains(result.Output, "synthetic checkout lint success") {
+		t.Fatalf("missing subprocess output: %q", result.Output)
+	}
+
+	var invocation struct {
+		Args []string `json:"args"`
+		Dir  string   `json:"dir"`
+	}
+	markerData, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read invocation marker: %v", err)
+	}
+	if err := json.Unmarshal(markerData, &invocation); err != nil {
+		t.Fatalf("decode invocation marker: %v", err)
+	}
+	wantArgs := []string{"run", "-mod=readonly", "-tags=gms_pure_go", "./scripts/pr-lint"}
+	if !reflect.DeepEqual(invocation.Args, wantArgs) {
+		t.Fatalf("subprocess args = %#v, want %#v", invocation.Args, wantArgs)
+	}
+	if invocation.Dir != beads {
+		t.Fatalf("subprocess dir = %q, want checkout root %q", invocation.Dir, beads)
+	}
+
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal CheckResult: %v", err)
+	}
+	var reported CheckResult
+	if err := json.Unmarshal(encoded, &reported); err != nil {
+		t.Fatalf("unmarshal CheckResult: %v", err)
+	}
+	if reported.Command != beadsPRLintDriverCommand || !reported.Passed {
+		t.Fatalf("JSON evidence = %#v, want passing checkout driver command", reported)
+	}
+}
+
+func TestRunFmtCheckAtFormattedRoot(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	cmd := exec.Command("gofmt", "-l", ".")
-	cmd.Dir = dir
-	output, _ := cmd.CombinedOutput()
-	unformatted := strings.TrimSpace(string(output))
-	if unformatted == "" {
-		t.Fatal("expected unformatted files to be listed")
+	result := runFmtCheckAt(dir)
+	if !result.Passed {
+		t.Fatalf("formatted root failed: %s", result.Output)
 	}
-	if !strings.Contains(unformatted, "bad.go") {
-		t.Fatalf("expected bad.go in output, got: %s", unformatted)
+}
+
+func TestRunFmtCheckAtFindsUnformattedFileOutsideCallerSubtree(t *testing.T) {
+	root := t.TempDir()
+	callerDir := filepath.Join(root, "nested", "caller")
+	outsideCaller := filepath.Join(root, "sibling", "bad.go")
+	if err := os.MkdirAll(callerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(outsideCaller), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outsideCaller, []byte("package sibling\nfunc  bad( )  {  }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(callerDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalDir); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	})
+
+	result := runFmtCheckAt(root)
+	if result.Passed {
+		t.Fatal("root formatting check passed despite unformatted sibling file")
+	}
+	if !strings.Contains(result.Output, "bad.go") {
+		t.Fatalf("root formatting check missed sibling file: %s", result.Output)
 	}
 }
 

--- a/engdocs/CI_CLEANUP_PLAN.md
+++ b/engdocs/CI_CLEANUP_PLAN.md
@@ -1,10 +1,10 @@
 # CI Cleanup Plan
 
-Last reviewed: 2026-08-10
+Last reviewed: 2026-08-14
 
 Freshness source: `engdocs/CI_TEST_SURFACE_AUDIT.md`, `.github/workflows/*.yml`,
-`.buildflags`, `.golangci.yml`, `scripts/ci/pr-lint.sh`, `Makefile`, package test
-manifests, and maintainer decision review.
+`.buildflags`, `.golangci.yml`, `scripts/ci/pr-lint.sh`, `scripts/pr-lint/`,
+`Makefile`, package test manifests, and maintainer decision review.
 
 This document records the agreed target shape for CI cleanup. It is the policy
 and roadmap layer; the current inventory remains in
@@ -51,8 +51,11 @@ Every PR, including docs-only PRs, should run the required Linux baseline:
 
 ## Wrapper Conventions
 
-Shell scripts under `scripts/ci/` are the source of truth. Make targets should
-be aliases for discoverability, not a second implementation of command policy.
+Repository-owned wrappers under `scripts/ci/` are the supported tier
+entrypoints. Make targets should be aliases for discoverability, not a second
+implementation of command policy. A wrapper may delegate shared policy to one
+repository-owned Go driver when production tooling also needs the same
+shell-free contract.
 
 Wrapper rules:
 
@@ -167,6 +170,10 @@ easy to identify and rerun. It includes:
   downloads, a five-minute timeout, and the `gms_pure_go` build tag.
 - A second non-CGO Windows cross-lint pass when the native target does not
   already cover that build tuple.
+
+The two lint passes and their target selection are owned by the
+checkout-local `scripts/pr-lint` Go driver. The Bash wrapper retains formatting,
+direct invocation, and aggregate timing without duplicating that policy.
 
 Both passes are SCOPED BY LANE. On a PR the wrapper takes
 `BD_LINT_NEW_FROM_MERGE_BASE` and reports only the findings that PR introduces,

--- a/engdocs/DOC_INVENTORY.md
+++ b/engdocs/DOC_INVENTORY.md
@@ -34,7 +34,7 @@ freshness source.
 | `reference/json-schema.md` | `Last reviewed:` marker tied to `cmd/bd/output.go`, `cmd/bd/errors.go`, and protocol tests. (Mintlify port: was `JSON_SCHEMA.md`.) |
 | `recovery/init-safety.md` | `Last reviewed:` marker tied to `cmd/bd/init*.go` safety code and tests. (Mintlify port: was `RECOVERY.md`.) |
 | `ERROR_HANDLING.md` | `Last reviewed:` marker tied to current command error exits and JSON error helpers. |
-| `LINTING.md` | `Last reviewed:` marker tied to `.golangci.yml`, `scripts/ci/pr-lint.sh`, the `Makefile` wrapper, and CI workflow wiring. |
+| `LINTING.md` | `Last reviewed:` marker tied to `.golangci.yml`, `scripts/ci/pr-lint.sh`, `scripts/pr-lint/`, the `Makefile` wrapper, and CI workflow wiring. |
 | `SERVE_RUNBOOK.md` | `Last reviewed:` marker tied to the operating-envelope constants in `internal/httpapi/server.go` and the log fields in its `event`/`request` emitters. |
 | `CI_CLEANUP_PLAN.md` | `Last reviewed:` marker tied to the CI audit, workflow files, wrapper scripts, `Makefile`, package manifests, and maintainer decision review. |
 | `design/otel/otel-data-model.md` | `Last reviewed:` marker tied to telemetry, Dolt storage, hooks, and AI call sites. |

--- a/engdocs/LINTING.md
+++ b/engdocs/LINTING.md
@@ -1,9 +1,9 @@
 # Linting Policy
 
-Last reviewed: 2026-08-10
+Last reviewed: 2026-08-14
 
-Freshness source: `.golangci.yml`, `scripts/ci/pr-lint.sh`, `Makefile`,
-`.github/workflows/pr.yml`, and `.github/workflows/main.yml`.
+Freshness source: `.golangci.yml`, `scripts/ci/pr-lint.sh`, `scripts/pr-lint/`,
+`Makefile`, `.github/workflows/pr.yml`, and `.github/workflows/main.yml`.
 
 This document explains the required Go lint gate for this codebase.
 
@@ -37,12 +37,16 @@ answered.
 
 The wrapper runs:
 
-- `make fmt-check`;
-- golangci-lint with `.golangci.yml`, readonly module downloads, a five-minute
-  timeout, the `gms_pure_go` build tag, and `--new-from-merge-base` when
-  `BD_LINT_NEW_FROM_MERGE_BASE` names a ref; and
-- a second non-CGO Windows cross-lint pass, on the same scope, when the native
-  host does not already cover that target.
+- the shared `scripts/ci/fmt-check.sh` formatting check; and
+- the checkout-owned `scripts/pr-lint` Go driver, which runs golangci-lint with
+  `.golangci.yml`, readonly module downloads, a five-minute timeout, the
+  `gms_pure_go` build tag, and `--new-from-merge-base` when
+  `BD_LINT_NEW_FROM_MERGE_BASE` names a ref, then runs the same scope for the
+  non-CGO Windows target when the native host does not already cover it.
+
+The shell wrapper records one aggregate timing for the Go lint driver. The
+driver prints a heading and result for each native or Windows pass so failures
+remain attributable without duplicating target-selection policy in Bash.
 
 ## Policy
 
@@ -64,7 +68,8 @@ test-fixture file reads, and documented security false positives.
 
 `pr-lint` stays separate from `pr-policy` and `pr-core` so failures are easy to
 identify and rerun. Its repository-owned wrapper is
-`scripts/ci/pr-lint.sh`, exposed as `make ci-pr-lint`.
+`scripts/ci/pr-lint.sh`, exposed as `make ci-pr-lint`; its lint policy is owned
+by the shell-free `scripts/pr-lint` Go driver.
 
 See [`CI_CLEANUP_PLAN.md`](CI_CLEANUP_PLAN.md) for the full CI tier policy.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,6 +19,11 @@ Each wrapper auto-detects the repository root, sources `.buildflags` when it
 invokes Go in the default build mode, and records per-command timing through
 `scripts/ci/lib/timing.sh`.
 
+`ci-pr-lint` keeps its supported Bash/Make entrypoint but delegates native and
+Windows/non-CGO target selection to the checkout-owned `scripts/pr-lint` Go
+driver. This is the same shell-free lint authority used by `bd preflight` in a
+Beads source checkout.
+
 Broad Go test wrappers also source `scripts/ci/lib/test-env.sh`, which creates a
 temporary HOME/XDG/Dolt root, isolates Git global/system config, clears runtime
 Beads/Dolt environment variables, and sets `BEADS_TEST_SKIP=dolt` before tests

--- a/scripts/check-doc-freshness.sh
+++ b/scripts/check-doc-freshness.sh
@@ -26,8 +26,8 @@ DOCS=(
     "docs/recovery/init-safety.md|cmd/bd/init.go;cmd/bd/init_safety.go;cmd/bd/init_safety_test.go"
     "engdocs/ERROR_HANDLING.md|cmd/bd/*.go;cmd/bd/errors.go"
     "engdocs/SERVE_RUNBOOK.md|internal/httpapi/server.go;internal/httpapi/events_watch.go;cmd/bd/serve.go;internal/httpapi/auth.go"
-    "engdocs/LINTING.md|.golangci.yml;scripts/ci/pr-lint.sh;Makefile;.github/workflows/pr.yml;.github/workflows/main.yml"
-    "engdocs/CI_CLEANUP_PLAN.md|engdocs/CI_TEST_SURFACE_AUDIT.md;.github/workflows/*.yml;.buildflags;.golangci.yml;scripts/ci/pr-lint.sh;Makefile"
+    "engdocs/LINTING.md|.golangci.yml;scripts/ci/pr-lint.sh;scripts/pr-lint/;Makefile;.github/workflows/pr.yml;.github/workflows/main.yml"
+    "engdocs/CI_CLEANUP_PLAN.md|engdocs/CI_TEST_SURFACE_AUDIT.md;.github/workflows/*.yml;.buildflags;.golangci.yml;scripts/ci/pr-lint.sh;scripts/pr-lint/;Makefile"
     "engdocs/design/otel/otel-data-model.md|internal/telemetry/;internal/storage/dolt/store.go;internal/compact/haiku.go;cmd/bd/find_duplicates.go;internal/hooks/"
 )
 

--- a/scripts/check_doc_freshness_test.go
+++ b/scripts/check_doc_freshness_test.go
@@ -23,8 +23,8 @@ var freshnessDocuments = []struct {
 	{"docs/recovery/init-safety.md", []string{"cmd/bd/init.go", "cmd/bd/init_safety.go", "cmd/bd/init_safety_test.go"}},
 	{"engdocs/ERROR_HANDLING.md", []string{"cmd/bd/*.go", "cmd/bd/errors.go"}},
 	{"engdocs/SERVE_RUNBOOK.md", []string{"internal/httpapi/server.go", "internal/httpapi/events_watch.go", "cmd/bd/serve.go", "internal/httpapi/auth.go"}},
-	{"engdocs/LINTING.md", []string{".golangci.yml", "scripts/ci/pr-lint.sh", "Makefile", ".github/workflows/pr.yml", ".github/workflows/main.yml"}},
-	{"engdocs/CI_CLEANUP_PLAN.md", []string{"engdocs/CI_TEST_SURFACE_AUDIT.md", ".github/workflows/*.yml", ".buildflags", ".golangci.yml", "scripts/ci/pr-lint.sh", "Makefile"}},
+	{"engdocs/LINTING.md", []string{".golangci.yml", "scripts/ci/pr-lint.sh", "scripts/pr-lint/", "Makefile", ".github/workflows/pr.yml", ".github/workflows/main.yml"}},
+	{"engdocs/CI_CLEANUP_PLAN.md", []string{"engdocs/CI_TEST_SURFACE_AUDIT.md", ".github/workflows/*.yml", ".buildflags", ".golangci.yml", "scripts/ci/pr-lint.sh", "scripts/pr-lint/", "Makefile"}},
 	{"engdocs/design/otel/otel-data-model.md", []string{"internal/telemetry/", "internal/storage/dolt/store.go", "internal/compact/haiku.go", "cmd/bd/find_duplicates.go", "internal/hooks/"}},
 }
 

--- a/scripts/ci/pr-lint.sh
+++ b/scripts/ci/pr-lint.sh
@@ -13,29 +13,10 @@ source "$REPO_ROOT/scripts/ci/lib/timing.sh"
 
 cd "$REPO_ROOT"
 
-# The PR lane sets this to the branch it merges into so only the issues the PR
-# introduces are reported; main's push lane leaves it unset and sweeps the
-# whole tree. See the lint comment in .github/workflows/pr.yml.
-lint_scope=()
-if [[ -n "${BD_LINT_NEW_FROM_MERGE_BASE:-}" ]]; then
-    lint_scope=(--new-from-merge-base="$BD_LINT_NEW_FROM_MERGE_BASE")
-fi
-
 ci_time "gofmt check" -- ./scripts/ci/fmt-check.sh
-ci_time "golangci-lint" -- \
-    golangci-lint run --config=.golangci.yml --modules-download-mode=readonly \
-        --timeout=5m --build-tags=gms_pure_go \
-        ${lint_scope[@]+"${lint_scope[@]}"} ./...
 
-# Other target tuples may not load files guarded by //go:build windows && !cgo.
-# Cross-lint that non-CGO Windows build too, unless the native target above
-# already matches it exactly.
-native_goos="$(go env GOOS)"
-native_cgo_enabled="$(go env CGO_ENABLED)"
-if [[ "$native_goos" != "windows" || "$native_cgo_enabled" != "0" ]]; then
-    ci_time "golangci-lint (windows)" -- \
-        env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 GOWORK=off \
-            golangci-lint run --config=.golangci.yml --modules-download-mode=readonly \
-                --timeout=5m --build-tags=gms_pure_go \
-                ${lint_scope[@]+"${lint_scope[@]}"} ./...
-fi
+# The checkout-owned Go driver is the single authority for native and
+# Windows/non-CGO lint arguments. Keep this wrapper as the supported direct
+# Bash/Make entrypoint and aggregate timing boundary.
+ci_time "golangci-lint (native + windows/non-CGO)" -- \
+    go run -mod=readonly -tags=gms_pure_go ./scripts/pr-lint

--- a/scripts/pr-lint/main.go
+++ b/scripts/pr-lint/main.go
@@ -1,0 +1,293 @@
+// pr-lint runs the repository's canonical Go lint passes without requiring
+// Make or Bash. The supported scripts/ci/pr-lint.sh entrypoint delegates here,
+// and bd preflight runs this checkout-owned command for the Beads source tree.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	beadsBuildTags      = "gms_pure_go"
+	goEnvTimeout        = 30 * time.Second
+	lintProcessTimeout  = 6 * time.Minute
+	lintReportedTimeout = "5m"
+)
+
+type commandSpec struct {
+	name string
+	args []string
+	dir  string
+	env  []string
+}
+
+type processRunner interface {
+	lookPath(string) (string, error)
+	output(context.Context, commandSpec) ([]byte, []byte, error)
+	run(context.Context, commandSpec, io.Writer, io.Writer) error
+}
+
+type osProcessRunner struct{}
+
+func (osProcessRunner) lookPath(name string) (string, error) {
+	return exec.LookPath(name)
+}
+
+func (osProcessRunner) output(ctx context.Context, spec commandSpec) ([]byte, []byte, error) {
+	cmd := exec.CommandContext(ctx, spec.name, spec.args...)
+	cmd.Dir = spec.dir
+	cmd.Env = spec.env
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.Bytes(), stderr.Bytes(), err
+}
+
+func (osProcessRunner) run(ctx context.Context, spec commandSpec, stdout, stderr io.Writer) error {
+	cmd := exec.CommandContext(ctx, spec.name, spec.args...) //nolint:gosec // G702: executable is PATH-resolved; argv positions are assembled internally, and the env merge-base remains one unshelled argv value.
+	cmd.Dir = spec.dir
+	cmd.Env = spec.env
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+type nativeGoEnvironment struct {
+	GOOS       string `json:"GOOS"`
+	CGOEnabled string `json:"CGO_ENABLED"`
+}
+
+func main() {
+	dir, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "determine repository root: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(run(os.Args[1:], dir, os.Environ(), os.Stdout, os.Stderr, osProcessRunner{}))
+}
+
+func run(args []string, dir string, environ []string, stdout, stderr io.Writer, runner processRunner) int {
+	if len(args) != 0 {
+		fmt.Fprintln(stderr, "usage: go run -mod=readonly -tags=gms_pure_go ./scripts/pr-lint")
+		return 2
+	}
+
+	goPath, err := runner.lookPath("go")
+	if err != nil {
+		fmt.Fprintf(stderr, "Go toolchain not found in PATH: %v\n", err)
+		return 1
+	}
+	lintPath, err := runner.lookPath("golangci-lint")
+	if err != nil {
+		fmt.Fprintf(stderr, "golangci-lint not found in PATH: %v\n", err)
+		return 1
+	}
+
+	effectiveEnv := buildEnvironment(environ, runtime.GOOS == "windows")
+	native, code := readNativeGoEnvironment(dir, effectiveEnv, goPath, stderr, runner)
+	if code != 0 {
+		return code
+	}
+
+	mergeBase, _ := environmentValue(effectiveEnv, "BD_LINT_NEW_FROM_MERGE_BASE", runtime.GOOS == "windows")
+	argsForLint := lintArgs(mergeBase)
+	if code := runLintPass(
+		"golangci-lint (native)",
+		commandSpec{name: lintPath, args: argsForLint, dir: dir, env: effectiveEnv},
+		stdout,
+		stderr,
+		runner,
+	); code != 0 {
+		return code
+	}
+
+	if native.GOOS == "windows" && native.CGOEnabled == "0" {
+		fmt.Fprintln(stdout, "==> golangci-lint (windows/amd64, non-CGO) already covered by native pass")
+		return 0
+	}
+
+	windowsEnv := setEnvironment(effectiveEnv, map[string]string{
+		"CGO_ENABLED": "0",
+		"GOARCH":      "amd64",
+		"GOOS":        "windows",
+		"GOWORK":      "off",
+	}, runtime.GOOS == "windows")
+	return runLintPass(
+		"golangci-lint (windows/amd64, non-CGO)",
+		commandSpec{name: lintPath, args: argsForLint, dir: dir, env: windowsEnv},
+		stdout,
+		stderr,
+		runner,
+	)
+}
+
+func readNativeGoEnvironment(
+	dir string,
+	environ []string,
+	goPath string,
+	stderr io.Writer,
+	runner processRunner,
+) (nativeGoEnvironment, int) {
+	ctx, cancel := context.WithTimeout(context.Background(), goEnvTimeout)
+	defer cancel()
+
+	spec := commandSpec{
+		name: goPath,
+		args: []string{"env", "-json", "GOOS", "CGO_ENABLED"},
+		dir:  dir,
+		env:  environ,
+	}
+	output, commandStderr, err := runner.output(ctx, spec)
+	writeDiagnostic(stderr, commandStderr)
+	if err != nil {
+		writeDiagnostic(stderr, output)
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			fmt.Fprintf(stderr, "go env exceeded %s\n", goEnvTimeout)
+			return nativeGoEnvironment{}, 1
+		}
+		fmt.Fprintf(stderr, "inspect native Go target: %v\n", err)
+		return nativeGoEnvironment{}, processExitCode(err)
+	}
+
+	var native nativeGoEnvironment
+	if err := json.Unmarshal(output, &native); err != nil {
+		fmt.Fprintf(stderr, "parse native Go target: %v\n", err)
+		return nativeGoEnvironment{}, 1
+	}
+	if native.GOOS == "" || native.CGOEnabled == "" {
+		fmt.Fprintf(stderr, "go env returned an incomplete target: GOOS=%q CGO_ENABLED=%q\n", native.GOOS, native.CGOEnabled)
+		return nativeGoEnvironment{}, 1
+	}
+	return native, 0
+}
+
+func writeDiagnostic(destination io.Writer, output []byte) {
+	if len(output) == 0 {
+		return
+	}
+	_, _ = destination.Write(output)
+	if output[len(output)-1] != '\n' {
+		fmt.Fprintln(destination)
+	}
+}
+
+func runLintPass(label string, spec commandSpec, stdout, stderr io.Writer, runner processRunner) int {
+	fmt.Fprintf(stdout, "==> %s\n", label)
+	ctx, cancel := context.WithTimeout(context.Background(), lintProcessTimeout)
+	defer cancel()
+
+	err := runner.run(ctx, spec, stdout, stderr)
+	if err == nil {
+		fmt.Fprintf(stdout, "<== %s succeeded\n", label)
+		return 0
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		fmt.Fprintf(stderr, "<== %s exceeded %s\n", label, lintProcessTimeout)
+		return 1
+	}
+	fmt.Fprintf(stderr, "<== %s failed: %v\n", label, err)
+	return processExitCode(err)
+}
+
+func lintArgs(mergeBase string) []string {
+	args := []string{
+		"run",
+		"--config=.golangci.yml",
+		"--modules-download-mode=readonly",
+		"--timeout=" + lintReportedTimeout,
+		"--build-tags=" + beadsBuildTags,
+	}
+	if mergeBase != "" {
+		args = append(args, "--new-from-merge-base="+mergeBase)
+	}
+	return append(args, "./...")
+}
+
+func buildEnvironment(environ []string, caseInsensitive bool) []string {
+	cgoEnabled, found := environmentValue(environ, "CGO_ENABLED", caseInsensitive)
+	if !found || cgoEnabled == "" {
+		cgoEnabled = "1"
+	}
+
+	goFlags, _ := environmentValue(environ, "GOFLAGS", caseInsensitive)
+	if !strings.Contains(goFlags, beadsBuildTags) {
+		if goFlags != "" {
+			goFlags += " "
+		}
+		goFlags += "-tags=" + beadsBuildTags
+	}
+
+	return setEnvironment(environ, map[string]string{
+		"BEADS_BUILD_TAGS": beadsBuildTags,
+		"CGO_ENABLED":      cgoEnabled,
+		"GOFLAGS":          goFlags,
+	}, caseInsensitive)
+}
+
+func setEnvironment(environ []string, overrides map[string]string, caseInsensitive bool) []string {
+	result := make([]string, 0, len(environ)+len(overrides))
+	for _, entry := range environ {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			result = append(result, entry)
+			continue
+		}
+		if containsEnvironmentKey(overrides, key, caseInsensitive) {
+			continue
+		}
+		result = append(result, entry)
+	}
+	for key, value := range overrides {
+		result = append(result, key+"="+value)
+	}
+	return result
+}
+
+func environmentValue(environ []string, wanted string, caseInsensitive bool) (string, bool) {
+	for index := len(environ) - 1; index >= 0; index-- {
+		key, value, ok := strings.Cut(environ[index], "=")
+		if ok && environmentKeysEqual(key, wanted, caseInsensitive) {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func containsEnvironmentKey(values map[string]string, wanted string, caseInsensitive bool) bool {
+	for key := range values {
+		if environmentKeysEqual(key, wanted, caseInsensitive) {
+			return true
+		}
+	}
+	return false
+}
+
+func environmentKeysEqual(left, right string, caseInsensitive bool) bool {
+	if caseInsensitive {
+		return strings.ToLower(left) == strings.ToLower(right)
+	}
+	return left == right
+}
+
+func processExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr interface{ ExitCode() int }
+	if errors.As(err, &exitErr) && exitErr.ExitCode() >= 0 {
+		return exitErr.ExitCode()
+	}
+	return 1
+}

--- a/scripts/pr-lint/main_test.go
+++ b/scripts/pr-lint/main_test.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type recordingRunner struct {
+	paths          map[string]string
+	goEnvOutput    string
+	goEnvStderr    string
+	goEnvErr       error
+	runErrors      []error
+	outputCommands []commandSpec
+	runCommands    []commandSpec
+}
+
+func (runner *recordingRunner) lookPath(name string) (string, error) {
+	if path, ok := runner.paths[name]; ok {
+		return path, nil
+	}
+	return "", errors.New("synthetic missing command")
+}
+
+func (runner *recordingRunner) output(_ context.Context, spec commandSpec) ([]byte, []byte, error) {
+	runner.outputCommands = append(runner.outputCommands, spec)
+	return []byte(runner.goEnvOutput), []byte(runner.goEnvStderr), runner.goEnvErr
+}
+
+func (runner *recordingRunner) run(_ context.Context, spec commandSpec, stdout, _ io.Writer) error {
+	runner.runCommands = append(runner.runCommands, spec)
+	_, _ = io.WriteString(stdout, "synthetic lint output\n")
+	index := len(runner.runCommands) - 1
+	if index < len(runner.runErrors) {
+		return runner.runErrors[index]
+	}
+	return nil
+}
+
+type syntheticExitError struct {
+	code int
+}
+
+func (err syntheticExitError) Error() string {
+	return "synthetic command failure"
+}
+
+func (err syntheticExitError) ExitCode() int {
+	return err.code
+}
+
+func TestRunUsesCanonicalNativeAndWindowsPasses(t *testing.T) {
+	runner := &recordingRunner{
+		paths: map[string]string{
+			"go":            "/tools/go",
+			"golangci-lint": "/tools/golangci-lint",
+		},
+		goEnvOutput: `{"GOOS":"linux","CGO_ENABLED":"1"}`,
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	environ := []string{
+		"PATH=/tools",
+		"BD_LINT_NEW_FROM_MERGE_BASE=origin/main",
+	}
+
+	code := run(nil, "/repo", environ, &stdout, &stderr, runner)
+	if code != 0 {
+		t.Fatalf("run exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if len(runner.outputCommands) != 1 {
+		t.Fatalf("go env calls = %d, want 1", len(runner.outputCommands))
+	}
+	wantGoArgs := []string{"env", "-json", "GOOS", "CGO_ENABLED"}
+	if got := runner.outputCommands[0].args; !reflect.DeepEqual(got, wantGoArgs) {
+		t.Fatalf("go env args = %#v, want %#v", got, wantGoArgs)
+	}
+	if len(runner.runCommands) != 2 {
+		t.Fatalf("lint calls = %d, want 2", len(runner.runCommands))
+	}
+	wantLintArgs := []string{
+		"run",
+		"--config=.golangci.yml",
+		"--modules-download-mode=readonly",
+		"--timeout=5m",
+		"--build-tags=gms_pure_go",
+		"--new-from-merge-base=origin/main",
+		"./...",
+	}
+	for index, command := range runner.runCommands {
+		if command.name != "/tools/golangci-lint" {
+			t.Fatalf("lint call %d executable = %q", index, command.name)
+		}
+		if command.dir != "/repo" {
+			t.Fatalf("lint call %d dir = %q, want /repo", index, command.dir)
+		}
+		if !reflect.DeepEqual(command.args, wantLintArgs) {
+			t.Fatalf("lint call %d args = %#v, want %#v", index, command.args, wantLintArgs)
+		}
+	}
+	assertEnvironmentValue(t, runner.runCommands[0].env, "CGO_ENABLED", "1", false)
+	assertEnvironmentValue(t, runner.runCommands[0].env, "BEADS_BUILD_TAGS", "gms_pure_go", false)
+	assertEnvironmentValue(t, runner.runCommands[0].env, "GOFLAGS", "-tags=gms_pure_go", false)
+	assertEnvironmentValue(t, runner.runCommands[1].env, "GOOS", "windows", false)
+	assertEnvironmentValue(t, runner.runCommands[1].env, "GOARCH", "amd64", false)
+	assertEnvironmentValue(t, runner.runCommands[1].env, "CGO_ENABLED", "0", false)
+	assertEnvironmentValue(t, runner.runCommands[1].env, "GOWORK", "off", false)
+	for _, heading := range []string{
+		"==> golangci-lint (native)",
+		"==> golangci-lint (windows/amd64, non-CGO)",
+	} {
+		if !strings.Contains(stdout.String(), heading) {
+			t.Fatalf("missing lane heading %q in output:\n%s", heading, stdout.String())
+		}
+	}
+}
+
+func TestLintArgsKeepsHostileMergeBaseInOneArgument(t *testing.T) {
+	mergeBase := `origin/main; printf injected >&2`
+	args := lintArgs(mergeBase)
+	want := "--new-from-merge-base=" + mergeBase
+	count := 0
+	for _, arg := range args {
+		if arg == want {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("hostile merge base occurrence count = %d, want 1; args=%#v", count, args)
+	}
+	if len(args) != 7 {
+		t.Fatalf("hostile merge base changed argv cardinality: %#v", args)
+	}
+}
+
+func TestRunSkipsDuplicateNativeWindowsNonCGOPass(t *testing.T) {
+	runner := &recordingRunner{
+		paths: map[string]string{
+			"go":            "go",
+			"golangci-lint": "golangci-lint",
+		},
+		goEnvOutput: `{"GOOS":"windows","CGO_ENABLED":"0"}`,
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run(nil, "/repo", []string{"CGO_ENABLED=0"}, &stdout, &stderr, runner)
+	if code != 0 {
+		t.Fatalf("run exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if len(runner.runCommands) != 1 {
+		t.Fatalf("lint calls = %d, want 1", len(runner.runCommands))
+	}
+	if !strings.Contains(stdout.String(), "already covered by native pass") {
+		t.Fatalf("missing duplicate-pass diagnostic:\n%s", stdout.String())
+	}
+}
+
+func TestOSProcessRunnerSeparatesStdoutAndStderr(t *testing.T) {
+	const helperEnvironment = "BEADS_PR_LINT_OUTPUT_HELPER"
+	if os.Getenv(helperEnvironment) == "1" {
+		_, _ = io.WriteString(os.Stdout, `{"GOOS":"windows","CGO_ENABLED":"0"}`)
+		_, _ = io.WriteString(os.Stderr, "synthetic benign go env warning\n")
+		os.Exit(0)
+	}
+
+	stdout, stderr, err := (osProcessRunner{}).output(context.Background(), commandSpec{
+		name: os.Args[0],
+		args: []string{"-test.run=^TestOSProcessRunnerSeparatesStdoutAndStderr$"},
+		env:  append(os.Environ(), helperEnvironment+"=1"),
+	})
+	if err != nil {
+		t.Fatalf("output helper failed: %v; stderr=%s", err, stderr)
+	}
+	if got, want := string(stdout), `{"GOOS":"windows","CGO_ENABLED":"0"}`; got != want {
+		t.Fatalf("stdout = %q, want JSON-only %q", got, want)
+	}
+	if got, want := string(stderr), "synthetic benign go env warning\n"; got != want {
+		t.Fatalf("stderr = %q, want warning-only %q", got, want)
+	}
+}
+
+func TestRunParsesGoEnvStdoutWhenSuccessfulCommandWarnsOnStderr(t *testing.T) {
+	runner := &recordingRunner{
+		paths: map[string]string{
+			"go":            "go",
+			"golangci-lint": "golangci-lint",
+		},
+		goEnvOutput: `{"GOOS":"windows","CGO_ENABLED":"0"}`,
+		goEnvStderr: "synthetic benign go env warning\n",
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run(nil, "/repo", []string{"CGO_ENABLED=0"}, &stdout, &stderr, runner)
+	if code != 0 {
+		t.Fatalf("run exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "synthetic benign go env warning") {
+		t.Fatalf("go env stderr warning was not surfaced: %q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "parse native Go target") {
+		t.Fatalf("go env stderr corrupted stdout JSON parsing: %q", stderr.String())
+	}
+	if len(runner.runCommands) != 1 {
+		t.Fatalf("lint calls = %d, want one native Windows/non-CGO pass", len(runner.runCommands))
+	}
+}
+
+func TestRunPreservesNativeLintExitCodeAndStops(t *testing.T) {
+	runner := &recordingRunner{
+		paths: map[string]string{
+			"go":            "go",
+			"golangci-lint": "golangci-lint",
+		},
+		goEnvOutput: `{"GOOS":"linux","CGO_ENABLED":"1"}`,
+		runErrors:   []error{syntheticExitError{code: 23}},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run(nil, "/repo", nil, &stdout, &stderr, runner)
+	if code != 23 {
+		t.Fatalf("run exit = %d, want 23", code)
+	}
+	if len(runner.runCommands) != 1 {
+		t.Fatalf("lint calls = %d, want only failed native pass", len(runner.runCommands))
+	}
+	if !strings.Contains(stderr.String(), "golangci-lint (native) failed") {
+		t.Fatalf("missing native failure diagnostic:\n%s", stderr.String())
+	}
+}
+
+func TestRunFailsClearlyWhenCapabilityIsMissing(t *testing.T) {
+	for _, missing := range []string{"go", "golangci-lint"} {
+		t.Run(missing, func(t *testing.T) {
+			paths := map[string]string{
+				"go":            "go",
+				"golangci-lint": "golangci-lint",
+			}
+			delete(paths, missing)
+			runner := &recordingRunner{paths: paths}
+			var stderr bytes.Buffer
+
+			if code := run(nil, "/repo", nil, io.Discard, &stderr, runner); code == 0 {
+				t.Fatal("missing capability unexpectedly passed")
+			}
+			if !strings.Contains(strings.ToLower(stderr.String()), missing) || !strings.Contains(stderr.String(), "PATH") {
+				t.Fatalf("missing %s diagnostic is unclear: %q", missing, stderr.String())
+			}
+		})
+	}
+}
+
+func TestBuildEnvironmentMatchesBuildFlagsContract(t *testing.T) {
+	environ := []string{
+		"PATH=/tools",
+		"CGO_ENABLED=0",
+		"GOFLAGS=-mod=readonly",
+		"BEADS_BUILD_TAGS=stale",
+	}
+	got := buildEnvironment(environ, false)
+	assertEnvironmentValue(t, got, "CGO_ENABLED", "0", false)
+	assertEnvironmentValue(t, got, "GOFLAGS", "-mod=readonly -tags=gms_pure_go", false)
+	assertEnvironmentValue(t, got, "BEADS_BUILD_TAGS", "gms_pure_go", false)
+
+	defaulted := buildEnvironment([]string{"CGO_ENABLED="}, false)
+	assertEnvironmentValue(t, defaulted, "CGO_ENABLED", "1", false)
+	assertEnvironmentValue(t, defaulted, "GOFLAGS", "-tags=gms_pure_go", false)
+}
+
+func TestBuildEnvironmentNormalizesWindowsKeyIdentity(t *testing.T) {
+	environ := []string{
+		"cgo_enabled=0",
+		"CGO_ENABLED=1",
+		"GoFlags=-mod=readonly",
+		"GOFLAGS=-trimpath",
+		"beads_build_tags=stale",
+		"BEADſ_BUILD_TAGS=near-collision",
+		"MALFORMED",
+		"=C:=C:\\source\\beads",
+	}
+	got := buildEnvironment(environ, true)
+
+	assertSingleLogicalEnvironmentKey(t, got, "CGO_ENABLED")
+	assertSingleLogicalEnvironmentKey(t, got, "GOFLAGS")
+	assertSingleLogicalEnvironmentKey(t, got, "BEADS_BUILD_TAGS")
+	assertEnvironmentValue(t, got, "CGO_ENABLED", "1", true)
+	assertEnvironmentValue(t, got, "GOFLAGS", "-trimpath -tags=gms_pure_go", true)
+	assertEnvironmentValue(t, got, "BEADS_BUILD_TAGS", "gms_pure_go", true)
+	for _, preserved := range []string{"BEADſ_BUILD_TAGS=near-collision", "MALFORMED", "=C:=C:\\source\\beads"} {
+		if !containsExact(got, preserved) {
+			t.Fatalf("environment entry %q was not preserved in %#v", preserved, got)
+		}
+	}
+}
+
+func TestRunRejectsArguments(t *testing.T) {
+	var stderr bytes.Buffer
+	code := run([]string{"--unexpected"}, "/repo", nil, io.Discard, &stderr, &recordingRunner{})
+	if code != 2 {
+		t.Fatalf("run exit = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Fatalf("missing usage diagnostic: %q", stderr.String())
+	}
+}
+
+func assertEnvironmentValue(t *testing.T, environ []string, key, want string, caseInsensitive bool) {
+	t.Helper()
+	got, found := environmentValue(environ, key, caseInsensitive)
+	if !found || got != want {
+		t.Fatalf("%s = %q, found=%v, want %q; env=%#v", key, got, found, want, environ)
+	}
+}
+
+func assertSingleLogicalEnvironmentKey(t *testing.T, environ []string, wanted string) {
+	t.Helper()
+	count := 0
+	for _, entry := range environ {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && strings.ToLower(key) == strings.ToLower(wanted) {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("logical environment key %s occurs %d times in %#v", wanted, count, environ)
+	}
+}
+
+func containsExact(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
+}

--- a/scripts/prlintmake/prlintmake_test.go
+++ b/scripts/prlintmake/prlintmake_test.go
@@ -52,6 +52,111 @@ func TestFmtCheckPreservesGofmtFailure(t *testing.T) {
 	}
 }
 
+func TestPRLintWrapperDelegatesPolicyToCheckoutGoDriver(t *testing.T) {
+	run := runPRLintWrapper(t, "exit 0\n")
+	if run.err != nil {
+		t.Fatalf("pr-lint wrapper failed: %v\n%s", run.err, run.output)
+	}
+	if run.goArgs != "run -mod=readonly -tags=gms_pure_go ./scripts/pr-lint" {
+		t.Fatalf("go args = %q, want checkout driver invocation", run.goArgs)
+	}
+	for _, want := range []string{
+		"CGO_ENABLED=1",
+		"BEADS_BUILD_TAGS=gms_pure_go",
+		"GOFLAGS=-mod=readonly -tags=gms_pure_go",
+		"BD_LINT_NEW_FROM_MERGE_BASE=origin/main",
+	} {
+		if !strings.Contains(run.goEnvironment, want+"\n") {
+			t.Fatalf("driver environment missing %q:\n%s", want, run.goEnvironment)
+		}
+	}
+	if !strings.Contains(run.output, "==> golangci-lint (native + windows/non-CGO)") ||
+		!strings.Contains(run.output, "<== golangci-lint (native + windows/non-CGO) succeeded") {
+		t.Fatalf("aggregate lint timing is not attributable:\n%s", run.output)
+	}
+}
+
+func TestPRLintWrapperReportsGoRunFailure(t *testing.T) {
+	run := runPRLintWrapper(t, "printf 'exit status 42\\n' >&2\nexit 1\n")
+	if got := processExitCode(run.err); got == 0 {
+		t.Fatalf("exit = %d, want nonzero; error=%v\n%s", got, run.err, run.output)
+	}
+	if !strings.Contains(run.output, "exit status 42") || !strings.Contains(run.output, "failed after") {
+		t.Fatalf("missing aggregate failure diagnostic:\n%s", run.output)
+	}
+}
+
+type prLintWrapperRun struct {
+	output        string
+	err           error
+	goArgs        string
+	goEnvironment string
+}
+
+func runPRLintWrapper(t *testing.T, goBody string) prLintWrapperRun {
+	t.Helper()
+	bash := testBash(t)
+	testRoot := t.TempDir()
+	shimDir := filepath.Join(testRoot, "pr-lint shims")
+	if err := os.MkdirAll(shimDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeShellExecutable(t, bash, filepath.Join(shimDir, "gofmt"), "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n")
+	writeShellExecutable(t, bash, filepath.Join(shimDir, "go"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >"$GO_ARGS_MARKER"
+printf 'CGO_ENABLED=%s\n' "${CGO_ENABLED-}" >"$GO_ENV_MARKER"
+printf 'BEADS_BUILD_TAGS=%s\n' "${BEADS_BUILD_TAGS-}" >>"$GO_ENV_MARKER"
+printf 'GOFLAGS=%s\n' "${GOFLAGS-}" >>"$GO_ENV_MARKER"
+printf 'BD_LINT_NEW_FROM_MERGE_BASE=%s\n' "${BD_LINT_NEW_FROM_MERGE_BASE-}" >>"$GO_ENV_MARKER"
+`+goBody)
+
+	argsMarker := filepath.Join(testRoot, "go-args")
+	envMarker := filepath.Join(testRoot, "go-environment")
+	path := shimDir + string(os.PathListSeparator) + os.Getenv("PATH")
+	if runtime.GOOS == "windows" {
+		path = msysPath(shimDir) + ":/usr/bin:/bin"
+	}
+	cmd := exec.Command(
+		bash,
+		"--noprofile",
+		"--norc",
+		"--",
+		shellVisiblePath(filepath.Join(sourceRepoRoot(), "scripts", "ci", "pr-lint.sh")),
+	)
+	cmd.Dir = sourceRepoRoot()
+	cmd.Env = environment(map[string]string{
+		"BASH_ENV":                    "",
+		"BASHOPTS":                    "",
+		"BD_LINT_NEW_FROM_MERGE_BASE": "origin/main",
+		"BEADS_BUILD_TAGS":            "stale",
+		"CGO_ENABLED":                 "",
+		"ENV":                         "",
+		"GOFLAGS":                     "-mod=readonly",
+		"GO_ARGS_MARKER":              shellVisiblePath(argsMarker),
+		"GO_ENV_MARKER":               shellVisiblePath(envMarker),
+		"LANG":                        "C",
+		"LC_ALL":                      "C",
+		"PATH":                        path,
+		"SHELLOPTS":                   "",
+	})
+	output, runErr := cmd.CombinedOutput()
+	args, argsErr := os.ReadFile(argsMarker)
+	if argsErr != nil {
+		t.Fatalf("read go argument marker: %v\n%s", argsErr, output)
+	}
+	environment, envErr := os.ReadFile(envMarker)
+	if envErr != nil {
+		t.Fatalf("read go environment marker: %v\n%s", envErr, output)
+	}
+	return prLintWrapperRun{
+		output:        normalizeNewlines(string(output)),
+		err:           runErr,
+		goArgs:        strings.TrimSpace(normalizeNewlines(string(args))),
+		goEnvironment: normalizeNewlines(string(environment)),
+	}
+}
+
 func runFmtCheck(t *testing.T, gofmtBody string) (string, error) {
 	t.Helper()
 	bash := testBash(t)


### PR DESCRIPTION
## What

Add a checkout-owned Go driver for the Beads repository's canonical native and
Windows/non-CGO lint passes. Both the supported `make ci-pr-lint` Bash wrapper
and Beads-source `bd preflight --check` now execute that same driver.

The static contributor checklist continues to advertise `make ci-pr-lint`.
Generic Go repositories keep the explicit `golangci-lint run ./...` contract,
and preflight's separate formatting check now runs from the detected project
root rather than only the caller's current subtree.

## Why

`bd preflight --check` previously ran one raw linter invocation, while the
maintained repository gate also owns exact config, readonly module mode,
timeout, merge-base scoping, and a conditional Windows non-CGO pass. That could
report the Beads checkout ready without running the required gate.

Invoking Make or Bash from the installed CLI would replace that drift with
host-specific executable discovery. Importing the policy into `bd` would freeze
it at the binary's build version. The new shell-free command instead comes from
the checkout being evaluated, so a new checkout remains authoritative.

## Decision points

- The driver owns lint argv, target selection, environment normalization, and
  per-pass process timeouts; the Bash wrapper retains formatting, timing, and
  the supported direct/Make entrypoint.
- Shared lint authority here covers the wrapper and Beads-source preflight.
  The standalone workflow lint action and pre-commit hook do not call the
  driver; workflow consolidation remains in #5629. The hook uses changed-lines
  scope, adds `--fix`, and omits the Windows pass.
- The driver uses six-minute per-pass contexts and a five-minute golangci-lint
  timeout. Cancelling preflight's outer thirteen-minute `go run` context does
  not guarantee immediate descendant cleanup.
- Environment normalization mirrors `.buildflags`: an appended
  `-tags=gms_pure_go` can override an inherited bare-Go tags value; it does not
  merge tag lists.
- A Beads checkout without the driver, Go, or golangci-lint fails clearly. The
  existing `--skip-lint` escape remains explicit and reported.
- `go env -json` stdout is parsed separately from diagnostic stderr, so a
  successful warning cannot corrupt machine output.
- Driver failures remain nonzero and diagnostic through `go run`; no numeric
  exit-code identity is claimed at the wrapper boundary.
- #5614 is a same-file rebase coordination point, not a semantic dependency.
  Maphew's #5632 adds explicit config, module mode, timeout, and build-tag
  arguments to the pre-commit hook; its ownership and scope remain separate.

## Validation

Current-base validation on native Windows at `8f5f331b`, using Go 1.26.5:

- Lint-driver and wrapper packages: all 17 test outcomes passed.
- All six affected preflight tests passed, including verifying the checkout-driver
  invocation and checking formatting outside the caller's subtree.
- All 26 current CI-workflow and doc-freshness parent tests passed with
  `integration,gms_pure_go`; these include the current main freshness registry.
- Documentation synchronization (6 tests), the doc-freshness script, and
  `git diff --check` passed.
- `mingw32-make ci-pr-lint` passed formatting plus complete native and
  Windows/amd64 non-CGO lint passes, with 0 issues in each pass.

The review follow-up changes comments and prose only. Its normal merge retains
current main and the existing implementation commits; no timeout or tag policy
was changed for these notes.

Fixes #5300.

_codex-unknown-model-unknown-reasoning on behalf of Ewen Cuthiell_
