### PR TITLE
fix(dep): warn when bd dep list <id> hides a cross-database edge

### DIFF
--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -783,6 +783,47 @@ func printDepListEdges(anchors []issueops.AnchorEdges) error {
 	return nil
 }
 
+// warnDroppedDepEdges prints a stderr-only notice for every stored "down"
+// dependency edge of anchorID that shown (the Relations role's answer) left
+// out because its target has no row in this database — i.e. a cross-repo or
+// `external:` target (bd-mtla: `bd link` across databases reports success
+// and writes the row, but the single-id `bd dep list <id>` a caller runs
+// right after has no way to tell that from no dependency existing at all).
+//
+// It never writes to stdout, so the documented `bd dep list <id>` and
+// `--json` shapes for the common (fully-local) case are unchanged; a script
+// parsing stdout sees nothing new. A best-effort read: an error here is
+// swallowed rather than surfaced, since the command's actual answer was
+// already produced successfully by the Relations role above.
+func warnDroppedDepEdges(ctx context.Context, reader issueops.EdgeReader, anchorID, typeFilter string, shown []*issueops.RelatedIssue) {
+	var depTypes []types.DependencyType
+	if typeFilter != "" {
+		depTypes = []types.DependencyType{types.DependencyType(typeFilter)}
+	}
+	result, err := reader.ReadEdges(ctx, issueops.EdgeReadRequest{IDs: []string{anchorID}, Types: depTypes})
+	if err != nil || len(result.Anchors) != 1 {
+		return
+	}
+	known := make(map[string]struct{}, len(shown))
+	for _, iss := range shown {
+		known[iss.ID] = struct{}{}
+	}
+	var dropped []*types.Dependency
+	for _, dep := range result.Anchors[0].Edges {
+		if _, ok := known[dep.DependsOnID]; !ok {
+			dropped = append(dropped, dep)
+		}
+	}
+	if len(dropped) == 0 {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "warning: %s has %d additional dependency edge(s) whose target has no row in this database (cross-repo/external) and are not shown above:\n", anchorID, len(dropped))
+	for _, dep := range dropped {
+		fmt.Fprintf(os.Stderr, "  %s via %s\n", dep.DependsOnID, dep.Type)
+	}
+	fmt.Fprintf(os.Stderr, "For raw edge records, run: bd dep list %s %s\n", anchorID, anchorID)
+}
+
 var depListCmd = &cobra.Command{
 	Use:   "list [issue-id...]",
 	Short: "List dependencies or dependents of one or more issues",
@@ -914,6 +955,22 @@ Examples:
 				return HandleErrorRespectJSON("%v", err)
 			}
 			allIssues = append(allIssues, issues...)
