### PR TITLE
fix(list): honor --sort/--reverse in the default tree renderer

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -315,7 +315,7 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 				return HandleError("loading dependencies for --deps: %v", depErr)
 			}
 			// Hierarchical --parent walks use an unlimited per-level query, so the tree is never page-truncated.
-			displayPrettyListWithDepsMode(treeIssues, false, allDeps, in.depsMode, false, in.ReadyFlag, in.Status)
+			displayPrettyListWithDepsMode(treeIssues, false, allDeps, in.depsMode, false, in.ReadyFlag, in.Status, in.SortBy, in.Reverse)
 			printSkipLabelsFooter(in.SkipLabels)
 			return nil
 		}
@@ -324,7 +324,7 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 		if depErr != nil && in.depsMode != "" {
 			return HandleError("loading dependencies for --deps: %v", depErr)
 		}
-		displayPrettyListWithDepsMode(issues, false, allDeps, in.depsMode, truncated, in.ReadyFlag, in.Status)
+		displayPrettyListWithDepsMode(issues, false, allDeps, in.depsMode, truncated, in.ReadyFlag, in.Status, in.SortBy, in.Reverse)
 		printTruncationHint(truncated, in.effectiveLimit)
 		printSkipLabelsFooter(in.SkipLabels)
 		return nil

