### PR TITLE
fix(server): honor Config.LenientOpen so a working-set reconcile can open past the dirty-table guard (#5781)

### DIFF
--- a/cmd/bd/store_factory.go
+++ b/cmd/bd/store_factory.go
@@ -104,7 +104,9 @@ func newDoltStore(ctx context.Context, cfg *dolt.Config) (s storage.DoltStorage,
 		// Working-set-reconcile commands (bd dolt commit, bd vc commit) must
 		// not be bricked by a pending-migration dirty-table refusal: that
 		// refusal's documented recovery is exactly the commit these commands
-		// run, so failing the open here would deadlock (#4566).
+		// run, so failing the open here would deadlock (#4566). The server
+		// arm above honors the same cfg.LenientOpen inside dolt.New; this
+		// branch is the embedded half of one policy, not the whole of it.
 		return embeddeddolt.OpenForWorkingSetReconcile(ctx, cfg.BeadsDir, cfg.Database, "main")
 	}
 	return embeddeddolt.Open(ctx, cfg.BeadsDir, cfg.Database, "main")

--- a/internal/storage/dolt/lenient_open_dirty_tables_integration_test.go
+++ b/internal/storage/dolt/lenient_open_dirty_tables_integration_test.go
@@ -1,0 +1,236 @@
+//go:build integration && !windows
+
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/storage/schema"
+	"github.com/steveyegge/beads/internal/testutil"
+	"github.com/steveyegge/beads/internal/testutil/integration"
+)
+
+// TestServerModeLenientOpenDirtyTableGate covers gastownhall/beads#5781, the
+// server-mode counterpart of #4566, which was fixed for embedded only. A pending
+// schema migration that alters a table carrying uncommitted rows must refuse a
+// plain writable open, but the working-set-reconcile open behind "bd dolt
+// commit" / "bd vc commit" (Config.LenientOpen) must still succeed, because
+// that commit is the refusal's own documented recovery. Against an external
+// Dolt server there is no equivalent of deleting the local database, so
+// without this the operator's only escape is hand-issuing DOLT_ADD/DOLT_COMMIT
+// through the raw dolt client.
+func TestServerModeLenientOpenDirtyTableGate(t *testing.T) {
+	integration.RequireDolt(t)
+	port, err := testutil.FindFreePort()
+	if err != nil {
+		t.Fatalf("find free port: %v", err)
+	}
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", strconv.Itoa(port))
+	t.Setenv("BEADS_DOLT_PORT", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "")
+
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatalf("mkdir beads dir: %v", err)
+	}
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("start local Dolt server: %v", err)
+	}
+	t.Cleanup(func() {
+		current, stateErr := doltserver.IsRunning(beadsDir)
+		if stateErr != nil {
+			t.Errorf("check local Dolt server before stop: %v", stateErr)
+			return
+		}
+		if current == nil || !current.Running {
+			return
+		}
+		if err := doltserver.Stop(beadsDir); err != nil {
+			t.Errorf("stop local Dolt server: %v", err)
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	t.Run("dirty database deadlocks a plain open and recovers through a lenient one", func(t *testing.T) {
+		const database = "lenient_dirty"
+		cfg := lenientOpenConfig(beadsDir, state.Port, database)
+		admin := prepareLenientOpenDatabaseAtV51(t, ctx, state.Port, database)
+		defer admin.Close()
+
+		if _, err := admin.ExecContext(ctx,
+			"INSERT INTO issues (id, title, description, design, acceptance_criteria, notes) VALUES (?, ?, '', '', '', '')",
+			database+"-1", "uncommitted issue",
+		); err != nil {
+			t.Fatalf("dirty issues table: %v", err)
+		}
+
+		gated, gateErr := New(ctx, cfg)
+		if gateErr == nil {
+			gated.Close()
+			t.Fatal("New (plain writable open) = nil, want *schema.DirtyTablesError")
+		}
+		var dirtyErr *schema.DirtyTablesError
+		if !errors.As(gateErr, &dirtyErr) {
+			t.Fatalf("New error = %T (%v), want error wrapping *schema.DirtyTablesError", gateErr, gateErr)
+		}
+		if !containsTable(dirtyErr.Tables, "issues") {
+			t.Fatalf("DirtyTablesError.Tables = %v, want to include %q", dirtyErr.Tables, "issues")
+		}
+
+		lenientCfg := lenientOpenConfig(beadsDir, state.Port, database)
+		lenientCfg.LenientOpen = true
+		store, err := New(ctx, lenientCfg)
+		if err != nil {
+			t.Fatalf("New (LenientOpen) = %v, want a usable store", err)
+		}
+		defer store.Close()
+
+		if got := lenientOpenSchemaVersion(t, ctx, store.db); got != 51 {
+			t.Fatalf("schema version after lenient open = %d, want 51 (the migration must stay skipped)", got)
+		}
+
+		if err := store.Commit(ctx, "checkpoint before migration"); err != nil {
+			t.Fatalf("Commit: %v", err)
+		}
+		if got := lenientOpenDirtyCount(t, ctx, store.db); got != 0 {
+			t.Fatalf("dolt_status rows after commit = %d, want 0", got)
+		}
+		store.Close()
+
+		migrated, err := New(ctx, lenientOpenConfig(beadsDir, state.Port, database))
+		if err != nil {
+			t.Fatalf("New (post-commit plain open): %v", err)
+		}
+		defer migrated.Close()
+		if got := lenientOpenSchemaVersion(t, ctx, migrated.db); got != schema.LatestVersion() {
+			t.Fatalf("schema version after post-commit open = %d, want latest %d", got, schema.LatestVersion())
+		}
+	})
+
+	t.Run("clean database still migrates through a lenient open", func(t *testing.T) {
+		const database = "lenient_clean"
+		admin := prepareLenientOpenDatabaseAtV51(t, ctx, state.Port, database)
+		defer admin.Close()
+
+		cfg := lenientOpenConfig(beadsDir, state.Port, database)
+		cfg.LenientOpen = true
+		store, err := New(ctx, cfg)
+		if err != nil {
+			t.Fatalf("New (LenientOpen, clean database): %v", err)
+		}
+		defer store.Close()
+		if got := lenientOpenSchemaVersion(t, ctx, store.db); got != schema.LatestVersion() {
+			t.Fatalf("schema version = %d, want latest %d (a lenient open must not skip migrations wholesale)",
+				got, schema.LatestVersion())
+		}
+	})
+}
+
+func lenientOpenConfig(beadsDir string, port int, database string) *Config {
+	return &Config{
+		Path:           filepath.Join(beadsDir, database),
+		BeadsDir:       beadsDir,
+		ServerHost:     "127.0.0.1",
+		ServerPort:     port,
+		ServerUser:     "root",
+		Database:       database,
+		CommitterName:  "Beads Test",
+		CommitterEmail: "beads@example.com",
+		MaxOpenConns:   1,
+	}
+}
+
+// prepareLenientOpenDatabaseAtV51 creates database on the running server,
+// migrates it to schema v51, and commits that baseline so the working set
+// starts clean. v51 leaves every later migration pending, including several
+// that alter `issues`. Returns an open connection to the prepared database.
+func prepareLenientOpenDatabaseAtV51(t *testing.T, ctx context.Context, port int, database string) *sql.DB {
+	t.Helper()
+	adminDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: port, User: "root"}.String()
+	admin, err := sql.Open("mysql", adminDSN)
+	if err != nil {
+		t.Fatalf("open admin connection: %v", err)
+	}
+	if _, err := admin.ExecContext(ctx, "CREATE DATABASE `"+database+"`"); err != nil {
+		admin.Close()
+		t.Fatalf("create database %s: %v", database, err)
+	}
+	if err := admin.Close(); err != nil {
+		t.Fatalf("close admin connection: %v", err)
+	}
+
+	dsn := doltutil.ServerDSN{Host: "127.0.0.1", Port: port, User: "root", Database: database}.String()
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open %s: %v", database, err)
+	}
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		db.Close()
+		t.Fatalf("pin %s: %v", database, err)
+	}
+	defer conn.Close()
+	if _, err := schema.MigrateUpTo(ctx, conn, 51); err != nil {
+		db.Close()
+		t.Fatalf("migrate %s to v51: %v", database, err)
+	}
+	if _, err := conn.ExecContext(ctx,
+		"CALL DOLT_COMMIT('-Am', 'test: v51 baseline', '--author', 'Beads Test <beads@example.com>')",
+	); err != nil {
+		db.Close()
+		t.Fatalf("commit v51 baseline: %v", err)
+	}
+	if got := lenientOpenSchemaVersion(t, ctx, conn); got != 51 {
+		db.Close()
+		t.Fatalf("baseline schema version = %d, want 51", got)
+	}
+	return db
+}
+
+type lenientOpenQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func lenientOpenSchemaVersion(t *testing.T, ctx context.Context, db lenientOpenQueryer) int {
+	t.Helper()
+	var version int
+	if err := db.QueryRowContext(ctx,
+		"SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+	).Scan(&version); err != nil {
+		t.Fatalf("read schema version: %v", err)
+	}
+	return version
+}
+
+func lenientOpenDirtyCount(t *testing.T, ctx context.Context, db lenientOpenQueryer) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM dolt_status").Scan(&count); err != nil {
+		t.Fatalf("count dolt_status: %v", err)
+	}
+	return count
+}
+
+func containsTable(tables []string, want string) bool {
+	for _, table := range tables {
+		if table == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -371,12 +371,14 @@ type Config struct {
 	ReadOnly       bool   // Open in read-only mode (skip schema init)
 	Preview        bool   // Non-mutating preview: embedded opens skip schema init and refuse writes
 
-	// LenientOpen opens the store leniently: embedded mode only. A migration
-	// gate refusal (#4259) or a dirty-working-set refusal (#4566) skips the
-	// migration instead of failing the open. Set for working-set-reconcile
-	// commands (bd dolt commit, bd vc commit; #4566), whose entire purpose is
-	// to clear the working set that the migration would otherwise refuse to
-	// touch. Ignored in server mode.
+	// LenientOpen opens the store leniently: a migration gate refusal (#4259)
+	// or a dirty-working-set refusal (#4566) skips the migration instead of
+	// failing the open. Set for working-set-reconcile commands (bd dolt
+	// commit, bd vc commit; #4566), whose entire purpose is to clear the
+	// working set that the migration would otherwise refuse to touch.
+	// Honored in embedded and server mode alike. Migrations still RUN on a
+	// lenient open — only those two refusals are tolerated — so a lenient
+	// open of a clean database converges normally.
 	LenientOpen bool
 
 	// Server connection options
@@ -2023,7 +2025,12 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	if !cfg.ReadOnly && !cfg.Gateway {
 		applied, err := store.initSchema(ctx, dbFacts.bootstrapHeal)
 		if err != nil {
-			return nil, fmt.Errorf("failed to initialize schema: %w", err)
+			if !cfg.LenientOpen || !warnLenientOpenRefusal(err) {
+				return nil, fmt.Errorf("failed to initialize schema: %w", err)
+			}
+			// A tolerated refusal still reports what the aborted pass
+			// applied (0 for both guards today, since each refuses before
+			// migrating), so the rebuild below stays correct either way.
 		}
 		// initSchema runs migrations over a separate pool (openMigrationDB).
 		// The Ping above already pinned a connection in store.db to the
@@ -2056,6 +2063,43 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	// close above. Must be the last thing before the success return.
 	storeReady = true
 	return store, nil
+}
+
+// warnLenientOpenRefusal reports whether a lenient open (Config.LenientOpen)
+// may continue past err instead of failing, warning on stderr when it may.
+//
+// Server mode reaches the same two pending-migration refusals embedded mode
+// relaxes for this intent (embeddeddolt's openWorkingSetReconcile): the #4566
+// dirty-table guard, whose documented recovery IS the commit these opens exist
+// to run, and the #4259 remote-migrate gate, a coordination stop with no
+// business blocking a commit of the local working set. Against an external
+// server the operator cannot sidestep either by deleting a local database, so
+// leaving them fatal here left the refusals with no in-band recovery at all
+// (#5781).
+//
+// Every other migration failure still fails the open, and the schema-skew and
+// identity guards run before this point either way: lenient relaxes migration,
+// not safety.
+func warnLenientOpenRefusal(err error) bool {
+	var dirtyErr *schema.DirtyTablesError
+	if errors.As(err, &dirtyErr) {
+		fmt.Fprintf(os.Stderr,
+			"Warning: %v\n"+
+				"  Committing the working set at the current schema; when it completes,\n"+
+				"  re-run 'bd migrate'.\n",
+			dirtyErr)
+		return true
+	}
+	var gateErr *schema.RemoteMigrateGateError
+	if errors.As(err, &gateErr) {
+		fmt.Fprintf(os.Stderr,
+			"Warning: %s"+
+				"  Working-set reconcile command: continuing on schema v%d without\n"+
+				"  migrating; the commit applies to the working set at the current schema.\n",
+			gateErr.UserMessage(), gateErr.CurrentVersion)
+		return true
+	}
+	return false
 }
 
 var (

--- a/internal/storage/schema/dirty_tables_error.go
+++ b/internal/storage/schema/dirty_tables_error.go
@@ -14,10 +14,12 @@ import "strings"
 // run cleanly. But those commit commands also open the store, and an open
 // runs MigrateUp - hitting this same guard before the commit that would
 // clear the dirty state ever gets a chance to run (gastownhall/beads#4566).
-// To break that deadlock, working-set-reconcile opens (embeddeddolt.
-// OpenForWorkingSetReconcile) detect this error type at open time via
-// errors.As and skip the migration instead of failing the open, so the
-// commit can proceed and clear the working set.
+// To break that deadlock, working-set-reconcile opens detect this error type
+// at open time via errors.As and skip the migration instead of failing the
+// open, so the commit can proceed and clear the working set. Both storage
+// modes do this — embeddeddolt.OpenForWorkingSetReconcile and server mode's
+// dolt.Config.LenientOpen — so the recovery this message names is reachable
+// wherever the guard fires.
 type DirtyTablesError struct {
 	Tables []string
 }


### PR DESCRIPTION
## What

Makes server mode honor `dolt.Config.LenientOpen`, so `bd dolt commit` /
`bd vc commit` can open a server-backed store whose working set is dirty on a
table a pending migration alters.

## Why

Fixes #5781.

`Config.LenientOpen` exists to break the #4566 deadlock:

```
migration refuses dirty table
  -> error says "run 'bd dolt commit'"
    -> bd dolt commit opens the store
      -> open runs the migration
        -> same refusal
```

#4567 broke that loop for embedded mode only. The flag already reaches server
mode — `cmd/bd/main.go:1435` sets it unconditionally from
`isWorkingSetReconcileCommand` — but `newServerMode` never read it
(`internal/storage/dolt/store.go:1972`), and the field's own doc comment said
"Ignored in server mode." So against an external Dolt server the refusal's
documented recovery was unexecutable.

Server mode is the worse case, not the milder one. Embedded's escape hatch is to
move the local database directory aside and `bd bootstrap` — there is no
equivalent against a shared server. The only working escape was to bypass `bd`
and hand-issue `CALL DOLT_ADD(...)` / `CALL DOLT_COMMIT(...)` through the raw
`dolt` client.

Found in the wild: 15 of 21 databases on one deployed server carried a
permanently dirty `config` table. `config` is not in `dolt_ignore`, and
`0030_migrate_local_metadata_keys.up.sql:27` already issues `DELETE FROM config`
— so a future migration touching `config` would have wedged all of them at once
with no in-band recovery.

## What it does

`newServerMode` still calls `initSchema`; on failure it tolerates exactly the
two refusals the embedded `openWorkingSetReconcile` intent relaxes
(`internal/storage/embeddeddolt/store.go:388-453`):

- `*schema.DirtyTablesError` — the #4566 guard, whose documented recovery *is*
  the commit these opens exist to run.
- `*schema.RemoteMigrateGateError` — the #4259 coordination stop, which has no
  business blocking a commit of the local working set.

Both warn on stderr and continue on the current schema, mirroring embedded's
wording. The gate case reuses `RemoteMigrateGateError.UserMessage()` rather than
duplicating embedded's hand-rolled guidance block.

### Deliberately not the one-line patch

Adding `&& !cfg.LenientOpen` to the `initSchema` gate over-skips: it would skip
migrations wholesale and diverge from embedded, which runs the pass and only
declines to fail on those two errors. A lenient open of a *clean* database still
migrates to latest. Any other migration failure still fails the open. The
negative case in the regression test is what guards this.

### Safety is unchanged

`schema.CheckForwardDrift` and project-identity verification both run *before*
this call site, so they are unaffected — a lenient open relaxes migration, not
safety.

Once both modes honor the flag, the "run `bd dolt commit`" advice in
`DirtyTablesError` is true wherever the guard fires, so it needs no mode-aware
rewording; its doc comment is updated to stop describing the recovery as
embedded-only.

## Not covered here

- The proxied-server path errors out early today ("proxy server store should be
  uow provider"), so it is unreachable. `internal/storage/uow` has its own
  `initSchema` with the same guard and would need separate treatment if that
  path is revived.
- #5168 — the *ignored*-source dirty-table guard is a different check: a
  deliberately untyped error fired mid-pass after the main migrations have
  applied. Honoring `LenientOpen` does not and should not relax it.
- #4934 / #5111 — `bd dolt commit` skipping the `config` table is commit-side.
  For a `config`-only dirty working set this PR lets the open succeed but the
  commit still lands nothing until those are fixed. The `issues` case, which is
  the one the migration guard actually blocks on, recovers fully. Related
  contributor work: #4383.

## Verification

New: `internal/storage/dolt/lenient_open_dirty_tables_integration_test.go`, the
server-mode twin of
`TestEmbeddedDirtyTablesGate_BlocksReopenThenWorkingSetReconcileRecovers`.
It starts a real `dolt sql-server` and:

1. builds a database at schema v51 with a clean committed baseline,
2. leaves an uncommitted row in `issues`,
3. asserts a plain writable open returns `*schema.DirtyTablesError` naming
   `issues`,
4. asserts a `LenientOpen` open succeeds and leaves the cursor at v51,
5. commits the working set and asserts `dolt_status` is empty,
6. asserts the next plain open migrates to `schema.LatestVersion()`,

plus the negative case: a `LenientOpen` open of a *clean* v51 database must
still reach `schema.LatestVersion()`.

Step 4 fails on `main` with the exact error from the issue; steps 3 and the
negative case pass on `main`, so the test is red only for the behavior this PR
changes.

```
go test -tags integration,gms_pure_go -run '^TestServerModeLenientOpenDirtyTableGate$' ./internal/storage/dolt/
```

Also run: `./scripts/test.sh` on `./internal/storage/dolt/...`,
`./internal/storage/schema/...`, `./internal/storage/embeddeddolt/...`,
`./cmd/bd/...`; then `make test` (green) and `make ci-pr-lint` (no new
findings — the 5 reported are a pre-existing macOS-only baseline, identical
with the branch stashed, in files this PR does not touch).
