### PR TITLE
fix(create): say --file is one issue per ## heading

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -851,7 +851,7 @@ func createDepsAcceptedTypeList() string {
 }
 
 func init() {
-	createCmd.Flags().StringP("file", "f", "", "Create multiple issues from markdown file")
+	createCmd.Flags().StringP("file", "f", "", "Create one issue per ## heading (### fields attach to that issue); for title plus description-from-file, use --body-file")
 	createCmd.Flags().String("graph", "", "Create a graph of issues with dependencies from JSON plan file")
 	createCmd.Flags().String("title", "", "Issue title (alternative to positional argument)")
 	createCmd.Flags().Bool("silent", false, "Output only the issue ID (for scripting)")

--- a/cmd/bd/create_dispatch_test.go
+++ b/cmd/bd/create_dispatch_test.go
@@ -171,3 +171,46 @@ func TestCreateSingleIssueAllowEmptyDescriptionRoundTrip(t *testing.T) {
 		t.Fatalf("expected issue %q to be created via --allow-empty-description opt-in", title)
 	}
 }
+
+// TestCreateFileDispatchRejectsPositionalTitle is a regression test for
+// gastownhall/beads#4643: --file is a batch-import route, so a positional
+// title has nowhere to go once createIssuesFromMarkdown takes over. This
+// asserts gatherCreateInput's existing guard still rejects the combination
+// before any issue is written, rather than silently discarding the title.
+func TestCreateFileDispatchRejectsPositionalTitle(t *testing.T) {
+	saveAndRestoreGlobals(t)
+	ensureCleanGlobalState(t)
+
+	readonlyMode = false
+	t.Cleanup(func() { readonlyMode = false })
+
+	fileFlag := createCmd.Flags().Lookup("file")
+	t.Cleanup(func() {
+		_ = fileFlag.Value.Set("")
+		fileFlag.Changed = false
+	})
+
+	tmpDir := t.TempDir()
+	mdPath := filepath.Join(tmpDir, "single.md")
+	if err := os.WriteFile(mdPath, []byte("## My Bead\n\nBody text.\n"), 0644); err != nil {
+		t.Fatalf("write markdown fixture: %v", err)
+	}
+
+	if err := createCmd.Flags().Set("file", mdPath); err != nil {
+		t.Fatalf("set --file: %v", err)
+	}
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = createCmd.RunE(createCmd, []string{"my new bead"})
+	})
+	if err == nil {
+		t.Fatal("expected --file dispatch with a positional title to be rejected")
+	}
+	if !strings.Contains(stderr, "cannot specify both title and --file flag") {
+		t.Fatalf("expected title/--file conflict message on stderr, got: %v (err: %v)", stderr, err)
+	}
+	if !strings.Contains(stderr, "--body-file") {
+		t.Fatalf("expected title/--file conflict to hint at --body-file, got: %v (err: %v)", stderr, err)
+	}
+}

--- a/cmd/bd/create_input.go
+++ b/cmd/bd/create_input.go
@@ -94,7 +94,7 @@ func gatherCreateInput(cmd *cobra.Command, args []string) (createInput, error) {
 	}
 	if in.markdownFile != "" {
 		if len(args) > 0 {
-			return in, HandleError("cannot specify both title and --file flag")
+			return in, HandleError("cannot specify both title and --file flag; for a single issue's description from a file, use --body-file")
 		}
 		if in.dryRun {
 			return in, HandleError("--dry-run is not supported with --file flag")

--- a/cmd/bd/create_input_test.go
+++ b/cmd/bd/create_input_test.go
@@ -40,6 +40,36 @@ func TestCreateCommandRegistersEmptyDescriptionOptIn(t *testing.T) {
 	}
 }
 
+func TestCreateFileFlagHelpDoesNotClaimSingleIssueGH4643(t *testing.T) {
+	f := createCmd.Flags().Lookup("file")
+	if f == nil {
+		t.Fatal("expected create to register --file")
+	}
+	if !strings.Contains(f.Usage, "one issue per") {
+		t.Fatalf("expected --file help text to name its per-heading batch behavior, got: %q", f.Usage)
+	}
+	if !strings.Contains(f.Usage, "--body-file") {
+		t.Fatalf("expected --file help text to point single-issue callers at --body-file, got: %q", f.Usage)
+	}
+}
+
+func TestGatherCreateInputRejectsTitleWithFile(t *testing.T) {
+	cmd := newCreateFlagsCommand(t, "--file", "issues.md")
+	var err error
+	stderr := captureStderr(t, func() {
+		_, err = gatherCreateInput(cmd, []string{"Some title"})
+	})
+	if err == nil {
+		t.Fatal("expected gatherCreateInput to reject a positional title with --file")
+	}
+	if !strings.Contains(stderr, "cannot specify both title and --file flag") {
+		t.Fatalf("expected title/--file conflict on stderr, got stderr=%q err=%v", stderr, err)
+	}
+	if !strings.Contains(stderr, "--body-file") {
+		t.Fatalf("expected title/--file conflict to hint at --body-file, got stderr=%q err=%v", stderr, err)
+	}
+}
+
 func TestGatherCreateInputRejectsEmptyBodyFile(t *testing.T) {
 	filePath := filepath.Join(t.TempDir(), "empty.md")
 	if err := os.WriteFile(filePath, nil, 0644); err != nil {

--- a/cmd/bd/markdown_test.go
+++ b/cmd/bd/markdown_test.go
@@ -154,6 +154,38 @@ Just a title and description.
 				},
 			},
 		},