--- a/cmd/bd/list_footer_counts_test.go
+++ b/cmd/bd/list_footer_counts_test.go
@@ -166,7 +166,7 @@ func TestDisplayWatchedIssueListReadyFooterDisclosesFilter(t *testing.T) {
 	// for; the footer is what is under test, and this keeps the file free of
 	// the cgo-tagged stub so it still compiles under CGO_ENABLED=0.
 	out := captureStdout(t, func() error {
-		displayWatchedIssueList(context.Background(), nil, issues, false, true, "")
+		displayWatchedIssueList(context.Background(), nil, issues, false, true, "", "", false)
 		return nil
 	})
 
@@ -186,7 +186,7 @@ func TestDisplayPrettyListWithDepsReadyFooterDisclosesFilter(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() error {
-		displayPrettyListWithDeps(issues, false, nil, false, true, "")
+		displayPrettyListWithDeps(issues, false, nil, false, true, "", "", false)
 		return nil
 	})
 	if strings.Contains(out, "in progress)") {
@@ -199,7 +199,7 @@ func TestDisplayPrettyListWithDepsReadyFooterDisclosesFilter(t *testing.T) {
 	// The other half: without --ready the same wrapper must keep the breakdown,
 	// so the fix cannot be "never print counts".
 	plain := captureStdout(t, func() error {
-		displayPrettyListWithDeps(issues, false, nil, false, false, "")
+		displayPrettyListWithDeps(issues, false, nil, false, false, "", "", false)
 		return nil
 	})
 	if !strings.Contains(plain, "in progress)") {
@@ -246,7 +246,7 @@ func TestDisplayPrettyListWithDepsReadyExplicitStatusFooter(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() error {
-		displayPrettyListWithDeps(issues, false, nil, false, true, "in_progress")
+		displayPrettyListWithDeps(issues, false, nil, false, true, "in_progress", "", false)
 		return nil
 	})
 	if strings.Contains(out, "open only") || strings.Contains(out, "excludes in_progress") {
@@ -257,7 +257,7 @@ func TestDisplayPrettyListWithDepsReadyExplicitStatusFooter(t *testing.T) {
 	}
 
 	depsOut := captureStdout(t, func() error {
-		displayPrettyListWithDepsMode(issues, false, nil, "scheduling", false, true, "in_progress")
+		displayPrettyListWithDepsMode(issues, false, nil, "scheduling", false, true, "in_progress", "", false)
 		return nil
 	})
 	if strings.Contains(depsOut, "open only") || strings.Contains(depsOut, "excludes in_progress") {
@@ -273,7 +273,7 @@ func TestDisplayWatchedIssueListReadyExplicitStatusFooter(t *testing.T) {
 		{ID: "bd-1", Title: "A", Status: types.StatusInProgress, Priority: 1, IssueType: types.TypeTask},
 	}
 	out := captureStdout(t, func() error {
-		displayWatchedIssueList(context.Background(), nil, issues, false, true, "in_progress")
+		displayWatchedIssueList(context.Background(), nil, issues, false, true, "in_progress", "", false)
 		return nil
 	})
 	if strings.Contains(out, "open only") || strings.Contains(out, "excludes in_progress") {

--- a/cmd/bd/list_helpers_test.go
+++ b/cmd/bd/list_helpers_test.go
@@ -317,7 +317,7 @@ func TestListDisplayPrettyList_TruncatedSummary(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() error {
-		displayPrettyListWithDepsMode(issues, false, nil, "", true, false, "")
+		displayPrettyListWithDepsMode(issues, false, nil, "", true, false, "", "", false)
 		return nil
 	})
 	if !strings.Contains(out, "Showing 2 issues") {
@@ -343,7 +343,7 @@ func TestDisplayWatchedIssueList_UsesDependencyHierarchy(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() error {
-		displayWatchedIssueList(context.Background(), store, []*types.Issue{child, parent}, false, false, "")
+		displayWatchedIssueList(context.Background(), store, []*types.Issue{child, parent}, false, false, "", "", false)
 		return nil
 	})
 

--- a/cmd/bd/list_proxied_server.go
+++ b/cmd/bd/list_proxied_server.go
@@ -156,7 +156,7 @@ func runListProxiedWatch(_ *cobra.Command, ctx context.Context, in listInput) er
 	if err != nil {
 		return fmt.Errorf("initial query: %w", err)
 	}
-	displayPrettyListWithDeps(issues, true, deps, hasMore, in.ReadyFlag, in.Status)
+	displayPrettyListWithDeps(issues, true, deps, hasMore, in.ReadyFlag, in.Status, in.SortBy, in.Reverse)
 	printTruncationHint(hasMore, in.effectiveLimit)
 	lastSnapshot := issueSnapshot(issues)
 
@@ -183,7 +183,7 @@ func runListProxiedWatch(_ *cobra.Command, ctx context.Context, in listInput) er
 			snap := issueSnapshot(issues)
 			if snap != lastSnapshot {
 				lastSnapshot = snap
-				displayPrettyListWithDeps(issues, true, deps, hasMore, in.ReadyFlag, in.Status)
+				displayPrettyListWithDeps(issues, true, deps, hasMore, in.ReadyFlag, in.Status, in.SortBy, in.Reverse)
 				printTruncationHint(hasMore, in.effectiveLimit)
 				fmt.Fprintf(os.Stderr, "\nWatching for changes... (Press Ctrl+C to exit)\n")
 			}
@@ -239,7 +239,7 @@ func renderProxiedListText(ctx context.Context, out io.Writer, issues []*types.I
 			printTruncationHint(truncated, in.effectiveLimit)
 			return nil
 		}
-		displayPrettyListWithDepsMode(issues, false, depsByIssueID, in.depsMode, truncated, in.ReadyFlag, in.Status)
+		displayPrettyListWithDepsMode(issues, false, depsByIssueID, in.depsMode, truncated, in.ReadyFlag, in.Status, in.SortBy, in.Reverse)
 		printTruncationHint(truncated, in.effectiveLimit)
 		printSkipLabelsFooter(in.SkipLabels)
 		return nil

--- a/cmd/bd/list_show_filter_modes.go
+++ b/cmd/bd/list_show_filter_modes.go
@@ -156,7 +156,7 @@ func loadWatchedIssues(ctx context.Context, store storage.DoltStorage, filter ty
 // names its scope instead of asserting an in-progress count the ready filter
 // forced to zero. A watch loop is where a stale "0 in progress" is most likely
 // to be read as a live fact, so this is the path that most needs it.
-func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore, issues []*types.Issue, truncated, readyFiltered bool, statusSelector string) {
+func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore, issues []*types.Issue, truncated, readyFiltered bool, statusSelector string, sortBy string, reverse bool) {
 	var allDeps map[string][]*types.Dependency
 	if store != nil {
 		deps, err := store.GetAllDependencyRecords(ctx)
@@ -164,7 +164,7 @@ func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore
 			allDeps = deps
 		}
 	}
-	displayPrettyListWithDeps(issues, true, allDeps, truncated, readyFiltered, statusSelector)
+	displayPrettyListWithDeps(issues, true, allDeps, truncated, readyFiltered, statusSelector, sortBy, reverse)
 }
 
 // watchIssues returns an error only for the initial query — a failure there
@@ -184,7 +184,7 @@ func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.Is
 	// below depends on; what is left is the cut and its verdict, and those are
 	// the shared epilogue's on every other listing this command has.
 	issues, truncated := workapi.FinishPage(issues, "", false, effectiveLimit, false)
-	displayWatchedIssueList(ctx, store, issues, truncated, ready, statusSelector)
+	displayWatchedIssueList(ctx, store, issues, truncated, ready, statusSelector, sortBy, reverse)
 	printTruncationHint(truncated, effectiveLimit)
 	lastSnapshot := issueSnapshot(issues)
 
@@ -214,7 +214,7 @@ func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.Is
 			snap := issueSnapshot(issues)
 			if snap != lastSnapshot {
 				lastSnapshot = snap
-				displayWatchedIssueList(ctx, store, issues, truncated, ready, statusSelector)
+				displayWatchedIssueList(ctx, store, issues, truncated, ready, statusSelector, sortBy, reverse)
 				printTruncationHint(truncated, effectiveLimit)
 				fmt.Fprintf(os.Stderr, "\nWatching for changes... (Press Ctrl+C to exit)\n")
 			}
@@ -256,7 +256,7 @@ func runListProxiedHierarchicalParent(ctx context.Context, uw uow.UnitOfWork, in
 	}
 
 	// Hierarchical --parent walks use an unlimited per-level query; never page-truncated.
-	displayPrettyListWithDepsMode(treeIssues, false, depsByIssueID, in.depsMode, false, in.ReadyFlag, in.Status)
+	displayPrettyListWithDepsMode(treeIssues, false, depsByIssueID, in.depsMode, false, in.ReadyFlag, in.Status, in.SortBy, in.Reverse)
 	printSkipLabelsFooter(in.SkipLabels)
 	return nil
 }

--- a/cmd/bd/list_tree.go
+++ b/cmd/bd/list_tree.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/utils"
+	"github.com/steveyegge/beads/internal/workapi"
 )
 
 // buildIssueTree builds parent-child tree structure from issues
@@ -111,18 +112,52 @@ func compareIssuesByPriority(a, b *types.Issue) int {
 	return utils.NaturalCompareIDs(a.ID, b.ID)
 }
 
+// sortListTreeGroup orders one tree level (roots, or children of one parent).
+// Empty sortBy keeps the tree's default (priority, then natural ID). A requested
+// --sort/--reverse uses the same CompareIssuesBy the JSON path uses, so a forest
+// of roots matches --json order and nested siblings follow the same field.
+func sortListTreeGroup(issues []*types.Issue, sortBy string, reverse bool) {
+	if len(issues) < 2 {
+		return
+	}
+	if sortBy == "" {
+		slices.SortFunc(issues, compareIssuesByPriority)
+		return
+	}
+	workapi.SortIssues(issues, sortBy, reverse)
+}
+
+// applyListTreeOrder is sortListTreeGroup plus a stability restore: when --sort
+// is set, restack this level into the page's already-applied display order
+// before comparing. FinishPage's sort is stable, so equal keys (same-second
+// updated_at) keep SQL/page order in --json; sorting from the tree's default
+// priority order would reshuffle those ties.
+func applyListTreeOrder(level, page []*types.Issue, sortBy string, reverse bool) {
+	if sortBy != "" && len(page) > 0 {
+		pos := make(map[string]int, len(page))
+		for i, issue := range page {
+			if issue != nil {
+				pos[issue.ID] = i
+			}
+		}
+		slices.SortStableFunc(level, func(a, b *types.Issue) int {
+			return cmp.Compare(pos[a.ID], pos[b.ID])
+		})
+	}
+	sortListTreeGroup(level, sortBy, reverse)
+}
+
 // printPrettyTree recursively prints the issue tree.
 // Children are ordered by dependency then priority when dr != nil (--deps), else
 // by priority (P0 first) for intuitive reading. When dr is set, each node's
 // dependency edges are annotated just beneath it.
-func printPrettyTree(childrenMap map[string][]*types.Issue, parentID string, prefix string, dr *depRender) {
+func printPrettyTree(childrenMap map[string][]*types.Issue, parentID string, prefix string, dr *depRender, page []*types.Issue, sortBy string, reverse bool) {
 	children := childrenMap[parentID]
 
 	if dr != nil {
 		children = orderSiblingsByDeps(children, dr.allDeps)
 	} else {
-		// Sort children by priority using same comparison as roots for consistency
-		slices.SortFunc(children, compareIssuesByPriority)
+		applyListTreeOrder(children, page, sortBy, reverse)
 	}
 
 	for i, child := range children {
@@ -138,7 +173,7 @@ func printPrettyTree(childrenMap map[string][]*types.Issue, parentID string, pre
 			extension = "    "
 		}
 		dr.annotationsFor(child.ID, prefix+extension)
-		printPrettyTree(childrenMap, child.ID, prefix+extension, dr)
+		printPrettyTree(childrenMap, child.ID, prefix+extension, dr, page, sortBy, reverse)
 	}
 }
 
@@ -147,7 +182,7 @@ func printPrettyTree(childrenMap map[string][]*types.Issue, parentID string, pre
 // There is no --ready arm behind this one: it is the plain tree, so the
 // summary keeps its status breakdown.
 func displayPrettyList(issues []*types.Issue, showHeader bool) {
-	displayPrettyListWithDeps(issues, showHeader, nil, false, false, "")
+	displayPrettyListWithDeps(issues, showHeader, nil, false, false, "", "", false)
 }
 
 // displayPrettyListWithDeps displays issues in tree format using dependency data.
@@ -155,8 +190,8 @@ func displayPrettyList(issues []*types.Issue, showHeader bool) {
 // / --status state rather than defaulted here: the watch paths reach the
 // summary through this wrapper, and a hardcoded false silently restores the
 // vacuous "(N open, 0 in progress)" that listFooterLine exists to suppress.
-func displayPrettyListWithDeps(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, truncated, readyFiltered bool, statusSelector string) {
-	displayPrettyListWithDepsMode(issues, showHeader, allDeps, "", truncated, readyFiltered, statusSelector)
+func displayPrettyListWithDeps(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, truncated, readyFiltered bool, statusSelector string, sortBy string, reverse bool) {
+	displayPrettyListWithDepsMode(issues, showHeader, allDeps, "", truncated, readyFiltered, statusSelector, sortBy, reverse)
 }
 
 // listFooterLine renders the one-line summary under a text listing.
@@ -217,7 +252,7 @@ func readyFooterScope(statusSelector string) string {
 // by --limit; the summary then says "Showing N" instead of "Total: N" (GH#5362).
 // readyFiltered means --ready was in force; statusSelector is the --status value
 // so the summary names the pin that actually applied — see listFooterLine.
-func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, depsMode string, truncated, readyFiltered bool, statusSelector string) {
+func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, depsMode string, truncated, readyFiltered bool, statusSelector string, sortBy string, reverse bool) {
 	if showHeader {
 		// Clear screen and show header
 		fmt.Print("\033[2J\033[H")
@@ -242,12 +277,14 @@ func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDe
 		}
 		dr = &depRender{mode: depsMode, allDeps: allDeps, inView: inView}
 		roots = orderSiblingsByDeps(roots, allDeps)
+	} else {
+		applyListTreeOrder(roots, issues, sortBy, reverse)
 	}
 
 	for _, issue := range roots {
 		fmt.Println(formatPrettyIssue(issue))
 		dr.annotationsFor(issue.ID, "")
-		printPrettyTree(childrenMap, issue.ID, "", dr)
+		printPrettyTree(childrenMap, issue.ID, "", dr, issues, sortBy, reverse)
 	}
 
 	// Summary — counts describe the shown page; never label a truncated page "Total".

--- a/cmd/bd/list_tree_sort_test.go
+++ b/cmd/bd/list_tree_sort_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func cloneIssues(in []*types.Issue) []*types.Issue {
+	out := make([]*types.Issue, len(in))
+	copy(out, in)
+	return out
+}
+
+func firstIndex(haystack, needle string) int {
+	i := strings.Index(haystack, needle)
+	if i < 0 {
+		return 1 << 30
+	}
+	return i
+}
+
+func assertIDOrder(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestSortListTreeGroup_DefaultPriorityThenID(t *testing.T) {
+	// Mixed insertion order so a no-op sort cannot pass.
+	issues := []*types.Issue{
+		{ID: "scr-z", Title: "Charlie", Priority: 2},
+		{ID: "scr-a", Title: "Alpha", Priority: 2},
+		{ID: "scr-m", Title: "Beta", Priority: 1},
+	}
+	sortListTreeGroup(issues, "", false)
+	assertIDOrder(t, idsOf(issues), "scr-m", "scr-a", "scr-z")
+}
+
+func TestSortListTreeGroup_ExplicitSortAndReverse(t *testing.T) {
+	issues := []*types.Issue{
+		{ID: "scr-z", Title: "Charlie", Priority: 2},
+		{ID: "scr-a", Title: "Alpha", Priority: 3},
+		{ID: "scr-m", Title: "Beta", Priority: 1},
+	}
+
+	byTitle := cloneIssues(issues)
+	sortListTreeGroup(byTitle, "title", false)
+	assertIDOrder(t, idsOf(byTitle), "scr-a", "scr-m", "scr-z")
+
+	reversed := cloneIssues(issues)
+	sortListTreeGroup(reversed, "title", true)
+	assertIDOrder(t, idsOf(reversed), "scr-z", "scr-m", "scr-a")
+}
+
+func TestSortListTreeGroup_EmptySortLeavesDefaultEvenWithReverse(t *testing.T) {
+	issues := []*types.Issue{
+		{ID: "scr-z", Title: "Charlie", Priority: 2},
+		{ID: "scr-a", Title: "Alpha", Priority: 2},
+		{ID: "scr-m", Title: "Beta", Priority: 1},
+	}
+	// --reverse with no --sort is a no-op on the JSON path (SortRows returns
+	// immediately). The tree must keep the same default, not invert priority.
+	sortListTreeGroup(issues, "", true)
+	assertIDOrder(t, idsOf(issues), "scr-m", "scr-a", "scr-z")
+}
+
+func TestDisplayPrettyList_HonorsSortReverseAndDefault(t *testing.T) {
+	t0 := time.Date(2026, 8, 21, 8, 54, 40, 0, time.UTC)
+	delta := &types.Issue{ID: "scr-1kx", Title: "Delta task", Status: types.StatusOpen, Priority: 3, IssueType: types.TypeTask, UpdatedAt: t0.Add(3 * time.Second)}
+	charlie := &types.Issue{ID: "scr-1py", Title: "Charlie task", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, UpdatedAt: t0.Add(1 * time.Second)}
+	alpha := &types.Issue{ID: "scr-t85", Title: "Alpha task", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, UpdatedAt: t0.Add(2 * time.Second)}
+	// Insertion order is neither priority, title, nor updated.
+	issues := []*types.Issue{delta, charlie, alpha}
+
+	defaultOut := captureStdout(t, func() error {
+		displayPrettyListWithDepsMode(cloneIssues(issues), false, nil, "", false, false, "", "", false)
+		return nil
+	})
+	if !(firstIndex(defaultOut, "scr-1py") < firstIndex(defaultOut, "scr-t85") && firstIndex(defaultOut, "scr-t85") < firstIndex(defaultOut, "scr-1kx")) {
+		t.Fatalf("default tree must stay priority-then-ID (Charlie P1, Alpha P2, Delta P3), got:\n%s", defaultOut)
+	}
+
+	titleOut := captureStdout(t, func() error {
+		displayPrettyListWithDepsMode(cloneIssues(issues), false, nil, "", false, false, "", "title", false)
+		return nil
+	})
+	if !(firstIndex(titleOut, "scr-t85") < firstIndex(titleOut, "scr-1py") && firstIndex(titleOut, "scr-1py") < firstIndex(titleOut, "scr-1kx")) {
+		t.Fatalf("--sort title must render Alpha, Charlie, Delta, got:\n%s", titleOut)
+	}
+
+	reverseOut := captureStdout(t, func() error {
+		displayPrettyListWithDepsMode(cloneIssues(issues), false, nil, "", false, false, "", "title", true)
+		return nil
+	})
+	if !(firstIndex(reverseOut, "scr-1kx") < firstIndex(reverseOut, "scr-1py") && firstIndex(reverseOut, "scr-1py") < firstIndex(reverseOut, "scr-t85")) {
+		t.Fatalf("--sort title --reverse must render Delta, Charlie, Alpha, got:\n%s", reverseOut)
+	}
+
+	updatedOut := captureStdout(t, func() error {
+		displayPrettyListWithDepsMode(cloneIssues(issues), false, nil, "", false, false, "", "updated", false)
+		return nil
+	})
+	// CompareIssuesBy("updated") is newest first, matching --json.
+	if !(firstIndex(updatedOut, "scr-1kx") < firstIndex(updatedOut, "scr-t85") && firstIndex(updatedOut, "scr-t85") < firstIndex(updatedOut, "scr-1py")) {
+		t.Fatalf("--sort updated must render newest first (Delta, Alpha, Charlie), got:\n%s", updatedOut)
+	}
+}
+
+func TestApplyListTreeOrder_EqualKeysKeepPageOrder(t *testing.T) {
+	same := time.Date(2026, 8, 21, 8, 54, 46, 0, time.UTC)
+	newer := same.Add(time.Second)
+	page := []*types.Issue{
+		{ID: "scr-1kx", Title: "Delta", Priority: 3, UpdatedAt: newer},
+		{ID: "scr-1py", Title: "Charlie", Priority: 1, UpdatedAt: same},
+		{ID: "scr-t85", Title: "Alpha", Priority: 2, UpdatedAt: same},
+		{ID: "scr-wh3", Title: "Beta", Priority: 0, UpdatedAt: same},
+	}
+	// Start from the tree's default priority order so a missing restore
+	// would emit Beta, Charlie, Alpha after the equal-key group.
+	level := []*types.Issue{page[3], page[1], page[2], page[0]}
+	applyListTreeOrder(level, page, "updated", false)
+	assertIDOrder(t, idsOf(level), "scr-1kx", "scr-1py", "scr-t85", "scr-wh3")
+}
+
+func TestDisplayPrettyList_SortAppliesToSiblings(t *testing.T) {
+	parent := &types.Issue{ID: "scr-p", Title: "Parent", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	childZ := &types.Issue{ID: "scr-z", Title: "Zebra", Status: types.StatusOpen, Priority: 0, IssueType: types.TypeTask}
+	childA := &types.Issue{ID: "scr-a", Title: "Aardvark", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	deps := map[string][]*types.Dependency{
+		"scr-z": {{IssueID: "scr-z", DependsOnID: "scr-p", Type: types.DepParentChild}},
+		"scr-a": {{IssueID: "scr-a", DependsOnID: "scr-p", Type: types.DepParentChild}},
+	}
+	issues := []*types.Issue{childZ, parent, childA}
+
+	defaultOut := captureStdout(t, func() error {
+		displayPrettyListWithDepsMode(cloneIssues(issues), false, deps, "", false, false, "", "", false)
+		return nil
+	})
+	// Default sibling order is priority: Zebra P0 before Aardvark P2.
+	if !(firstIndex(defaultOut, "scr-z") < firstIndex(defaultOut, "scr-a")) {
+		t.Fatalf("default sibling order must stay priority (Zebra P0 before Aardvark P2), got:\n%s", defaultOut)
+	}
+
+	titleOut := captureStdout(t, func() error {
+		displayPrettyListWithDepsMode(cloneIssues(issues), false, deps, "", false, false, "", "title", false)
+		return nil
+	})
+	if !(firstIndex(titleOut, "scr-a") < firstIndex(titleOut, "scr-z")) {
+		t.Fatalf("--sort title must order siblings Aardvark then Zebra, got:\n%s", titleOut)
+	}
+}


### PR DESCRIPTION
## What

Honor `--sort` and `--reverse` in `bd list`'s default tree renderer so text output uses the same order as `--json`.

## Why

Addresses #5811, reported by @postoso.

`issueops.Reader.List` already applies `--sort`/`--reverse` via `workapi.FinishPage`, and `--json` plus `--flat` print that page order. The default text path is `--tree` (`--tree` defaults true). That renderer then re-sorted every level by priority then ID, so the requested order never reached the screen.

`--pretty=false` does not turn tree off, which is why the issue reproduced with `--pretty=false` and `--long` as well as the default listing.

This does not overlap #5714: that PR is docs-only `--reverse` help wording on `bd list` / `bd search` / `bd query`. This change is behavior-only and does not edit those help strings.

## Verification

Empirical repro on origin/main (`66048d4fb`): four issues updated in Charlie → Alpha → Delta → Beta order.

Before (default text `--sort updated`): P0, P1, P2, P3 — tree default, not updated_at.

After (same command, same workspace): same ID order as `--json --sort updated`.

`--sort title` / `--sort title --reverse` match `--json`. Default (no `--sort`) still prints priority then ID.

Tests (CGO-free, scoped; do not run the full unscoped `./cmd/bd` suite):

```bash
CGO_ENABLED=0 go test -tags gms_pure_go -count=1 -timeout 5m ./cmd/bd \
  -run 'TestSortListTreeGroup|TestDisplayPrettyList_Honors|TestDisplayPrettyList_SortApplies|TestApplyListTreeOrder'
```

6 tests, all PASS.

Lint:

```bash
BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint
```

gofmt check pass; golangci-lint 0 issues (unix and windows). Windows run printed a pre-existing `generated_file_filter` warning against `/tmp/beads-baseline-check/...` (file not found); not introduced by this change.

- [x] `go build -tags gms_pure_go ./cmd/bd`
- [x] `go vet -tags gms_pure_go ./cmd/bd`
- [x] scoped `CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd -run 'TestSortListTreeGroup|TestDisplayPrettyList_Honors|TestDisplayPrettyList_SortApplies|TestApplyListTreeOrder'`
- [x] `BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint`
- [ ] full unscoped `./cmd/bd` suite (recipe: hangs without Docker; not run)

`--deps` still owns sibling order. Nested listings keep parent-child structure and apply the sort per level. `--long` without `--flat` still takes the tree branch (pre-existing flag composition).
