### PR TITLE
Add BEADS_DOLT_PASSWORD_COMMAND: KindSecret credential-command rung for the Dolt server password

### DIFF
--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -555,6 +555,21 @@ func (c *Config) GetDoltCredentialCommand() string {
 	return os.Getenv("BEADS_DOLT_CREDENTIAL_COMMAND")
 }
 
+// GetDoltPasswordCommand returns the server secret-credential command:
+// BEADS_DOLT_PASSWORD_COMMAND. Empty means no command — the existing
+// BEADS_DOLT_PASSWORD / credentials-file ladder in GetDoltServerPasswordForPort
+// applies. Mirrors GetDoltCredentialCommand exactly, but for a KindSecret
+// credential (a password) rather than a KindIdentity token: the command's
+// stdout is read the same way (bare token, or a
+// {token,expirationTimestamp} / {access_token,expires_in} envelope), and it
+// is resolved by dolt.ApplyPasswordCommand into the connection password slot
+// instead of the username slot. Env-only for the same reason as the
+// credential command: a metadata-sourced command is arbitrary code run on
+// open, so persisting it waits on a workspace-trust gate.
+func (c *Config) GetDoltPasswordCommand() string {
+	return os.Getenv("BEADS_DOLT_PASSWORD_COMMAND")
+}
+
 // GetDoltDatabase returns the Dolt SQL database name.
 // Checks BEADS_DOLT_SERVER_DATABASE env var first, then config, then default.
 func (c *Config) GetDoltDatabase() string {
@@ -598,6 +613,12 @@ func (c *Config) GetDoltServerPassword() string {
 // This avoids a mismatch where metadata.json says port 3308 (tunnel) but the
 // doltserver port file says 3307 (local), causing the credentials file lookup
 // to use the wrong [host:port] section.
+//
+// This is the static/fallback tier only. BEADS_DOLT_PASSWORD_COMMAND
+// (GetDoltPasswordCommand) is a higher-priority rung resolved earlier, in the
+// canonical open path (dolt.ApplyPasswordCommand, called from
+// applyResolvedConfig) — mirroring how BEADS_DOLT_CREDENTIAL_COMMAND is
+// resolved by ApplyGatewayCredential rather than inside GetDoltServerUser.
 func (c *Config) GetDoltServerPasswordForPort(port int) string {
 	if p := os.Getenv("BEADS_DOLT_PASSWORD"); p != "" {
 		return p

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -271,13 +271,23 @@ func applyResolvedConfig(ctx context.Context, beadsDir string, fileCfg *configfi
 	if !applied && cfg.ServerUser == "" {
 		cfg.ServerUser = fileCfg.GetDoltServerUser()
 	}
+	// Resolve the server secret command (the connection password). Unlike the
+	// identity command above, this runs unconditionally: GetDoltServerPasswordForPort
+	// (env var + credentials file, below) already applies regardless of server mode, so
+	// the command rung mirrors that scope instead of gating on IsDoltServerMode(). It
+	// fails closed (see ApplyPasswordCommand) — a configured-but-failing command aborts
+	// the open rather than silently falling back to the static tier.
+	passwordApplied, err := ApplyPasswordCommand(ctx, fileCfg, cfg)
+	if err != nil {
+		return fmt.Errorf("resolving dolt password command: %w", err)
+	}
 	// Populate password and TLS the same way the CLI CRUD path does. Without
 	// this, callers that rely on NewFromConfigWithOptions (e.g. doctor's
 	// SharedStore) fail to reach externally-hosted Dolt servers that keep
 	// credentials in ~/.config/beads/credentials, while bd create/list/close
 	// succeed (bd-h5k7). GetDoltServerPasswordForPort checks BEADS_DOLT_PASSWORD
 	// env first, then credentials file keyed by [host:resolved-port].
-	if cfg.ServerPassword == "" {
+	if !passwordApplied && cfg.ServerPassword == "" {
 		cfg.ServerPassword = fileCfg.GetDoltServerPasswordForPort(cfg.ServerPort)
 	}
 	if !cfg.ServerTLS {

--- a/internal/storage/dolt/password_credential.go
+++ b/internal/storage/dolt/password_credential.go
@@ -1,0 +1,45 @@
+package dolt
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/creds"
+)
+
+// ApplyPasswordCommand resolves the server secret command
+// (BEADS_DOLT_PASSWORD_COMMAND) into cfg.ServerPassword. It mirrors
+// ApplyGatewayCredential's mechanics exactly — same env-only command source, same
+// fail-closed walk — but for a KindSecret credential placed in the connection
+// password slot instead of a KindIdentity token placed in the username slot.
+//
+// It is a no-op ((false, nil)) when cfg.ServerPassword is already set (a
+// caller/flag preset, or an earlier BEADS_DOLT_PASSWORD env var already applied by
+// the caller, wins) or no command is configured. It fails closed: a
+// configured-but-failing command aborts the open and never falls back to
+// GetDoltServerPasswordForPort's static BEADS_DOLT_PASSWORD / credentials-file tier
+// — a wrong or stale password must never silently apply.
+func ApplyPasswordCommand(ctx context.Context, fileCfg *configfile.Config, cfg *Config) (bool, error) {
+	if cfg.ServerPassword != "" {
+		return false, nil
+	}
+	cred, ok, err := creds.ResolveLadder(ctx, creds.CommandSource{
+		Command: fileCfg.GetDoltPasswordCommand(),
+		Kind:    creds.KindSecret,
+		Label:   "BEADS_DOLT_PASSWORD_COMMAND",
+	})
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+	// Defense in depth: the value is placed in the password slot, so a
+	// non-secret credential must never reach it.
+	if cred.Kind != creds.KindSecret {
+		return false, fmt.Errorf("dolt: credential from %s is not a secret; refusing to place it in the connection password", cred.Source)
+	}
+	cfg.ServerPassword = cred.Value
+	return true, nil
+}

--- a/internal/storage/dolt/password_credential_test.go
+++ b/internal/storage/dolt/password_credential_test.go
@@ -1,0 +1,121 @@
+package dolt
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+// A configured secret command resolves the token into the password slot.
+func TestApplyPasswordCommand(t *testing.T) {
+	t.Setenv("BEADS_DOLT_PASSWORD_COMMAND", "printf s3cr3t")
+	cfg := &Config{}
+	applied, err := ApplyPasswordCommand(context.Background(), &configfile.Config{}, cfg)
+	if err != nil || !applied {
+		t.Fatalf("applied=%v err=%v", applied, err)
+	}
+	if cfg.ServerPassword != "s3cr3t" {
+		t.Fatalf("ServerPassword = %q, want s3cr3t", cfg.ServerPassword)
+	}
+}
+
+// An ExecCredential/OAuth-style JSON envelope resolves the token.
+func TestApplyPasswordCommandJSONEnvelope(t *testing.T) {
+	t.Setenv("BEADS_DOLT_PASSWORD_COMMAND", `printf '{"access_token":"pw-1","expires_in":300}'`)
+	cfg := &Config{}
+	if _, err := ApplyPasswordCommand(context.Background(), &configfile.Config{}, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ServerPassword != "pw-1" {
+		t.Fatalf("ServerPassword = %q, want pw-1", cfg.ServerPassword)
+	}
+}
+
+// Fail-closed: a failing helper aborts and never leaves a fallback password.
+func TestApplyPasswordCommandFailsClosed(t *testing.T) {
+	t.Setenv("BEADS_DOLT_PASSWORD_COMMAND", "false")
+	cfg := &Config{}
+	applied, err := ApplyPasswordCommand(context.Background(), &configfile.Config{}, cfg)
+	if err == nil {
+		t.Fatal("expected an error when the helper fails")
+	}
+	if !strings.Contains(err.Error(), "BEADS_DOLT_PASSWORD_COMMAND") {
+		t.Fatalf("error should name the command var, got %v", err)
+	}
+	if applied || cfg.ServerPassword != "" {
+		t.Fatalf("on failure the config must be untouched: %+v", cfg)
+	}
+}
+
+// A caller/flag-preset ServerPassword wins and the helper is never run (a failing
+// command doubles as an exec detector — no error means it never executed).
+func TestApplyPasswordCommandPresetWins(t *testing.T) {
+	t.Setenv("BEADS_DOLT_PASSWORD_COMMAND", "false")
+	cfg := &Config{ServerPassword: "preset"}
+	applied, err := ApplyPasswordCommand(context.Background(), &configfile.Config{}, cfg)
+	if err != nil {
+		t.Fatalf("preset should short-circuit before running the helper: %v", err)
+	}
+	if applied || cfg.ServerPassword != "preset" {
+		t.Fatalf("preset password must be preserved untouched: %+v", cfg)
+	}
+}
+
+// Not configured: no-op, config untouched.
+func TestApplyPasswordCommandNotConfigured(t *testing.T) {
+	t.Setenv("BEADS_DOLT_PASSWORD_COMMAND", "")
+	cfg := &Config{}
+	applied, err := ApplyPasswordCommand(context.Background(), &configfile.Config{}, cfg)
+	if err != nil || applied {
+		t.Fatalf("applied=%v err=%v, want (false,nil)", applied, err)
+	}
+	if cfg.ServerPassword != "" {
+		t.Fatalf("config must be untouched when not configured: %+v", cfg)
+	}
+}
+
+// Through applyResolvedConfig: with no BEADS_DOLT_PASSWORD env var and no
+// credentials file (INI absent), a configured BEADS_DOLT_PASSWORD_COMMAND
+// resolves the connection password — proving bd can get its password from the
+// command alone. It also runs regardless of dolt_mode (unlike the identity
+// command, GetDoltServerPasswordForPort's static tier already applies
+// unconditionally, so the command rung mirrors that scope).
+func TestApplyResolvedConfigPasswordCommand(t *testing.T) {
+	t.Run("command resolves the password with no env var and no credentials file", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_PASSWORD_COMMAND", "printf hunter2")
+		t.Setenv("BEADS_DOLT_PASSWORD", "")
+		t.Setenv("BEADS_CREDENTIALS_FILE", "/nonexistent/credentials")
+		cfg := &Config{}
+		if err := applyResolvedConfig(context.Background(), t.TempDir(), &configfile.Config{}, cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ServerPassword != "hunter2" {
+			t.Fatalf("ServerPassword = %q, want hunter2", cfg.ServerPassword)
+		}
+	})
+	t.Run("no command falls back to the static BEADS_DOLT_PASSWORD tier", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_PASSWORD_COMMAND", "")
+		t.Setenv("BEADS_DOLT_PASSWORD", "static-pw")
+		cfg := &Config{}
+		if err := applyResolvedConfig(context.Background(), t.TempDir(), &configfile.Config{}, cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ServerPassword != "static-pw" {
+			t.Fatalf("ServerPassword = %q, want static-pw", cfg.ServerPassword)
+		}
+	})
+	t.Run("a failing command aborts the open instead of falling back to the static tier", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_PASSWORD_COMMAND", "false")
+		t.Setenv("BEADS_DOLT_PASSWORD", "static-pw")
+		cfg := &Config{}
+		err := applyResolvedConfig(context.Background(), t.TempDir(), &configfile.Config{}, cfg)
+		if err == nil {
+			t.Fatal("expected an error when the command fails")
+		}
+		if cfg.ServerPassword != "" {
+			t.Fatalf("on failure the config must be untouched, got ServerPassword=%q", cfg.ServerPassword)
+		}
+	})
+}


### PR DESCRIPTION
## What
Adds `BEADS_DOLT_PASSWORD_COMMAND`, a credential-command rung for the Dolt server *password*, mirroring the existing `BEADS_DOLT_CREDENTIAL_COMMAND` (identity/username) mechanism exactly:

- `configfile.GetDoltPasswordCommand()` — env-only getter, sibling to `GetDoltCredentialCommand`.
- `dolt.ApplyPasswordCommand(ctx, fileCfg, cfg)` — resolves the command via the existing `creds.ResolveLadder`/`creds.CommandSource` machinery (`Kind: creds.KindSecret`) into `cfg.ServerPassword`, sibling to `ApplyGatewayCredential`.
- Wired into `applyResolvedConfig` (the canonical open path used by `NewFromConfig`/`NewFromConfigWithOptions`, and therefore every real `bd` command), right next to the existing identity-command resolution.

Same vendor-neutral credential-process idiom as the identity command (kubectl ExecCredential / AWS credential_process / git credential helper): the operator points the command at whatever mints the secret. Same output parsing (bare token or `{token,expirationTimestamp}`/`{access_token,expires_in}` JSON envelope), same process-lifetime cache, same fail-closed semantics — a configured-but-failing command aborts the open and never silently falls back to `BEADS_DOLT_PASSWORD` / the `~/.config/beads/credentials` file.

## Why
Lets a client point `bd` at a CLI that mints Dolt credentials directly (our use case: BugToPrompt's MCP-hosted org databases), the same way `BEADS_DOLT_CREDENTIAL_COMMAND` already lets it mint the connection identity for gateway servers.

## Scoping note
The password command runs unconditionally (no `IsDoltServerMode()`/`IsSharedServerMode()` gate), unlike the identity command — `GetDoltServerPasswordForPort`'s existing static tier already applies regardless of mode, so this mirrors that scope. It is intentionally not threaded into the ad-hoc `*dolt.Config` builders in `cmd/bd/doctor/*`, `bootstrap.go`'s `cloneViaServer`, or `dolt.go`'s `runExternalDoltStatus` — consistent with how `BEADS_DOLT_CREDENTIAL_COMMAND` doesn't reach those paths either today (they never call `ApplyGatewayCredential`). Extending those diagnostic/status paths to the same ladder would be a separate, larger-surface change.

## Testing
New `internal/storage/dolt/password_credential_test.go` (6 tests, mirroring `gateway_credential_test.go`'s coverage): command resolution (bare + JSON envelope), fail-closed on a failing helper, preset-wins short-circuit, not-configured no-op, and an `applyResolvedConfig`-level integration test proving the password resolves via the command with no `BEADS_DOLT_PASSWORD` and no credentials file present, and that a failing command aborts rather than falling back.

```
go test ./internal/configfile/... ./internal/creds/... ./internal/storage/dolt/...
ok  	github.com/steveyegge/beads/internal/configfile
ok  	github.com/steveyegge/beads/internal/creds
ok  	github.com/steveyegge/beads/internal/storage/dolt
```