### PR TITLE
fix(list): honor --status when combined with --ready

### DIFF
--- a/backend/conformance/audit_dependencies_readiness.go
+++ b/backend/conformance/audit_dependencies_readiness.go
@@ -385,27 +385,28 @@ func testAuditReadyTypeAndPinnedExclusions(t *testing.T, f Factory) {
 // Statuses, the legacy open/in_progress default when both are empty, and a
 // custom (non-built-in) status flowing through the same IN clause.
 //
-// THIS IS THE ONLY OBSERVER OF THE OR-SET ARM, AND IT COVERS EVERY SEAM THE ARM
-// IS REACHABLE FROM. No role can ask for it — publicops.ReadyRequest carries no
-// status field of any kind, which RunReadyCounterCountsOnlyTheOpenRowsItsListingLists
-// says from the other side — and no in-tree caller sets it either. Every builder
-// that renders a ready query sends the SINGULAR status: workapi.BuildReadyFilter
-// and BuildReadyCountFilter send StatusOpen, and ReadyFilterFromIssueFilter sends
-// StatusOpen while dropping IssueFilter.Statuses, which BuildListFilter has
-// already resolved to open under --ready (issueops/reader_ready_scope.go states
-// that override and why the projection has nothing to drop). What is left is the
-// storage seam this file runs against, which backend.DoltStorage publishes to
-// out-of-tree backends — so Statuses is a public filter field whose only reachable
-// consumer class is exactly the one RunAll is the proof obligation for.
+// THE OR-SET ARM IS REACHABLE FROM `bd list --status a,b --ready`.
+// ReadyFilterFromIssueFilter copies IssueFilter.Statuses onto the ready-work
+// filter instead of dropping it, and BuildListFilter no longer always
+// resolves --ready to open: an explicit selector is the intersection
+// (GH#5832; issueops/reader_ready_scope.go states the honor path).
+// publicops.ReadyRequest still carries no status field of any kind, which
+// RunReadyCounterCountsOnlyTheOpenRowsItsListingLists says from the other
+// side, so `bd ready` — workapi.BuildReadyFilter and BuildReadyCountFilter —
+// still send the SINGULAR StatusOpen. The list --ready path is the in-tree
+// caller that sets Statuses. This file remains the storage-seam observer
+// for the OR-set arm against backend.DoltStorage, which publishes the field
+// to out-of-tree backends; RunAll is still the proof obligation for that
+// seam.
 //
 // The unit-of-work provider's ready union renders this arm from the same shared
 // builder (sqlbuild.BuildReadyWorkWhere), applied to the wisps table as well as
 // issues where the classic stack projects the wisp plane onto a types.IssueFilter
 // instead. Its copy is deliberately unpinned rather than overlooked: that provider
-// is not a storage.DoltStorage, so no external caller reaches it, and no in-tree
-// caller sets Statuses at all. Promoting a status set onto ReadyRequest is what
-// would make it reachable, and would move this case to reader_contract.go beside
-// RunReaderReadySetOwnsItsStatusPinnedAndTemplateDecisions, where all three
+// is not a storage.DoltStorage, so no external caller reaches it. A status set on
+// ReadyRequest would additionally make `bd ready` vote on this case, and would
+// move it to reader_contract.go beside
+// RunReaderReadySetOwnsItsStatusPinnedAndTemplateDecisions, where the ready-role
 // wirings would vote on it.
 func testAuditReadyMultiStatusFilter(t *testing.T, f Factory) {
 	s := f(t)

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -240,7 +240,7 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 	}
 
 	if in.watchMode {
-		if err := watchIssues(ctx, activeStore, filter, in.ReadyFlag, in.ParentID, in.SortBy, in.Reverse, in.effectiveLimit); err != nil {
+		if err := watchIssues(ctx, activeStore, filter, in.ReadyFlag, in.ParentID, in.SortBy, in.Reverse, in.effectiveLimit, in.Status); err != nil {
 			if capErr := handleMaxRowsError(err); capErr != nil {
 				return capErr
 			}
@@ -315,7 +315,7 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 				return HandleError("loading dependencies for --deps: %v", depErr)
 			}
 			// Hierarchical --parent walks use an unlimited per-level query, so the tree is never page-truncated.
-			displayPrettyListWithDepsMode(treeIssues, false, allDeps, in.depsMode, false, in.ReadyFlag)
+			displayPrettyListWithDepsMode(treeIssues, false, allDeps, in.depsMode, false, in.ReadyFlag, in.Status)
 			printSkipLabelsFooter(in.SkipLabels)
 			return nil
 		}
@@ -324,7 +324,7 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 		if depErr != nil && in.depsMode != "" {
 			return HandleError("loading dependencies for --deps: %v", depErr)
 		}
-		displayPrettyListWithDepsMode(issues, false, allDeps, in.depsMode, truncated, in.ReadyFlag)
+		displayPrettyListWithDepsMode(issues, false, allDeps, in.depsMode, truncated, in.ReadyFlag, in.Status)
 		printTruncationHint(truncated, in.effectiveLimit)
 		printSkipLabelsFooter(in.SkipLabels)
 		return nil

--- a/cmd/bd/list_footer_counts_test.go
+++ b/cmd/bd/list_footer_counts_test.go
@@ -58,6 +58,7 @@ func TestListFooterLineCountsAreJustified(t *testing.T) {
 		name                     string
 		total, open, inProgress  int
 		truncated, readyFiltered bool
+		statusSelector           string
 		facts                    footerFacts
 	}{
 		{
@@ -90,11 +91,19 @@ func TestListFooterLineCountsAreJustified(t *testing.T) {
 			total: 0, open: 0, inProgress: 0,
 			facts: footerFacts{"total": 0, "open": 0, "in_progress": 0},
 		},
+		{
+			// Explicit --status under --ready is a different pin. The footer
+			// names that selector and must not reuse the default-open sentence.
+			name:  "ready-filtered, explicit in_progress",
+			total: 3, open: 0, inProgress: 3, readyFiltered: true,
+			statusSelector: "in_progress",
+			facts:          footerFacts{"total": 3},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			line := listFooterLine(tt.total, tt.open, tt.inProgress, tt.truncated, tt.readyFiltered)
+			line := listFooterLine(tt.total, tt.open, tt.inProgress, tt.truncated, tt.readyFiltered, tt.statusSelector)
 			assertEveryNumberIsJustified(t, line, tt.facts)
 
 			// The headline count always describes the rows actually rendered.
@@ -110,7 +119,7 @@ func TestListFooterLineCountsAreJustified(t *testing.T) {
 // reader cannot distinguish "none exist" from "none survived the filter".
 func TestListFooterLineReadyOmitsVacuousInProgressCount(t *testing.T) {
 	// 40 in-progress issues match the same query; --ready removed them all.
-	line := listFooterLine(6, 6, 0, false, true)
+	line := listFooterLine(6, 6, 0, false, true, "")
 
 	if strings.Contains(line, "in progress)") {
 		t.Errorf("--ready summary asserts an in-progress count that the filter forced to zero: %q", line)
@@ -126,7 +135,7 @@ func TestListFooterLineReadyOmitsVacuousInProgressCount(t *testing.T) {
 // Without --ready the breakdown is a genuine finding and must survive: this is
 // the half of the behaviour the fix must not regress.
 func TestListFooterLineUnfilteredKeepsBreakdown(t *testing.T) {
-	line := listFooterLine(9, 6, 3, false, false)
+	line := listFooterLine(9, 6, 3, false, false, "")
 	for _, want := range []string{"Total: 9 issues", "6 open", "3 in progress"} {
 		if !strings.Contains(line, want) {
 			t.Errorf("unfiltered summary lost %q, got: %q", want, line)
@@ -157,7 +166,7 @@ func TestDisplayWatchedIssueListReadyFooterDisclosesFilter(t *testing.T) {
 	// for; the footer is what is under test, and this keeps the file free of
 	// the cgo-tagged stub so it still compiles under CGO_ENABLED=0.
 	out := captureStdout(t, func() error {
-		displayWatchedIssueList(context.Background(), nil, issues, false, true)
+		displayWatchedIssueList(context.Background(), nil, issues, false, true, "")
 		return nil
 	})
 
@@ -177,7 +186,7 @@ func TestDisplayPrettyListWithDepsReadyFooterDisclosesFilter(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() error {
-		displayPrettyListWithDeps(issues, false, nil, false, true)
+		displayPrettyListWithDeps(issues, false, nil, false, true, "")
 		return nil
 	})
 	if strings.Contains(out, "in progress)") {
@@ -190,7 +199,7 @@ func TestDisplayPrettyListWithDepsReadyFooterDisclosesFilter(t *testing.T) {
 	// The other half: without --ready the same wrapper must keep the breakdown,
 	// so the fix cannot be "never print counts".
 	plain := captureStdout(t, func() error {
-		displayPrettyListWithDeps(issues, false, nil, false, false)
+		displayPrettyListWithDeps(issues, false, nil, false, false, "")
 		return nil
 	})
 	if !strings.Contains(plain, "in progress)") {
@@ -201,7 +210,7 @@ func TestDisplayPrettyListWithDepsReadyFooterDisclosesFilter(t *testing.T) {
 // Truncation and readiness are independent scopes and both must be disclosed
 // when both apply — neither may silently mask the other.
 func TestListFooterLineTruncationDisclosedAlongsideReady(t *testing.T) {
-	line := listFooterLine(5, 5, 0, true, true)
+	line := listFooterLine(5, 5, 0, true, true, "")
 	if !strings.Contains(line, "truncated by --limit") {
 		t.Errorf("truncated page must say so even under --ready, got: %q", line)
 	}
@@ -210,5 +219,67 @@ func TestListFooterLineTruncationDisclosedAlongsideReady(t *testing.T) {
 	}
 	if strings.Contains(line, "Total:") {
 		t.Errorf("a truncated page must never be labelled Total: %q", line)
+	}
+}
+
+// GH#5832: an explicit --status under --ready is a different pin. The default
+// "open only — --ready excludes in_progress" sentence must not be reused.
+func TestListFooterLineReadyExplicitStatusNamesSelector(t *testing.T) {
+	line := listFooterLine(3, 0, 3, false, true, "in_progress")
+	if strings.Contains(line, "open only") || strings.Contains(line, "excludes in_progress") {
+		t.Errorf("explicit --status must not reuse the default-open sentence: %q", line)
+	}
+	if !strings.Contains(line, "in_progress only") {
+		t.Errorf("explicit --status footer must name the selected status, got: %q", line)
+	}
+	if strings.Contains(line, "in progress)") {
+		t.Errorf("--ready summary must still omit the vacuous in-progress count: %q", line)
+	}
+}
+
+// --pretty/--tree/--deps share displayPrettyListWithDepsMode; --watch uses
+// displayWatchedIssueList. Both must thread the explicit selector so the
+// default-open sentence cannot leak through a wrapper.
+func TestDisplayPrettyListWithDepsReadyExplicitStatusFooter(t *testing.T) {
+	issues := []*types.Issue{
+		{ID: "bd-1", Title: "A", Status: types.StatusInProgress, Priority: 1, IssueType: types.TypeTask},
+	}
+
+	out := captureStdout(t, func() error {
+		displayPrettyListWithDeps(issues, false, nil, false, true, "in_progress")
+		return nil
+	})
+	if strings.Contains(out, "open only") || strings.Contains(out, "excludes in_progress") {
+		t.Errorf("--status in_progress --ready --pretty reused the default-open sentence: %q", out)
+	}
+	if !strings.Contains(out, "in_progress only") {
+		t.Errorf("--status in_progress --ready --pretty must name the selected status, got: %q", out)
+	}
+
+	depsOut := captureStdout(t, func() error {
+		displayPrettyListWithDepsMode(issues, false, nil, "scheduling", false, true, "in_progress")
+		return nil
+	})
+	if strings.Contains(depsOut, "open only") || strings.Contains(depsOut, "excludes in_progress") {
+		t.Errorf("--status in_progress --ready --deps reused the default-open sentence: %q", depsOut)
+	}
+	if !strings.Contains(depsOut, "in_progress only") {
+		t.Errorf("--status in_progress --ready --deps must name the selected status, got: %q", depsOut)
+	}
+}
+
+func TestDisplayWatchedIssueListReadyExplicitStatusFooter(t *testing.T) {
+	issues := []*types.Issue{
+		{ID: "bd-1", Title: "A", Status: types.StatusInProgress, Priority: 1, IssueType: types.TypeTask},
+	}
+	out := captureStdout(t, func() error {
+		displayWatchedIssueList(context.Background(), nil, issues, false, true, "in_progress")
+		return nil
+	})
+	if strings.Contains(out, "open only") || strings.Contains(out, "excludes in_progress") {
+		t.Errorf("--status in_progress --ready --watch reused the default-open sentence: %q", out)
+	}
+	if !strings.Contains(out, "in_progress only") {
+		t.Errorf("--status in_progress --ready --watch must name the selected status, got: %q", out)
 	}
 }

--- a/cmd/bd/list_helpers_test.go
+++ b/cmd/bd/list_helpers_test.go
@@ -317,7 +317,7 @@ func TestListDisplayPrettyList_TruncatedSummary(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() error {
-		displayPrettyListWithDepsMode(issues, false, nil, "", true, false)
+		displayPrettyListWithDepsMode(issues, false, nil, "", true, false, "")
 		return nil
 	})
 	if !strings.Contains(out, "Showing 2 issues") {
@@ -343,7 +343,7 @@ func TestDisplayWatchedIssueList_UsesDependencyHierarchy(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() error {
-		displayWatchedIssueList(context.Background(), store, []*types.Issue{child, parent}, false, false)
+		displayWatchedIssueList(context.Background(), store, []*types.Issue{child, parent}, false, false, "")
 		return nil
 	})
 

--- a/cmd/bd/list_proxied_server.go
+++ b/cmd/bd/list_proxied_server.go
@@ -156,7 +156,7 @@ func runListProxiedWatch(_ *cobra.Command, ctx context.Context, in listInput) er
 	if err != nil {
 		return fmt.Errorf("initial query: %w", err)
 	}
-	displayPrettyListWithDeps(issues, true, deps, hasMore, in.ReadyFlag)
+	displayPrettyListWithDeps(issues, true, deps, hasMore, in.ReadyFlag, in.Status)
 	printTruncationHint(hasMore, in.effectiveLimit)
 	lastSnapshot := issueSnapshot(issues)
 
@@ -183,7 +183,7 @@ func runListProxiedWatch(_ *cobra.Command, ctx context.Context, in listInput) er
 			snap := issueSnapshot(issues)
 			if snap != lastSnapshot {
 				lastSnapshot = snap
-				displayPrettyListWithDeps(issues, true, deps, hasMore, in.ReadyFlag)
+				displayPrettyListWithDeps(issues, true, deps, hasMore, in.ReadyFlag, in.Status)
 				printTruncationHint(hasMore, in.effectiveLimit)
 				fmt.Fprintf(os.Stderr, "\nWatching for changes... (Press Ctrl+C to exit)\n")
 			}
@@ -239,7 +239,7 @@ func renderProxiedListText(ctx context.Context, out io.Writer, issues []*types.I
 			printTruncationHint(truncated, in.effectiveLimit)
 			return nil
 		}
-		displayPrettyListWithDepsMode(issues, false, depsByIssueID, in.depsMode, truncated, in.ReadyFlag)
+		displayPrettyListWithDepsMode(issues, false, depsByIssueID, in.depsMode, truncated, in.ReadyFlag, in.Status)
 		printTruncationHint(truncated, in.effectiveLimit)
 		printSkipLabelsFooter(in.SkipLabels)
 		return nil

--- a/cmd/bd/list_show_filter_modes.go
+++ b/cmd/bd/list_show_filter_modes.go
@@ -156,7 +156,7 @@ func loadWatchedIssues(ctx context.Context, store storage.DoltStorage, filter ty
 // names its scope instead of asserting an in-progress count the ready filter
 // forced to zero. A watch loop is where a stale "0 in progress" is most likely
 // to be read as a live fact, so this is the path that most needs it.
-func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore, issues []*types.Issue, truncated, readyFiltered bool) {
+func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore, issues []*types.Issue, truncated, readyFiltered bool, statusSelector string) {
 	var allDeps map[string][]*types.Dependency
 	if store != nil {
 		deps, err := store.GetAllDependencyRecords(ctx)
@@ -164,7 +164,7 @@ func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore
 			allDeps = deps
 		}
 	}
-	displayPrettyListWithDeps(issues, true, allDeps, truncated, readyFiltered)
+	displayPrettyListWithDeps(issues, true, allDeps, truncated, readyFiltered, statusSelector)
 }
 
 // watchIssues returns an error only for the initial query — a failure there
@@ -174,7 +174,7 @@ func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore
 // runListCore route a MaxRows cap violation through handleMaxRowsError for
 // exit-code-2 semantics instead of watchIssues swallowing it and exiting 0
 // (be-x42v.4 follow-up, review MUST-FIX 5).
-func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.IssueFilter, ready bool, parentID string, sortBy string, reverse bool, effectiveLimit int) error {
+func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.IssueFilter, ready bool, parentID string, sortBy string, reverse bool, effectiveLimit int, statusSelector string) error {
 	// Initial display
 	issues, err := loadWatchedIssues(ctx, store, filter, ready, parentID, sortBy, reverse)
 	if err != nil {
@@ -184,7 +184,7 @@ func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.Is
 	// below depends on; what is left is the cut and its verdict, and those are
 	// the shared epilogue's on every other listing this command has.
 	issues, truncated := workapi.FinishPage(issues, "", false, effectiveLimit, false)
-	displayWatchedIssueList(ctx, store, issues, truncated, ready)
+	displayWatchedIssueList(ctx, store, issues, truncated, ready, statusSelector)
 	printTruncationHint(truncated, effectiveLimit)
 	lastSnapshot := issueSnapshot(issues)
 
@@ -214,7 +214,7 @@ func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.Is
 			snap := issueSnapshot(issues)
 			if snap != lastSnapshot {
 				lastSnapshot = snap
-				displayWatchedIssueList(ctx, store, issues, truncated, ready)
+				displayWatchedIssueList(ctx, store, issues, truncated, ready, statusSelector)
 				printTruncationHint(truncated, effectiveLimit)
 				fmt.Fprintf(os.Stderr, "\nWatching for changes... (Press Ctrl+C to exit)\n")
 			}
@@ -256,7 +256,7 @@ func runListProxiedHierarchicalParent(ctx context.Context, uw uow.UnitOfWork, in
 	}
 
 	// Hierarchical --parent walks use an unlimited per-level query; never page-truncated.
-	displayPrettyListWithDepsMode(treeIssues, false, depsByIssueID, in.depsMode, false, in.ReadyFlag)
+	displayPrettyListWithDepsMode(treeIssues, false, depsByIssueID, in.depsMode, false, in.ReadyFlag, in.Status)
 	printSkipLabelsFooter(in.SkipLabels)
 	return nil
 }

--- a/cmd/bd/list_tree.go
+++ b/cmd/bd/list_tree.go
@@ -147,26 +147,28 @@ func printPrettyTree(childrenMap map[string][]*types.Issue, parentID string, pre
 // There is no --ready arm behind this one: it is the plain tree, so the
 // summary keeps its status breakdown.
 func displayPrettyList(issues []*types.Issue, showHeader bool) {
-	displayPrettyListWithDeps(issues, showHeader, nil, false, false)
+	displayPrettyListWithDeps(issues, showHeader, nil, false, false, "")
 }
 
 // displayPrettyListWithDeps displays issues in tree format using dependency data.
-// readyFiltered must be threaded from the caller's --ready state rather than
-// defaulted here: the watch paths reach the summary through this wrapper, and a
-// hardcoded false silently restores the vacuous "(N open, 0 in progress)" that
-// listFooterLine exists to suppress.
-func displayPrettyListWithDeps(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, truncated, readyFiltered bool) {
-	displayPrettyListWithDepsMode(issues, showHeader, allDeps, "", truncated, readyFiltered)
+// readyFiltered and statusSelector must be threaded from the caller's --ready
+// / --status state rather than defaulted here: the watch paths reach the
+// summary through this wrapper, and a hardcoded false silently restores the
+// vacuous "(N open, 0 in progress)" that listFooterLine exists to suppress.
+func displayPrettyListWithDeps(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, truncated, readyFiltered bool, statusSelector string) {
+	displayPrettyListWithDepsMode(issues, showHeader, allDeps, "", truncated, readyFiltered, statusSelector)
 }
 
 // listFooterLine renders the one-line summary under a text listing.
 //
 // The status breakdown is only meaningful when the query could have returned
-// more than one status. Under --ready it cannot: BuildListFilter pins
-// filter.Status to open (internal/workapi/list.go), so every row is open by
-// construction and the breakdown degenerates to a tautology — "(N open, 0 in
-// progress)" is what it prints for ANY database, including one with a thousand
-// in-progress issues matching the same label.
+// more than one status. Under --ready the query is status-pinned: the default
+// (no --status, or --status all) is still open, so "(N open, 0 in progress)"
+// is a tautology for ANY database, including one with a thousand in-progress
+// issues matching the same label. An explicit --status is the intersection
+// (GH#5832), and the same tautology applies to whatever selector was asked
+// for — the footer must name that selector rather than reuse the default-open
+// sentence.
 //
 // Printed next to a real count that number reads as a finding rather than an
 // artifact of the flag: "0 in progress" answers the question "is anything in
@@ -175,13 +177,14 @@ func displayPrettyListWithDeps(issues []*types.Issue, showHeader bool, allDeps m
 // construction, say what was excluded instead of asserting a count for it. This
 // is the same principle as the truncation arm below, which refuses to label a
 // cut-off page "Total" (GH#5362): a count is only honest alongside its scope.
-func listFooterLine(total, open, inProgress int, truncated, readyFiltered bool) string {
+func listFooterLine(total, open, inProgress int, truncated, readyFiltered bool, statusSelector string) string {
 	if readyFiltered {
 		// No status breakdown: --ready makes it vacuous. Name the scope instead.
+		scope := readyFooterScope(statusSelector)
 		if truncated {
-			return fmt.Sprintf("Showing %d ready issues (open only — --ready excludes in_progress); more match (truncated by --limit). Use --limit 0 for all.", total)
+			return fmt.Sprintf("Showing %d ready issues (%s); more match (truncated by --limit). Use --limit 0 for all.", total, scope)
 		}
-		return fmt.Sprintf("Ready: %d issues with no active blockers (open only — --ready excludes in_progress)", total)
+		return fmt.Sprintf("Ready: %d issues with no active blockers (%s)", total, scope)
 	}
 	if truncated {
 		return fmt.Sprintf("Showing %d issues (%d open, %d in progress); more match (truncated by --limit). Use --limit 0 for all.",
@@ -190,14 +193,31 @@ func listFooterLine(total, open, inProgress int, truncated, readyFiltered bool) 
 	return fmt.Sprintf("Total: %d issues (%d open, %d in progress)", total, open, inProgress)
 }
 
+// readyFooterScope names the status pin a --ready listing actually used.
+// Empty / "all" still take the open default; an explicit selector is the
+// intersection and must not reuse "excludes in_progress" (GH#5832).
+func readyFooterScope(statusSelector string) string {
+	var parts []string
+	for _, part := range strings.Split(statusSelector, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			parts = append(parts, part)
+		}
+	}
+	if len(parts) == 0 || (len(parts) == 1 && parts[0] == "all") {
+		return "open only — --ready excludes in_progress"
+	}
+	return strings.Join(parts, ",") + " only"
+}
+
 // displayPrettyListWithDepsMode displays issues in tree format. When depsMode is
 // "scheduling" or "all", the tree also annotates each node's dependency edges and
 // orders siblings by their scheduling dependencies (see orderSiblingsByDeps). An
 // empty depsMode is the plain parent-child tree. truncated means the page was cut
 // by --limit; the summary then says "Showing N" instead of "Total: N" (GH#5362).
-// readyFiltered means --ready was in force, which pins the query to open issues —
-// see listFooterLine for why the summary must say so.
-func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, depsMode string, truncated, readyFiltered bool) {
+// readyFiltered means --ready was in force; statusSelector is the --status value
+// so the summary names the pin that actually applied — see listFooterLine.
+func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, depsMode string, truncated, readyFiltered bool, statusSelector string) {
 	if showHeader {
 		// Clear screen and show header
 		fmt.Print("\033[2J\033[H")
@@ -243,7 +263,7 @@ func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDe
 			inProgressCount++
 		}
 	}
-	fmt.Println(listFooterLine(len(issues), openCount, inProgressCount, truncated, readyFiltered))
+	fmt.Println(listFooterLine(len(issues), openCount, inProgressCount, truncated, readyFiltered, statusSelector))
 	fmt.Println()
 	fmt.Println("Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred")
 	fmt.Println("Priority: P0–P4 (label only; not a status icon)")

--- a/internal/workapi/list.go
+++ b/internal/workapi/list.go
@@ -224,7 +224,12 @@ func BuildListFilter(in issueops.ListRequest, cfg ListConfig) (types.IssueFilter
 	statusParts := splitStatusSelector(in.Status)
 	statusAll := len(statusParts) == 1 && statusParts[0] == "all"
 
-	if in.ReadyFlag {
+	// --ready defaults to open (the blocker-aware query's historical pin),
+	// but an explicit --status is an intersection, not an override. Dropping
+	// the selector used to answer `bd list --status X --ready` with the
+	// unfiltered ready set (GH#5832). `--status all` is the no-filter
+	// spelling, so the open default still applies there.
+	if in.ReadyFlag && (len(statusParts) == 0 || statusAll) {
 		s := types.StatusOpen
 		filter.Status = &s
 	} else if len(statusParts) > 0 && !statusAll {

--- a/internal/workapi/list.go
+++ b/internal/workapi/list.go
@@ -469,9 +469,10 @@ func splitStatusSelector(status string) []string {
 // pinned-carrying beads: the pinned or hooked status, or — when the selector
 // actually applies to the query — the "all" selector, which promises every
 // status. The pinned default is not forced off for a filter that asks for
-// those beads. allApplies is false under --ready, which forces status open
-// and otherwise ignores the selector, so "all" must not lift the pinned
-// default there.
+// those beads. allApplies is false under --ready: `--status all` (and the
+// omitted selector) still pin open, so "all" must not lift the pinned
+// default there. Explicit selectors are honored under --ready (GH#5832);
+// pinned and hooked still return true regardless of allApplies.
 func statusSelectsPinned(parts []string, allApplies bool) bool {
 	for _, part := range parts {
 		switch part {

--- a/internal/workapi/list_pinned_test.go
+++ b/internal/workapi/list_pinned_test.go
@@ -66,11 +66,11 @@ func TestPinnedDefaultBySelector(t *testing.T) {
 		}
 	})
 
-	// --ready forces status open and otherwise IGNORES the selector, so an
-	// "all" that the query never applies must not have a pinned side effect
+	// `--status all` is the no-filter spelling, so --ready still pins open.
+	// An "all" that the query never applies must not have a pinned side effect
 	// either. Without this, `bd list --ready --status=all` would admit pinned
 	// beads into a ready listing that is filtered to open.
-	t.Run("--ready ignores the selector, including for pinned", func(t *testing.T) {
+	t.Run("--ready --status=all does not admit pinned", func(t *testing.T) {
 		got := pinnedDefault(t, issueops.ListRequest{Status: "all", ReadyFlag: true})
 		if got == nil || *got {
 			t.Errorf("--ready --status=all: Pinned = %v, want false", got)

--- a/internal/workapi/list_ready_status_test.go
+++ b/internal/workapi/list_ready_status_test.go
@@ -1,0 +1,123 @@
+package workapi
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// TestReadyStatusAndReadyIntersect pins GH#5832: `bd list --status X --ready`
+// is the intersection, not the unfiltered ready set. These are builder and
+// projection tests so they stay in the CGO_ENABLED=0 lane.
+func TestReadyStatusAndReadyIntersect(t *testing.T) {
+	t.Run("status X --ready keeps status X", func(t *testing.T) {
+		filter, err := BuildListFilter(issueops.ListRequest{ReadyFlag: true, Status: "in_progress"}, ListConfig{})
+		if err != nil {
+			t.Fatalf("BuildListFilter: %v", err)
+		}
+		if filter.Status == nil || *filter.Status != types.StatusInProgress {
+			t.Fatalf("IssueFilter.Status = %v, want %q", filter.Status, types.StatusInProgress)
+		}
+		wf := ReadyFilterFromIssueFilter(filter)
+		if wf.Status != types.StatusInProgress {
+			t.Fatalf("WorkFilter.Status = %q, want %q", wf.Status, types.StatusInProgress)
+		}
+		if len(wf.Statuses) != 0 {
+			t.Fatalf("WorkFilter.Statuses = %v, want empty", wf.Statuses)
+		}
+	})
+
+	t.Run("custom status --ready keeps the custom status", func(t *testing.T) {
+		cfg := ListConfig{CustomStatuses: []types.CustomStatus{{Name: "unrefined", Category: types.CategoryWIP}}}
+		filter, err := BuildListFilter(issueops.ListRequest{ReadyFlag: true, Status: "unrefined"}, cfg)
+		if err != nil {
+			t.Fatalf("BuildListFilter: %v", err)
+		}
+		if filter.Status == nil || *filter.Status != types.Status("unrefined") {
+			t.Fatalf("IssueFilter.Status = %v, want %q", filter.Status, "unrefined")
+		}
+		wf := ReadyFilterFromIssueFilter(filter)
+		if wf.Status != types.Status("unrefined") {
+			t.Fatalf("WorkFilter.Status = %q, want %q", wf.Status, "unrefined")
+		}
+	})
+
+	t.Run("zero-match status is not rewritten to the open ready set", func(t *testing.T) {
+		plain, err := BuildListFilter(issueops.ListRequest{ReadyFlag: true}, ListConfig{})
+		if err != nil {
+			t.Fatalf("BuildListFilter(ready): %v", err)
+		}
+		if got := ReadyFilterFromIssueFilter(plain).Status; got != types.StatusOpen {
+			t.Fatalf("plain --ready WorkFilter.Status = %q, want %q", got, types.StatusOpen)
+		}
+
+		filtered, err := BuildListFilter(issueops.ListRequest{ReadyFlag: true, Status: "in_progress"}, ListConfig{})
+		if err != nil {
+			t.Fatalf("BuildListFilter(ready+in_progress): %v", err)
+		}
+		wf := ReadyFilterFromIssueFilter(filtered)
+		if wf.Status != types.StatusInProgress {
+			t.Fatalf("WorkFilter.Status = %q, want %q (must not fall back to the unfiltered ready pin)", wf.Status, types.StatusInProgress)
+		}
+		if wf.Status == ReadyFilterFromIssueFilter(plain).Status {
+			t.Fatal("zero-match --status was rewritten to the unfiltered ready status")
+		}
+	})
+
+	t.Run("plain --ready still pins open", func(t *testing.T) {
+		filter, err := BuildListFilter(issueops.ListRequest{ReadyFlag: true}, ListConfig{})
+		if err != nil {
+			t.Fatalf("BuildListFilter: %v", err)
+		}
+		if filter.Status == nil || *filter.Status != types.StatusOpen {
+			t.Fatalf("IssueFilter.Status = %v, want %q", filter.Status, types.StatusOpen)
+		}
+		if got := ReadyFilterFromIssueFilter(filter).Status; got != types.StatusOpen {
+			t.Fatalf("WorkFilter.Status = %q, want %q", got, types.StatusOpen)
+		}
+	})
+
+	t.Run("status all --ready keeps the open default", func(t *testing.T) {
+		filter, err := BuildListFilter(issueops.ListRequest{ReadyFlag: true, Status: "all"}, ListConfig{})
+		if err != nil {
+			t.Fatalf("BuildListFilter: %v", err)
+		}
+		if filter.Status == nil || *filter.Status != types.StatusOpen {
+			t.Fatalf("IssueFilter.Status = %v, want %q", filter.Status, types.StatusOpen)
+		}
+	})
+
+	t.Run("multi-status --ready copies the OR set", func(t *testing.T) {
+		filter, err := BuildListFilter(issueops.ListRequest{ReadyFlag: true, Status: "open,in_progress"}, ListConfig{})
+		if err != nil {
+			t.Fatalf("BuildListFilter: %v", err)
+		}
+		want := []types.Status{types.StatusOpen, types.StatusInProgress}
+		if !reflect.DeepEqual(filter.Statuses, want) {
+			t.Fatalf("IssueFilter.Statuses = %v, want %v", filter.Statuses, want)
+		}
+		if filter.Status != nil {
+			t.Fatalf("IssueFilter.Status = %v, want nil when Statuses is set", filter.Status)
+		}
+		wf := ReadyFilterFromIssueFilter(filter)
+		if wf.Status != "" {
+			t.Fatalf("WorkFilter.Status = %q, want empty so Statuses is not ignored", wf.Status)
+		}
+		if !reflect.DeepEqual(wf.Statuses, want) {
+			t.Fatalf("WorkFilter.Statuses = %v, want %v", wf.Statuses, want)
+		}
+	})
+
+	t.Run("invalid status --ready errors instead of dropping --status", func(t *testing.T) {
+		_, err := BuildListFilter(issueops.ListRequest{ReadyFlag: true, Status: "not-a-status"}, ListConfig{})
+		if err == nil {
+			t.Fatal("BuildListFilter unexpectedly succeeded")
+		}
+		if !strings.Contains(err.Error(), "invalid status") || !strings.Contains(err.Error(), "not-a-status") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/workapi/ready.go
+++ b/internal/workapi/ready.go
@@ -41,7 +41,9 @@ func LimitOr(limit *int, fallback int) int {
 // own to shape, and running it through here would change it.
 func BuildReadyFilter(in issueops.ReadyRequest) (types.WorkFilter, error) {
 	filter := types.WorkFilter{
-		// Open only, not in_progress - the same set `bd list --ready` shows.
+		// Open only, not in_progress - the same set `bd list --ready` shows
+		// when --status is omitted (an explicit --status is an intersection;
+		// GH#5832).
 		Status: types.StatusOpen,
 		Type:   utils.NormalizeIssueType(in.IssueType),
 		Limit:  LimitOr(in.Limit, DefaultReadyLimit),

--- a/internal/workapi/sort.go
+++ b/internal/workapi/sort.go
@@ -48,7 +48,6 @@ func CompareIssuesBy(a, b *types.Issue, sortBy string) int {
 // filter on.
 func ReadyFilterFromIssueFilter(filter types.IssueFilter) types.WorkFilter {
 	wf := types.WorkFilter{
-		Status:         types.StatusOpen,
 		Limit:          filter.Limit,
 		Offset:         filter.Offset,
 		Labels:         filter.Labels,
@@ -69,6 +68,18 @@ func ReadyFilterFromIssueFilter(filter types.IssueFilter) types.WorkFilter {
 		// listing prints. Dropping it here would answer `bd list --ready
 		// --brief` with full rows and nothing to say why.
 		Lite: filter.Lite,
+	}
+	// Status is copied the same way as assignee/priority/labels: an explicit
+	// selector on the list filter is the ready-work selector too. The open
+	// default is only the fallback when BuildListFilter did not write one
+	// (plain `--ready`, or `--ready --status all`). Hard-coding StatusOpen
+	// here used to drop `--status` even after the builder honored it (GH#5832).
+	if filter.Status != nil {
+		wf.Status = *filter.Status
+	} else if len(filter.Statuses) > 0 {
+		wf.Statuses = append([]types.Status(nil), filter.Statuses...)
+	} else {
+		wf.Status = types.StatusOpen
 	}
 	if filter.IssueType != nil {
 		wf.Type = string(*filter.IssueType)

--- a/internal/workapi/testdata/list_filter_golden.json
+++ b/internal/workapi/testdata/list_filter_golden.json
@@ -1151,7 +1151,7 @@
     }
   },
   {
-    "name": "ready_flag_overrides_status",
+    "name": "ready_flag_honors_status",
     "params": {
       "ReadyFlag": true,
       "Status": "closed",
@@ -1159,7 +1159,7 @@
     },
     "config": {},
     "filter": {
-      "Status": "open",
+      "Status": "closed",
       "Statuses": null,
       "Priority": null,
       "IssueType": null,

--- a/issueops/reader.go
+++ b/issueops/reader.go
@@ -340,7 +340,9 @@ type ListRequest struct {
 	// narrower filter vocabulary than this request can describe, and only part
 	// of the request reaches it.
 	//
-	// WHAT IT CARRIES: IssueType, all five label forms, Assignee, NoAssignee,
+	// WHAT IT CARRIES: Status/Statuses (an explicit --status is the
+	// intersection; AllFlag and `--status all` still take the open default),
+	// IssueType, all five label forms, Assignee, NoAssignee,
 	// the exact Priority, ParentID, MolType, WispType, MetadataFields,
 	// HasMetadataKey, the type exclusions (ExcludeTypes, and with them
 	// IncludeGates and IncludeInfra), IncludeEphemeral — the ready query has an
@@ -348,8 +350,7 @@ type ListRequest struct {
 	// IncludeInfra's plane half crosses with it — Limit, Offset and the MaxRows
 	// cap with its attribution. SortBy and Reverse
 	// still apply, because the display order is applied to the page after the
-	// query rather than inside it. Status and AllFlag are resolved to "open"
-	// and have no further effect: ready work is open work.
+	// query rather than inside it.
 	//
 	// WHAT IT REFUSES: every other filter here is one the ready query cannot
 	// carry, so combining it with ReadyFlag returns ErrValidation naming the

--- a/issueops/reader_ready_scope.go
+++ b/issueops/reader_ready_scope.go
@@ -29,7 +29,7 @@ type readyScopeField struct {
 // Four groups are deliberately ABSENT, because listing them here would refuse
 // requests that are answered correctly today:
 //
-//   - What the projection carries: IssueType, all five label forms, Assignee,
+//   - What the projection carries: Status/Statuses (GH#5832), IssueType, all five label forms, Assignee,
 //     NoAssignee, the exact Priority, ParentID, MolType, WispType,
 //     MetadataFields, HasMetadataKey, ExcludeTypes (and with it IncludeGates
 //     and IncludeInfra's type suppression), IncludeEphemeral (and with it
@@ -46,12 +46,15 @@ type readyScopeField struct {
 //     Refusing that would be refusing a correct answer over its cost, and the
 //     promise is already stated where a caller reads it (ListRequest.ReadyFlag).
 //
-//   - Status and AllFlag. The builder resolves both to "open" under ReadyFlag
-//     before the projection ever runs, so IssueFilter.Statuses is never
-//     populated on this path and there is nothing for the projection to drop.
-//     Ready work is open work; that override is pinned by the builder's golden
-//     file (internal/workapi/testdata/list_filter_golden.json,
-//     ready_flag_overrides_status).
+//   - AllFlag, and `--status all`. The builder resolves both to "open" under
+//     ReadyFlag before the projection ever runs (`all` is the no-filter
+//     spelling). An explicit --status is carried: BuildListFilter writes it
+//     onto IssueFilter and ReadyFilterFromIssueFilter copies Status/Statuses
+//     onto the ready-work filter, so `bd list --status X --ready` is the
+//     intersection rather than the unfiltered ready set (GH#5832). Status is
+//     therefore ABSENT from this drop set because it is honored, not because
+//     it is overridden. The default-open pin is the golden
+//     `ready_flag` case; the honor path is `ready_flag_honors_status`.
 //
 //   - NoPinnedFlag. Pinned is dropped by the projection, but the ready-work
 //     WHERE clause excludes pinned rows unconditionally


### PR DESCRIPTION

## What

Make `bd list --status X --ready` the intersection of the two flags.

`--ready` without `--status` still defaults to open (unchanged). An explicit
`--status` is now the ready-work status selector, the same way `--label` /
`--assignee` / `--priority` already compose with `--ready`. `--status all`
stays the no-filter spelling and keeps the open default.

Text footers on `--pretty` / `--tree` / `--watch` / `--deps` follow the same
rule: the default-open sentence ("open only — --ready excludes in_progress")
prints only for that default pin. An explicit `--status` is named instead
(e.g. `in_progress only`). ReadyFlag / Statuses / statusSelectsPinned /
BuildReadyFilter comments now describe the honor path rather than the old
"ready work is open work" pin.

Reported by @justin-candor.

## Why

Fixes #5832.

On current `main`, `bd list --status unrefined --ready` dropped `--status`
with no warning and returned the unfiltered ready set (open issues). Same
for `--status in_progress --ready` when the workspace had zero in_progress
issues.

Two sites did it:

1. `BuildListFilter` (`internal/workapi/list.go`) pinned `StatusOpen` whenever
   `ReadyFlag` was set, skipping `applyStatusParts`.
2. `ReadyFilterFromIssueFilter` (`internal/workapi/sort.go`) hard-coded
   `Status: types.StatusOpen`, so even a filter that had the right status
   lost it on the way to `GetReadyWork`.

Open PR #3777 ("honor deferred filters for ready list queries") forwards
`Deferred` through the same projection. It does not carry `--status`. This
change does not touch deferred handling.

Two adjacent PRs of mine touch nearby ground, disclosed here so maintainers
can sequence merges: PR #5919 (list `--sort`/`--reverse` text-sort fix)
edits six of the same `cmd/bd` list files, so this branch and #5919 conflict
textually — whichever lands second, I will rebase and re-run the suite
promptly. And once both this change and PR #5918 (ready-work widening to
custom active-category statuses) land, the widening composes with the open
pin: plain `--ready` and an explicit `--status open` will also match custom
active-category statuses, while any non-open selector — including a custom
status — remains an exact match, as in this PR.

Note on the issue's "unrefined --ready should be empty" expectation: ready
work is "unblocked + not pinned" at the requested status. `--status
unrefined --ready` now returns unrefined issues that are unblocked, not the
open ready set and not a silent empty-from-override. `--status in_progress
--ready` with no in_progress issues returns `[]`.

The footer change is the same honesty rule as GH#5362: a count (or a claim
that something was excluded) is only printed for the pin that actually
applied. Intersection semantics are unchanged.

## Verification

Built from this branch with `go build -tags gms_pure_go` (no ICU CGO flags).
Repro workspace was a `mktemp -d` with Gas Town `BEADS_*` env stripped so
`bd init` did not attach to a live Dolt server.

### Before (origin/main @ dbb6df7e9)

```text
bd list --status unrefined --json
# -> unrefined issue only (repro-w0n)

bd list --status unrefined --ready --json
# -> open ready issue (repro-b3q). Unrefined issue absent.

bd list --status in_progress --ready --json
# -> same open ready issue. There are zero in_progress issues.

bd list --ready --json
# -> open ready issue
```

### After (this branch)

```text
bd list --status unrefined --json
# -> unrefined issue only (repro-khl)

bd list --status unrefined --ready --json
# -> unrefined issue (repro-khl). Open ready issue absent.

bd list --status in_progress --ready --json
# -> []

bd list --ready --json
# -> open ready issue (repro-7lu)
```

### Checks

```text
$ gofmt -l internal/workapi/list.go internal/workapi/sort.go \
    internal/workapi/list_ready_status_test.go \
    internal/workapi/list_pinned_test.go \
    issueops/reader_ready_scope.go
# (empty)

$ go vet -tags gms_pure_go ./cmd/bd/... ./internal/workapi ./issueops
# (no output)

$ CGO_ENABLED=0 go test -tags gms_pure_go -count=1 -timeout 20m \
    ./internal/workapi ./issueops
ok  	github.com/steveyegge/beads/internal/workapi	1.118s
ok  	github.com/steveyegge/beads/issueops	0.562s

$ BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint
==> gofmt check
All Go files are properly formatted
==> golangci-lint
0 issues.
==> golangci-lint (windows)
0 issues.
```

Did not run the full `./cmd/bd` suite (Docker-gated / hangs without Docker,
as documented in CONTRIBUTING/TESTING).

### Round-2 checks (contract docs + footer; HEAD 3b7704ea7)

CLI `bd init` / `--proxied-server` repro from round 1 was **not replayed**.
Query intersection was not changed this round. That CLI path is UNVERIFIED
here (CGO=0 `bd init` can attach to a live Dolt server unless `BEADS_*` is
stripped; `--proxied-server` was not exercised).

```text
$ gofmt -l issueops/reader.go backend/conformance/audit_dependencies_readiness.go \
    internal/workapi/list.go internal/workapi/ready.go \
    cmd/bd/list_tree.go cmd/bd/list.go cmd/bd/list_show_filter_modes.go \
    cmd/bd/list_proxied_server.go cmd/bd/list_helpers_test.go \
    cmd/bd/list_footer_counts_test.go
# (empty)

$ CGO_ENABLED=0 go vet -tags gms_pure_go ./cmd/bd/... ./internal/workapi ./issueops
# (no output)

$ CGO_ENABLED=0 go test -tags gms_pure_go -count=1 -timeout 20m \
    ./internal/workapi ./issueops ./cmd/bd/ \
    -run 'TestList|TestReady|TestFooter|TestDisplay'
ok  	github.com/steveyegge/beads/internal/workapi	0.217s
ok  	github.com/steveyegge/beads/issueops	0.483s [no tests to run]
ok  	github.com/steveyegge/beads/cmd/bd	2.638s

New footer tests that ran:
TestListFooterLineReadyExplicitStatusNamesSelector
TestDisplayPrettyListWithDepsReadyExplicitStatusFooter
TestDisplayWatchedIssueListReadyExplicitStatusFooter
TestListFooterLineCountsAreJustified/ready-filtered,_explicit_in_progress

$ BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint
==> gofmt check
All Go files are properly formatted
==> golangci-lint
0 issues.
==> golangci-lint (windows)
0 issues.
```
