### PR TITLE
fix(doctor): reap leaked test dolt sql-servers from CGO_ENABLED=0 suites

### DIFF
--- a/cmd/bd/doctor/dolt_e2e_test.go
+++ b/cmd/bd/doctor/dolt_e2e_test.go
@@ -61,6 +61,18 @@ func testMainInner(m *testing.M) int {
 	// The dolt.New database-name firewall requires this opt-in to allow
 	// doctor_pkg_shared and doctest_*-prefixed databases through.
 	os.Setenv("BEADS_TEST_SERVER", "1")
+
+	// Pin t.TempDir() under a suite-owned root so SweepOrphanedTestServers
+	// can reap AutoStart leftovers whose t.TempDir() cleanup failed because
+	// the live child still holds the tree (gastownhall/beads#5631).
+	root, pinErr := testutil.PinSuiteTempRoot("beads-doctor-tests-*")
+	if pinErr != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: suite temp root: %v\n", pinErr)
+		return 1
+	}
+	suiteTempRoot = root
+	defer os.RemoveAll(root)
+
 	if err := testutil.EnsureDoltContainerForTestMain(); err != nil {
 		fmt.Fprintf(os.Stderr, "WARN: %v, skipping Dolt tests\n", err)
 	} else {
@@ -88,8 +100,8 @@ func testMainInner(m *testing.M) int {
 
 	// Best-effort reap of any dolt sql-server left running under a temp dir
 	// this suite created (e.g. a SIGKILLed run) — see
-	// gastownhall/beads mybd-q6cz.
-	doltserver.SweepOrphanedTestServers(testBDDir)
+	// gastownhall/beads mybd-q6cz / #5631.
+	doltserver.SweepOrphanedTestServers(root, testBDDir)
 
 	os.Unsetenv("BEADS_DOLT_PORT")
 	os.Unsetenv("BEADS_TEST_MODE")

--- a/cmd/bd/doctor/fix/suite_temp_test.go
+++ b/cmd/bd/doctor/fix/suite_temp_test.go
@@ -1,0 +1,39 @@
+package fix
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// suiteTempRoot is the TestMain-owned temp directory that t.TempDir must
+// land under so SweepOrphanedTestServers can reap leaked sql-servers.
+var suiteTempRoot string
+
+func TestTempDirLandsUnderSuiteSweepRoot(t *testing.T) {
+	if suiteTempRoot == "" {
+		t.Fatal("TestMain did not pin suiteTempRoot; leaked dolt sql-server processes cannot be swept")
+	}
+	tmp := t.TempDir()
+	if !pathUnderRoot(tmp, suiteTempRoot) {
+		t.Fatalf("t.TempDir() %q is not under suiteTempRoot %q", tmp, suiteTempRoot)
+	}
+}
+
+func pathUnderRoot(dir, root string) bool {
+	dir = evalOrSelf(dir)
+	root = evalOrSelf(root)
+	if dir == root {
+		return true
+	}
+	sep := string(os.PathSeparator)
+	return strings.HasPrefix(dir, strings.TrimRight(root, sep)+sep)
+}
+
+func evalOrSelf(p string) string {
+	if r, err := filepath.EvalSymlinks(p); err == nil {
+		return r
+	}
+	return p
+}

--- a/cmd/bd/doctor/fix/testmain_cgo_test.go
+++ b/cmd/bd/doctor/fix/testmain_cgo_test.go
@@ -31,24 +31,24 @@ func testMainInner(m *testing.M) int {
 		defer testutil.TerminateDoltContainer()
 	}
 
-	// Suite-owned root for the orphan-server sweep below. Must never be a
-	// shared/global temp dir (see SweepOrphanedTestServers) — this one is
-	// unique to this test run and removed when it exits.
-	suiteTempRoot, tempRootErr := os.MkdirTemp("", "beads-fix-tests-*")
-	if tempRootErr != nil {
-		fmt.Fprintf(os.Stderr, "WARN: failed to create suite temp root: %v\n", tempRootErr)
+	// Pin t.TempDir() under a suite-owned root so the sweep below can reap
+	// AutoStart leftovers whose directory cleanup failed because the live
+	// child still holds the tree (gastownhall/beads#5631). Must never be a
+	// shared/global temp dir (see SweepOrphanedTestServers).
+	root, pinErr := testutil.PinSuiteTempRoot("beads-fix-tests-*")
+	if pinErr != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: suite temp root: %v\n", pinErr)
+		return 1
 	}
+	suiteTempRoot = root
+	defer os.RemoveAll(root)
 
 	code := m.Run()
 
 	// Best-effort reap of any dolt sql-server left running under this
 	// suite's own temp root (e.g. a SIGKILLed run) — see
-	// gastownhall/beads mybd-q6cz.
-	doltserver.SweepOrphanedTestServers(suiteTempRoot)
-
-	if suiteTempRoot != "" {
-		os.RemoveAll(suiteTempRoot)
-	}
+	// gastownhall/beads mybd-q6cz / #5631.
+	doltserver.SweepOrphanedTestServers(root)
 	os.Unsetenv("BEADS_DOLT_PORT")
 	os.Unsetenv("BEADS_TEST_MODE")
 	os.Unsetenv("BEADS_TEST_SERVER")

--- a/cmd/bd/doctor/fix/testmain_nocgo_test.go
+++ b/cmd/bd/doctor/fix/testmain_nocgo_test.go
@@ -1,0 +1,33 @@
+//go:build !cgo
+
+package fix
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/testutil"
+)
+
+// CGO_ENABLED=0 fix tests compile this TestMain instead of the cgo one.
+// Without it, FixMissingMetadata AutoStart leaves detached sql-servers
+// running after t.TempDir() cleanup (gastownhall/beads#5631).
+func TestMain(m *testing.M) {
+	os.Exit(testMainInner(m))
+}
+
+func testMainInner(m *testing.M) int {
+	root, err := testutil.PinSuiteTempRoot("beads-fix-tests-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: suite temp root: %v\n", err)
+		return 1
+	}
+	suiteTempRoot = root
+	defer os.RemoveAll(root)
+
+	code := m.Run()
+	doltserver.SweepOrphanedTestServers(root)
+	return code
+}

