### PR TITLE
feat(creds): resolve dolt server password through an external command

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -428,11 +428,21 @@ func existingBootstrapDBPlan(beadsDir string, cfg *configfile.Config, isServer, 
 	}
 
 	if isServer {
+		// Fail closed: a configured-but-failing BEADS_DOLT_PASSWORD_COMMAND
+		// must not silently downgrade the probe to the credentials file.
+		// Report it through the plan (same shape as a failed DB check below)
+		// so bootstrap refuses to act on unverifiable credentials.
+		probePass, err := cfg.GetDoltServerPassword()
+		if err != nil {
+			plan.Action = "none"
+			plan.Reason = fmt.Sprintf("Could not resolve dolt server password: %v", err)
+			return plan, true
+		}
 		probeCfg := bootstrapServerProbeConfig{
 			host:     cfg.GetDoltServerHost(),
 			port:     bootstrapServerPort(beadsDir, cfg, isSharedServer),
 			user:     cfg.GetDoltServerUser(),
-			pass:     cfg.GetDoltServerPassword(),
+			pass:     probePass,
 			database: cfg.GetDoltDatabase(),
 			tls:      cfg.GetDoltServerTLS(),
 		}
@@ -946,12 +956,18 @@ func cloneViaEmbedded(ctx context.Context, beadsDir, remoteURL, dbName string) e
 // servers where bd does not know the filesystem layout.
 func cloneViaServer(ctx context.Context, beadsDir, remoteURL, dbName string, cfg *configfile.Config) error {
 	port := serverClonePort(beadsDir, cfg)
+	// Fail closed: a configured-but-failing password helper aborts the clone
+	// rather than silently downgrading to the credentials file.
+	password, err := cfg.GetDoltServerPasswordForPort(port)
+	if err != nil {
+		return fmt.Errorf("resolve dolt server password for clone: %w", err)
+	}
 	dsn := doltutil.ServerDSN{
 		Socket:   cfg.GetDoltServerSocket(),
 		Host:     cfg.GetDoltServerHost(),
 		Port:     port,
 		User:     cfg.GetDoltServerUser(),
-		Password: cfg.GetDoltServerPasswordForPort(port),
+		Password: password,
 		TLS:      cfg.GetDoltServerTLS(),
 		// No Database — DOLT_CLONE creates the database.
 	}.String()

--- a/cmd/bd/doctor/dolt.go
+++ b/cmd/bd/doctor/dolt.go
@@ -40,12 +40,16 @@ func openDoltDB(beadsDir string) (*sql.DB, *configfile.Config, error) {
 	}
 
 	// Resolve the password using the credentials file fallback keyed by the
-	// resolved runtime port — matching the CRUD path. Env var BEADS_DOLT_PASSWORD
-	// still takes precedence inside GetDoltServerPasswordForPort. Without this,
-	// externally-hosted Dolt servers that keep credentials in
-	// ~/.config/beads/credentials fail doctor checks with "Access denied" while
-	// regular CRUD commands succeed (bd-h5k7).
-	password := cfg.GetDoltServerPasswordForPort(port)
+	// resolved runtime port — matching the CRUD path. BEADS_DOLT_PASSWORD, then
+	// the BEADS_DOLT_PASSWORD_COMMAND helper, then the credentials file — and a
+	// failing configured helper fails closed. Without this, externally-hosted
+	// Dolt servers that keep credentials in ~/.config/beads/credentials fail
+	// doctor checks with "Access denied" while regular CRUD commands succeed
+	// (bd-h5k7).
+	password, err := cfg.GetDoltServerPasswordForPort(port)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving dolt server password: %w", err)
+	}
 
 	connStr := doltutil.ServerDSN{
 		Host:     host,

--- a/cmd/bd/doctor/federation.go
+++ b/cmd/bd/doctor/federation.go
@@ -39,7 +39,16 @@ func doltServerConfig(beadsDir, doltPath string) *dolt.Config {
 		cfg.ServerPort = doltserver.DefaultConfig(beadsDir).Port
 		cfg.ServerUser = bcfg.GetDoltServerUser()
 		cfg.ServerTLS = bcfg.GetDoltServerTLS()
-		cfg.ServerPassword = bcfg.GetDoltServerPasswordForPort(cfg.ServerPort)
+		// doltServerConfig has ~a dozen DoctorCheck callers and no error
+		// channel, so a failing password helper is reported on stderr and the
+		// password stays empty — the check then fails its own connection
+		// (access denied) instead of silently downgrading to the credentials
+		// file. Fail-closed holds; the reason is one stderr line away.
+		if password, err := bcfg.GetDoltServerPasswordForPort(cfg.ServerPort); err != nil {
+			fmt.Fprintf(os.Stderr, "bd doctor: %v\n", err)
+		} else {
+			cfg.ServerPassword = password
+		}
 	}
 	dolt.ApplyCLIAutoStart(beadsDir, cfg)
 	return cfg

--- a/cmd/bd/doctor/fix/metadata.go
+++ b/cmd/bd/doctor/fix/metadata.go
@@ -523,11 +523,17 @@ func isExpectedProbeError(err error) bool {
 
 func openServerCatalogDB(beadsDir string, cfg *configfile.Config) (*sql.DB, error) {
 	port := doltserver.DefaultConfig(beadsDir).Port
+	// Fail closed: a configured-but-failing password helper aborts rather than
+	// silently downgrading to the credentials file.
+	password, err := cfg.GetDoltServerPasswordForPort(port)
+	if err != nil {
+		return nil, fmt.Errorf("resolving dolt server password: %w", err)
+	}
 	connStr := doltutil.ServerDSN{
 		Host:     cfg.GetDoltServerHost(),
 		Port:     port,
 		User:     cfg.GetDoltServerUser(),
-		Password: cfg.GetDoltServerPasswordForPort(port),
+		Password: password,
 		TLS:      cfg.GetDoltServerTLS(),
 	}.String()
 	return sql.Open("mysql", connStr)

--- a/cmd/bd/doctor/fix/remotes.go
+++ b/cmd/bd/doctor/fix/remotes.go
@@ -17,7 +17,12 @@ func openFixDB(beadsDir string, cfg *configfile.Config) (*sql.DB, error) {
 	host := cfg.GetDoltServerHost()
 	user := cfg.GetDoltServerUser()
 	database := cfg.GetDoltDatabase()
-	password := cfg.GetDoltServerPassword()
+	// Fail closed: a configured-but-failing password helper aborts rather than
+	// silently downgrading to the credentials file.
+	password, err := cfg.GetDoltServerPassword()
+	if err != nil {
+		return nil, fmt.Errorf("resolving dolt server password: %w", err)
+	}
 	port := doltserver.DefaultConfig(beadsDir).Port
 
 	connStr := doltutil.ServerDSN{

--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -489,7 +489,18 @@ func CheckFreshClone(repoPath string) DoctorCheck {
 			// the actual server runs on a different port (e.g. 3306 for
 			// externally-hosted Dolt). That mismatch produced spurious
 			// "Fresh clone detected" warnings (bd-tzo9).
-			password := cfg.GetDoltServerPasswordForPort(port)
+			// Fail closed: a failing password helper surfaces as the check's
+			// error rather than silently downgrading to the credentials file.
+			password, err := cfg.GetDoltServerPasswordForPort(port)
+			if err != nil {
+				return DoctorCheck{
+					Name:    "Fresh Clone",
+					Status:  StatusError,
+					Message: "Could not resolve dolt server password",
+					Detail:  err.Error(),
+					Fix:     "Fix or unset BEADS_DOLT_PASSWORD_COMMAND, then re-run bd doctor",
+				}
+			}
 			dbName := cfg.GetDoltDatabase()
 			result := checkFreshCloneDB(host, port, user, password, dbName, cfg.GetDoltServerTLS())
 			if result.Reachable {

--- a/cmd/bd/doctor/perf_dolt.go
+++ b/cmd/bd/doctor/perf_dolt.go
@@ -107,16 +107,20 @@ func runDoltServerDiagnostics(metrics *DoltPerfMetrics, host string, port int, d
 	metrics.ServerMode = true
 
 	// Resolve credentials from config and environment, matching openDoltDB behavior.
-	// GetDoltServerPasswordForPort checks BEADS_DOLT_PASSWORD env first, then
-	// falls back to ~/.config/beads/credentials keyed by [host:port] — required
-	// for externally-hosted Dolt servers (bd-h5k7).
+	// BEADS_DOLT_PASSWORD, then the BEADS_DOLT_PASSWORD_COMMAND helper, then
+	// ~/.config/beads/credentials keyed by [host:port] — required for
+	// externally-hosted Dolt servers (bd-h5k7). A failing configured helper
+	// fails closed instead of silently downgrading to the file.
 	user := configfile.DefaultDoltServerUser
 	var password string
 	var tls bool
 	if cfg, err := configfile.Load(beadsDir); err == nil && cfg != nil {
 		user = cfg.GetDoltServerUser()
 		tls = cfg.GetDoltServerTLS()
-		password = cfg.GetDoltServerPasswordForPort(port)
+		password, err = cfg.GetDoltServerPasswordForPort(port)
+		if err != nil {
+			return fmt.Errorf("resolving dolt server password: %w", err)
+		}
 	}
 
 	dsn := doltutil.ServerDSN{

--- a/cmd/bd/doctor/server.go
+++ b/cmd/bd/doctor/server.go
@@ -289,12 +289,23 @@ func checkDoltVersion(cfg *configfile.Config, beadsDir string) (DoctorCheck, *sq
 	port := doltserver.DefaultConfig(beadsDir).Port
 	user := cfg.GetDoltServerUser()
 
-	// Resolve password the same way the CRUD path does: BEADS_DOLT_PASSWORD env
-	// takes precedence (checked inside GetDoltServerPasswordForPort), with a
-	// fallback to ~/.config/beads/credentials keyed by [host:port]. Using the
-	// resolved runtime port is required because the port file may differ from
-	// the metadata port (bd-h5k7).
-	password := cfg.GetDoltServerPasswordForPort(port)
+	// Resolve password the same way the CRUD path does: BEADS_DOLT_PASSWORD,
+	// then the BEADS_DOLT_PASSWORD_COMMAND helper, then the credentials file
+	// keyed by [host:port]. Using the resolved runtime port is required because
+	// the port file may differ from the metadata port (bd-h5k7). A failing
+	// configured helper fails closed — the check reports it instead of silently
+	// downgrading to the file.
+	password, err := cfg.GetDoltServerPasswordForPort(port)
+	if err != nil {
+		return DoctorCheck{
+			Name:     "Dolt Version",
+			Status:   StatusError,
+			Message:  "Could not resolve dolt server password",
+			Detail:   err.Error(),
+			Fix:      "Fix or unset BEADS_DOLT_PASSWORD_COMMAND, then re-run bd doctor",
+			Category: CategoryFederation,
+		}, nil
+	}
 
 	// Build DSN without database (just to test server connectivity)
 	connStr := doltutil.ServerDSN{

--- a/cmd/bd/doctor_health.go
+++ b/cmd/bd/doctor_health.go
@@ -43,13 +43,20 @@ func runCheckHealth(path string) error {
 	}
 	database := cfg.GetDoltDatabase()
 
+	// Fail closed: a configured-but-failing password helper aborts the health
+	// check rather than silently downgrading to the credentials file.
+	password, err := cfg.GetDoltServerPasswordForPort(port)
+	if err != nil {
+		return fmt.Errorf("resolving dolt server password: %w", err)
+	}
+
 	var issues []string
 
 	dsn := doltutil.ServerDSN{
 		Host:     host,
 		Port:     port,
 		User:     cfg.GetDoltServerUser(),
-		Password: cfg.GetDoltServerPasswordForPort(port),
+		Password: password,
 		Database: database,
 		Timeout:  2 * time.Second,
 		TLS:      cfg.GetDoltServerTLS(),

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -1227,7 +1227,13 @@ func runExternalDoltStatus(beadsDir string, cfg *configfile.Config) {
 	user := cfg.GetDoltServerUser()
 	database := cfg.GetDoltDatabase()
 	tls := cfg.GetDoltServerTLS()
-	password := cfg.GetDoltServerPasswordForPort(port)
+	// Fail closed: a configured-but-failing password helper aborts the status
+	// report rather than silently downgrading to the credentials file.
+	password, err := cfg.GetDoltServerPasswordForPort(port)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error resolving dolt server password: %v\n", err)
+		return
+	}
 
 	dsn := doltutil.ServerDSN{
 		Host:     host,

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -2546,7 +2546,12 @@ Aborting.`, ui.RenderWarn("⚠"), location, ui.RenderAccent("bd list"), prefix)
 				host := cfg.GetDoltServerHost()
 				port := doltserver.DefaultConfig(beadsDir).Port
 				dbName := cfg.GetDoltDatabase()
-				password := cfg.GetDoltServerPassword()
+				// Fail closed: a configured-but-failing password helper aborts
+				// rather than silently downgrading to the credentials file.
+				password, err := cfg.GetDoltServerPassword()
+				if err != nil {
+					return fmt.Errorf("resolving dolt server password: %w", err)
+				}
 				user := cfg.GetDoltServerUser()
 
 				result := checkDatabaseOnServer(host, port, user, password, dbName, cfg.GetDoltServerTLS())

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -273,7 +273,13 @@ func resolveDoltServerConnection(ctx context.Context, beadsDir string, fileCfg *
 	}
 	// Use the resolved port for credential lookup — metadata.json port
 	// and runtime port can diverge (e.g., tunnel on 3308 vs local on 3307).
-	doltCfg.ServerPassword = fileCfg.GetDoltServerPasswordForPort(doltCfg.ServerPort)
+	// Fails closed: a configured-but-failing BEADS_DOLT_PASSWORD_COMMAND aborts
+	// here rather than silently downgrading to the credentials file.
+	password, err := fileCfg.GetDoltServerPasswordForPort(doltCfg.ServerPort)
+	if err != nil {
+		return fmt.Errorf("resolving dolt server password: %w", err)
+	}
+	doltCfg.ServerPassword = password
 	doltCfg.ServerTLS = fileCfg.GetDoltServerTLS()
 	return nil
 }

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -1,6 +1,7 @@
 package configfile
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/creds"
 	"github.com/steveyegge/beads/internal/storage/backendnames"
 )
 
@@ -555,6 +557,20 @@ func (c *Config) GetDoltCredentialCommand() string {
 	return os.Getenv("BEADS_DOLT_CREDENTIAL_COMMAND")
 }
 
+// GetDoltPasswordCommand returns the Dolt server password command:
+// BEADS_DOLT_PASSWORD_COMMAND. Empty means no command — the static
+// BEADS_DOLT_PASSWORD / credentials-file path applies. The command's stdout is a
+// short-lived secret (bare, or a {token,expirationTimestamp} / {access_token,expires_in}
+// envelope) placed in the password slot of a direct server connection, so an external
+// helper (vault, a token-minting CLI) can supply the Dolt password without it ever
+// being persisted. It is deliberately read from the environment only, NOT
+// metadata.json: a metadata-sourced command is arbitrary code run on open, so
+// persisting it waits on a workspace-trust gate — the same trust gate as
+// BEADS_DOLT_CREDENTIAL_COMMAND above.
+func (c *Config) GetDoltPasswordCommand() string {
+	return os.Getenv("BEADS_DOLT_PASSWORD_COMMAND")
+}
+
 // GetDoltDatabase returns the Dolt SQL database name.
 // Checks BEADS_DOLT_SERVER_DATABASE env var first, then config, then default.
 func (c *Config) GetDoltDatabase() string {
@@ -580,14 +596,15 @@ func (c *Config) GetGlobalProjectID() string {
 // GetDoltServerPassword returns the Dolt server password.
 // Checks in order:
 //  1. BEADS_DOLT_PASSWORD env var (highest priority, existing behavior)
-//  2. Credentials file lookup by [host:port] section
+//  2. BEADS_DOLT_PASSWORD_COMMAND helper (see GetDoltServerPasswordForPort)
+//  3. Credentials file lookup by [host:port] section
 //     (path from BEADS_CREDENTIALS_FILE env var, or ~/.config/beads/credentials)
-//  3. Empty string (no password)
+//  4. Empty string (no password)
 //
 // Note: uses the port from configfile (metadata.json / env var), which may differ
 // from the resolved runtime port (doltserver port file). If you have the resolved
 // port, prefer GetDoltServerPasswordForPort for correct credentials file lookup.
-func (c *Config) GetDoltServerPassword() string {
+func (c *Config) GetDoltServerPassword() (string, error) {
 	return c.GetDoltServerPasswordForPort(c.GetDoltServerPort())
 }
 
@@ -598,15 +615,72 @@ func (c *Config) GetDoltServerPassword() string {
 // This avoids a mismatch where metadata.json says port 3308 (tunnel) but the
 // doltserver port file says 3307 (local), causing the credentials file lookup
 // to use the wrong [host:port] section.
-func (c *Config) GetDoltServerPasswordForPort(port int) string {
-	if p := os.Getenv("BEADS_DOLT_PASSWORD"); p != "" {
-		return p
+//
+// Resolution walks creds.ResolveLadder, first configured rung wins:
+//  1. BEADS_DOLT_PASSWORD env var (a static secret beats a helper — no exec)
+//  2. BEADS_DOLT_PASSWORD_COMMAND helper (creds.CommandSource, KindSecret)
+//  3. Credentials file lookup by [host:port] section
+//
+// The signature returns an error where it used to return a bare string. That
+// change is the point of the command rung: a configured-but-failing helper must
+// fail closed — abort — not silently downgrade to the credentials file, which is
+// exactly the downgrade ResolveLadder exists to prevent. Swallowing the error
+// here (string return, log-and-continue) was rejected: callers would build a DSN
+// with an empty password and surface a misleading "access denied" far from the
+// broken helper. This mirrors ApplyGatewayCredential, the existing fail-closed
+// credential hook for BEADS_DOLT_CREDENTIAL_COMMAND. context.Background() is fine:
+// the helper self-caps at creds' 30 s command timeout, and these call sites do not
+// thread a request context. A helper may also print a username (Vault dynamic
+// pair); it is deliberately ignored — wiring it would change user resolution,
+// which is GetDoltServerUser's job.
+func (c *Config) GetDoltServerPasswordForPort(port int) (string, error) {
+	cred, ok, err := creds.ResolveLadder(context.Background(),
+		envSecretSource{envVar: "BEADS_DOLT_PASSWORD"},
+		creds.CommandSource{
+			Command: c.GetDoltPasswordCommand(),
+			Kind:    creds.KindSecret,
+			Label:   "BEADS_DOLT_PASSWORD_COMMAND",
+		},
+		filePasswordSource{cfg: c, port: port},
+	)
+	if err != nil {
+		return "", err
 	}
-	host := c.GetDoltServerHost()
-	if p := LookupCredentialsPassword(host, port); p != "" {
-		return p
+	if !ok {
+		return "", nil
 	}
-	return ""
+	return cred.Value, nil
+}
+
+// envSecretSource is the static env-var rung of the password ladder: configured
+// when the variable is set to a non-empty value. It cannot fail.
+type envSecretSource struct{ envVar string }
+
+func (s envSecretSource) Name() string { return s.envVar }
+
+func (s envSecretSource) Resolve(context.Context) (creds.Credential, bool, error) {
+	if v := os.Getenv(s.envVar); v != "" {
+		return creds.Credential{Value: v, Kind: creds.KindSecret}, true, nil
+	}
+	return creds.Credential{}, false, nil
+}
+
+// filePasswordSource is the credentials-file rung, keyed by [host:port].
+// LookupCredentialsPassword returns "" on any error (missing/unreadable file),
+// so this rung reports "not configured" rather than failing — an absent file
+// falls through to no password, the pre-ladder behavior.
+type filePasswordSource struct {
+	cfg  *Config
+	port int
+}
+
+func (s filePasswordSource) Name() string { return "credentials-file" }
+
+func (s filePasswordSource) Resolve(context.Context) (creds.Credential, bool, error) {
+	if p := LookupCredentialsPassword(s.cfg.GetDoltServerHost(), s.port); p != "" {
+		return creds.Credential{Value: p, Kind: creds.KindSecret}, true, nil
+	}
+	return creds.Credential{}, false, nil
 }
 
 // GetDoltServerTLS returns whether TLS is enabled for server connections.

--- a/internal/configfile/credentials_test.go
+++ b/internal/configfile/credentials_test.go
@@ -99,7 +99,10 @@ func TestLookupCredentialsPassword_EnvVarTakesPrecedence(t *testing.T) {
 	t.Setenv("BEADS_DOLT_PASSWORD", "envPass")
 
 	cfg := DefaultConfig()
-	got := cfg.GetDoltServerPassword()
+	got, err := cfg.GetDoltServerPassword()
+	if err != nil {
+		t.Fatalf("GetDoltServerPassword() error = %v", err)
+	}
 	if got != "envPass" {
 		t.Errorf("GetDoltServerPassword() = %q, want %q (env var should take precedence)", got, "envPass")
 	}
@@ -120,7 +123,10 @@ func TestLookupCredentialsPassword_FallsBackToFile(t *testing.T) {
 	t.Setenv("BEADS_DOLT_PASSWORD", "")
 
 	cfg := DefaultConfig()
-	got := cfg.GetDoltServerPassword()
+	got, err := cfg.GetDoltServerPassword()
+	if err != nil {
+		t.Fatalf("GetDoltServerPassword() error = %v", err)
+	}
 	if got != "filePass" {
 		t.Errorf("GetDoltServerPassword() = %q, want %q (should fall back to credentials file)", got, "filePass")
 	}
@@ -148,7 +154,10 @@ password=workServerPass
 	personal := DefaultConfig()
 	personal.DoltServerHost = "127.0.0.1"
 	personal.DoltServerPort = 3307
-	got := personal.GetDoltServerPassword()
+	got, err := personal.GetDoltServerPassword()
+	if err != nil {
+		t.Fatalf("personal project password resolve error: %v", err)
+	}
 	if got != "personalDevPass" {
 		t.Errorf("personal project password = %q, want %q", got, "personalDevPass")
 	}
@@ -157,7 +166,10 @@ password=workServerPass
 	work := DefaultConfig()
 	work.DoltServerHost = "beads.work.internal"
 	work.DoltServerPort = 3307
-	got = work.GetDoltServerPassword()
+	got, err = work.GetDoltServerPassword()
+	if err != nil {
+		t.Fatalf("work project password resolve error: %v", err)
+	}
 	if got != "workServerPass" {
 		t.Errorf("work project password = %q, want %q", got, "workServerPass")
 	}
@@ -190,21 +202,98 @@ password=tunnelPass
 	cfg.DoltServerPort = 3308 // metadata.json says tunnel port
 
 	// GetDoltServerPassword uses config port (3308) → tunnelPass
-	got := cfg.GetDoltServerPassword()
+	got, err := cfg.GetDoltServerPassword()
+	if err != nil {
+		t.Fatalf("GetDoltServerPassword() error = %v", err)
+	}
 	if got != "tunnelPass" {
 		t.Errorf("GetDoltServerPassword() = %q, want %q", got, "tunnelPass")
 	}
 
 	// GetDoltServerPasswordForPort with resolved runtime port (3307) → localPass
-	got = cfg.GetDoltServerPasswordForPort(3307)
+	got, err = cfg.GetDoltServerPasswordForPort(3307)
+	if err != nil {
+		t.Fatalf("GetDoltServerPasswordForPort(3307) error = %v", err)
+	}
 	if got != "localPass" {
 		t.Errorf("GetDoltServerPasswordForPort(3307) = %q, want %q", got, "localPass")
 	}
 
 	// GetDoltServerPasswordForPort with tunnel port (3308) → tunnelPass
-	got = cfg.GetDoltServerPasswordForPort(3308)
+	got, err = cfg.GetDoltServerPasswordForPort(3308)
+	if err != nil {
+		t.Fatalf("GetDoltServerPasswordForPort(3308) error = %v", err)
+	}
 	if got != "tunnelPass" {
 		t.Errorf("GetDoltServerPasswordForPort(3308) = %q, want %q", got, "tunnelPass")
+	}
+}
+
+// The BEADS_DOLT_PASSWORD_COMMAND rung: a working helper beats the credentials
+// file, the static env var beats the helper, no helper falls back to the file,
+// and a failing helper aborts — it must never silently downgrade to the file.
+func TestGetDoltServerPasswordForPort_CommandRung(t *testing.T) {
+	tmpDir := t.TempDir()
+	credFile := filepath.Join(tmpDir, "credentials")
+	if err := os.WriteFile(credFile, []byte("[127.0.0.1:3307]\npassword=filePass\n"), 0600); err != nil {
+		t.Fatalf("failed to write credentials file: %v", err)
+	}
+	t.Setenv("BEADS_CREDENTIALS_FILE", credFile)
+
+	tests := []struct {
+		name            string
+		envPassword     string
+		passwordCommand string
+		wantPass        string
+		wantErr         bool
+	}{
+		{
+			name:            "command beats credentials file",
+			passwordCommand: "printf cmdPass",
+			wantPass:        "cmdPass",
+		},
+		{
+			name:            "static BEADS_DOLT_PASSWORD beats command",
+			envPassword:     "envPass",
+			passwordCommand: "printf overriddenCmdPass",
+			wantPass:        "envPass",
+		},
+		{
+			name:     "no command falls back to credentials file",
+			wantPass: "filePass",
+		},
+		{
+			name:            "failing helper never falls back to credentials file",
+			passwordCommand: "exit 1",
+			wantErr:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BEADS_DOLT_PASSWORD", tt.envPassword)
+			t.Setenv("BEADS_DOLT_PASSWORD_COMMAND", tt.passwordCommand)
+
+			cfg := DefaultConfig()
+			cfg.DoltServerHost = "127.0.0.1"
+
+			got, err := cfg.GetDoltServerPasswordForPort(3307)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("GetDoltServerPasswordForPort(3307) = %q, nil error; want an error — a configured helper that exits non-zero must abort the ladder, not fall back to the credentials file (fail-closed regression)", got)
+				}
+				if got != "" {
+					t.Fatalf("GetDoltServerPasswordForPort(3307) = %q alongside error %v; want empty password on error", got, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetDoltServerPasswordForPort(3307) error = %v", err)
+			}
+			if got != tt.wantPass {
+				t.Errorf("GetDoltServerPasswordForPort(3307) = %q, want %q", got, tt.wantPass)
+			}
+		})
 	}
 }
 

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -275,10 +275,16 @@ func applyResolvedConfig(ctx context.Context, beadsDir string, fileCfg *configfi
 	// this, callers that rely on NewFromConfigWithOptions (e.g. doctor's
 	// SharedStore) fail to reach externally-hosted Dolt servers that keep
 	// credentials in ~/.config/beads/credentials, while bd create/list/close
-	// succeed (bd-h5k7). GetDoltServerPasswordForPort checks BEADS_DOLT_PASSWORD
-	// env first, then credentials file keyed by [host:resolved-port].
+	// succeed (bd-h5k7). GetDoltServerPasswordForPort walks BEADS_DOLT_PASSWORD,
+	// then the BEADS_DOLT_PASSWORD_COMMAND helper, then the credentials file
+	// keyed by [host:resolved-port] — and fails closed when a configured helper
+	// errors, so the open aborts instead of downgrading to the file.
 	if cfg.ServerPassword == "" {
-		cfg.ServerPassword = fileCfg.GetDoltServerPasswordForPort(cfg.ServerPort)
+		password, err := fileCfg.GetDoltServerPasswordForPort(cfg.ServerPort)
+		if err != nil {
+			return fmt.Errorf("resolving dolt server password: %w", err)
+		}
+		cfg.ServerPassword = password
 	}
 	if !cfg.ServerTLS {
 		cfg.ServerTLS = fileCfg.GetDoltServerTLS()


### PR DESCRIPTION
Adds `BEADS_DOLT_PASSWORD_COMMAND`, a credential source that shells out to a helper and reads the password from its stdout. That is how a password manager, a cloud secret store, or a short-lived token minter gets wired in without `bd` ever holding the secret on disk.

The motivation is a shared Dolt server used by several machines. Today the options are an env var (visible in the process table, awkward to rotate) or a plaintext password in the credentials file. Neither works well when the secret is short-lived.

## The ladder

Resolution order is env, then command, then the credentials file. It is **fail-closed at every rung**: if `BEADS_DOLT_PASSWORD_COMMAND` is set and the helper exits non-zero, resolution aborts. It does **not** quietly fall through to the credentials file.

That behaviour is the whole point of the change. A configured credential source that breaks is an operational error the operator needs to see. Silently reaching for a different secret is how a rotated credential appears to keep working right up until it stops, in a way that is very hard to debug.

## Signature change

`GetDoltServerPasswordForPort` now returns `(string, error)` instead of a bare `string`.

This is the part worth arguing about, so here is the reasoning: a string-only return can swallow exactly the one error that must not be swallowed. Keeping the old signature would mean a failing helper is indistinguishable from an empty password, and the fail-closed guarantee above becomes unenforceable.

All 14 call sites are migrated. One of them, `cmd/bd/doctor/federation.go`, has no error channel available at that point; it is marked as an explicit exception in the code rather than quietly ignoring the error.

`GetDoltPasswordCommand()` reads only the environment variable, so there is no new config-file surface to maintain.

## Verification

`go test ./internal/configfile/... ./internal/creds/...` passes and `go vet` is clean on both packages. Unit tests cover each rung of the ladder and each failure mode.

Beyond the unit tests, this was exercised against a real `bd` binary built from the branch, using a helper script that appends to a sentinel file and prints a password:

1. **Credentials file absent** — the helper runs (sentinel written) and its stdout is used as the password; the only failure is the unreachable server it was pointed at.
2. **Credentials file present, helper exits 17** — resolution aborts with `resolving dolt server password: credential source BEADS_DOLT_PASSWORD_COMMAND: credential command failed: exit status 17`. The file password is never read and no connection is attempted.

The second case is the one that matters: with a valid password sitting in the credentials file, a broken helper still refuses to connect.

A control run with the file present and no command configured reaches the connection attempt normally, confirming the file path itself is untouched by the change.

## Compatibility

Nothing changes for existing setups. With `BEADS_DOLT_PASSWORD_COMMAND` unset the ladder behaves exactly as before: env, then credentials file.

Happy to split the signature change into its own commit if you would rather review it separately.