### PR TITLE
test: restore migration 0052 round-trip coverage (up/down/up, ~2K rows)

### DIFF
--- a/internal/storage/dolt/migration_0052_test.go
+++ b/internal/storage/dolt/migration_0052_test.go
@@ -1,0 +1,352 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestMigration0052_RoundTrip covers the be-eei (D4v2) reversibility
+// acceptance criterion: migration 0052 (renumbered from 0033 across schema
+// history) must round-trip cleanly with the row population intact.
+// Sequence: setup (migration already applied by setupTestStore) → verify the
+// D4v2 index set is present and the dropped legacy index is absent → seed a
+// non-trivial row fixture → run the 0052 down SQL → verify the D4v2 indexes
+// are gone, the legacy idx_issues_status is restored, and row count is
+// unchanged → run the 0052 up SQL again → verify the D4v2 indexes are back,
+// the legacy index is dropped, and a sampled row set still matches.
+//
+// The indexes don't affect row data — they're pure metadata — so the
+// row-count and sample-row invariants are the primary correctness signal. A
+// missed DROP or malformed CREATE in the migration would surface here.
+//
+// Fixture scale: 2K rows per be-eei §8 guardrail 3. The round-trip
+// demonstrates the DDL is correct under a meaningful population without
+// pushing the test beyond a reasonable timeout.
+//
+// Up/down SQL is run via the existing runMigrationSQL(path) helper
+// (pr4107_corruption_test.go), which reads the file from disk and executes
+// its full body as a single ExecContext call. That single-call shape is
+// required, not just convenient: 0052's guarded DDL sets session-scoped
+// @has_old/@sql user variables across PREPARE/EXECUTE/DEALLOCATE triples,
+// and those variables only persist within one connection — a loop of
+// per-statement calls against the *sql.DB pool could split them across
+// different pooled connections and break the guard.
+func TestMigration0052_RoundTrip(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// Seed + DDL round-trip needs more wall-time than the default 30s
+	// testTimeout; use 5x so this stays well inside -timeout 600s without
+	// flaking on slower Dolt server startups.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*testTimeout)
+	defer cancel()
+
+	const (
+		upSQLPath   = "../schema/migrations/0052_add_date_indexes.up.sql"
+		downSQLPath = "../schema/migrations/0052_add_date_indexes.down.sql"
+	)
+
+	// D4v2 (be-eei §4): composite (status, updated_at) replaces the
+	// pre-0052 idx_issues_status, and standalone idx_issues_defer_until is
+	// added. idx_issues_status must not coexist with the composite after
+	// migration up.
+	d4v2Indexes := []string{
+		"idx_issues_status_updated_at",
+		"idx_issues_defer_until",
+	}
+	legacyStatusIndex := []string{"idx_issues_status"}
+
+	// Phase 1: post-initial-migration. Composite + defer_until must exist,
+	// and the legacy idx_issues_status must be gone, because setupTestStore
+	// runs every embedded .up.sql including 0052.
+	assertIndexesPresent(t, ctx, store, d4v2Indexes, "after initial migration")
+	assertIndexesAbsent(t, ctx, store, legacyStatusIndex, "after initial migration")
+
+	// Seed 2K permanent issues — enough to prove the DDL round-trip under a
+	// meaningful population without pushing the test beyond a reasonable
+	// timeout (see the function-level comment for the scaling rationale).
+	const fixtureSize = 2_000
+	seedDateIndexFixture(t, ctx, store, fixtureSize)
+
+	// Capture the count and a stable sample of IDs before the round-trip.
+	wantCount := countIssues(t, ctx, store)
+	if wantCount < fixtureSize {
+		t.Fatalf("seed produced %d rows; want >=%d", wantCount, fixtureSize)
+	}
+	sampleIDs := sampleIssueIDs(t, ctx, store, 50)
+
+	// Phase 2: apply the down SQL. D4v2 indexes must disappear; legacy
+	// idx_issues_status must come back; rows must not change.
+	runMigrationSQL(t, ctx, store, downSQLPath)
+	assertIndexesAbsent(t, ctx, store, d4v2Indexes, "after down migration")
+	assertIndexesPresent(t, ctx, store, legacyStatusIndex, "after down migration")
+	if got := countIssues(t, ctx, store); got != wantCount {
+		t.Fatalf("down migration changed row count: got %d, want %d", got, wantCount)
+	}
+
+	// Phase 3: re-apply the up SQL. D4v2 indexes must return; legacy index
+	// drops again; rows must still be byte-identical against the sample.
+	runMigrationSQL(t, ctx, store, upSQLPath)
+	assertIndexesPresent(t, ctx, store, d4v2Indexes, "after re-running up migration")
+	assertIndexesAbsent(t, ctx, store, legacyStatusIndex, "after re-running up migration")
+	if got := countIssues(t, ctx, store); got != wantCount {
+		t.Fatalf("up re-run changed row count: got %d, want %d", got, wantCount)
+	}
+	verifySampleIssues(t, ctx, store, sampleIDs)
+}
+
+// assertIndexesPresent runs SHOW INDEX FROM issues and asserts each named
+// index appears at least once. SHOW INDEX lists one row per key-part, so a
+// composite index like idx_issues_status_updated_at surfaces twice (once
+// per column); presence — not cardinality — is the invariant.
+func assertIndexesPresent(t *testing.T, ctx context.Context, store *DoltStore, indexes []string, phase string) {
+	t.Helper()
+	got := indexNames(t, ctx, store)
+	var missing []string
+	for _, want := range indexes {
+		if !got[want] {
+			missing = append(missing, want)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("%s: missing indexes %v; got %v", phase, missing, sortedKeys(got))
+	}
+}
+
+func assertIndexesAbsent(t *testing.T, ctx context.Context, store *DoltStore, indexes []string, phase string) {
+	t.Helper()
+	got := indexNames(t, ctx, store)
+	var present []string
+	for _, unwanted := range indexes {
+		if got[unwanted] {
+			present = append(present, unwanted)
+		}
+	}
+	if len(present) > 0 {
+		t.Fatalf("%s: indexes still present after drop: %v", phase, present)
+	}
+}
+
+func indexNames(t *testing.T, ctx context.Context, store *DoltStore) map[string]bool {
+	t.Helper()
+	rows, err := store.db.QueryContext(ctx, "SHOW INDEX FROM issues")
+	if err != nil {
+		t.Fatalf("SHOW INDEX FROM issues: %v", err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatalf("SHOW INDEX columns: %v", err)
+	}
+	keyNameCol := -1
+	for i, c := range cols {
+		if strings.EqualFold(c, "Key_name") {
+			keyNameCol = i
+			break
+		}
+	}
+	if keyNameCol < 0 {
+		t.Fatalf("SHOW INDEX output has no Key_name column; got %v", cols)
+	}
+
+	got := make(map[string]bool)
+	for rows.Next() {
+		scanDest := make([]any, len(cols))
+		holders := make([]sql.NullString, len(cols))
+		for i := range holders {
+			scanDest[i] = &holders[i]
+		}
+		if err := rows.Scan(scanDest...); err != nil {
+			t.Fatalf("SHOW INDEX scan: %v", err)
+		}
+		if holders[keyNameCol].Valid {
+			got[holders[keyNameCol].String] = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("SHOW INDEX iter: %v", err)
+	}
+	return got
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func countIssues(t *testing.T, ctx context.Context, store *DoltStore) int {
+	t.Helper()
+	var n int
+	if err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues").Scan(&n); err != nil {
+		t.Fatalf("count issues: %v", err)
+	}
+	return n
+}
+
+// sampleIssueIDs collects N evenly-spaced IDs for the round-trip integrity
+// check. Uses a deterministic ORDER BY so the sample is stable across runs.
+func sampleIssueIDs(t *testing.T, ctx context.Context, store *DoltStore, n int) []string {
+	t.Helper()
+	rows, err := store.db.QueryContext(ctx,
+		"SELECT id FROM issues ORDER BY id ASC LIMIT ?", n)
+	if err != nil {
+		t.Fatalf("sample ids: %v", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("sample id scan: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("sample id iter: %v", err)
+	}
+	if len(ids) != n {
+		t.Fatalf("sample returned %d ids; want %d", len(ids), n)
+	}
+	return ids
+}
+
+// verifySampleIssues spot-checks that a known set of issue IDs still exist
+// and that their title/status/type round-tripped unchanged after up→down→up.
+// Index operations don't touch row data, but a malformed DDL could in theory
+// trigger Dolt table restructuring; this guards against that worst case.
+func verifySampleIssues(t *testing.T, ctx context.Context, store *DoltStore, ids []string) {
+	t.Helper()
+	for _, id := range ids {
+		iss, err := store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("sample verify GetIssue(%s): %v", id, err)
+		}
+		if iss == nil {
+			t.Fatalf("sample verify: issue %s disappeared after round-trip", id)
+		}
+		if iss.ID != id {
+			t.Fatalf("sample verify: got id %s, want %s", iss.ID, id)
+		}
+		if !strings.HasPrefix(iss.Title, "date-idx ") {
+			t.Fatalf("sample verify %s: title mutated to %q", id, iss.Title)
+		}
+	}
+}
+
+// TestMigration0052_ExplainCapture prints EXPLAIN output for the two read
+// shapes D4v2 targets (bd stale's status+updated_at predicate, and bd ready's
+// deferred-parents defer_until predicate) so the PR description can cite the
+// planner's index usage — be-eei §8 guardrail 4. Not a pass/fail gate — the
+// `go test -v` output is the artifact and the reviewer validates it. Skipped
+// unless explicitly opted in to keep CI quiet.
+func TestMigration0052_ExplainCapture(t *testing.T) {
+	if testing.Short() {
+		t.Skip("explain capture is verbose; run with -v explicitly")
+	}
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*testTimeout)
+	defer cancel()
+
+	seedDateIndexFixture(t, ctx, store, 1_000)
+
+	// Dolt's EXPLAIN doesn't accept bind parameters, and the tabular EXPLAIN
+	// output has NULL bigint columns (rows, filtered) that the MySQL driver
+	// can't round-trip into any Go type cleanly. EXPLAIN FORMAT=TREE returns
+	// a single text column (the plan tree), which is what we want to capture
+	// in the PR anyway — it names the index the planner picks.
+	cases := []struct {
+		label string
+		query string
+	}{
+		{
+			// Target: idx_issues_status_updated_at. Matches the
+			// GetStaleIssuesInTx predicate (issueops/stale.go:26-32):
+			// status IN (...) as the equality prefix, updated_at < cutoff
+			// as the range suffix, ORDER BY updated_at aligning with the
+			// suffix so no sort step.
+			label: "bd stale (status IN + updated_at < cutoff)",
+			query: "EXPLAIN FORMAT=TREE SELECT id FROM issues WHERE status IN ('open','in_progress') AND updated_at < '2020-01-01' AND (ephemeral = 0 OR ephemeral IS NULL) ORDER BY updated_at ASC LIMIT 50",
+		},
+		{
+			// Target: idx_issues_defer_until. Matches the
+			// getChildrenOfDeferredParentsInTx predicate
+			// (ready_work.go:279): defer_until IS NOT NULL skips the
+			// NULL-majority leaf, then range scan on defer_until > now.
+			label: "bd ready deferred-parents (defer_until IS NOT NULL AND defer_until > now)",
+			query: "EXPLAIN FORMAT=TREE SELECT id FROM issues WHERE defer_until IS NOT NULL AND defer_until > UTC_TIMESTAMP()",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			rows, err := store.db.QueryContext(ctx, tc.query)
+			if err != nil {
+				t.Fatalf("EXPLAIN %q: %v", tc.label, err)
+			}
+			defer rows.Close()
+			t.Logf("\n=== EXPLAIN: %s ===", tc.label)
+			for rows.Next() {
+				var plan sql.NullString
+				if err := rows.Scan(&plan); err != nil {
+					t.Fatalf("scan: %v", err)
+				}
+				if plan.Valid {
+					t.Logf("%s", plan.String)
+				}
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatalf("rows: %v", err)
+			}
+		})
+	}
+}
+
+// seedDateIndexFixture populates the store with N permanent issues. Status
+// is cycled across open/in_progress/closed so the composite
+// idx_issues_status_updated_at has non-trivial leading-column cardinality;
+// date columns (started/closed/due/defer_until) stay NULL at seed time —
+// real-world distribution is NULL-majority and the indexes we ship are
+// expected to handle that.
+func seedDateIndexFixture(t *testing.T, ctx context.Context, store *DoltStore, totalN int) {
+	t.Helper()
+
+	const batch = 500
+	statuses := []types.Status{types.StatusOpen, types.StatusInProgress, types.StatusClosed}
+	issueTypes := []types.IssueType{types.TypeTask, types.TypeBug, types.TypeFeature}
+
+	for start := 0; start < totalN; start += batch {
+		end := start + batch
+		if end > totalN {
+			end = totalN
+		}
+		chunk := make([]*types.Issue, 0, end-start)
+		for i := start; i < end; i++ {
+			iss := &types.Issue{
+				ID:        fmt.Sprintf("date-idx-%06d", i),
+				Title:     fmt.Sprintf("date-idx %06d", i),
+				Status:    statuses[i%len(statuses)],
+				Priority:  i % 5,
+				IssueType: issueTypes[i%len(issueTypes)],
+			}
+			chunk = append(chunk, iss)
+		}
+		if err := store.CreateIssuesWithFullOptions(ctx, chunk, "test", storage.BatchCreateOptions{
+			SkipPrefixValidation: true,
+		}); err != nil {
+			t.Fatalf("seed date-idx batch %d: %v", start, err)
+		}
+	}
+}

--- a/internal/storage/dolt/migration_0052_test.go
+++ b/internal/storage/dolt/migration_0052_test.go
@@ -35,11 +35,13 @@ import (
 // Isolation, and why it is load-bearing here rather than incidental: this test
 // DROPs and re-CREATEs shared indexes (idx_issues_status_updated_at among
 // them) partway through. That is only safe because setupTestStore puts each
-// test on its own Dolt branch via testutil.StartTestBranch (dolt_test.go:173).
+// test on its own Dolt branch via testutil.StartTestBranch (dolt_test.go:174).
 // On the shared testSharedDB without that branch, a concurrent test in this
 // package would observe the table mid-round-trip with its indexes missing — a
-// package-wide hazard, not a local one. Do not add t.Parallel() here, and do
-// not "optimize" the per-test branch away.
+// package-wide hazard, not a local one. Do not "optimize" the per-test branch
+// away. (setupTestStore calls t.Parallel() itself at dolt_test.go:140, so this
+// test does run in parallel with the rest of the package — the branch, not
+// serialization, is what makes that safe.)
 //
 // Up/down SQL is run via the existing runMigrationSQL(path) helper
 // (pr4107_corruption_test.go), which reads the file from disk and executes
@@ -215,8 +217,11 @@ func countIssues(t *testing.T, ctx context.Context, store *DoltStore) int {
 // first N rows inserted rather than a spread across the table.
 func sampleIssueIDs(t *testing.T, ctx context.Context, store *DoltStore, n int) []string {
 	t.Helper()
+	// Scope to this fixture's own rows: the caller parses the trailing ordinal
+	// out of each id with strconv.Atoi, which hard-fails on any foreign id that
+	// happens to sort ahead of "date-idx-".
 	rows, err := store.db.QueryContext(ctx,
-		"SELECT id FROM issues ORDER BY id ASC LIMIT ?", n)
+		"SELECT id FROM issues WHERE id LIKE 'date-idx-%' ORDER BY id ASC LIMIT ?", n)
 	if err != nil {
 		t.Fatalf("sample ids: %v", err)
 	}
@@ -325,12 +330,19 @@ func TestMigration0052_ExplainCapture(t *testing.T) {
 	cases := []struct {
 		label string
 		query string
-		// wantIndex is the substring Dolt's EXPLAIN FORMAT=TREE emits for the
-		// index this shape must use, e.g.
-		// "IndexedTableAccess(issues) index: [issues.status,issues.updated_at]".
-		// Matching the column list rather than the index NAME is deliberate:
-		// the plan names columns, not the index identifier, so this is the
-		// strongest claim the output actually supports.
+		// wantIndex is the substring Dolt's EXPLAIN FORMAT=TREE emits on the
+		// IndexedTableAccess node for the index this shape must use.
+		//
+		// The "index: [" prefix is load-bearing, not decoration. The plan's
+		// Filter node echoes the query's own predicate, so a bare column list
+		// like "issues.defer_until" appears in the output of a FULL TABLE SCAN
+		// too — the exact regression this gate exists to catch would pass. Only
+		// the "index: [...]" wrapper appears solely on IndexedTableAccess.
+		//
+		// Matching the column list rather than the index NAME is still
+		// deliberate: the plan names columns, not the index identifier, so
+		// that is the strongest claim the output supports. The wrapper is what
+		// anchors it to the node that proves index use.
 		wantIndex string
 	}{
 		{
@@ -341,7 +353,7 @@ func TestMigration0052_ExplainCapture(t *testing.T) {
 			// suffix so no sort step.
 			label:     "bd stale (status IN + updated_at < cutoff)",
 			query:     "EXPLAIN FORMAT=TREE SELECT id FROM issues WHERE status IN ('open','in_progress') AND updated_at < '2020-01-01' AND (ephemeral = 0 OR ephemeral IS NULL) ORDER BY updated_at ASC LIMIT 50",
-			wantIndex: "issues.status,issues.updated_at",
+			wantIndex: "index: [issues.status,issues.updated_at]",
 		},
 		{
 			// Target: idx_issues_defer_until. Matches the
@@ -350,7 +362,7 @@ func TestMigration0052_ExplainCapture(t *testing.T) {
 			// NULL-majority leaf, then range scan on defer_until > now.
 			label:     "bd ready deferred-parents (defer_until IS NOT NULL AND defer_until > now)",
 			query:     "EXPLAIN FORMAT=TREE SELECT id FROM issues WHERE defer_until IS NOT NULL AND defer_until > UTC_TIMESTAMP()",
-			wantIndex: "issues.defer_until",
+			wantIndex: "index: [issues.defer_until]",
 		},
 	}
 

--- a/internal/storage/dolt/migration_0052_test.go
+++ b/internal/storage/dolt/migration_0052_test.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -29,6 +31,15 @@ import (
 // Fixture scale: 2K rows per be-eei §8 guardrail 3. The round-trip
 // demonstrates the DDL is correct under a meaningful population without
 // pushing the test beyond a reasonable timeout.
+//
+// Isolation, and why it is load-bearing here rather than incidental: this test
+// DROPs and re-CREATEs shared indexes (idx_issues_status_updated_at among
+// them) partway through. That is only safe because setupTestStore puts each
+// test on its own Dolt branch via testutil.StartTestBranch (dolt_test.go:173).
+// On the shared testSharedDB without that branch, a concurrent test in this
+// package would observe the table mid-round-trip with its indexes missing — a
+// package-wide hazard, not a local one. Do not add t.Parallel() here, and do
+// not "optimize" the per-test branch away.
 //
 // Up/down SQL is run via the existing runMigrationSQL(path) helper
 // (pr4107_corruption_test.go), which reads the file from disk and executes
@@ -177,11 +188,15 @@ func indexNames(t *testing.T, ctx context.Context, store *DoltStore) map[string]
 	return got
 }
 
+// sortedKeys returns the map's keys in ascending order. Map iteration is
+// randomized, so without the sort the index names in a failure message
+// reorder between runs and two reports of the same failure do not compare.
 func sortedKeys(m map[string]bool) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {
 		out = append(out, k)
 	}
+	sort.Strings(out)
 	return out
 }
 
@@ -194,8 +209,10 @@ func countIssues(t *testing.T, ctx context.Context, store *DoltStore) int {
 	return n
 }
 
-// sampleIssueIDs collects N evenly-spaced IDs for the round-trip integrity
-// check. Uses a deterministic ORDER BY so the sample is stable across runs.
+// sampleIssueIDs collects the first N issue IDs in id order for the round-trip
+// integrity check. The ORDER BY makes the sample deterministic across runs;
+// the fixture seeds ids as a zero-padded sequence, so "first N by id" is the
+// first N rows inserted rather than a spread across the table.
 func sampleIssueIDs(t *testing.T, ctx context.Context, store *DoltStore, n int) []string {
 	t.Helper()
 	rows, err := store.db.QueryContext(ctx,
@@ -221,10 +238,17 @@ func sampleIssueIDs(t *testing.T, ctx context.Context, store *DoltStore, n int) 
 	return ids
 }
 
-// verifySampleIssues spot-checks that a known set of issue IDs still exist
-// and that their title/status/type round-tripped unchanged after up→down→up.
-// Index operations don't touch row data, but a malformed DDL could in theory
-// trigger Dolt table restructuring; this guards against that worst case.
+// verifySampleIssues spot-checks that a known set of issue IDs still exist and
+// that their title, status and issue type round-tripped unchanged after
+// up→down→up. Index operations don't touch row data, but a malformed DDL could
+// in theory trigger Dolt table restructuring; this guards against that worst
+// case.
+//
+// Expected status and type are recomputed from the ordinal encoded in the id
+// rather than read back from a "before" snapshot, so the check cannot be
+// satisfied by a value the round-trip itself corrupted symmetrically. This
+// mirrors seedDateIndexFixture's own statuses[i%3] / issueTypes[i%3] cycling —
+// keep the two in step if the fixture changes.
 func verifySampleIssues(t *testing.T, ctx context.Context, store *DoltStore, ids []string) {
 	t.Helper()
 	for _, id := range ids {
@@ -240,6 +264,18 @@ func verifySampleIssues(t *testing.T, ctx context.Context, store *DoltStore, ids
 		}
 		if !strings.HasPrefix(iss.Title, "date-idx ") {
 			t.Fatalf("sample verify %s: title mutated to %q", id, iss.Title)
+		}
+		ordinal, err := strconv.Atoi(strings.TrimPrefix(id, "date-idx-"))
+		if err != nil {
+			t.Fatalf("sample verify %s: unexpected id shape (fixture changed?): %v", id, err)
+		}
+		fixtureStatuses := []types.Status{types.StatusOpen, types.StatusInProgress, types.StatusClosed}
+		fixtureTypes := []types.IssueType{types.TypeTask, types.TypeBug, types.TypeFeature}
+		if want := fixtureStatuses[ordinal%len(fixtureStatuses)]; iss.Status != want {
+			t.Fatalf("sample verify %s: status mutated to %q, want %q", id, iss.Status, want)
+		}
+		if want := fixtureTypes[ordinal%len(fixtureTypes)]; iss.IssueType != want {
+			t.Fatalf("sample verify %s: issue type mutated to %q, want %q", id, iss.IssueType, want)
 		}
 	}
 }

--- a/internal/storage/dolt/migration_0052_test.go
+++ b/internal/storage/dolt/migration_0052_test.go
@@ -244,12 +244,24 @@ func verifySampleIssues(t *testing.T, ctx context.Context, store *DoltStore, ids
 	}
 }
 
-// TestMigration0052_ExplainCapture prints EXPLAIN output for the two read
-// shapes D4v2 targets (bd stale's status+updated_at predicate, and bd ready's
-// deferred-parents defer_until predicate) so the PR description can cite the
-// planner's index usage — be-eei §8 guardrail 4. Not a pass/fail gate — the
-// `go test -v` output is the artifact and the reviewer validates it. Skipped
-// unless explicitly opted in to keep CI quiet.
+// TestMigration0052_ExplainCapture asserts that the planner actually picks the
+// D4v2 indexes for the two read shapes they exist for (bd stale's
+// status+updated_at predicate, and bd ready's deferred-parents defer_until
+// predicate), and prints the plans as the be-eei §8 guardrail 4 artifact.
+//
+// It began as a print-only diagnostic. Review of PR #5796 pointed out that the
+// PR body advertised "EXPLAIN-verified query-plan assertions" while the test
+// could not fail — it only t.Logf'd. Since the right index names demonstrably
+// do appear, asserting on them costs nothing and converts a one-shot artifact
+// into a standing planner-regression gate: if a future schema or Dolt upgrade
+// silently stops using idx_issues_status_updated_at, an index whose entire
+// justification is that these two queries use it, this now fails instead of
+// printing a plan nobody reads.
+//
+// Still skipped unless explicitly opted in, to keep CI quiet — which does mean
+// the gate only bites when someone runs it. That is the same bargain the
+// fixture cost already forced; the assertion is strictly better than the
+// t.Logf it replaces.
 //
 // The opt-in is an environment check rather than a short-mode skip: this is
 // a diagnostic-artifact boundary, not the runtime/stress/large-fixture case
@@ -277,6 +289,13 @@ func TestMigration0052_ExplainCapture(t *testing.T) {
 	cases := []struct {
 		label string
 		query string
+		// wantIndex is the substring Dolt's EXPLAIN FORMAT=TREE emits for the
+		// index this shape must use, e.g.
+		// "IndexedTableAccess(issues) index: [issues.status,issues.updated_at]".
+		// Matching the column list rather than the index NAME is deliberate:
+		// the plan names columns, not the index identifier, so this is the
+		// strongest claim the output actually supports.
+		wantIndex string
 	}{
 		{
 			// Target: idx_issues_status_updated_at. Matches the
@@ -284,16 +303,18 @@ func TestMigration0052_ExplainCapture(t *testing.T) {
 			// status IN (...) as the equality prefix, updated_at < cutoff
 			// as the range suffix, ORDER BY updated_at aligning with the
 			// suffix so no sort step.
-			label: "bd stale (status IN + updated_at < cutoff)",
-			query: "EXPLAIN FORMAT=TREE SELECT id FROM issues WHERE status IN ('open','in_progress') AND updated_at < '2020-01-01' AND (ephemeral = 0 OR ephemeral IS NULL) ORDER BY updated_at ASC LIMIT 50",
+			label:     "bd stale (status IN + updated_at < cutoff)",
+			query:     "EXPLAIN FORMAT=TREE SELECT id FROM issues WHERE status IN ('open','in_progress') AND updated_at < '2020-01-01' AND (ephemeral = 0 OR ephemeral IS NULL) ORDER BY updated_at ASC LIMIT 50",
+			wantIndex: "issues.status,issues.updated_at",
 		},
 		{
 			// Target: idx_issues_defer_until. Matches the
 			// getChildrenOfDeferredParentsInTx predicate
 			// (ready_work.go:279): defer_until IS NOT NULL skips the
 			// NULL-majority leaf, then range scan on defer_until > now.
-			label: "bd ready deferred-parents (defer_until IS NOT NULL AND defer_until > now)",
-			query: "EXPLAIN FORMAT=TREE SELECT id FROM issues WHERE defer_until IS NOT NULL AND defer_until > UTC_TIMESTAMP()",
+			label:     "bd ready deferred-parents (defer_until IS NOT NULL AND defer_until > now)",
+			query:     "EXPLAIN FORMAT=TREE SELECT id FROM issues WHERE defer_until IS NOT NULL AND defer_until > UTC_TIMESTAMP()",
+			wantIndex: "issues.defer_until",
 		},
 	}
 
@@ -304,18 +325,29 @@ func TestMigration0052_ExplainCapture(t *testing.T) {
 				t.Fatalf("EXPLAIN %q: %v", tc.label, err)
 			}
 			defer rows.Close()
-			t.Logf("\n=== EXPLAIN: %s ===", tc.label)
+			var planText strings.Builder
 			for rows.Next() {
 				var plan sql.NullString
 				if err := rows.Scan(&plan); err != nil {
 					t.Fatalf("scan: %v", err)
 				}
 				if plan.Valid {
-					t.Logf("%s", plan.String)
+					planText.WriteString(plan.String)
+					planText.WriteByte('\n')
 				}
 			}
 			if err := rows.Err(); err != nil {
 				t.Fatalf("rows: %v", err)
+			}
+
+			// The plan is the be-eei guardrail 4 artifact; log it either way so
+			// a failure reports what the planner actually chose instead of just
+			// that it was not what we wanted.
+			t.Logf("\n=== EXPLAIN: %s ===\n%s", tc.label, planText.String())
+
+			if !strings.Contains(planText.String(), tc.wantIndex) {
+				t.Errorf("planner did not use the D4v2 index for %s.\nwant plan to contain: %s\ngot plan:\n%s",
+					tc.label, tc.wantIndex, planText.String())
 			}
 		})
 	}

--- a/internal/storage/dolt/migration_0052_test.go
+++ b/internal/storage/dolt/migration_0052_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -249,9 +250,15 @@ func verifySampleIssues(t *testing.T, ctx context.Context, store *DoltStore, ids
 // planner's index usage — be-eei §8 guardrail 4. Not a pass/fail gate — the
 // `go test -v` output is the artifact and the reviewer validates it. Skipped
 // unless explicitly opted in to keep CI quiet.
+//
+// The opt-in is an environment check rather than a short-mode skip: this is
+// a diagnostic-artifact boundary, not the runtime/stress/large-fixture case
+// that scripts/check-testing-short.sh reserves short-mode skips for. Matches
+// the BEADS_RUN_DOLT_UPSTREAM_REPRO gate on the sibling repro test in this
+// package.
 func TestMigration0052_ExplainCapture(t *testing.T) {
-	if testing.Short() {
-		t.Skip("explain capture is verbose; run with -v explicitly")
+	if os.Getenv("BEADS_RUN_EXPLAIN_CAPTURE") == "" {
+		t.Skip("set BEADS_RUN_EXPLAIN_CAPTURE=1 to capture migration 0052 EXPLAIN plans (run with -v)")
 	}
 
 	store, cleanup := setupTestStore(t)

--- a/release-gates/be-s424-migration-0052-roundtrip-gate.md
+++ b/release-gates/be-s424-migration-0052-roundtrip-gate.md
@@ -1,0 +1,109 @@
+# Release gate — Restore migration 0052 (formerly 0033) round-trip test (be-s424)
+
+- **Builder bead (CLOSED):** be-auu.5 — restore migration_0033_test.go
+  (renumbered 0052) round-trip test (up/down/up, ~2K rows), recovering test
+  coverage lost to a silent rebase-corruption casualty on the be-auu epic.
+- **Deploy bead:** be-s424
+- **Review bead:** be-d9xm — verdict **PASS**, recorded on commit
+  `961aa8cddb4034fb7742f7ec74e4b6297a84f5c8`
+- **Commits:** `bd8e1e6352457186420fc0cb931f6e00815e0f3a` (RED, test-only) then
+  `961aa8cddb4034fb7742f7ec74e4b6297a84f5c8` (GREEN, empty verification
+  commit — no production code change), 1 file cumulative over `origin/main`
+- **Branch:** `builder/be-auu.5` (pushed to `fork`, i.e. `quad341/beads`);
+  deploy branch `deploy/be-s424-gate` cut from the reviewed SHA
+- **Evaluated:** 2026-08-15 by beads/deployer
+
+## Scope
+
+Restores test coverage for migration 0052 (renumbered from 0033 across
+several rebases: 0033→0043→0048→0052), a composite-index migration
+(`idx_issues_status_updated_at` + `idx_issues_defer_until`) that already
+shipped correctly in production via PR #3662 (commit `0268ba894`). The
+original up/down/up round-trip test over ~2K rows was a silent casualty of
+an earlier clean-auto-merge rebase (documented in the be-auu epic's
+extraction findings), discovered and flagged as follow-up by the be-1ubq
+reviewer during an unrelated schema-perf extraction. This bead recovers that
+coverage: adds `internal/storage/dolt/migration_0052_test.go` (352 lines)
+with `TestMigration0052_RoundTrip` (up→down→up over 2K rows) and
+`TestMigration0052_ExplainCapture` (EXPLAIN-verified query-plan assertions
+for two representative queries, confirming the D4v2 indexes are load-bearing,
+not just present). No production code changes — the underlying migration is
+already correct and live; this is pure test-restoration.
+
+Diff scope, confirmed via `git diff --name-only origin/main...HEAD` (1 file):
+
+- `internal/storage/dolt/migration_0052_test.go` — new test file, +352/-0
+
+## Gate criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | **PASS** | be-d9xm records `verdict: pass` on commit `961aa8cddb4034fb7742f7ec74e4b6297a84f5c8` (matches deploy_commit exactly), with full security/style/spec write-ups. |
+| 2 | Acceptance criteria met | **PASS** | be-auu.5's AC names the pre-renumbering filename `migration_0033_test.go`; the review bead documents the 0033→0052 renumbering and confirms `TestMigration0052_RoundTrip` fully covers the stated round-trip/2K-row requirement under the canonical hermetic test entrypoint. No uncovered criteria. |
+| 3 | Tests pass | **PASS** | Independently re-run with real podman/Dolt containers (not trusted from the reviewer's report) — see "Tests run" below. 4/4 PASS, 0 FAIL, 0 SKIP, matching the reviewer's own reported counts exactly. |
+| 4 | No unresolved HIGH findings | **PASS** | Zero HIGH (and zero MEDIUM) findings. `security_findings: none` (diff is one additive test file, all SQL parameterized or fixed-literal, no production code touched). `style_findings: none` (gofmt/golangci-lint/go vet all clean per review; independently re-confirmed below). |
+| 5 | Clean working tree | **PASS** | `git status` on the evaluated commit shows no staged/unstaged changes to tracked files (only pre-existing, unrelated untracked scratch files in the worktree, never staged). |
+| 6 | Clean divergence from `origin/main` | **PASS** | `git merge-base --is-ancestor origin/main 961aa8cdd` succeeds; HEAD is exactly 2 commits (RED + GREEN) ahead of a freshly-fetched `origin/main`, 0 behind. No rebase needed. |
+| 7 | Single feature theme | **PASS** | Exactly one file touched (`migration_0052_test.go`), no unrelated changes riding along. |
+
+## Tests run on release branch (independent re-verification)
+
+Static checks, independently re-run:
+
+| Check | Result |
+|---|---|
+| `go build ./...` | clean, rc=0 |
+| `go vet ./...` | clean, rc=0 |
+| `gofmt -l` on the diff file | clean, 0 files listed |
+
+Diff-owned tests (`internal/storage/dolt/migration_0052_test.go`), run with
+real podman/Dolt containers — `DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
+TESTCONTAINERS_RYUK_DISABLED=true BEADS_TEST_ENV_RUN_DOLT=1 GOFLAGS=-count=1
+./scripts/test.sh -v -run 'TestMigration0052' ./internal/storage/dolt/...`,
+matching the reviewer's own documented methodology:
+
+| Test | Result | Duration |
+|---|---|---|
+| `TestMigration0052_RoundTrip` | PASS | 33.04s |
+| `TestMigration0052_ExplainCapture` | PASS | 18.69s |
+| `.../bd_stale_(status_IN_+_updated_at_<_cutoff)` | PASS | — |
+| `.../bd_ready_deferred-parents_(defer_until...)` | PASS | — |
+
+4/4 PASS on the first attempt, matching the reviewer's reported 4 PASS / 0
+FAIL / 0 SKIP exactly — no discrepancy requiring flake-triage re-runs
+(contrast with be-uoat, where a first-pass mismatch against the reviewer's
+report triggered a 3x-rerun investigation; no such mismatch occurred here).
+
+## Findings from reviews (no action required)
+
+From be-d9xm: no HIGH or MEDIUM findings. No carried-forward informational
+items. One documentation note: `ExplainCapture`'s test comments cite an
+unresolvable spec id ("be-eei", not found in `bd search` or repo docs) —
+informational only, not a gating claim, self-contained documentation.
+
+## Process notes
+
+- `assert_deploy_ancestry_scope` (referenced by the deployer protocol as a
+  required pre-branch-cut check) was not found defined anywhere in
+  `scripts/rebase-resolve-lib.sh` or elsewhere in the repo — confirmed via a
+  repo-wide grep. Its documented checks (no `.claude/**` paths in the commit
+  range; commits cite accepted bead IDs) were performed manually instead:
+  both commits in range cite `be-auu.5` (closed, accepted builder bead), and
+  the cumulative diff touches zero `.claude/**` paths. Recommend filing a
+  follow-up bead to add this function to the shared lib so future deploys
+  don't need to reconstruct the check by hand.
+- `PUSH_REMOTE` resolved to `fork` (`quad341/beads`), confirmed via a live
+  dry-run push (not assumed from precedent) — the same remote the builder
+  branch itself used. The `headfork`/`quad341/beads-sec003-contrib`
+  rename-redirect concern noted in the be-uoat gate record does not block a
+  normal `git push` to `fork`; that concern may be specific to PR
+  base-repo resolution rather than git push/fetch.
+
+## Verdict
+
+**PASS** — all 7 criteria pass. Deploy branch `deploy/be-s424-gate` cut from
+`961aa8cddb4034fb7742f7ec74e4b6297a84f5c8`, pushed to `fork`
+(`quad341/beads`), PR opened against `gastownhall/beads:main`. Per the
+repo-authority carve-out (gastownhall/beads is a repo we contribute to, not
+maintain), the deployer's responsibility ends at the open PR — merge belongs
+to upstream maintainers.

--- a/release-gates/be-s424-migration-0052-roundtrip-gate.md
+++ b/release-gates/be-s424-migration-0052-roundtrip-gate.md
@@ -23,14 +23,18 @@ original up/down/up round-trip test over ~2K rows was a silent casualty of
 an earlier clean-auto-merge rebase (documented in the be-auu epic's
 extraction findings), discovered and flagged as follow-up by the be-1ubq
 reviewer during an unrelated schema-perf extraction. This bead recovers that
-coverage: adds `internal/storage/dolt/migration_0052_test.go` (352 lines)
+coverage: adds `internal/storage/dolt/migration_0052_test.go` (352 lines as
+gated; 439 at the current PR head — see the addendum)
 with `TestMigration0052_RoundTrip` (up→down→up over 2K rows) and
 `TestMigration0052_ExplainCapture` (EXPLAIN-verified query-plan assertions
 for two representative queries, confirming the D4v2 indexes are load-bearing,
 not just present). No production code changes — the underlying migration is
 already correct and live; this is pure test-restoration.
 
-Diff scope, confirmed via `git diff --name-only origin/main...HEAD` (1 file):
+Diff scope **as gated**, at source commit `961aa8cdd` — not the current PR
+head, which also carries this gate record and the review-response commits
+(addendum below has the current numbers). Confirmed via
+`git diff --name-only origin/main...961aa8cdd` (1 file):
 
 - `internal/storage/dolt/migration_0052_test.go` — new test file, +352/-0
 
@@ -70,7 +74,9 @@ matching the reviewer's own documented methodology:
 | `.../bd_ready_deferred-parents_(defer_until...)` | PASS | — |
 
 4/4 PASS on the first attempt, matching the reviewer's reported 4 PASS / 0
-FAIL / 0 SKIP exactly — no discrepancy requiring flake-triage re-runs
+FAIL / 0 SKIP exactly. (That 4/4 is the `BEADS_RUN_EXPLAIN_CAPTURE=1` count at
+the gated commit. On the **default** path `ExplainCapture` now skips, so the
+default count is 3 PASS / 1 SKIP — see the addendum.) — no discrepancy requiring flake-triage re-runs
 (contrast with be-uoat, where a first-pass mismatch against the reviewer's
 report triggered a 3x-rerun investigation; no such mismatch occurred here).
 
@@ -107,3 +113,60 @@ informational only, not a gating claim, self-contained documentation.
 repo-authority carve-out (gastownhall/beads is a repo we contribute to, not
 maintain), the deployer's responsibility ends at the open PR — merge belongs
 to upstream maintainers.
+
+---
+
+## Addendum — review response round 2 (2026-09-06, PR #5796)
+
+`bee` filed a second CHANGES_REQUESTED at `6e4c68019` on 2026-09-03. All items addressed.
+
+**Blocker — the second EXPLAIN assertion was vacuous.** Confirmed, and reproduced independently rather than taken on report. `wantIndex: "issues.defer_until"` matched the plan's **Filter** node, which echoes the query's own predicate, so it passed on a full table scan — precisely the regression the gate exists to catch.
+
+Mutation-tested against a real `dolthub/dolt-sql-server:2.2.0` container by dropping `idx_issues_defer_until` after the fixture seed:
+
+| Index | Assertion | Result |
+|---|---|---|
+| dropped | `issues.defer_until` (old, bare) | **PASS** — vacuous |
+| dropped | `index: [issues.defer_until]` (new) | **FAIL** — gate bites |
+| present | `index: [issues.defer_until]` (new) | PASS |
+
+The degraded plan under the drop:
+
+```
+Project
+ ├─ columns: [issues.id]
+ └─ Filter
+     ├─ ((NOT(issues.defer_until IS NULL)) AND (issues.defer_until > ...))
+     └─ Table
+         ├─ name: issues
+```
+
+`└─ Table` instead of `IndexedTableAccess`, and the Filter line still contains the bare `issues.defer_until` — which is exactly why the old form could not fail. Both assertions now carry the `index: [...]` wrapper, which appears only on an `IndexedTableAccess` node. The comment above the field records why the wrapper is load-bearing, so it is not "simplified" back out later.
+
+**Nits, all fixed:**
+
+- The header said "Do not add `t.Parallel()` here" while `setupTestStore` calls it itself (`dolt_test.go:140`) — every run prints `=== PAUSE`. The note now says what is actually load-bearing: the per-test Dolt branch, not serialization.
+- Citation corrected `dolt_test.go:173` → `:174` (the `testutil.StartTestBranch` line).
+- `sampleIssueIDs` now scopes its query with `WHERE id LIKE 'date-idx-%'`, so the caller's `strconv.Atoi` cannot hard-fail on a foreign id that sorts ahead of the fixture.
+- This gate record's own accounting, above.
+
+**Current accounting** at the PR head, against `origin/main` @ `c0d8da42d`:
+
+| File | Lines |
+|---|---|
+| `internal/storage/dolt/migration_0052_test.go` | 439 (427 at the reviewed head, +12 here) |
+| `release-gates/be-s424-migration-0052-roundtrip-gate.md` | gate record + this addendum |
+
+**Verification** (real container, `TESTCONTAINERS_RYUK_DISABLED=true`, ambient `BEADS_DOLT_SERVER_PORT` unset so the suite cannot silently target the shared city server):
+
+```
+BEADS_RUN_EXPLAIN_CAPTURE=1  go test ./internal/storage/dolt/ -run TestMigration0052 -count=1 -v
+  --- PASS: TestMigration0052_ExplainCapture (7.82s)   both subtests PASS
+  --- PASS: TestMigration0052_RoundTrip     (16.23s)
+
+default path (no env var)
+  --- SKIP: TestMigration0052_ExplainCapture
+  --- PASS: TestMigration0052_RoundTrip     (15.41s)
+```
+
+`gofmt -l internal/storage/dolt/`: clean. The gate verdict is unchanged — still test-only, still no production code, and the EXPLAIN assertions now actually hold the line they claimed to.


### PR DESCRIPTION
## What

Adds `TestMigration0052_RoundTrip` and `TestMigration0052_ExplainCapture` to
`internal/storage/dolt/migration_0052_test.go`, covering the composite
`idx_issues_status_updated_at` + `idx_issues_defer_until` migration
(originally numbered 0033) with:

- A full up→down→up round trip over ~2K rows, confirming the migration
  applies and reverts cleanly with no data loss.
- `EXPLAIN`-verified query-plan assertions for two representative query
  shapes (stale-issue lookup, deferred-parent lookup), confirming the new
  indexes are actually used by the planner — not just present in the schema.

## Why

This migration already shipped correctly in production (#3662), but its
dedicated round-trip test was lost during an earlier rebase and never
landed. This PR restores that coverage with no production code changes.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` all clean.
- New tests run against a real Dolt server (testcontainers): 4/4 pass.