--- a/cmd/bd/doctor/suite_temp_test.go
+++ b/cmd/bd/doctor/suite_temp_test.go
@@ -1,0 +1,39 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// suiteTempRoot is the TestMain-owned temp directory that t.TempDir must
+// land under so SweepOrphanedTestServers can reap leaked sql-servers.
+var suiteTempRoot string
+
+func TestTempDirLandsUnderSuiteSweepRoot(t *testing.T) {
+	if suiteTempRoot == "" {
+		t.Fatal("TestMain did not pin suiteTempRoot; leaked dolt sql-server processes cannot be swept")
+	}
+	tmp := t.TempDir()
+	if !pathUnderRoot(tmp, suiteTempRoot) {
+		t.Fatalf("t.TempDir() %q is not under suiteTempRoot %q", tmp, suiteTempRoot)
+	}
+}
+
+func pathUnderRoot(dir, root string) bool {
+	dir = evalOrSelf(dir)
+	root = evalOrSelf(root)
+	if dir == root {
+		return true
+	}
+	sep := string(os.PathSeparator)
+	return strings.HasPrefix(dir, strings.TrimRight(root, sep)+sep)
+}
+
+func evalOrSelf(p string) string {
+	if r, err := filepath.EvalSymlinks(p); err == nil {
+		return r
+	}
+	return p
+}

--- a/cmd/bd/doctor/testmain_nocgo_test.go
+++ b/cmd/bd/doctor/testmain_nocgo_test.go
@@ -1,0 +1,33 @@
+//go:build !cgo
+
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/testutil"
+)
+
+// CGO_ENABLED=0 doctor tests compile this TestMain instead of the cgo e2e
+// one. Without it, tests that AutoStart a detached dolt sql-server leave
+// the process running after t.TempDir() cleanup (gastownhall/beads#5631).
+func TestMain(m *testing.M) {
+	os.Exit(testMainInner(m))
+}
+
+func testMainInner(m *testing.M) int {
+	root, err := testutil.PinSuiteTempRoot("beads-doctor-tests-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: suite temp root: %v\n", err)
+		return 1
+	}
+	suiteTempRoot = root
+	defer os.RemoveAll(root)
+
+	code := m.Run()
+	doltserver.SweepOrphanedTestServers(root)
+	return code
+}

--- a/internal/testutil/suite_temp.go
+++ b/internal/testutil/suite_temp.go
@@ -1,0 +1,28 @@
+package testutil
+
+import (
+	"os"
+)
+
+// PinSuiteTempRoot creates a suite-owned temp directory and points
+// GOTMPDIR, TMPDIR, TMP, and TEMP at it so testing.T.TempDir (Go 1.24+
+// uses GOTMPDIR) and os.MkdirTemp land under a root
+// SweepOrphanedTestServers can reap.
+//
+// Call from TestMain before m.Run(). The caller owns cleanup: sweep
+// first, then RemoveAll the returned path. Never pass os.TempDir() as
+// a sweep root — that would reap other suites' live servers
+// (scripts/test.sh -p N).
+func PinSuiteTempRoot(pattern string) (string, error) {
+	root, err := os.MkdirTemp("", pattern)
+	if err != nil {
+		return "", err
+	}
+	for _, key := range []string{"GOTMPDIR", "TMPDIR", "TMP", "TEMP"} {
+		if err := os.Setenv(key, root); err != nil {
+			_ = os.RemoveAll(root)
+			return "", err
+		}
+	}
+	return root, nil
+}

