### PR TITLE
fix(list): resolve short/partial parent IDs for --parent (#5440)

### DIFF
--- a/cmd/bd/list_embedded_test.go
+++ b/cmd/bd/list_embedded_test.go
@@ -503,6 +503,29 @@ func TestEmbeddedList(t *testing.T) {
 		}
 	})
 
+	t.Run("parent_filter_short_id", func(t *testing.T) {
+		// Regression for #5440: a --parent value without its project prefix
+		// (e.g. "c7v" instead of "tl-c7v") must resolve the same way
+		// `bd history <shortid>` already does (GH#4868), not error "not found".
+		// Uses the plain (non-JSON) render, matching the issue's own repro and
+		// tree_parent above -- --json --parent takes a different code path
+		// (reader.List's own filter, not getHierarchicalChildren) that this
+		// fix does not touch; see the relay notes for that separate finding.
+		idParts := strings.Split(seed.epic, "-")
+		shortID := idParts[len(idParts)-1]
+		if shortID == seed.epic {
+			t.Fatalf("test setup: seed.epic %q has no prefix to strip", seed.epic)
+		}
+
+		out := bdList(t, bd, dir, "--parent", shortID)
+		if !strings.Contains(out, seed.childTaskA) {
+			t.Errorf("child A %s should appear with --parent %s (short id):\n%s", seed.childTaskA, shortID, out)
+		}
+		if !strings.Contains(out, seed.childTaskB) {
+			t.Errorf("child B %s should appear with --parent %s (short id):\n%s", seed.childTaskB, shortID, out)
+		}
+	})
+
 	t.Run("no_parent", func(t *testing.T) {
 		issues := bdListJSON(t, bd, dir, "--no-parent")
 		if containsID(issues, seed.childTaskA) {

--- a/cmd/bd/list_show_filter_modes.go
+++ b/cmd/bd/list_show_filter_modes.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -11,6 +12,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/utils"
 	"github.com/steveyegge/beads/internal/workapi"
 )
 
@@ -47,6 +49,16 @@ import (
 // getHierarchicalChildren handles the --tree --parent combination logic.
 // baseFilter carries CLI filters (--type, --status, etc.) through the recursive walk.
 func getHierarchicalChildren(ctx context.Context, store storage.DoltStorage, dbPath string, parentID string, baseFilter types.IssueFilter) ([]*types.Issue, error) {
+	// Accept a short/partial parent ID the same way `bd history <id>` does
+	// (GH#4868's mechanism, not applied here before). Not-found IDs fall
+	// through unchanged so the existing "parent issue '%s' not found" path
+	// below still fires with the id the user actually typed.
+	if resolved, err := utils.ResolvePartialID(ctx, store, parentID); err == nil {
+		parentID = resolved
+	} else if errors.Is(err, utils.ErrAmbiguousID) {
+		return nil, err
+	}
+
 	// First verify that the parent issue exists
 	var parentIssue *types.Issue
 	err := withStorage(ctx, store, dbPath, func(s storage.DoltStorage) error {


### PR DESCRIPTION
Fixes #5440.

`bd list --parent <shortid>` (e.g. `c7v` instead of `tm-c7v`) errored `not found: issue c7v` instead of resolving the way `bd history <shortid>` already does (GH#4868).

**Fix:** `getHierarchicalChildren` (the function the issue's own error text traces to) now calls `utils.ResolvePartialID` -- the same helper `bd history` already uses -- right at the top, before its existing parent-existence check. Mirrors `history.go`'s exact error handling: resolved -> replace the ID; ambiguous -> hard error; genuinely not found -> fall through unchanged so the existing "parent issue '%s' not found" message still fires with what the user actually typed.

**Scoped deliberately -- three related things found but not fixed here, flagging for a maintainer call:**
1. The proxied-server equivalent (`gatherProxiedHierarchical`) -- `history.go` itself documents proxied mode intentionally passes the raw ID through since there's no local store to resolve against. Not an oversight, existing convention.
2. `--json --parent <shortid>` takes a completely different code path (`reader.List`'s own filter, built by `BuildListFilter`, never touching `getHierarchicalChildren`) and has the same underlying gap but fails differently: silently returns `[]` instead of erroring. Confirmed via manual repro. Real, separate defect in a different layer -- broader than this issue asked for.
3. The same bug shape appears in `bd create --parent`, `bd ready --parent`, `bd label --parent` -- all independently call `GetIssue` on a raw `--parent` value. Found via grep while tracing this, not independently verified beyond that, not reported in this issue.

**Testing:** real embedded-Dolt CLI subprocess test (`TestEmbeddedList/parent_filter_short_id`, `BEADS_TEST_EMBEDDED_DOLT=1`), using the plain (non-JSON) render to match the issue's own repro and the existing `tree_parent` test's pattern. First test draft used the JSON-output helper and passed trivially even against unfixed code -- caught by tracing exactly which branch `--json` takes (an early return in `list.go`, well before `getHierarchicalChildren`); rewrote to actually exercise the code path the fix touches. RED confirmed properly after the rewrite, GREEN after the fix. Full `TestEmbeddedList` suite (51 subtests) green, run twice. `go vet` clean, pre-commit hook clean.

---

Generated with [Claude Code](https://claude.com/claude-code)