### PR TITLE
fix(storage): include custom active-category statuses in bd ready

### DIFF
--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -174,6 +174,68 @@ func TestGetReadyWork_StatusFilter(t *testing.T) {
 	}
 }
 
+// TestGetReadyWork_CustomActiveCategory pins GH#5831: `bd ready` pins
+// StatusOpen, and that pin is the active category — built-in open plus any
+// custom status whose category is active. WIP/done/frozen/unspecified
+// customs stay out; in_progress stays out.
+func TestGetReadyWork_CustomActiveCategory(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.SetConfig(ctx, "status.custom", "triaged:active,polishing:wip,shipped:done,parked:frozen,legacy"); err != nil {
+		t.Fatalf("SetConfig status.custom: %v", err)
+	}
+
+	mk := func(id string, status types.Status) {
+		t.Helper()
+		iss := &types.Issue{
+			ID:        id,
+			Title:     id,
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", id, err)
+		}
+		if status != types.StatusOpen {
+			if err := store.UpdateIssue(ctx, id, map[string]interface{}{"status": string(status)}, "tester"); err != nil {
+				t.Fatalf("UpdateIssue %s -> %s: %v", id, status, err)
+			}
+		}
+	}
+	mk("rw-ca-open", types.StatusOpen)
+	mk("rw-ca-active", types.Status("triaged"))
+	mk("rw-ca-wip", types.Status("polishing"))
+	mk("rw-ca-done", types.Status("shipped"))
+	mk("rw-ca-frozen", types.Status("parked"))
+	mk("rw-ca-legacy", types.Status("legacy"))
+	mk("rw-ca-inprog", types.StatusInProgress)
+
+	work, err := store.GetReadyWork(ctx, types.WorkFilter{Status: types.StatusOpen})
+	if err != nil {
+		t.Fatalf("GetReadyWork: %v", err)
+	}
+	got := map[string]bool{}
+	for _, w := range work {
+		got[w.ID] = true
+	}
+	if !got["rw-ca-open"] {
+		t.Errorf("built-in open missing from ready set: %v", issueIDs(work))
+	}
+	if !got["rw-ca-active"] {
+		t.Errorf("custom active-category status missing from ready set: %v", issueIDs(work))
+	}
+	for _, id := range []string{"rw-ca-wip", "rw-ca-done", "rw-ca-frozen", "rw-ca-legacy", "rw-ca-inprog"} {
+		if got[id] {
+			t.Errorf("%s should not appear in the StatusOpen ready set: %v", id, issueIDs(work))
+		}
+	}
+}
+
 func TestGetReadyWork_PriorityFilter(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/storage/issueops/ready_work_test.go
+++ b/internal/storage/issueops/ready_work_test.go
@@ -244,6 +244,32 @@ func TestGetChildrenOfDeferredParentsInTx_IgnoresMissingWispDependenciesTable(t 
 	}
 }
 