--- a/internal/testutil/suite_temp_test.go
+++ b/internal/testutil/suite_temp_test.go
@@ -1,0 +1,55 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPinSuiteTempRootRedirectsMkdirTemp(t *testing.T) {
+	oldGOTMPDIR := os.Getenv("GOTMPDIR")
+	oldTMPDIR := os.Getenv("TMPDIR")
+	oldTMP := os.Getenv("TMP")
+	oldTEMP := os.Getenv("TEMP")
+	t.Cleanup(func() {
+		_ = os.Setenv("GOTMPDIR", oldGOTMPDIR)
+		_ = os.Setenv("TMPDIR", oldTMPDIR)
+		_ = os.Setenv("TMP", oldTMP)
+		_ = os.Setenv("TEMP", oldTEMP)
+	})
+
+	root, err := PinSuiteTempRoot("beads-pin-suite-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+
+	if os.Getenv("GOTMPDIR") != root {
+		t.Fatalf("GOTMPDIR=%q, want pinned root %q", os.Getenv("GOTMPDIR"), root)
+	}
+	child, err := os.MkdirTemp(os.Getenv("GOTMPDIR"), "child-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isUnderRoot(child, root) {
+		t.Fatalf("GOTMPDIR MkdirTemp child %q is not under pinned root %q", child, root)
+	}
+}
+
+func isUnderRoot(dir, root string) bool {
+	dir = resolve(dir)
+	root = resolve(root)
+	if dir == root {
+		return true
+	}
+	sep := string(os.PathSeparator)
+	return strings.HasPrefix(dir, strings.TrimRight(root, sep)+sep)
+}
+
+func resolve(p string) string {
+	if r, err := filepath.EvalSymlinks(p); err == nil {
+		return r
+	}
+	return p
+}


### PR DESCRIPTION
Fixes #5631

## What

Doctor test suites that AutoStart a managed `dolt sql-server` were leaving those processes running after the test binary exited. `CGO_ENABLED=0` builds compiled no TestMain at all; the existing cgo TestMains swept a suite temp root that `t.TempDir()` was not actually under.

This pins `GOTMPDIR`/`TMPDIR` to a suite-owned directory before `m.Run()`, adds a `!cgo` TestMain for `cmd/bd/doctor` and `cmd/bd/doctor/fix`, and sweeps that root on exit. Production detach (`Setpgid` + `Process.Release()`) is unchanged.

## Why

maphew reproduced four leaked servers on Linux (main @ 1b67d0b1f) whose `--config` paths were already-deleted `t.TempDir()` roots: `TestFixMissingMetadata_EmptyBackend`, `TestFixMissingMetadata_DoltConfigExists`, `TestCheckDatabaseVersion_BareParentWorktreeFallback`, and `TestCheckDatabaseVersionWithStore_BareParentWorktreeServerModeNoLocalDolt`. Independently corroborated on darwin/arm64 at origin/main `66048d4fb`: the same four tests leaked, and `t.TempDir()` cleanup cannot finish while the child still holds the tree, so the `cwdDeleted` sweep signal never fires.

`#4592` added Linux `Pdeathsig` + suite-exit sweep, and `#5876` fixed TestMain `os.Exit` skipping defers. Those do not cover `CGO_ENABLED=0` doctor packages (no TestMain) or Go 1.24+ `t.TempDir()` which creates children under `GOTMPDIR`, not `TMPDIR`.

## Verification

```bash
# Before (origin/main). Four leaked servers whose --config path is under $TMPDIR.
# Kill only those PIDs afterwards; do not pkill broadly.
TMPDIR=$(mktemp -d) GOTMPDIR=$TMPDIR
export TMPDIR GOTMPDIR CGO_ENABLED=0
# strip BEADS_* first
go test -tags gms_pure_go ./cmd/bd/doctor/... -count=1
pgrep -lf 'dolt sql-server'

# After this branch: no new sql-server PIDs from $TMPDIR. Sweep log may show
# "Info: swept N orphaned test dolt sql-server process(es)".
go test -tags gms_pure_go ./internal/testutil ./cmd/bd/doctor/... -count=1
BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint
```

On this machine after the fix: `./internal/testutil` ok, `./cmd/bd/doctor/fix` ok, `./internal/doltserver` sweep tests ok, `./test/testmainconvention` ok, `make ci-pr-lint` 0 issues. `./cmd/bd/doctor` still fails `TestCheckBeadsRole_NotConfigured` and `TestCheckBeadsRole_NotGitRepo` because the ambient git config has `beads.role=maintainer` — same two failures on unmodified origin/main, out of scope.

## Notes

- Darwin has no `Pdeathsig`; the suite-exit sweep is the actual reaper there.
- `SweepOrphanedTestServers` must never be handed a shared `os.TempDir()` root (documented caller contract; the pinned roots here are unique `MkdirTemp` children), so parallel `scripts/test.sh -p N` suites cannot kill each other.
- Credit: maphew's repro and issue; prior art in #4592 / #5876.
