### PR TITLE
docs(release-gates): annotate be-tqwx gate record with be-mv0ww correction note (be-mv0ww.2)

### DIFF
--- a/release-gates/be-tqwx-schema-migrations-pool-poison-gate.md
+++ b/release-gates/be-tqwx-schema-migrations-pool-poison-gate.md
@@ -290,3 +290,21 @@ reconciliation above). Per this rig's contributor-only carve-out for
 `gastownhall/beads`, the deployer's job ends here: no merge (`gh pr merge`
 is forbidden for all rig agents), no merge-request routed to mayor/mpr, no
 mayor handoff — mirroring be-tqwx's own precedent on this identical branch.
+
+## Correction note (added 2026-08-20)
+
+The original criterion 3 "Tests pass" PASS verdict near the top of this file
+was based on a test run narrower than this project's required full-scope
+command: a 9-test `-run` filter across only 2 of 3 relevant packages
+(`internal/storage/dolt`, `internal/storage/schema`), never including
+`internal/storage/uow`. A full-suite run on this same PR found 37 failing
+tests across `internal/storage/schema` and `internal/storage/uow`.
+
+This gap and its fix are tracked in be-mv0ww (process fix: be-mv0ww.1,
+currently open). See also the "Post-hoc annotation" section above, which
+documents the same underlying finding from be-crwzj's investigation and
+cites the parent epic be-mv0ww; this note adds the specific process-fix
+sub-task id that epic tracks (be-mv0ww.1). Filed as be-mv0ww.2.
+
+This note does not change that original verdict — it documents that the
+verdict was reached on incomplete evidence.


### PR DESCRIPTION
## Summary

The original criterion 3 ("Tests pass") PASS verdict recorded in
`release-gates/be-tqwx-schema-migrations-pool-poison-gate.md` was based on a
test run narrower than this project's required full-scope command: a 9-test
`-run` filter across only 2 of 3 relevant packages, never including
`internal/storage/uow`. A full-suite run on the same PR later found 37
failing tests across `internal/storage/schema` and `internal/storage/uow`
(already documented in the file's existing "Post-hoc annotation" section).

This PR adds one additional correction note to that same file, purely
additive (0 deletions), that cites the specific process-fix sub-task
(be-mv0ww.1) the parent epic be-mv0ww tracks for closing this gap in the
release-gate template itself. It does not alter the original verdict text —
it documents that the verdict was reached on incomplete evidence, same as
the existing annotation above it.

## Test plan

- [x] Diff confirmed additive-only: `git diff --stat` shows 1 file changed,
      18 insertions(+), 0 deletions(-)
- [x] Confirmed no Go source reads or embeds `release-gates/` content
      (`grep -rln release-gates --include=*.go .` → 0 matches), so this
      change is structurally incapable of altering any test outcome
- [x] `go build ./...`, `go vet ./...` clean
- [x] `gc beads-contributor pre-pr-check` — 0 blockers, 0 warnings

Full release-gate record: `release-gates/be-tqwx-schema-migrations-pool-poison-gate.md`

---
_claude-code-claude-sonnet-5-unknown-reasoning on behalf of Jim Wordelman_
