### PR TITLE
fix(test): stdio leak guard baselines at first test, not var-init (#5881)

### DIFF
--- a/cmd/bd/aaa_stdio_baseline_test.go
+++ b/cmd/bd/aaa_stdio_baseline_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// baselineStdout/baselineStderr are the os.Stdout/os.Stderr objects as the
+// FIRST test in this package saw them, captured here rather than at package
+// var-init: under `go test -json` (what gotestsum runs, so every CI coverage
+// leg) the testing framework itself reassigns os.Stderr = os.Stdout inside
+// M.Run so both streams interleave cleanly into one test2json event stream
+// (go1.26 testing/testing.go:2391, go.dev/issue/33419). That swap is the
+// framework's, not a test's; a leak guard that baselines at var-init convicts
+// the framework on every -json run (#5881) while measuring nothing about the
+// tests. This file is named aaa_* so its test is declared first: go test runs
+// tests in declaration order across files sorted by name (no -shuffle here).
+var baselineStdout, baselineStderr *os.File
+
+func TestAAAStdioBaseline(t *testing.T) {
+	baselineStdout, baselineStderr = os.Stdout, os.Stderr
+}

--- a/cmd/bd/zz_stdio_leak_guard_test.go
+++ b/cmd/bd/zz_stdio_leak_guard_test.go
@@ -5,28 +5,29 @@ import (
 	"testing"
 )
 
-// realStdout/realStderr are captured at package-variable initialization, before
-// any test runs, so they are the process's genuine streams.
-var (
-	realStdout = os.Stdout
-	realStderr = os.Stderr
-)
-
-// TestZZStdioNotLeaked fails if any test in this package reassigned os.Stdout or
-// os.Stderr and did not restore it. A capture helper that restores in a defer
-// cannot trip this; one that restores on the happy path only will trip it as soon
-// as its callback calls t.Fatal. See be-gh02.
+// TestZZStdioNotLeaked fails if any test in this package reassigned os.Stdout
+// or os.Stderr and did not restore it. A capture helper that restores in a
+// defer cannot trip this; one that restores on the happy path only will trip
+// it as soon as its callback calls t.Fatal. See be-gh02.
+//
+// The baseline is what the FIRST test saw (aaa_stdio_baseline_test.go), not
+// the var-init streams: under `go test -json` the testing framework swaps
+// os.Stderr to os.Stdout inside M.Run (go.dev/issue/33419), after var-init
+// and before any test, and that framework swap is not a leak (#5881).
 func TestZZStdioNotLeaked(t *testing.T) {
-	if os.Stdout != realStdout {
+	if baselineStdout == nil || baselineStderr == nil {
+		t.Skip("stdio baseline not captured (TestAAAStdioBaseline filtered out); nothing to compare against")
+	}
+	if os.Stdout != baselineStdout {
 		t.Errorf("os.Stdout was leaked by an earlier test (now fd=%d name=%q); "+
 			"a capture helper restored it on the happy path only - move the restore into a defer",
 			os.Stdout.Fd(), os.Stdout.Name())
-		os.Stdout = realStdout
+		os.Stdout = baselineStdout
 	}
-	if os.Stderr != realStderr {
+	if os.Stderr != baselineStderr {
 		t.Errorf("os.Stderr was leaked by an earlier test (now fd=%d name=%q); "+
 			"a capture helper restored it on the happy path only - move the restore into a defer",
 			os.Stderr.Fd(), os.Stderr.Name())
-		os.Stderr = realStderr
+		os.Stderr = baselineStderr
 	}
 }


### PR DESCRIPTION
Fixes #5881.

## Root cause (not a beads bug)

Under `go test -json` — what gotestsum runs, i.e. exactly the CI coverage leg — the **Go testing framework itself** reassigns `os.Stderr = os.Stdout` inside `M.Run`, so both streams interleave cleanly into one test2json event stream: go1.26.5 `testing/testing.go:2391`, citing go.dev/issue/33419. The swap lands after package var-init and before the first test.

`zz_stdio_leak_guard_test.go` baselined at var-init, so under `-json` it convicted the framework on every run — the "ubuntu main only" failures were really "-json only" (repro on darwin with plain `go test -json`). Bisect evidence on probe branch `bee/zzleak-probe-5881` (#5883, closing unmerged): probe test `aa` (alphabetically first) already sees `os.Stderr` = fd 1 `/dev/stdout`; STDIOCHK checkpoints through the whole TestMain window (`entry` → `pre-m.Run`) are all clean. Full chain on the issue.

## Fix

Capture the baseline in the alphabetically-first **test** (`aaa_stdio_baseline_test.go`) instead of at var-init, so the guard measures exactly what it promises — *did any test leak a stdio swap* — and stays blind to the framework's sanctioned redirect. Under a `-run` filter that excludes the baseline test, the guard skips instead of comparing against a pre-framework baseline.

## Verified (enumerated)

- `go test -tags gms_pure_go -short -count=1 -run 'TestAAAStdioBaseline|TestZZStdioNotLeaked' ./cmd/bd` → ok (plain mode)
- same with `-json` → both tests **pass** (previously both failed in this mode)
- `-run 'TestZZStdioNotLeaked'` alone → guard **skips** cleanly
- `gofmt` clean, `go vet ./cmd/bd` clean
- Test order note: go test runs tests in declaration order across files sorted by name; `aaa_*` precedes every other test file in the package and no `-shuffle` is used in CI.