### PR TITLE
fix(gate): evaluate cross-rig bead gates via prefix routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`bd gate check` resolves bead gates whose target lives in a prefix-routed
+  rig** ([#5859](https://github.com/gastownhall/beads/pull/5859)). After a local
+  miss, the evaluator follows the target bead ID through `routes.jsonl` and
+  reads the owning store without writing to it. This covers explicit gate
+  checks in embedded, server, and proxied-server command paths; the legacy
+  `<rig>:<bead-id>` await value remains accepted for compatibility.
+
 - **Write commands now refuse to run while a MIGRATION-FREEZE sentinel sits
   at the town root** (dc-6jaq), mirroring the gate the gt CLI already applies
   to `gt mail send`/`nudge`/`sling`/`assign`. `bd create`/`update`/`close`/

--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -568,7 +568,7 @@ func checkGateSatisfaction(issue *types.Issue) error {
 	case issue.AwaitType == "timer":
 		resolved, escalated, reason, err = checkTimer(issue, time.Now())
 	case issue.AwaitType == "bead":
-		resolved, reason = checkBeadGate(rootCtx, store, issue.AwaitID)
+		resolved, reason = checkBeadGate(rootCtx, routedBeadGateGetter{localStore: store}, issue.AwaitID)
 		if resolved {
 			return nil
 		}

--- a/cmd/bd/gate.go
+++ b/cmd/bd/gate.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/metrics"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 )
@@ -33,9 +34,9 @@ Gate types:
   gh:pr   - Waits for PR merge (Phase 3)
   bead    - Waits for another bead to close (Phase 4)
 
-For bead gates, await_id is a bead ID in this rig's database (e.g., "bd-abc123").
-The historical cross-rig form <rig>:<bead-id> can no longer be evaluated
-(multi-rig routing removed) and stays pending until resolved manually.
+For bead gates, await_id may be a bead ID in this rig's database (e.g.,
+"bd-abc123") or the historical cross-rig form <rig>:<bead-id>. Cross-rig
+targets resolve through the bead ID's prefix route in routes.jsonl.
 
 Examples:
   bd gate list           # Show all open gates
@@ -669,7 +670,7 @@ Examples:
 			}
 		}
 