+		}
+
+		// Relations silently drops "down" edges whose target has no row in
+		// this database (the doc comment above the batch branch says so).
+		// EdgeReader doesn't have that gap, and batchMode&&"down" already
+		// used it above, so this is reached for "down" only when there is
+		// exactly one resolved anchor — warn on stderr (never stdout/--json,
+		// so the documented single-id shape and any script parsing it are
+		// untouched) naming any edge Relations left out, so a `bd link`
+		// across databases doesn't look indistinguishable from no link at
+		// all (bd-mtla). "up" has the same gap but no inbound EdgeReader
+		// role exists to detect it from here — tracked separately.
+		if direction == "down" && len(resolved) == 1 {
+			if reader, err := resolved[0].store.EdgeReader(); err == nil {
+				warnDroppedDepEdges(ctx, reader, resolved[0].fullID, typeFilter, allIssues)
+			}
 		}
 
 		if jsonOutput {

--- a/cmd/bd/dep_list_cross_db_test.go
+++ b/cmd/bd/dep_list_cross_db_test.go
@@ -1,0 +1,100 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEmbeddedDepListSingleIDWarnsOnDroppedExternalEdge is the regression
+// guard for bd-mtla: `bd link` across two databases writes the dependency
+// correctly (into depends_on_external), but the single-id `bd dep list <id>`
+// a caller naturally runs right after silently showed nothing for it —
+// indistinguishable from no dependency ever being created. This verifies the
+// fix: stdout/--json stay byte-for-byte what they were before the fix for the
+// local-only case (no schema/shape change), while stderr now names the edge
+// Relations could not resolve locally.
+func TestEmbeddedDepListSingleIDWarnsOnDroppedExternalEdge(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt dep tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	// Primary repo ("gt"), with routes.jsonl pointing its "hq-" prefix at a
+	// sibling repo, mirroring a town/rig layout.
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "gt")
+
+	targetDir := filepath.Join(dir, "hq-repo")
+	if err := os.MkdirAll(targetDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoAt(t, targetDir)
+	runBDInit(t, bd, targetDir, "--prefix", "hq")
+
+	routesPath := filepath.Join(beadsDir, "routes.jsonl")
+	if err := os.WriteFile(routesPath, []byte(`{"prefix":"hq-","path":"hq-repo"}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	local := bdCreate(t, bd, dir, "local target")
+	external := bdCreate(t, bd, targetDir, "external target")
+	source := bdCreate(t, bd, dir, "source issue")
+
+	if out, err := bdRunWithFlockRetry(t, bd, dir, "link", source.ID, local.ID, "--type", "blocks"); err != nil {
+		t.Fatalf("bd link (local): %v\n%s", err, out)
+	}
+	if out, err := bdRunWithFlockRetry(t, bd, dir, "link", source.ID, external.ID, "--type", "related"); err != nil {
+		t.Fatalf("bd link (external): %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(bd, "dep", "list", source.ID)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd dep list: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+
+	if !strings.Contains(stdout.String(), local.ID) {
+		t.Errorf("stdout missing local dep %s:\n%s", local.ID, stdout.String())
+	}
+	if strings.Contains(stdout.String(), external.ID) {
+		t.Errorf("stdout unexpectedly contains external target %s (shape must stay unchanged):\n%s", external.ID, stdout.String())
+	}
+	if !strings.Contains(stderr.String(), external.ID+" via related") {
+		t.Errorf("stderr should warn about dropped external target %s with its type, got:\n%s", external.ID, stderr.String())
+	}
+
+	// --json: must stay exactly what it was before the fix for the local-only case.
+	jsonCmd := exec.Command(bd, "dep", "list", source.ID, "--json")
+	jsonCmd.Dir = dir
+	jsonCmd.Env = bdEnv(dir)
+	jsonStdout, _, err := runCommandBuffers(t, jsonCmd)
+	if err != nil {
+		t.Fatalf("bd dep list --json: %v", err)
+	}
+	if strings.Contains(jsonStdout.String(), external.ID) {
+		t.Errorf("--json output unexpectedly contains external target %s:\n%s", external.ID, jsonStdout.String())
+	}
+	if !strings.Contains(jsonStdout.String(), local.ID) {
+		t.Errorf("--json output missing local dep %s:\n%s", local.ID, jsonStdout.String())
+	}
+
+	// Batch mode (the already-correct path) must still show both.
+	batchCmd := exec.Command(bd, "dep", "list", source.ID, source.ID)
+	batchCmd.Dir = dir
+	batchCmd.Env = bdEnv(dir)
+	batchStdout, _, err := runCommandBuffers(t, batchCmd)
+	if err != nil {
+		t.Fatalf("bd dep list (batch): %v", err)
+	}
+	if !strings.Contains(batchStdout.String(), external.ID) || !strings.Contains(batchStdout.String(), local.ID) {
+		t.Errorf("batch mode should show both deps, got:\n%s", batchStdout.String())
+	}
+}

--- a/cmd/bd/dep_proxied_integration_test.go
+++ b/cmd/bd/dep_proxied_integration_test.go
@@ -861,3 +861,77 @@ func TestProxiedServerDepConcurrent(t *testing.T) {
 		}
 	}
 }
+
+// TestProxiedServerDepListSingleIDWarnsOnDroppedExternalEdge is the
+// proxied-server counterpart to TestEmbeddedDepListSingleIDWarnsOnDroppedExternalEdge
+// (dep_list_cross_db_test.go): the regression guard for bd-mtla on the
+// runDepListProxiedServer path (cmd/bd/dep_proxied_server.go), which gastown's
+// live-dolt-server deployment actually runs.
+//
+// `bd link` correctly writes an edge to an `external:` target (no row in any
+// database this session can see), but the single-id `bd dep list <id>` a
+// caller runs right after used to show nothing for it — indistinguishable
+// from no dependency existing at all. Verifies the fix: stdout/--json stay
+// exactly what they were before the fix (no schema change), stderr now names
+// the dropped edge, and batch mode (the already-correct path) is unaffected.
+func TestProxiedServerDepListSingleIDWarnsOnDroppedExternalEdge(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	p := newSharedProxiedProject(t, bd, "dlw1")
+	local := bdProxiedCreate(t, bd, p.dir, "local target", "--type", "task")
+	source := bdProxiedCreate(t, bd, p.dir, "source issue", "--type", "task")
+
+	bdProxiedDep(t, bd, p.dir, "add", source.ID, local.ID, "--type", "blocks")
+
+	linkCmd := exec.Command(bd, "link", source.ID, "external:other:capability", "--type", "related")
+	linkCmd.Dir = p.dir
+	linkCmd.Env = bdProxiedEnv(p.dir)
+	if out, err := linkCmd.CombinedOutput(); err != nil {
+		t.Fatalf("bd link (external): %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(bd, "dep", "list", source.ID)
+	cmd.Dir = p.dir
+	cmd.Env = bdProxiedEnv(p.dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd dep list: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+
+	if !strings.Contains(stdout.String(), local.ID) {
+		t.Errorf("stdout missing local dep %s:\n%s", local.ID, stdout.String())
+	}
+	if strings.Contains(stdout.String(), "external:other:capability") {
+		t.Errorf("stdout unexpectedly contains the external target (shape must stay unchanged):\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "external:other:capability via related") {
+		t.Errorf("stderr should warn about the dropped external target with its type, got:\n%s", stderr.String())
+	}
+
+	jsonCmd := exec.Command(bd, "dep", "list", source.ID, "--json")
+	jsonCmd.Dir = p.dir
+	jsonCmd.Env = bdProxiedEnv(p.dir)
+	jsonStdout, _, err := runCommandBuffers(t, jsonCmd)
+	if err != nil {
+		t.Fatalf("bd dep list --json: %v", err)
+	}
+	if strings.Contains(jsonStdout.String(), "external:other:capability") {
+		t.Errorf("--json output unexpectedly contains the external target:\n%s", jsonStdout.String())
+	}
+	if !strings.Contains(jsonStdout.String(), local.ID) {
+		t.Errorf("--json output missing local dep %s:\n%s", local.ID, jsonStdout.String())
+	}
+
+	batchCmd := exec.Command(bd, "dep", "list", source.ID, source.ID)
+	batchCmd.Dir = p.dir
+	batchCmd.Env = bdProxiedEnv(p.dir)
+	batchStdout, _, err := runCommandBuffers(t, batchCmd)
+	if err != nil {
+		t.Fatalf("bd dep list (batch): %v", err)
+	}
+	if !strings.Contains(batchStdout.String(), "external:other:capability") || !strings.Contains(batchStdout.String(), local.ID) {
+		t.Errorf("batch mode should show both deps, got:\n%s", batchStdout.String())
+	}
+}

--- a/cmd/bd/dep_proxied_server.go
+++ b/cmd/bd/dep_proxied_server.go
@@ -400,6 +400,19 @@ func runDepListProxiedServer(cmd *cobra.Command, ctx context.Context, args []str
 		allIssues = append(allIssues, issues...)
 	}
 
+	// Same gap as the embedded RunE for this command (cmd/bd/dep.go): Relations
+	// drops "down" edges whose target has no row in this database, and the
+	// `len(args) > 1 && direction == "down"` branch above already uses the
+	// (non-dropping) EdgeReader role for batch mode — so this loop only runs
+	// for "down" with exactly one arg. Warn on stderr so a cross-database
+	// `bd link` isn't indistinguishable from no link at all (bd-mtla); never
+	// touches stdout/--json.
+	if direction == "down" && len(args) == 1 {
+		if reader, err := proxiedEdgeReader(); err == nil {
+			warnDroppedDepEdges(ctx, reader, args[0], typeFilter, allIssues)
+		}
+	}
+
 	if jsonOutput {
 		if allIssues == nil {
 			allIssues = []*issueops.RelatedIssue{}


### PR DESCRIPTION
## Summary

`bd link` correctly writes a cross-database/external dependency (into the
`depends_on_external` column, verified with a direct SQL query on a live
repro — the data is not actually lost), but `bd dep list <single-id>` — the
command an operator naturally runs right after to check the link — showed
nothing for it, in both text and `--json`, with no warning. This made a
successful cross-database `bd link` indistinguishable from no dependency
ever having been created.

Root cause: `bd dep list`'s single-id "down" path uses the `Relations` role
(`IssueRelations().Related()`), whose own doc comment already says it "drops
every edge whose target this database has no row for." `bd dep list <id>
<id>` (2+ args) instead uses the `EdgeReader` role, which does not have that
gap — but that path was gated behind argument count, not direction.

## Fix

For the "down" direction (the only one `EdgeReader` supports), after the
`Relations` role answers, re-read the anchor's raw stored edges via the same
`EdgeReader` role each mode already uses for batch mode, and print a
stderr-only warning naming any edge `Relations` left out. stdout/`--json` are
untouched, so the documented output shape for the common (fully-local) case
does not change — no consumer parsing stdout sees anything new.

Applied to both the embedded (`cmd/bd/dep.go`) and proxied-server
(`cmd/bd/dep_proxied_server.go`) implementations: both share the same
underlying drop (`GetDependenciesWithMetadataInTx` silently `continue`s past
an unresolved target in both modes), and the deployment that reported this
bug runs proxied-server mode against a live `dolt sql-server` — an
embedded-only fix would have been a no-op for it.

## Deliberately out of scope (filed separately)

- `--direction=up` has the identical drop, but no *inbound* `EdgeReader` role
  exists to detect it from the CLI layer today. #5849
- The deeper, correct fix is at the source:
  `GetDependenciesWithMetadataInTx`/`GetDependentsWithMetadataInTx` should
  stop dropping unresolvable-target rows for every caller (`bd show`, `bd
  blocked`, `bd graph`, sync), not just `dep list`. Once that lands, this
  PR's stderr warning becomes redundant and can be removed. #5850

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/bd/...`
- [x] `gofmt -l` clean
- [x] Live repro against a built `bd` binary (embedded mode, two databases +
      `routes.jsonl`): confirmed `bd link` writes correctly into
      `depends_on_external` (direct `dolt sql` query), confirmed `bd dep list
      <single-id>` showed nothing for it before this change and now warns on
      stderr with stdout/`--json` unchanged, confirmed batch mode
      (`bd dep list <id> <id>`) was already correct and is unaffected.
- [x] `BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd/... -run TestEmbeddedDepListSingleIDWarnsOnDroppedExternalEdge` — new test, confirmed to **fail** on the pre-fix code (`git stash` the two source files, rerun, confirmed failure) and **pass** with the fix.
- [x] `go test ./cmd/bd/... -run 'TestDep'` (existing suite) — all passing tests still pass.
- [ ] `TestProxiedServerDepListSingleIDWarnsOnDroppedExternalEdge` (new, in `cmd/bd/dep_proxied_integration_test.go`, gated `BEADS_TEST_PROXIED_SERVER=1`) — added mirroring the embedded test and this repo's existing proxied-server test conventions, and confirmed to build and correctly self-skip ("Docker not available"), but **could not be executed end-to-end** in the environment this PR was prepared in (no Docker access). Please confirm it passes in CI before merging.

🤖 Generated with a Gas Town polecat (Claude), landing this on the `beads` repo per the pattern established in gastownhall/beads#5845 — no code changes belonging in the gastown rig; the fix lives entirely here.