+func TestGetReadyWorkInTxOpenIncludesCustomActive(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	mock.ExpectQuery(deferredParentProbeRegex("issues")).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(deferredParentProbeRegex("wisps")).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`SELECT id FROM issues\s+WHERE \(status = \? OR status IN \(SELECT name FROM custom_statuses WHERE category = 'active'\)\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).WillReturnError(sql.ErrNoRows)
+
+	got, err := GetReadyWorkInTx(
+		context.Background(),
+		tx,
+		types.WorkFilter{Status: types.StatusOpen},
+	)
+	if err != nil {
+		t.Fatalf("GetReadyWorkInTx: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no rows, got %d", len(got))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
 func TestGetReadyWorkInTxStatusesSingleQuery(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/sqlbuild/ready.go
+++ b/internal/storage/sqlbuild/ready.go
@@ -95,7 +95,15 @@ func BuildReadyWorkWhere(filter types.WorkFilter, tables FilterTables, in ReadyW
 	var args []any
 	switch {
 	case filter.Status != "":
-		statusClause = "status = ?"
+		// Singular StatusOpen is the `bd ready` pin and means the ready-
+		// eligible set: built-in open plus category-active custom statuses,
+		// matching the ready_issues view since migration 0025 (GH#5831).
+		// Any other singular status stays exact.
+		if filter.Status == types.StatusOpen {
+			statusClause = "(status = ? OR status IN (SELECT name FROM custom_statuses WHERE category = 'active'))"
+		} else {
+			statusClause = "status = ?"
+		}
 		args = append(args, string(filter.Status))
 	case len(filter.Statuses) > 0:
 		ph, statusArgs := InPlaceholders(filter.Statuses)

--- a/internal/storage/sqlbuild/sqlbuild_test.go
+++ b/internal/storage/sqlbuild/sqlbuild_test.go
@@ -396,9 +396,23 @@ func TestBuildReadyWorkWhereStatusFilter(t *testing.T) {
 		{
 			name:            "SingularStatusWinsOverStatuses",
 			filter:          types.WorkFilter{Status: "open", Statuses: []types.Status{"blocked", "pinned"}},
-			wantClause:      "status = ?",
+			wantClause:      "(status = ? OR status IN (SELECT name FROM custom_statuses WHERE category = 'active'))",
 			rejectClause:    "status IN (?",
 			wantLeadingArgs: []any{"open"},
+		},
+		{
+			name:            "OpenIncludesCustomActiveCategory",
+			filter:          types.WorkFilter{Status: types.StatusOpen},
+			wantClause:      "status IN (SELECT name FROM custom_statuses WHERE category = 'active')",
+			rejectClause:    "status IN ('open', 'in_progress')",
+			wantLeadingArgs: []any{"open"},
+		},
+		{
+			name:            "NonOpenSingularStatusStaysExact",
+			filter:          types.WorkFilter{Status: types.StatusInProgress},
+			wantClause:      "status = ?",
+			rejectClause:    "custom_statuses",
+			wantLeadingArgs: []any{"in_progress"},
 		},
 		{
 			name:         "EmptyFilterLegacyDefault",


### PR DESCRIPTION
## What

Honor the documented promise that a custom status with category `active` appears in `bd ready`. `BuildReadyWorkWhere` now expands the singular `StatusOpen` pin (what `bd ready` / `BuildReadyFilter` actually pass) to built-in `open` plus any `custom_statuses` row whose category is `active` — the same predicate the `ready_issues` view has used since migration 0025.

## Why

Reported by Justin Clemens (@justin-candor). Addresses #5831.

`bd statuses --help` says category `active` "appears in `bd ready`". `bd update --claim` already honors that set (#4164 / #4334). `GetReadyWork` did not: it treated `StatusOpen` as an exact match, so a custom active status never showed up.

This is a different path from the staged #5832 work (`bd list --status X --ready` / `BuildListFilter` / `ReadyFilterFromIssueFilter`). That branch does not touch `internal/storage/sqlbuild/ready.go`. The diffs are non-overlapping.

Known pre-existing divergence, not fixed here: the classic (non-db) stack's wisp arm converts a singular status to an exact match (`internal/storage/issueops/ready_work.go:324-326`), so a *wisp* in a custom active status still won't surface under `--include-ephemeral` on that stack — the widened predicate covers regular issues on both stacks and wisps on the db stack.


## Verification

Empirical CLI repro (strip `BEADS_*`; binary built `-tags gms_pure_go` without `CGO_ENABLED=0` so embedded Dolt `bd init` works):

```bash
tmpdir=$(mktemp -d)
cd "$tmpdir"
bd init --prefix repro --quiet
bd config set status.custom "probe_active:active"
ID=$(bd create "active custom should be ready" -t task -p 2 --json | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
bd update "$ID" --status probe_active
bd ready --json
```

- **Before (origin/main):** `bd ready --json` → `[]` while `bd show` reports `probe_active`.
- **After:** `bd ready --json` includes the issue with `"status": "probe_active"`.
- **Edges:** built-in `open` still appears; custom `wip` / `done` / `frozen` still excluded.

Scoped tests (`CGO_ENABLED=0 -tags gms_pure_go -count=1`; full `./cmd/bd` not run — hangs without Docker):

```
go test -tags gms_pure_go -count=1 -timeout 20m \
  ./internal/storage/sqlbuild ./internal/storage/issueops ./internal/storage/dolt \
  -run 'TestBuildReadyWorkWhereStatusFilter|TestGetReadyWorkInTxOpenIncludesCustomActive|TestGetReadyWork_CustomActiveCategory|TestGetReadyWork_StatusFilter|TestGetReadyWork_EmptyStore'
```

All three packages: ok.

Lint: `BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint` — gofmt ok, golangci-lint 0 issues (linux + windows).