+		{
+			name: "GH-4643 H2-per-section briefing file parses as three issues",
+			content: `## Problem
+Something is broken.
+
+## Context
+Extra background.
+
+## Acceptance Criteria
+It should work.
+`,
+			expected: []*IssueTemplate{
+				{
+					Title:       "Problem",
+					Description: "Something is broken.",
+					Priority:    2,
+					IssueType:   "task",
+				},
+				{
+					Title:       "Context",
+					Description: "Extra background.",
+					Priority:    2,
+					IssueType:   "task",
+				},
+				{
+					Title:       "Acceptance Criteria",
+					Description: "It should work.",
+					Priority:    2,
+					IssueType:   "task",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

Makes `bd create --file`/`-f` name its actual batch behavior: one issue per
`##` heading, with `###` subsections attaching fields to that issue. A
well-formed file with a single `##` is still a `--file` job. Callers who
want a positional title plus a description loaded from a file should use
`--body-file`. The title + `--file` error now says the same thing, because
that is the path the reporter actually hit.

## Why

Addresses #4643. `--file` is a batch-import route. Its help text used to
read "Create multiple issues from markdown file" without naming the
per-heading semantics or `--body-file`. @seanmartinsmith reported a briefing
file that used `##` for sections of one issue (`## Problem` / `## Context` /
`## Acceptance Criteria`) and silently became three issues, because bd
treats every H2 as a new issue and only `###` (H3) subsections attach fields
to a single issue.

`bd comment -f` and `bd batch -f` do use `-f`/`--file` to mean "read one
value from this file." `bd note` registers long `--file` only (no `-f`
shortcut). That still makes `create`'s batch meaning of `--file` easy to
miss if you pattern-match across the CLI.

I confirmed the issue's own literal repro — `bd create "title" -f file.md` —
is already rejected on `origin/main` by `gatherCreateInput` ("cannot specify
both title and --file flag"). This PR keeps that rejection and adds a
`--body-file` hint on that error, which is what a caller sees; they do not
see `bd create --help` first. What's still live, and deliberately not
changed here, is `--file` used alone against a file whose author intended
`##` for sections of one issue. bd cannot distinguish that from a genuine
batch file by content alone, so this stays a docs/error-hint fix.

`docs/CLI_REFERENCE.md` and `docs/cli-reference/create.md` are generated
from a pinned release tag (`docs/cli-docs.pin` = `v1.2.2`) and are not
touched here; they'll pick up the corrected help text at the next docs
regeneration for a release that includes this change.

## Verification

Environment: builds/tests use `gms_pure_go` (beads never links ICU — see
`engdocs/ICU-POLICY.md`). No `CGO_CFLAGS`/`CGO_LDFLAGS`/icu4c flags.

Commands actually run, with real outcomes:

```
go build -tags gms_pure_go ./cmd/bd
# BUILD_OK

gofmt -l cmd/bd/create.go cmd/bd/create_input.go cmd/bd/create_dispatch_test.go cmd/bd/create_input_test.go cmd/bd/markdown_test.go
# (no output — clean)

go vet -tags gms_pure_go ./cmd/bd/
# VET_OK

go test -tags gms_pure_go ./cmd/bd/... \
  -run 'TestParseMarkdownFile$|TestCreateFileDispatchRejectsPositionalTitle|TestCreateFileFlagHelpDoesNotClaimSingleIssueGH4643|TestGatherCreateInputRejectsTitleWithFile|TestCreateFromMarkdownFile' \
  -v -count=1 -timeout 20m
# PASS: TestCreateFileDispatchRejectsPositionalTitle
# PASS: TestCreateFileFlagHelpDoesNotClaimSingleIssueGH4643
# PASS: TestGatherCreateInputRejectsTitleWithFile
# PASS: TestCreateFromMarkdownFile (131.71s)
#     PASS: creates_every_template_in_the_file
#     PASS: a_refused_template_leaves_nothing_behind
#     PASS: ephemeral_is_honoured_rather_than_accepted_and_ignored
#     PASS: writes_the_edges_the_file_declares
# PASS: TestParseMarkdownFile (incl. "GH-4643 H2-per-section briefing file parses as three issues")
# ok  	github.com/steveyegge/beads/cmd/bd	(scoped; later re-run of the unit tests: 2.647s)

BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint
# gofmt check: All Go files are properly formatted
# golangci-lint (native, scoped to this diff): 0 issues.
# golangci-lint (GOOS=windows cross-lint, scoped to this diff): 0 issues.

bash ~/.claude/skills/oss-daily/scripts/oss-comment-check.sh /Users/vishnu/workplace/oss/beads
# VERDICT: CLEAN — no comment-density findings vs host-repo baseline

git apply --check <patch>   # against a git-archive of origin/main
# APPLY_CHECK_OK
```

I did not re-run the full `./cmd/bd/...` package suite (UNVERIFIED this
round). Docker is not available here, so tests that need a live Dolt test
server report `WARN: Docker not available, skipping Dolt tests`.
