### PR TITLE
fix(create): refuse to auto-vivify a workspace at an ambiguous relative --repo target

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -413,7 +413,12 @@ var createCmd = &cobra.Command{
 				targetBeadsDir := routing.ExpandPath(repoPath)
 				debug.Logf("DEBUG: Routing to target repo: %s\n", targetBeadsDir)
 
-				if err := ensureBeadsDirForPath(rootCtx, targetBeadsDir, store); err != nil {
+				// Auto-routed paths (routing.mode: auto, routing.default)
+				// come from config, not caller input, so they're always
+				// allowed to auto-vivify as before; only an explicit --repo
+				// flag value can be ambiguous.
+				allowCreate := !isAmbiguousRepoTarget(cmd.Flags().Changed("repo"), repoOverride)
+				if err := ensureBeadsDirForPath(rootCtx, targetBeadsDir, store, allowCreate); err != nil {
 					return HandleError("failed to initialize target repo: %v", err)
 				}
 
@@ -953,10 +958,23 @@ func openDryRunTargetStore(ctx context.Context, repoPath string) (storage.DoltSt
 	return store, nil
 }
 
+// isAmbiguousRepoTarget reports whether an explicit --repo value is a
+// bare/relative filesystem path (not absolute, not "~/"-prefixed). Such a
+// value silently resolves against the current working directory (see
+// routing.ExpandPath) rather than failing, so a misresolved value (e.g. a
+// typo) previously wrote a bead into a brand-new, disconnected database
+// instead of erroring (bd-8d3f).
+func isAmbiguousRepoTarget(repoFlagChanged bool, repoOverride string) bool {
+	return repoFlagChanged && !filepath.IsAbs(repoOverride) && !strings.HasPrefix(repoOverride, "~/")
+}
+
 // ensureBeadsDirForPath ensures a beads directory exists at the target path.
 // If the .beads directory doesn't exist, it creates it and initializes with
 // the same prefix as the source store (T010, T012: prefix inheritance).
-func ensureBeadsDirForPath(ctx context.Context, targetPath string, sourceStore storage.DoltStorage) error {
+//
+// When allowCreate is false, a target with no existing workspace is refused
+// instead of fabricated — see isAmbiguousRepoTarget.
+func ensureBeadsDirForPath(ctx context.Context, targetPath string, sourceStore storage.DoltStorage, allowCreate bool) error {
 	beadsDir := filepath.Join(targetPath, ".beads")
 	metadataPath := filepath.Join(beadsDir, "metadata.json")
 
@@ -964,6 +982,10 @@ func ensureBeadsDirForPath(ctx context.Context, targetPath string, sourceStore s
 	// metadata.json is the canonical marker for an initialized beads dir.
 	if _, err := os.Stat(metadataPath); err == nil {
 		return nil
+	}
+
+	if !allowCreate {
+		return fmt.Errorf("no beads workspace found at %s and --repo's value is a relative/bare path, so it won't be auto-created here (this is likely not the target you intended). Pass an absolute or \"~/\"-prefixed --repo path to an existing workspace instead", targetPath)
 	}
 
 	// Create .beads directory

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -1120,6 +1120,74 @@ func TestEmbeddedCreateCrossRepoUninit(t *testing.T) {
 	}
 }
 
+// TestEmbeddedCreateRepoRelativeUninitRefused is a regression test for
+// bd-8d3f: a bare/relative --repo value with no existing workspace resolves
+// silently against the current working directory (routing.ExpandPath has no
+// concept of an external rig/alias registry), so it must be refused instead
+// of auto-creating a disconnected database that the caller never intended
+// and nothing else will ever route to. Contrast with
+// TestEmbeddedCreateCrossRepoUninit, which uses an absolute --repo path and
+// must still succeed.
+func TestEmbeddedCreateRepoRelativeUninitRefused(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "src")
+
+	relTarget := "some-other-rig"
+	out, err := bdRunWithFlockRetry(t, bd, dir, "create", "--json", "Should not land anywhere", "--repo", relTarget)
+	if err == nil {
+		t.Fatalf("expected bd create --repo %q to fail for an uninitialized relative target, got success: %s", relTarget, out)
+	}
+	if !strings.Contains(string(out), "absolute") {
+		t.Errorf("expected error to explain the absolute/~-prefixed path requirement, got: %s", out)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(dir, relTarget, ".beads")); !os.IsNotExist(statErr) {
+		t.Errorf("expected no .beads directory to be fabricated at %s, stat err = %v", filepath.Join(dir, relTarget), statErr)
+	}
+}
+
+// TestEmbeddedCreateRepoRelativeExistingWorkspaceUnaffected verifies the
+// bd-8d3f gate only blocks *fabricating* a new workspace: a relative --repo
+// value that already has an initialized workspace at the resolved path must
+// keep working exactly as before, since ensureBeadsDirForPath's existing
+// os.Stat(metadata.json) check returns early before the new gate runs.
+func TestEmbeddedCreateRepoRelativeExistingWorkspaceUnaffected(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "src")
+
+	relTarget := "already-initialized-sibling"
+	absTarget := filepath.Join(dir, relTarget)
+	if err := os.MkdirAll(absTarget, 0750); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoAt(t, absTarget)
+
+	// Initialize the target workspace first via an absolute --repo path
+	// (the already-covered, unambiguous case).
+	first := bdCreate(t, bd, dir, "Seed issue", "--repo", absTarget)
+	if first.ID == "" {
+		t.Fatal("expected issue ID for absolute --repo seed create")
+	}
+
+	// A relative --repo pointing at that SAME, now-initialized workspace
+	// must succeed unaffected by the bd-8d3f gate: the gate only blocks
+	// fabricating a workspace that doesn't exist yet.
+	second := bdCreate(t, bd, dir, "Should land in the pre-existing workspace", "--repo", relTarget)
+	if second.ID == "" {
+		t.Fatal("expected issue ID for relative --repo pointing at an existing workspace")
+	}
+}
+
 // TestEmbeddedCreateWithGitRemote verifies bd create works end-to-end when a
 // git remote exists (which enables auto-backup in PersistentPostRun). This
 // catches panics from unimplemented methods called after the create succeeds.

--- a/cmd/bd/create_input_test.go
+++ b/cmd/bd/create_input_test.go
@@ -207,3 +207,38 @@ func newCreateFlagsCommand(t *testing.T, args ...string) *cobra.Command {
 	}
 	return cmd
 }
+
+// TestIsAmbiguousRepoTarget covers bd-8d3f: an explicit relative/bare --repo
+// value with no existing workspace must be refused rather than silently
+// auto-vivified. Table-tested at the pure-function level since the embedded
+// dolt round trip is ~15s per case.
+func TestIsAmbiguousRepoTarget(t *testing.T) {
+	tests := []struct {
+		name          string
+		flagChanged   bool
+		repoOverride  string
+		wantAmbiguous bool
+	}{
+		{"relative flag value is ambiguous", true, "some-other-rig", true},
+		{"nested relative flag value is ambiguous", true, "../sibling", true},
+		{"absolute flag value is unambiguous", true, "/abs/path", false},
+		{"tilde-prefixed flag value is unambiguous", true, "~/planning", false},
+		// Regression: an explicit but empty --repo value is the most
+		// ambiguous possible input (it silently resolves to the cwd, see
+		// routing.ExpandPath) and must still be gated, not exempted.
+		{"explicit empty flag value is ambiguous", true, "", true},
+		// Auto-routed paths (routing.mode: auto / routing.default) never
+		// set the --repo flag, so they're always exempt from the gate
+		// regardless of their shape.
+		{"unset flag is never ambiguous, relative-looking value", false, "some-other-rig", false},
+		{"unset flag is never ambiguous, empty value", false, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAmbiguousRepoTarget(tt.flagChanged, tt.repoOverride)
+			if got != tt.wantAmbiguous {
+				t.Errorf("isAmbiguousRepoTarget(%v, %q) = %v, want %v", tt.flagChanged, tt.repoOverride, got, tt.wantAmbiguous)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`bd create --repo <target>` silently created a brand-new, empty, disconnected
beads database at any nonexistent `--repo` target path via
`ensureBeadsDirForPath`, with no warning and no way to distinguish "routed to
an existing workspace" from "just fabricated a new one."

`routing.ExpandPath` resolves a bare/relative `--repo` value purely against
the current working directory (`filepath.Abs`); it has no concept of any
external alias or registry. So a `--repo` value that gets misresolved (wrong
cwd, a value the caller expected to mean something other than a literal
filesystem path, a typo) silently writes a bead into an orphan database that
nothing else will ever open. The create reports success and returns a
valid-looking ID; the bead is then unreadable from every other context —
silent data loss, not a lookup problem.

## Fix

Adds a gate: an explicit `--repo` value that is relative (not absolute, not
`~/`-prefixed) and has no existing workspace at the resolved path is now
refused with a clear error instead of silently fabricated.

- Auto-routed paths (`routing.mode: auto`, `routing.default`) are unaffected
  — they come from trusted config, not ad-hoc caller input, and never set the
  `--repo` flag.
- A relative `--repo` value pointing at an *already-initialized* workspace is
  unaffected — the gate only blocks fabrication, never routing to an
  existing target.
- Every documented `--repo` usage (`docs/multi-agent/routing.md`,
  `docs/multi-agent/multi-repo-migration.md`) already passes an absolute or
  `~/`-prefixed path, so no legitimate documented workflow changes behavior.

`isAmbiguousRepoTarget` is factored out as a small pure helper so the gate
condition is unit-testable without spinning up embedded Dolt.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/bd/...`
- [x] `gofmt -l` clean
- [x] `go test ./cmd/bd/... -run TestIsAmbiguousRepoTarget -v` (7 cases, incl. the empty-string edge case and the auto-routing exemption)
- [x] `BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd/... -run 'TestEmbedded.*Repo|TestCreateRepo' -v` — all green, including the new `TestEmbeddedCreateRepoRelativeUninitRefused` (proves the refusal and that no phantom `.beads` dir is created) and `TestEmbeddedCreateRepoRelativeExistingWorkspaceUnaffected` (proves the gate doesn't affect a relative `--repo` pointing at an existing target)
- [x] Confirmed pre-existing `TestEmbeddedCreateCrossRepoUninit` (absolute-path case) still passes unchanged