### PR TITLE
fix(labels): bump updated_at on label mutation (#5442)

### DIFF
--- a/internal/storage/embeddeddolt/get_issue_test.go
+++ b/internal/storage/embeddeddolt/get_issue_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
@@ -281,6 +282,70 @@ func TestAddLabel(t *testing.T) {
 		}
 		if len(labels) != 1 {
 			t.Errorf("expected 1 label, got %v", labels)
+		}
+	})
+
+	// Regression for #5442: label mutations wrote the labels/wisp_labels row
+	// and an events row, but never touched the issue's updated_at column,
+	// so --updated-after filtering, stale-upsert rejection, and LWW merge
+	// were all blind to label-only churn.
+	t.Run("bumps_updated_at", func(t *testing.T) {
+		te := newTestEnv(t, "ua")
+		ctx := t.Context()
+
+		issue := &types.Issue{
+			ID:        "ua-touch",
+			Title:     "Label bumps updated_at",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue: %v", err)
+		}
+		if err := te.store.Commit(ctx, "create issue"); err != nil {
+			t.Fatalf("Commit: %v", err)
+		}
+
+		before, err := te.store.GetIssue(ctx, "ua-touch")
+		if err != nil {
+			t.Fatalf("GetIssue (before add): %v", err)
+		}
+
+		// updated_at has second-level granularity (matches the issue's own
+		// repro, which sleeps between mutations for the same reason).
+		time.Sleep(1100 * time.Millisecond)
+
+		if err := te.store.AddLabel(ctx, "ua-touch", "alpha", "tester"); err != nil {
+			t.Fatalf("AddLabel: %v", err)
+		}
+		if err := te.store.Commit(ctx, "add label"); err != nil {
+			t.Fatalf("Commit: %v", err)
+		}
+
+		afterAdd, err := te.store.GetIssue(ctx, "ua-touch")
+		if err != nil {
+			t.Fatalf("GetIssue (after add): %v", err)
+		}
+		if !afterAdd.UpdatedAt.After(before.UpdatedAt) {
+			t.Fatalf("AddLabel must bump updated_at (#5442): before=%v after=%v", before.UpdatedAt, afterAdd.UpdatedAt)
+		}
+
+		time.Sleep(1100 * time.Millisecond)
+
+		if err := te.store.RemoveLabel(ctx, "ua-touch", "alpha", "tester"); err != nil {
+			t.Fatalf("RemoveLabel: %v", err)
+		}
+		if err := te.store.Commit(ctx, "remove label"); err != nil {
+			t.Fatalf("Commit: %v", err)
+		}
+
+		afterRemove, err := te.store.GetIssue(ctx, "ua-touch")
+		if err != nil {
+			t.Fatalf("GetIssue (after remove): %v", err)
+		}
+		if !afterRemove.UpdatedAt.After(afterAdd.UpdatedAt) {
+			t.Fatalf("RemoveLabel must bump updated_at (#5442): before=%v after=%v", afterAdd.UpdatedAt, afterRemove.UpdatedAt)
 		}
 	})
 }

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -161,6 +162,14 @@ func AddLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID,
 	}); err != nil {
 		return fmt.Errorf("add label: record event: %w", err)
 	}
+	// A label write bypasses UpdateIssueInTx entirely, so it must bump
+	// updated_at itself -- otherwise --updated-after filtering, stale-upsert
+	// rejection, and LWW merge are all blind to label-only churn (#5442).
+	// Must run before RecordEventInTx below so the journal snapshot below
+	// captures the bumped value, matching UpdateIssueInTx's own ordering.
+	if err := touchUpdatedAtInTx(ctx, tx, issueTableFor(labelTable), issueID); err != nil {
+		return fmt.Errorf("add label: %w", err)
+	}
 	// A label is part of the bead snapshot, so a label write journals as an
 	// update carrying the complete post-mutation set.
 	return RecordEventInTx(ctx, tx, EventUpdate, issueID, actor)
@@ -194,5 +203,42 @@ func RemoveLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issue
 	}); err != nil {
 		return fmt.Errorf("remove label: record event: %w", err)
 	}
+	if err := touchUpdatedAtInTx(ctx, tx, issueTableFor(labelTable), issueID); err != nil {
+		return fmt.Errorf("remove label: %w", err)
+	}
 	return RecordEventInTx(ctx, tx, EventUpdate, issueID, actor)
