### PR TITLE
ci: retry the module fetch in pr-policy-wrapper, not the build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -367,6 +367,41 @@ jobs:
           go-version-file: 'go.mod'
           cache: false
 
+      # Same cold-fetch exposure as pr.yml's pr-policy-wrapper: setup-go above
+      # runs with cache: false, so every run pulls the whole module graph from
+      # the proxy. Retrying it here means a proxy blip costs seconds instead of
+      # failing a required check.
+      #
+      # Deliberately NOT wrapped around the build: `make ci-pr-policy` runs a
+      # `go build ./cmd/bd` (scripts/ci/pr-policy.sh, build_docs_binary), and a
+      # compile error is not transient. See pr.yml's copy for the full rationale.
+      #
+      # 3 attempts x 120s + 2 backoffs x 10s = 380s worst case. 8m leaves ~100s
+      # of headroom, matching the bounded apt-get steps in migration-test.yml.
+      - name: Download modules
+        timeout-minutes: 8
+        run: |
+          downloaded=""
+          for attempt in 1 2 3; do
+            if timeout 120 go mod download; then
+              downloaded=yes
+              break
+            fi
+            echo "::warning::go mod download attempt $attempt failed or timed out"
+            # No backoff after the final attempt - there is nothing left to wait for.
+            if [ "$attempt" -lt 3 ]; then
+              sleep 10
+            fi
+          done
+          # Unlike the best-effort apt-get retries elsewhere in this repo, this
+          # one is load-bearing: nothing downstream can build without the
+          # modules. Fail here, naming the fetch, so a module outage is not
+          # reported as a build failure.
+          if [ -z "$downloaded" ]; then
+            echo "::error::go mod download failed after 3 attempts - module fetch failure, not a build failure"
+            exit 1
+          fi
+
       - name: Run PR policy wrapper
         run: make ci-pr-policy
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -631,6 +631,43 @@ jobs:
           go-version-file: 'go.mod'
           cache: false
 
+      # The module fetch is the only part of this job that talks to the network,
+      # and setup-go above runs with cache: false, so every run pulls the whole
+      # module graph from the proxy. Doing it here, retried, means a proxy blip
+      # costs seconds instead of failing a required check.
+      #
+      # Deliberately NOT wrapped around the build: `make ci-pr-policy` runs a
+      # `go build ./cmd/bd` (scripts/ci/pr-policy.sh, build_docs_binary), and a
+      # compile error is not transient. Retrying it would make a genuinely broken
+      # build take three attempts to report and look like a slow one. The fetch
+      # has a legitimate transient failure mode; the build does not.
+      #
+      # 3 attempts x 120s + 2 backoffs x 10s = 380s worst case. 8m leaves ~100s
+      # of headroom, matching the bounded apt-get steps in migration-test.yml.
+      - name: Download modules
+        timeout-minutes: 8
+        run: |
+          downloaded=""
+          for attempt in 1 2 3; do
+            if timeout 120 go mod download; then
+              downloaded=yes
+              break
+            fi
+            echo "::warning::go mod download attempt $attempt failed or timed out"
+            # No backoff after the final attempt - there is nothing left to wait for.
+            if [ "$attempt" -lt 3 ]; then
+              sleep 10
+            fi
+          done
+          # Unlike the best-effort apt-get retries elsewhere in this repo, this
+          # one is load-bearing: nothing downstream can build without the
+          # modules. Fail here, naming the fetch, so a module outage is not
+          # reported as a build failure.
+          if [ -z "$downloaded" ]; then
+            echo "::error::go mod download failed after 3 attempts - module fetch failure, not a build failure"
+            exit 1
+          fi
+
       - name: Run PR policy wrapper
         run: make ci-pr-policy
 


### PR DESCRIPTION
An offer, not a complaint — this is your CI and you may well have reasons to
decline. It is one commit touching one job in `pr.yml`; dropping it unpicks
nothing.

## What happened

`PR Policy (wrapper timing)` is a required check. On a **docs-only** PR — one
markdown file, +18/−0 — it failed with:

```
stream error: stream ID NNN; INTERNAL_ERROR; received from peer
```

That is a `proxy.golang.org` outage, roughly 12 seconds wide. The job died
fetching module zips, before it evaluated any repository content.

The reason I am fairly confident it was the network and not the change: all the
workflow runs on that commit were triggered at the same instant and share the
same head SHA. Three passed outright, and inside the one failing run, 40 other
jobs built the same module graph from the same commit and passed. The split was
by clock, not by content — and nothing in a one-file docs diff could have caused
a module fetch to fail.

## Why it can happen at all

`pr-policy-wrapper` (`.github/workflows/pr.yml`) runs `setup-go` with
`cache: false`, then `make ci-pr-policy`, which reaches
`scripts/ci/pr-policy.sh` → `build_docs_binary` → `go build ./cmd/bd`. So every
run of that required job pulls the whole module graph from the proxy, and
nothing anywhere retries it. A required check that can be failed by someone
else's network tends, over time, to get waved through on reflex — which is how a
real failure eventually gets waved through too.

## What this changes

One step, before the wrapper: fetch the modules, retried.

**The build is deliberately left unwrapped.** Wrapping `go build` in a retry
would make a genuine compile error take three attempts to report and a broken
build look like a slow one. A module fetch has a legitimate transient failure
mode; a compile does not. So only the fetch retries, and with the cache warm the
later `go build` compiles without touching the network. If the retry is
exhausted, the step fails naming the *fetch*, so a proxy outage is never
reported as a build failure.

The loop copies the shape you already use for the bounded `apt-get` steps in
`migration-test.yml` and `release.yml`: three attempts, a per-attempt `timeout`,
a fixed backoff with none after the last, and a step-level `timeout-minutes`
above the worst case (3 × 120s + 2 × 10s = 380s, capped at 8m — the same ~100s
of headroom those steps leave).

## Two things I did not do, on purpose

1. **I did not add the step to `aptStepBudgets()`** in
   `scripts/ci_workflow_apt_get_timeout_test.go`. That table is apt-specific, and
   widening it is a second concern. Happy to add an equivalent guard for this
   step in a follow-up if you want the budget arithmetic pinned by a test the way
   the apt steps are.

2. **I did not touch `cache: false`.** A warm cache would avoid most of this
   fetch entirely, which arguably makes this change a mitigation rather than a
   fix — but that setting has real trade-offs (cache poisoning, staleness masking
   a dependency change) and it was presumably chosen deliberately. Different
   concern, different PR, and yours to decide.

## Testing

`go test ./scripts/` passes (the existing workflow-shape tests are unaffected).
The retry block was exercised directly in both directions: a command failing all
three attempts emits the three warnings and exits 1 with the fetch named, and one
failing once then succeeding recovers after a single backoff and exits 0.