-		results := evaluateGates(ctx, filteredGates, time.Now(), store, persistAwaitID)
+		results := evaluateGates(ctx, filteredGates, time.Now(), routedBeadGateGetter{localStore: store}, persistAwaitID)
 
 		resolvedCount, escalatedCount, errorCount := applyGateCheckResults(
 			results, dryRun, escalateFlag,
@@ -1182,27 +1183,48 @@ type issueGetter interface {
 	GetIssue(ctx context.Context, id string) (*types.Issue, error)
 }
 
+// routedBeadGateGetter gives direct-mode gate checks the same local -> prefix
+// route -> contributor fallback used by other read commands. Routed stores are
+// opened read-only and closed before the result is returned.
+type routedBeadGateGetter struct {
+	localStore storage.DoltStorage
+}
+
+func (g routedBeadGateGetter) GetIssue(ctx context.Context, id string) (*types.Issue, error) {
+	if g.localStore == nil {
+		return nil, fmt.Errorf("no local store available")
+	}
+	result, err := getIssueWithRouting(ctx, g.localStore, id)
+	if err != nil {
+		return nil, err
+	}
+	defer result.Close()
+	return result.Issue, nil
+}
+
 // checkBeadGate checks if a bead gate is satisfied.
 // Returns (satisfied, reason).
 //
-// A plain await_id (no colon) names a bead in THIS rig's database: the gate
-// resolves once that bead closes — the common case, an agent idle-waiting on
-// local work (wy-hgms2; the old unconditional cross-rig refusal left every
-// local bead gate permanently pending and its waiters asleep).
-//
-// The historical cross-rig form <rig>:<bead-id> cannot be evaluated since
-// multi-rig routing was removed; it stays pending with a descriptive message.
+// A plain await_id names a bead in this rig. The historical
+// <rig>:<bead-id> form uses the bead ID as the routed lookup key; the rig
+// component is retained for compatibility while routes.jsonl remains keyed by
+// bead prefix. The supplied getter owns local-versus-routed lookup policy.
 func checkBeadGate(ctx context.Context, st issueGetter, awaitID string) (bool, string) {
 	if awaitID == "" {
 		return false, "bead gate has no await_id"
 	}
+	targetID := awaitID
 	if strings.Contains(awaitID, ":") {
-		return false, fmt.Sprintf("cross-rig bead gate %q cannot be checked (multi-rig routing removed)", awaitID)
+		parts := strings.SplitN(awaitID, ":", 2)
+		if parts[0] == "" || parts[1] == "" {
+			return false, fmt.Sprintf("invalid cross-rig bead gate %q: expected <rig>:<bead-id>", awaitID)
+		}
+		targetID = parts[1]
 	}
 	if st == nil {
 		return false, fmt.Sprintf("bead gate %q: no local store available", awaitID)
 	}
-	issue, err := st.GetIssue(ctx, awaitID)
+	issue, err := st.GetIssue(ctx, targetID)
 	if err != nil {
 		return false, fmt.Sprintf("bead gate %q: %v", awaitID, err)
 	}
@@ -1210,9 +1232,9 @@ func checkBeadGate(ctx context.Context, st issueGetter, awaitID string) (bool, s
 		return false, fmt.Sprintf("bead gate %q: bead not found", awaitID)
 	}
 	if issue.Status == types.StatusClosed {
-		return true, fmt.Sprintf("bead %s closed", awaitID)
+		return true, fmt.Sprintf("bead %s closed", targetID)
 	}
-	return false, fmt.Sprintf("bead %s is %s", awaitID, issue.Status)
+	return false, fmt.Sprintf("bead %s is %s", targetID, issue.Status)
 }
 
 // closeGate closes a gate issue with the given reason

--- a/cmd/bd/gate_proxied_server.go
+++ b/cmd/bd/gate_proxied_server.go
@@ -50,7 +50,7 @@ func (proxiedFreshReadGetter) GetIssue(ctx context.Context, id string) (*types.I
 
 	result, routeErr := resolveViaPrefixRouting(ctx, id)
 	if routeErr != nil {
-		return nil, routeErr
+		return nil, localErr
 	}
 	defer result.Close()
 	return result.Issue, nil

--- a/cmd/bd/gate_proxied_server.go
+++ b/cmd/bd/gate_proxied_server.go
@@ -39,8 +39,21 @@ func (proxiedFreshReadGetter) GetIssue(ctx context.Context, id string) (*types.I
 	if err != nil {
 		return nil, err
 	}
-	defer uw.Close(ctx)
-	return uw.IssueUseCase().GetIssue(ctx, id)
+	issue, localErr := uw.IssueUseCase().GetIssue(ctx, id)
+	uw.Close(ctx)
+	if localErr == nil {
+		return issue, nil
+	}
+	if !gateProxiedNotFound(localErr) {
+		return nil, localErr
+	}
+
+	result, routeErr := resolveViaPrefixRouting(ctx, id)
+	if routeErr != nil {
+		return nil, routeErr
+	}
+	defer result.Close()
+	return result.Issue, nil
 }
 
 func runGateCheckProxiedServer(cmd *cobra.Command, ctx context.Context) error {

--- a/cmd/bd/gate_routing_test.go
+++ b/cmd/bd/gate_routing_test.go
@@ -1,0 +1,77 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestCheckBeadGateCrossRigPrefixRoute proves the full evaluator seam: the
+// historical rig:id value is reduced to the target bead ID, the current
+// routes.jsonl prefix router opens the foreign store read-only, and target
+// lifecycle state determines whether the gate resolves.
+//
+// NOTE: This test uses os.Chdir and cannot run in parallel with other tests.
+func TestCheckBeadGateCrossRigPrefixRoute(t *testing.T) {
+	ctx := context.Background()
+	townRoot := t.TempDir()
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	rigBeadsDir := filepath.Join(townRoot, "rig", ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0o755); err != nil {
+		t.Fatalf("create town beads dir: %v", err)
+	}
+	if err := os.MkdirAll(rigBeadsDir, 0o755); err != nil {
+		t.Fatalf("create rig beads dir: %v", err)
+	}
+
+	townDBPath := filepath.Join(townBeadsDir, "dolt")
+	townStore := newTestStoreIsolatedDB(t, townDBPath, "hq")
+	rigStore := newTestStoreIsolatedDB(t, filepath.Join(rigBeadsDir, "dolt"), "gt")
+	for _, issue := range []*types.Issue{
+		{ID: "gt-closed", Title: "Closed routed target", Status: types.StatusClosed, Priority: 2, IssueType: types.TypeTask},
+		{ID: "gt-open", Title: "Open routed target", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+	} {
+		if err := rigStore.CreateIssue(ctx, issue, "test"); err != nil {
+			t.Fatalf("create routed issue %s: %v", issue.ID, err)
+		}
+	}
+	if err := rigStore.Close(); err != nil {
+		t.Fatalf("close rig store: %v", err)
+	}
+
+	routesPath := filepath.Join(townBeadsDir, "routes.jsonl")
+	if err := os.WriteFile(routesPath, []byte(`{"prefix":"gt-","path":"rig"}`), 0o644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	oldDBPath := dbPath
+	dbPath = townDBPath
+	t.Cleanup(func() { dbPath = oldDBPath })
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("change to town root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	getter := routedBeadGateGetter{localStore: townStore}
+	resolved, reason := checkBeadGate(ctx, getter, "rig:gt-closed")
+	if !resolved {
+		t.Fatalf("closed cross-rig target did not resolve gate: %s", reason)
+	}
+
+	resolved, reason = checkBeadGate(ctx, getter, "rig:gt-open")
+	if resolved {
+		t.Fatalf("open cross-rig target unexpectedly resolved gate: %s", reason)
+	}
+	if !gateTestContainsIgnoreCase(reason, "open") {
+		t.Fatalf("pending reason %q does not report target status", reason)
+	}
+}

--- a/cmd/bd/gate_test.go
+++ b/cmd/bd/gate_test.go
@@ -154,28 +154,40 @@ func TestShouldCheckGate(t *testing.T) {
 type fakeBeadGateGetter struct {
 	issues map[string]*types.Issue
 	err    error
+	gotID  string
 }
 
 func (f *fakeBeadGateGetter) GetIssue(_ context.Context, id string) (*types.Issue, error) {
+	f.gotID = id
 	if f.err != nil {
 		return nil, f.err
 	}
 	return f.issues[id], nil
 }
 
-func TestCheckBeadGate_CrossRigStaysPending(t *testing.T) {
+func TestCheckBeadGate_CrossRigUsesBeadIDForRoutedLookup(t *testing.T) {
 	ctx := context.Background()
+	st := &fakeBeadGateGetter{issues: map[string]*types.Issue{
+		"gt-abc": {ID: "gt-abc", Status: types.StatusClosed},
+	}}
 
-	// The cross-rig <rig>:<bead-id> form cannot be evaluated since multi-rig
-	// routing was removed; it must stay pending with the explanatory message,
-	// never consult the store, and never resolve.
+	satisfied, reason := checkBeadGate(ctx, st, "gastown:gt-abc")
+	if !satisfied {
+		t.Fatalf("expected closed routed bead to satisfy gate, got reason %q", reason)
+	}
+	if st.gotID != "gt-abc" {
+		t.Fatalf("routed lookup ID = %q, want %q", st.gotID, "gt-abc")
+	}
+}
+
+func TestCheckBeadGate_InvalidCrossRigFormat(t *testing.T) {
+	ctx := context.Background()
 	tests := []struct {
 		name    string
 		awaitID string
 	}{
 		{name: "missing rig", awaitID: ":gt-abc"},
 		{name: "missing bead", awaitID: "my-project:"},
-		{name: "well-formed cross-rig", awaitID: "nonexistent:some-id"},
 	}
 
 	for _, tt := range tests {
@@ -184,8 +196,8 @@ func TestCheckBeadGate_CrossRigStaysPending(t *testing.T) {
 			if satisfied {
 				t.Errorf("expected not satisfied for %q", tt.awaitID)
 			}
-			if !gateTestContainsIgnoreCase(reason, "multi-rig routing removed") {
-				t.Errorf("reason %q does not contain %q", reason, "multi-rig routing removed")
+			if !gateTestContainsIgnoreCase(reason, "expected <rig>:<bead-id>") {
+				t.Errorf("reason %q does not describe the expected format", reason)
 			}
 		})
 	}

--- a/cmd/bd/gate_test.go
+++ b/cmd/bd/gate_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"slices"
 	"sync"
 	"testing"
@@ -177,6 +179,19 @@ func TestCheckBeadGate_CrossRigUsesBeadIDForRoutedLookup(t *testing.T) {
 	}
 	if st.gotID != "gt-abc" {
 		t.Fatalf("routed lookup ID = %q, want %q", st.gotID, "gt-abc")
+	}
+}
+
+func TestProxiedFreshReadGetterPreservesLocalNotFoundWhenRoutingUnavailable(t *testing.T) {
+	withStubbedProxiedLookup(t, nil)
+
+	oldDBPath := dbPath
+	dbPath = filepath.Join(t.TempDir(), ".beads", "dolt")
+	t.Cleanup(func() { dbPath = oldDBPath })
+
+	_, err := (proxiedFreshReadGetter{}).GetIssue(context.Background(), "bd-missing")
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetIssue error = %v, want original local not-found", err)
 	}
 }
 


### PR DESCRIPTION
## What

- Evaluate historical `<rig>:<bead-id>` bead gates through the current
  read-only prefix-routing seam.
- Preserve plain local bead-ID gates.
- Use the same routed lookup for direct `gate check` and close-time gate
  satisfaction checks.
- Give proxied-server checks a prefix-route fallback after a local not-found.
- Reject malformed cross-rig values with the expected format.

## Why

Local bead-gate evaluation was restored in `1fe77e4a`, but cross-rig values
were left behind an unconditional `multi-rig routing removed` refusal. Prefix
routing was later restored in the narrower current architecture by #2954, so
cross-rig gates could be created and block readiness but could never
self-resolve.

This patch reuses that existing route. It does not restore the deleted global
multi-rig router, change schema, or write to a foreign store.

## Test evidence

- `./scripts/test.sh -run '^(TestCheckBeadGate|TestCheckGateSatisfaction_BeadGateInvalidFormat)' ./cmd/bd/...`
- `./scripts/test.sh -run '^TestCheckBeadGateCrossRigPrefixRoute$' ./cmd/bd/...`
  - exercises two disposable Dolt stores plus a real `routes.jsonl`
  - proves a closed foreign target resolves and an open target stays pending
- `./scripts/test.sh ./cmd/bd/...`
- `make test` — all packages pass, 38.2% total coverage
- `git diff --check`

`make ci-pr-lint` reaches the pinned v2.10.1 linter but fails on two unchanged
macOS gosec findings. The same command fails identically in a detached, clean
`origin/main` worktree at `ed382cbd`; tracked separately in #5858. Formatting
passes and this diff does not touch either reported file.

## Prior art

Preflight found no open PR implementing cross-rig bead-gate evaluation. #5851
was reviewed first because it touches cross-database dependency visibility; it
does not evaluate gates and this change does not overlap its files.

Fixes #5857

_codex-unknown-model-unknown-reasoning on behalf of Klas Hesselman_
