### PR TITLE
fix(embeddeddolt): commit pending changes before push (#5433)

### DIFF
--- a/internal/storage/embeddeddolt/push_commit_pending_test.go
+++ b/internal/storage/embeddeddolt/push_commit_pending_test.go
@@ -1,0 +1,112 @@
+//go:build cgo
+
+package embeddeddolt
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func wantStopRemote(t *testing.T, err error) {
+	t.Helper()
+	if !errors.Is(err, errStopRemote) {
+		t.Fatalf("error = %v, want errStopRemote (stopped before the remote entry point)", err)
+	}
+}
+
+func wantRemoteNotFound(t *testing.T, err error) {
+	t.Helper()
+	if err == nil || !strings.Contains(err.Error(), "remote") {
+		t.Fatalf("error = %v, want a remote-not-found failure (no real remote is configured in this test store)", err)
+	}
+}
+
+// TestPushCommitsPendingChangesFirst is a regression test for #5433: every
+// Pull variant auto-commits pending changes before pulling (GH#2474), but no
+// Push variant did, so a write that landed in the working set but was never
+// explicitly committed (auto-commit off, or a session that ended right after
+// a write with no intervening commit) silently pushed nothing new while
+// still reporting success. Push/ForcePush/PushRemote/PushTo now call
+// CommitPending first, matching Pull's own pattern.
+//
+// Uses captureRemoteEntryPoints (remote_peer_auth_test.go) to stop each verb
+// at its remote entry point with errStopRemote, keeping the test off the
+// network while still exercising the real CommitPending call that runs
+// before it.
+func TestPushCommitsPendingChangesFirst(t *testing.T) {
+	ctx := t.Context()
+
+	cases := []struct {
+		name string
+		call func(*EmbeddedDoltStore) error
+		// wantErr checks the error from call. Push/ForcePush/PushRemote route
+		// through the swappable vcPush/vcForcePush vars that
+		// captureRemoteEntryPoints intercepts with errStopRemote before any
+		// network IO. PushTo calls versioncontrolops.Push directly (no
+		// swappable seam for it), so it actually attempts the push and fails
+		// on "remote not found" -- still proves CommitPending ran first,
+		// since that failure only happens after this fix's guard clause.
+		wantErr func(t *testing.T, err error)
+	}{
+		{"Push", func(s *EmbeddedDoltStore) error { return s.Push(ctx) }, wantStopRemote},
+		{"ForcePush", func(s *EmbeddedDoltStore) error { return s.ForcePush(ctx) }, wantStopRemote},
+		{"PushRemote", func(s *EmbeddedDoltStore) error { return s.PushRemote(ctx, defaultRemote, false) }, wantStopRemote},
+		{"PushTo", func(s *EmbeddedDoltStore) error { return s.PushTo(ctx, defaultRemote) }, wantRemoteNotFound},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newPeerAuthTestStore(t)
+
+			// newPeerAuthTestStore opens a bare store with no issue_prefix
+			// configured yet; give it one and commit so the fixture itself
+			// isn't the pending change this test is trying to isolate.
+			if err := store.SetConfig(ctx, "issue_prefix", "fedauth"); err != nil {
+				t.Fatalf("SetConfig(issue_prefix): %v", err)
+			}
+			if err := store.Commit(ctx, "bd init"); err != nil {
+				t.Fatalf("Commit(bd init): %v", err)
+			}
+
+			var got presentedAuth
+			captureRemoteEntryPoints(t, &got)
+
+			beforeCreate, err := store.GetCurrentCommit(ctx)
+			if err != nil {
+				t.Fatalf("GetCurrentCommit (before create): %v", err)
+			}
+
+			issue := &types.Issue{
+				ID:        "fedauth-" + tc.name,
+				Title:     "pending change",
+				Status:    types.StatusOpen,
+				Priority:  2,
+				IssueType: types.TypeTask,
+			}
+			if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+				t.Fatalf("CreateIssue: %v", err)
+			}
+
+			afterCreate, err := store.GetCurrentCommit(ctx)
+			if err != nil {
+				t.Fatalf("GetCurrentCommit (after create): %v", err)
+			}
+			if afterCreate != beforeCreate {
+				t.Fatalf("test invariant broken: CreateIssue committed on its own (HEAD moved %s -> %s) -- this test needs a genuinely pending change to be meaningful", beforeCreate, afterCreate)
+			}
+
+			tc.wantErr(t, tc.call(store))
+
+			afterPush, err := store.GetCurrentCommit(ctx)
+			if err != nil {
+				t.Fatalf("GetCurrentCommit (after %s): %v", tc.name, err)
+			}
+			if afterPush == afterCreate {
+				t.Fatalf("%s must commit pending changes before pushing (#5433): HEAD did not move (%s), the created issue is still uncommitted", tc.name, afterPush)
+			}
+		})
+	}
+}

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -501,6 +501,14 @@ func (s *EmbeddedDoltStore) ListRemotes(ctx context.Context) ([]storage.RemoteIn
 // where before it read it holding no lock at all.
 
 func (s *EmbeddedDoltStore) Push(ctx context.Context) error {
+	// GH#5433: every Pull variant below auto-commits pending changes first;
+	// push never did, so a working set with pending-but-uncommitted changes
+	// (auto-commit off, or a session that ended right after a write with no
+	// intervening commit) silently pushed nothing new and still reported
+	// success.
+	if _, err := s.CommitPending(ctx, "beads"); err != nil {
+		return fmt.Errorf("commit pending before push: %w", err)
+	}
 	return s.withPeerAuth(ctx, defaultRemote, func(user string) error {
 		return s.withMutatingDBConn(ctx, func(db versioncontrolops.DBConn) error {
 			return vcPush(ctx, db, defaultRemote, s.branch, user)
@@ -566,6 +574,10 @@ func (s *EmbeddedDoltStore) PullRemoteWithStrategy(ctx context.Context, remote, 
 }
 
 func (s *EmbeddedDoltStore) ForcePush(ctx context.Context) error {
+	// GH#5433: see Push.
+	if _, err := s.CommitPending(ctx, "beads"); err != nil {
+		return fmt.Errorf("commit pending before push: %w", err)
+	}
 	return s.withPeerAuth(ctx, defaultRemote, func(user string) error {
 		return s.withMutatingDBConn(ctx, func(db versioncontrolops.DBConn) error {
 			return vcForcePush(ctx, db, defaultRemote, s.branch, user)
@@ -574,6 +586,10 @@ func (s *EmbeddedDoltStore) ForcePush(ctx context.Context) error {
 }
 
 func (s *EmbeddedDoltStore) PushRemote(ctx context.Context, remote string, force bool) error {
+	// GH#5433: see Push.
+	if _, err := s.CommitPending(ctx, "beads"); err != nil {
+		return fmt.Errorf("commit pending before push: %w", err)
+	}
 	return s.withPeerAuth(ctx, remote, func(user string) error {
 		return s.withMutatingDBConn(ctx, func(db versioncontrolops.DBConn) error {
 			if force {
@@ -610,6 +626,10 @@ func (s *EmbeddedDoltStore) Fetch(ctx context.Context, peer string) error {
 }
 
 func (s *EmbeddedDoltStore) PushTo(ctx context.Context, peer string) error {
+	// GH#5433: see Push.
+	if _, err := s.CommitPending(ctx, "beads"); err != nil {
+		return fmt.Errorf("commit pending before push: %w", err)
+	}
 	return s.withPeerAuth(ctx, peer, func(user string) error {
 		return s.withMutatingDBConn(ctx, func(db versioncontrolops.DBConn) error {
 			return versioncontrolops.Push(ctx, db, peer, s.branch, user)


### PR DESCRIPTION
Fixes one confirmed half of #5433 -- the push-honesty gap @vishnujayvel traced and @morioka1206 explicitly asked to see as a narrow PR ("Yes, please open the push-honesty PR. That is the surface that actually cost us."). Does not claim to solve the separate, still-unexplained silent-stall mystery both of you independently concluded has no known deterministic trigger.

Quoting @vishnujayvel's own trace, verified against current `main` before writing anything: every Pull variant calls `CommitPending` before pulling; no Push variant does. Push never flushes the working set, then prints "Push complete." on nil error with no remote-ref or working-set check.

**Fix:** `Push`, `ForcePush`, `PushRemote`, `PushTo` (all in `internal/storage/embeddeddolt/version_control.go`) now call `s.CommitPending(ctx, "beads")` first, exactly matching the pattern every Pull variant already uses (GH#2474). Closes the confirmed asymmetry.

**Deliberately not built here, flagging for a maintainer call:**
1. The other half of "push honesty" -- verifying the remote ref actually advanced and reporting accurately instead of unconditionally printing "Push complete." on nil error. Distinguishing a legitimate no-op push (already in sync) from one that had something to send but transferred nothing is a real design call, not mechanical -- didn't want to guess at it in this pass.
2. Server-mode has the identical gap: `internal/storage/dolt`'s `Push`/`ForcePush`/`PushRemote` all route through `pushToRemote`, which also never calls `CommitPending`. Same shape of bug, probably wants the same fix, left untouched since the issue and the trace are both embedded-mode specific.
3. The mystery stall itself remains unexplained -- this closes one real, confirmed contributing gap, not the whole issue.

**Testing:** `TestPushCommitsPendingChangesFirst`, table-driven over all four Push variants -- creates a genuinely pending (uncommitted) issue, verified via `GetCurrentCommit` before/after `CreateIssue` so the test fails loudly if `CreateIssue` ever starts auto-committing and silently makes the test meaningless -- then calls each Push variant and asserts HEAD moved. `Push`/`ForcePush`/`PushRemote` use the existing swappable test seam to stop before real network IO; `PushTo` has no equivalent seam, so it actually attempts the push and fails on "remote not found" in this remote-less test store -- still proves `CommitPending` ran first, since that failure only happens after the new guard clause. All four failed pre-fix, all four pass post-fix. Full remote-verb/peer-auth suite still green -- confirms this doesn't disturb credential resolution or the shared test seam. `go vet` clean, `go build ./...` clean.

---

Generated with [Claude Code](https://claude.com/claude-code)