+}
+
+// issueTableFor returns the issue table ("issues" or "wisps") that owns
+// labelTable ("labels" or "wisp_labels"). WispTableRouting only ever
+// produces these two pairings, so the mapping is exhaustive -- deriving it
+// this way avoids an extra IsActiveWispInTx probe query when the caller
+// already resolved and passed in labelTable/eventTable explicitly (e.g.
+// embeddeddolt/dolt Transaction.AddLabel, which also need the routed table
+// name for their own dirty-table tracking).
+func issueTableFor(labelTable string) string {
+	if labelTable == "wisp_labels" {
+		return "wisps"
+	}
+	return "issues"
+}
+
+// touchUpdatedAtInTx bumps an issue's updated_at without touching any other
+// column. Callers that mutate an issue through a side channel other than
+// UpdateIssueInTx -- label add/remove write directly to the labels/
+// wisp_labels table, bypassing the normal field-update path entirely --
+// must call this so --updated-after filtering, stale-upsert rejection, and
+// LWW merge all see the edit (#5442). Also mints a fresh row_lock, matching
+// every other issues/wisps content write (see the freshRowLock invariant in
+// lease.go) -- otherwise this write would be invisible to RowVersion-gated
+// optimistic-concurrency checks.
+func touchUpdatedAtInTx(ctx context.Context, tx DBTX, issueTable, issueID string) error {
+	rowLockClause, rowLockArgs := RowLockClause()
+	args := append([]interface{}{time.Now().UTC()}, rowLockArgs...)
+	args = append(args, issueID)
+	//nolint:gosec // G201: issueTable is from issueTableFor ("issues" or "wisps")
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET updated_at = ?, %s WHERE id = ?`, issueTable, rowLockClause), args...); err != nil {
+		return fmt.Errorf("touch updated_at: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
Fixes #5442.

`bd label add/remove` and `bd update --add-label/--remove-label` never bump the issue's `updated_at` column, so `--updated-after` filtering, stale-upsert rejection, and LWW merge are all blind to label-only churn.

The issue was filed against an older `main` (1453 commits behind current) and its cited functions (`ExecuteUpdate`, `ApplyLabelPatch`) no longer exist -- re-traced from scratch on current code before building anything. `AddLabelInTx`/`RemoveLabelInTx` (`internal/storage/issueops/labels.go`) are still the funnel every label mutation goes through on both storage backends. They already call `RecordEventInTx` at the end, which looked like it might already be a fix -- traced it down and confirmed it only writes to a separate audit journal table, never touches `issues.updated_at`. Wrote a real embedded-Dolt test first and watched it fail (`before == after`) to confirm the bug is still fully real, not just reasoned about.

**Fix:** `touchUpdatedAtInTx` -- a plain `UPDATE issues|wisps SET updated_at = ?` scoped to the mutated row, called from both functions right before their existing `RecordEventInTx` call (matches `UpdateIssueInTx`'s own ordering). `issueTableFor(labelTable)` derives `"issues"`/`"wisps"` from the already-known `labelTable` value instead of adding a second probe query -- both backends have real callers that pass `labelTable`/`eventTable` explicitly specifically to avoid that extra query, so resolving it unconditionally would have silently added one to every label mutation. Also mints a fresh `row_lock` (`RowLockClause()`) -- the repo's own `TestAllIssueRowWritesStampRowLock` AST guard caught the first draft for skipping this, since every issues/wisps write touching `updated_at` must stamp `row_lock` too.

**Testing:** real embedded-Dolt integration test (`BEADS_TEST_EMBEDDED_DOLT=1`), not sqlmock -- create an issue, add a label, assert `updated_at` advanced; remove it, assert it advanced again. RED pre-fix (`before==after`), GREEN post-fix. `TestAllIssueRowWritesStampRowLock` passes (17 writes verified, was 16). Full `issueops` unit suite and the targeted `embeddeddolt` label/issue slice both green. `go vet`/`gofmt` clean. Pre-commit hook (gofmt + golangci-lint, this repo's pinned CI version) clean, 0 issues.

---

Generated with [Claude Code](https://claude.com/claude-code)