### PR TITLE
Container-local git-remote fixture for dolt server-mode tests

### DIFF
--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -4,6 +4,7 @@ package dolt
 
 import (
 	"context"
+	"database/sql"
 	"encoding/csv"
 	"fmt"
 	"os"
@@ -16,10 +17,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/storage/schema"
+	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
 	"github.com/steveyegge/beads/internal/testutil"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -61,6 +64,7 @@ type gitRemoteSetup struct {
 	remoteDir string // bare git repo path
 	remoteURL string // file:// URL for the bare repo
 	sourceDir string // dolt source repo directory
+	dbName    string // Dolt database name (container fixtures only; empty for host-based setupGitRemote)
 }
 
 // setupGitRemote creates a bare git repo (seeded with an initial commit)
@@ -613,6 +617,52 @@ func TestGitRemoteSpecialCharacters(t *testing.T) {
 // remote these tests push/pull against is provisioned inside that same
 // container (see the rule at the top of this file), not on the host.
 
+// provisionContainerGitRemote creates a bare git repo with a seeded initial
+// commit inside the shared dolt-sql-server container, at a path unique to
+// this test (derived from suffix). The dolt-sql-server process — not this
+// test process — is what pushes to and pulls from this remote, so it must
+// live in the container's own filesystem; see the rule at the top of this
+// file. The repo is provisioned under testutil.DoltContainerGitRemoteMountDir(),
+// a host directory bind-mounted into the container at the identical path,
+// so host-side CLI verification helpers in this file (doltClone, queryCSV,
+// etc.) can also reach it by the same path string — a plain container-only
+// /tmp path would be invisible to those. Returns the bare repo's path and
+// its file:// URL, valid on both sides.
+func provisionContainerGitRemote(t *testing.T, suffix string) (remoteDir, remoteURL string) {
+	t.Helper()
+
+	ctx := context.Background()
+	container := testutil.DoltContainerHandle()
+
+	base := filepath.Join(testutil.DoltContainerGitRemoteMountDir(), "bd-remote-"+suffix)
+	remoteDir = base + "/remote.git"
+	seedDir := base + "/seed"
+
+	testcontainers.RequireContainerExec(ctx, t, container, []string{"sh", "-c", "mkdir -p " + base})
+	testcontainers.RequireContainerExec(ctx, t, container, []string{"git", "init", "--bare", "-b", "main", remoteDir})
+
+	seedScript := fmt.Sprintf(
+		"set -e\n"+
+			"mkdir -p %s\n"+
+			"cd %s\n"+
+			"git init -b main\n"+
+			"git -c user.name=test -c user.email=test@example.com commit --allow-empty -m init\n"+
+			"git remote add origin %s\n"+
+			"git push -u origin main\n",
+		seedDir, seedDir, remoteDir,
+	)
+	testcontainers.RequireContainerExec(ctx, t, container, []string{"sh", "-c", seedScript})
+
+	t.Cleanup(func() {
+		if _, _, err := container.Exec(ctx, []string{"sh", "-c", "rm -rf " + base}); err != nil {
+			t.Logf("cleanup: rm -rf %s in container: %v", base, err)
+		}
+	})
+
+	remoteURL = "file://" + remoteDir
+	return remoteDir, remoteURL
+}
+
 // setupContainerGitRemote creates a bare git repo inside the shared
 // dolt-sql-server container and returns a DoltStore connected with that
 // repo configured as "origin".
@@ -628,28 +678,17 @@ func setupContainerGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func())
 		t.Fatalf("failed to create base dir: %v", err)
 	}
 
-	// Create bare git repo with initial commit (same as setupGitRemote)
-	remoteDir := filepath.Join(baseDir, "remote.git")
-	runCmd(t, baseDir, "git", "init", "--bare", "-b", "main", remoteDir)
-
-	seedDir := filepath.Join(baseDir, "seed")
-	if err := os.MkdirAll(seedDir, 0o755); err != nil {
-		os.RemoveAll(baseDir)
-		t.Fatalf("failed to create seed dir: %v", err)
-	}
-	runCmd(t, seedDir, "git", "init", "-b", "main")
-	runCmd(t, seedDir, "git", "commit", "--allow-empty", "-m", "init")
-	runCmd(t, seedDir, "git", "remote", "add", "origin", remoteDir)
-	runCmd(t, seedDir, "git", "push", "-u", "origin", "main")
-
-	remoteURL := "file://" + remoteDir
-
 	// Create container DoltStore
 	doltDir := filepath.Join(baseDir, "embedded-dolt")
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	dbName := uniqueTestDBName(t)
+
+	// The bare git repo lives inside the dolt-sql-server container, not on
+	// the host — see provisionContainerGitRemote's doc comment.
+	remoteDir, remoteURL := provisionContainerGitRemote(t, dbName)
+
 	store, err := New(ctx, &Config{
 		Path:            doltDir,
 		CommitterName:   "test",
@@ -662,11 +701,21 @@ func setupContainerGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func())
 		t.Fatalf("failed to create container DoltStore: %v", err)
 	}
 
-	// Set issue prefix (required for CreateIssue)
+	// Set issue prefix (required for CreateIssue). SetConfig only writes the
+	// working set; Commit deliberately excludes the config table (GH#2455),
+	// so without an explicit CommitWithConfig here this stays dirty forever
+	// and later trips the pre-pull dirty-config guard (GH#2455/GH#2474) —
+	// the host-based fixture avoids this by committing via CLI `dolt commit
+	// -A`, which stages everything including config.
 	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
 		store.Close()
 		os.RemoveAll(baseDir)
 		t.Fatalf("failed to set prefix: %v", err)
+	}
+	if err := store.CommitWithConfig(ctx, "Set issue prefix"); err != nil {
+		store.Close()
+		os.RemoveAll(baseDir)
+		t.Fatalf("failed to commit prefix config: %v", err)
 	}
 
 	// Add git remote via SQL
@@ -681,6 +730,7 @@ func setupContainerGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func())
 		remoteDir: remoteDir,
 		remoteURL: remoteURL,
 		sourceDir: doltDir,
+		dbName:    dbName,
 	}
 
 	cleanup := func() {
@@ -692,6 +742,22 @@ func setupContainerGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func())
 }
 
 func TestGitRemotePushPull(t *testing.T) {
+	// Architect decision 2026-08-20 (be-nn2m notes): same root gate as
+	// TestGitRemotePushSkipsUserPrePushHook, on the Pull side. This
+	// fixture's store never runs a local `dolt init`, so hasCLIDatabase()
+	// (store.go ~3498) is always false and pullTransport's
+	// prepareCLIRouteForGitProtocol (~3558) falls through to the SQL-only
+	// `CALL DOLT_PULL` path — which does not reliably pick up commits an
+	// external, non-Dolt-SQL process (the host `dolt` CLI, via a real git
+	// push below) wrote to the git-protocol remote. store.Pull(ctx)
+	// reports success; the data simply never arrives. Tracked in the
+	// broadened be-9i0yq. Body and assertions below are kept intact, not
+	// weakened, per that decision.
+	t.Skip("SQL-routed CALL DOLT_PULL does not reliably see commits an " +
+		"external host-CLI `dolt push` wrote to a git-protocol remote " +
+		"(same hasCLIDatabase() gate as the push-hook-suppression gap) " +
+		"— tracked in be-9i0yq")
+
 	store, setup, cleanup := setupContainerGitRemote(t)
 	defer cleanup()
 
@@ -800,6 +866,22 @@ func TestGitRemoteHasRemote(t *testing.T) {
 //
 // Mirrors PR #3626 / GH#3340 (the commit-side sibling) at the push site.
 func TestGitRemotePushSkipsUserPrePushHook(t *testing.T) {
+	// Architect decision 2026-08-20 (be-nn2m notes): this fixture's
+	// setupContainerGitRemote store can only ever route through CALL
+	// DOLT_PUSH (hasCLIDatabase()/CLIDir(), store.go ~2845 & 3494, are never
+	// true for a server-mode store with no CLI-initialized local .dolt dir).
+	// GH#3724's applyNoGitHooksToCmd (credentials.go:507) only guards the
+	// CLI-routed doltCLIPush path, which is structurally unreachable here —
+	// confirmed empirically (a manually planted pre-push hook against a
+	// SQL-routed push fires). Whether this also reaches real
+	// external-server deployments (not just this fixture) is tracked
+	// separately in be-9i0yq. Body and assertions below are kept intact,
+	// not weakened, per that decision.
+	t.Skip("SQL-routed CALL DOLT_PUSH does not honor GH#3724 hook suppression " +
+		"(that fix only covers the CLI-routed push path) — tracked in be-9i0yq, " +
+		"which is investigating whether this also affects real external-server " +
+		"deployments or is fixture-specific")
+
 	if runtime.GOOS == "windows" {
 		t.Skip("hook script uses POSIX shell; the bug + fix are platform-agnostic but this assertion isn't")
 	}
@@ -944,19 +1026,38 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 		t.Fatalf("source Push failed: %v", err)
 	}
 
-	// Step 2: Bootstrap clone from git remote
-	// Close source store first to avoid driver conflicts,
-	// then use BootstrapFromGitRemoteWithDB + open a new store.
+	// Step 2: Bootstrap clone from git remote. Close source store first to
+	// avoid driver conflicts.
+	//
+	// Architect decision 2026-08-20 (be-nn2m notes): BootstrapFromGitRemoteWithDB
+	// is the wrong helper for this fixture's server architecture -- it does a
+	// real host-side `dolt clone`, correct only for owned-server/CLI mode
+	// (cmd/bd/bootstrap.go's cloneViaEmbedded path) where a locally-owned
+	// server also reads from that host directory. This fixture's shared
+	// testcontainer is an *external* server in exactly the sense
+	// cmd/bd/bootstrap.go already models (resolveRemoteCloneMode,
+	// cloneViaServer at 947-979): clone server-side via CALL DOLT_CLONE over
+	// a raw SQL connection -- the same call cloneViaServer itself makes --
+	// then New() a normal store against the resulting database name. No
+	// cfg.Path/Config semantics involved.
 	sourceStore.Close()
 
 	cloneDoltDir := filepath.Join(setup.baseDir, "clone-dolt")
-	cloneDBName := "clonedb"
-	bootstrapped, err := BootstrapFromGitRemoteWithDB(ctx, cloneDoltDir, setup.remoteURL, cloneDBName)
+	cloneDBName := uniqueTestDBName(t)
+
+	adminDSN := doltutil.ServerDSN{
+		Host: "127.0.0.1",
+		Port: testutil.DoltContainerPortInt(),
+		User: "root",
+	}.String()
+	adminConn, err := sql.Open("mysql", adminDSN)
 	if err != nil {
-		t.Fatalf("BootstrapFromGitRemoteWithDB failed: %v", err)
+		t.Fatalf("failed to open admin connection for clone: %v", err)
 	}
-	if !bootstrapped {
-		t.Fatal("expected bootstrap to occur (no existing dolt dir)")
+	defer adminConn.Close()
+
+	if err := versioncontrolops.DoltClone(ctx, adminConn, setup.remoteURL, cloneDBName, ""); err != nil {
+		t.Fatalf("DoltClone failed: %v", err)
 	}
 
 	cloneStore, err := New(ctx, &Config{
@@ -964,7 +1065,7 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 		CommitterName:   "clone-user",
 		CommitterEmail:  "clone@example.com",
 		Database:        cloneDBName,
-		CreateIfMissing: true, // clone creates a new database
+		CreateIfMissing: false, // CALL DOLT_CLONE already created the database
 	})
 	if err != nil {
 		t.Fatalf("failed to open cloned store: %v", err)
@@ -1008,13 +1109,17 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 	// Close clone store before re-opening source
 	cloneStore.Close()
 
-	// Step 4: Re-open source and pull — verify bidirectional sync
+	// Step 4: Re-open source and pull — verify bidirectional sync. Reuses the
+	// original dbName from setup rather than rediscovering it: the data lives
+	// in the container's Dolt server, not under setup.baseDir on the host, so
+	// scanning the host directory for a ".dolt" subdir (the old approach)
+	// never finds anything real in this fixture.
 	sourceStore2, err := New(ctx, &Config{
 		Path:            filepath.Join(setup.baseDir, "embedded-dolt"),
 		CommitterName:   "test",
 		CommitterEmail:  "test@example.com",
-		Database:        findClonedDBName(t, filepath.Join(setup.baseDir, "embedded-dolt")),
-		CreateIfMissing: true, // re-open may use dynamically discovered DB name
+		Database:        setup.dbName,
+		CreateIfMissing: false, // must reconnect to the existing database, not create a new empty one
 	})
 	if err != nil {
 		t.Fatalf("failed to re-open source store: %v", err)
@@ -1050,6 +1155,20 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 }
 
 func TestCreateIssueAfterPull(t *testing.T) {
+	// Architect decision 2026-08-20 (be-nn2m notes): same root gate as
+	// TestGitRemotePushPull / TestGitRemotePushSkipsUserPrePushHook. This
+	// fixture's store never runs a local `dolt init`, so hasCLIDatabase()
+	// (store.go ~3498) is always false and Pull falls through to the
+	// SQL-only `CALL DOLT_PULL` path, which does not reliably pick up a
+	// commit the host `dolt` CLI pushed to the git-protocol remote.
+	// store.Pull(ctx) reports success (nil error); ai-clone-001 simply
+	// never arrives. Tracked in the broadened be-9i0yq. Body and
+	// assertions below are kept intact, not weakened, per that decision.
+	t.Skip("SQL-routed CALL DOLT_PULL does not reliably see commits an " +
+		"external host-CLI `dolt push` wrote to a git-protocol remote " +
+		"(same hasCLIDatabase() gate as the push-hook-suppression gap) " +
+		"— tracked in be-9i0yq")
+
 	store, setup, cleanup := setupContainerGitRemote(t)
 	defer cleanup()
 
@@ -1129,27 +1248,6 @@ func TestCreateIssueAfterPull(t *testing.T) {
 			t.Errorf("expected %s to exist", id)
 		}
 	}
-}
-
-// findClonedDBName discovers the database name inside a dolt directory
-// by looking for subdirectories containing .dolt.
-func findClonedDBName(t *testing.T, doltDir string) string {
-	t.Helper()
-	entries, err := os.ReadDir(doltDir)
-	if err != nil {
-		t.Fatalf("failed to read dolt dir %s: %v", doltDir, err)
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		doltSubDir := filepath.Join(doltDir, entry.Name(), ".dolt")
-		if info, statErr := os.Stat(doltSubDir); statErr == nil && info.IsDir() {
-			return entry.Name()
-		}
-	}
-	t.Fatalf("no dolt database found in %s", doltDir)
-	return ""
 }
 
 // TestGitRemoteExternalServerRouting verifies that SQL-visible git-protocol

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -42,6 +42,18 @@ import (
 //
 // Run:
 //   go test -tags='cgo integration' -run TestGitRemote ./internal/storage/dolt/
+//
+// A fixture in this package (//go:build integration) may never assume the
+// dolt-sql-server process shares a filesystem or a loopback network
+// namespace with the test process. If a fixture needs an auxiliary resource
+// (a git remote, a second server, any external endpoint) that the *server*
+// must reach, provision that resource inside the server's own container via
+// Exec/CopyToContainer first. Reach for a bind-mount only with a written
+// justification for why in-container provisioning doesn't work. Do not
+// assume bare network reachability (127.0.0.1, host.docker.internal, or
+// otherwise) without verifying it directly against the container runtime
+// actually in use (this repo currently runs rootless Podman) — verify,
+// don't infer from a Docker-Desktop mental model.
 
 // gitRemoteSetup holds resources for a git-remote test scenario.
 type gitRemoteSetup struct {
@@ -588,16 +600,23 @@ func TestGitRemoteSpecialCharacters(t *testing.T) {
 	}
 }
 
-// --- Embedded driver git remote tests ---
+// --- DoltStore git remote tests ---
 //
 // These tests verify that Dolt's git remote support works through the
 // SQL driver, not just the CLI. This is the critical question for the
 // Dolt-in-Git spike: can we use store.Push() and store.Pull() with a
 // bare git repo as the remote?
+//
+// The DoltStore under test here always talks to the shared dolt-sql-server
+// test container over TCP (see testmain_test.go) — there is no in-process
+// "embedded" engine in this package to contrast it with. The bare git
+// remote these tests push/pull against is provisioned inside that same
+// container (see the rule at the top of this file), not on the host.
 
-// setupEmbeddedGitRemote creates a bare git repo and returns a DoltStore
-// connected with the bare repo configured as "origin".
-func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) {
+// setupContainerGitRemote creates a bare git repo inside the shared
+// dolt-sql-server container and returns a DoltStore connected with that
+// repo configured as "origin".
+func setupContainerGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) {
 	t.Helper()
 	skipIfNoDolt(t)
 	skipIfNoGit(t)
@@ -625,7 +644,7 @@ func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) 
 
 	remoteURL := "file://" + remoteDir
 
-	// Create embedded DoltStore
+	// Create container DoltStore
 	doltDir := filepath.Join(baseDir, "embedded-dolt")
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -640,7 +659,7 @@ func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) 
 	})
 	if err != nil {
 		os.RemoveAll(baseDir)
-		t.Fatalf("failed to create embedded DoltStore: %v", err)
+		t.Fatalf("failed to create container DoltStore: %v", err)
 	}
 
 	// Set issue prefix (required for CreateIssue)
@@ -650,7 +669,7 @@ func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) 
 		t.Fatalf("failed to set prefix: %v", err)
 	}
 
-	// Add git remote via embedded SQL
+	// Add git remote via SQL
 	if err := store.AddRemote(ctx, "origin", remoteURL); err != nil {
 		store.Close()
 		os.RemoveAll(baseDir)
@@ -672,14 +691,14 @@ func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) 
 	return store, setup, cleanup
 }
 
-func TestGitRemoteEmbeddedPushPull(t *testing.T) {
-	store, setup, cleanup := setupEmbeddedGitRemote(t)
+func TestGitRemotePushPull(t *testing.T) {
+	store, setup, cleanup := setupContainerGitRemote(t)
 	defer cleanup()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// Create test data via embedded store
+	// Create test data via the store
 	issue := &types.Issue{
 		ID:        "emb-git-001",
 		Title:     "Embedded git remote test",
@@ -696,7 +715,7 @@ func TestGitRemoteEmbeddedPushPull(t *testing.T) {
 		t.Fatalf("Commit failed: %v", err)
 	}
 
-	// Push via embedded driver — this is the key verification
+	// Push via the store — this is the key verification
 	if err := store.Push(ctx); err != nil {
 		t.Fatalf("Push failed: %v", err)
 	}
@@ -713,11 +732,11 @@ func TestGitRemoteEmbeddedPushPull(t *testing.T) {
 		t.Errorf("clone: title = %q, want %q", rows[0]["title"], "Embedded git remote test")
 	}
 
-	// Now test Pull: add data in the clone, push via CLI, pull into embedded store
+	// Now test Pull: add data in the clone, push via CLI, pull into the store
 	sourceInsertIssue(t, cloneDir, "emb-git-002", "Added in clone")
 	sourceCommitAndPush(t, cloneDir, "Add emb-git-002 from clone")
 
-	// Pull via embedded driver
+	// Pull via the store
 	if err := store.Pull(ctx); err != nil {
 		t.Fatalf("Pull failed: %v", err)
 	}
@@ -732,11 +751,11 @@ func TestGitRemoteEmbeddedPushPull(t *testing.T) {
 		t.Errorf("pull: title = %q, want %q", title, "Added in clone")
 	}
 
-	t.Log("Embedded driver git remote push/pull verified successfully")
+	t.Log("git remote push/pull verified successfully")
 }
 
-func TestGitRemoteEmbeddedHasRemote(t *testing.T) {
-	store, _, cleanup := setupEmbeddedGitRemote(t)
+func TestGitRemoteHasRemote(t *testing.T) {
+	store, _, cleanup := setupContainerGitRemote(t)
 	defer cleanup()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -785,7 +804,7 @@ func TestGitRemotePushSkipsUserPrePushHook(t *testing.T) {
 		t.Skip("hook script uses POSIX shell; the bug + fix are platform-agnostic but this assertion isn't")
 	}
 
-	store, setup, cleanup := setupEmbeddedGitRemote(t)
+	store, setup, cleanup := setupContainerGitRemote(t)
 	defer cleanup()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -896,9 +915,9 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 	// 2. Clone bootstraps from git remote (BootstrapFromGitRemote path)
 	// 3. Clone adds issues, commits, pushes
 	// 4. Source pulls — verifies bidirectional sync
-	// All via embedded DoltStore methods.
+	// All via DoltStore methods.
 
-	sourceStore, setup, cleanup := setupEmbeddedGitRemote(t)
+	sourceStore, setup, cleanup := setupContainerGitRemote(t)
 	defer cleanup()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -926,8 +945,8 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 	}
 
 	// Step 2: Bootstrap clone from git remote
-	// Close source store first to avoid embedded driver conflicts,
-	// then use BootstrapFromGitRemoteWithDB + open a new embedded store.
+	// Close source store first to avoid driver conflicts,
+	// then use BootstrapFromGitRemoteWithDB + open a new store.
 	sourceStore.Close()
 
 	cloneDoltDir := filepath.Join(setup.baseDir, "clone-dolt")
@@ -1031,7 +1050,7 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 }
 
 func TestCreateIssueAfterPull(t *testing.T) {
-	store, setup, cleanup := setupEmbeddedGitRemote(t)
+	store, setup, cleanup := setupContainerGitRemote(t)
 	defer cleanup()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -976,7 +976,11 @@ func (s *DoltStore) doltSpanAttrs() []attribute.KeyValue {
 		s.spanAttrsCache = []attribute.KeyValue{
 			attribute.String("db.system", "dolt"),
 			attribute.Bool("db.readonly", s.readOnly),
-			attribute.Bool("db.server_mode", true), // TODO: update when embedded mode returns
+			// DoltStore (this package) is always server-mode. The split from
+			// embedded mode is permanent, not pending; see
+			// internal/storage/embeddeddolt for the separate embedded-mode
+			// implementation used by solo/standalone deployments.
+			attribute.Bool("db.server_mode", true),
 		}
 	})
 	return s.spanAttrsCache

--- a/internal/testutil/testdoltserver.go
+++ b/internal/testutil/testdoltserver.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql" // required by testcontainers Dolt module
+	"github.com/moby/moby/api/types/container"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/dolt"
 )
@@ -28,15 +30,16 @@ const serverStartTimeout = 60 * time.Second
 
 // Module-level singleton state.
 var (
-	doltServerOnce    sync.Once
-	doltServerErr     error
-	doltTestPort      string
-	doltSingletonSrv  *doltServer
-	doltTerminateOnce sync.Once
-	dockerOnce        sync.Once
-	dockerAvail       bool
-	doltCheckOnce     sync.Once
-	doltCached        doltReadiness
+	doltServerOnce        sync.Once
+	doltServerErr         error
+	doltTestPort          string
+	doltSingletonSrv      *doltServer
+	doltTerminateOnce     sync.Once
+	dockerOnce            sync.Once
+	dockerAvail           bool
+	doltCheckOnce         sync.Once
+	doltCached            doltReadiness
+	doltGitRemoteMountDir string
 )
 
 // doltReadiness describes why Dolt integration tests can or cannot run.
@@ -138,6 +141,19 @@ func startDoltContainer() error {
 	ctx, cancel := context.WithTimeout(context.Background(), serverStartTimeout)
 	defer cancel()
 
+	// Bind-mount a dedicated host directory into the container at the
+	// identical path. dolt-sql-server (in the container) and the test
+	// process (on the host) can then both reach files under this path by
+	// the same string — e.g. a git remote one side provisions and the
+	// other side clones/pushes to via CLI. Mounting a distinctly-named
+	// leaf dir, rather than the tmp root itself, means this can never
+	// shadow whatever the container's own /tmp is used for internally.
+	mountDir := filepath.Join(os.TempDir(), "beads-dolt-git-remote-mount")
+	if err := os.MkdirAll(mountDir, 0o755); err != nil {
+		return fmt.Errorf("creating git-remote mount dir: %w", err)
+	}
+	doltGitRemoteMountDir = mountDir
+
 	ctr, err := dolt.Run(ctx, DoltDockerImage,
 		dolt.WithDatabase("beads_test"),
 		// Docker port-forwarding makes connections appear as non-localhost
@@ -145,6 +161,18 @@ func startDoltContainer() error {
 		// "localhost", so root@localhost won't match external connections.
 		// Set to "%" so root can connect from any host.
 		testcontainers.WithEnv(map[string]string{"DOLT_ROOT_HOST": "%"}),
+		// testcontainers.WithMounts+BindMount is not used here: this
+		// version's mapToDockerMounts() only logs a warning and drops
+		// BindOptions for bind-type sources, so there is no way to carry
+		// an SELinux relabel through that typed path. Under rootless
+		// Podman with SELinux enforcing (as on this rig), the container
+		// gets "permission denied" on an otherwise-0755, correctly-owned
+		// bind-mounted host dir unless the mount is relabeled — hence the
+		// raw HostConfig.Binds entry with the classic ":Z" (private
+		// relabel) suffix, verified by manual `podman run -v ...:Z` repro.
+		testcontainers.WithHostConfigModifier(func(hc *container.HostConfig) {
+			hc.Binds = append(hc.Binds, mountDir+":"+mountDir+":Z")
+		}),
 	)
 	if err != nil {
 		return fmt.Errorf("starting Dolt container: %w", err)
@@ -269,6 +297,27 @@ func DoltContainerPort() string {
 func DoltContainerPortInt() int {
 	p, _ := strconv.Atoi(doltTestPort)
 	return p
+}
+
+// DoltContainerHandle returns the shared Dolt container so tests can Exec
+// commands inside it — e.g. to provision a bare git remote that the
+// dolt-sql-server process (not the test process) must be able to reach.
+// Callers must call RequireDoltContainer(t) first, same as the other
+// DoltContainer* accessors.
+func DoltContainerHandle() testcontainers.Container {
+	return doltSingletonSrv.container
+}
+
+// DoltContainerGitRemoteMountDir returns a host directory that is
+// bind-mounted into the shared Dolt container at the identical path, so
+// files created under it are visible to both the test process (host) and
+// the dolt-sql-server process (container) by the same path string. Use
+// this — not an arbitrary container-only or host-only tmp dir — for any
+// fixture (like a git remote) that both sides must independently reach.
+// Callers must call RequireDoltContainer(t) first, same as the other
+// DoltContainer* accessors.
+func DoltContainerGitRemoteMountDir() string {
+	return doltGitRemoteMountDir
 }
 
 // TerminateDoltContainer stops and removes the shared Dolt container.

--- a/release-gates/be-2ym7w-git-remote-fixture-gate.md
+++ b/release-gates/be-2ym7w-git-remote-fixture-gate.md
@@ -1,0 +1,154 @@
+# Release Gate: be-2ym7w — Deploy review, container-local git-remote fixture for dolt server-mode tests
+
+- **Bead:** be-2ym7w (deploy review; molecule be-q1w44)
+- **Review bead:** be-r2msq (PASS round 2, beads/reviewer) — round 1 request-changes was solely a
+  diff-owned-SKIP/no-waiver gate; mayor granted a narrow, dated, be-r2msq-scoped waiver for the 3
+  SKIPs below, recorded in be-r2msq's own notes and `metadata.waiver_ref`. Style, security, and
+  acceptance-criteria coverage were already clean in round 1; commit unchanged since.
+- **Build bead:** be-nn2m (be-b81f decision: container-local git-remote fixture, Option D)
+- **Deploy commit:** `fe59756f8de2a0bcf7e7999fa32277fa72541d0e`
+- **Source branch:** `builder/be-nn2m` — provenance only, not pushed to or used as PR head
+- **Deploy branch:** `deploy/be-2ym7w-gate` — freshly cut, isolated, checked out directly from the
+  commit above.
+- **Push target:** `headfork` (`quad341/beads-sec003-contrib.git`)
+- **PR:** https://github.com/gastownhall/beads/pull/5925 (base `main`, head
+  `quad341:deploy/be-2ym7w-gate`, 2 commits, tip `fe59756f8de2a0bcf7e7999fa32277fa72541d0e`)
+- **Date:** 2026-08-21
+
+## Scope
+
+Provisions a bare git remote inside the shared `dolt-sql-server` testcontainer (be-b81f Option D)
+via a bind-mounted host directory visible to both the test process and the container at the same
+path, plus a container `Exec` accessor for tests that need it directly. `TestGitRemoteSyncRoundTrip`'s
+clone step now clones server-side via `CALL DOLT_CLONE` over a raw SQL connection
+(`versioncontrolops.DoltClone`), mirroring `cmd/bd/bootstrap.go`'s `cloneViaServer` pattern.
+
+## Gate criteria
+
+| # | Criterion | Result | Notes |
+|---|-----------|--------|-------|
+| 1 | Review PASS | ✅ PASS | be-r2msq: reviewed and passed by beads/reviewer (round 2) |
+| 2 | Acceptance criteria met | ✅ PASS | be-r2msq: all be-nn2m deliverables (1-4) covered; deliverable 3 (comment reword) non-functional/untestable by nature |
+| 3 | Tests pass (diff-owned) | ✅ PASS | 15 PASS, 0 FAIL, 3 SKIP re-run independently — see table below, exact match to be-r2msq's counts |
+| 3b | Policy/lint lane | ✅ PASS* | `make ci-pr-policy` fails solely on the documented `.githooks/commit-msg` environmental false positive; see below |
+| 4 | No unresolved HIGH findings | ✅ PASS | be-r2msq recorded no blocking security findings (2 informational-only, both traced and non-exploitable) |
+| 5 | Clean working tree | ✅ PASS | No stray stash activity this round (checked `git stash list` before and after — unchanged 12 stale entries, none new); working tree matched target commit byte-for-byte throughout |
+| 6 | Clean divergence from origin/main | ❌ **NOT CLEAN** | Real content conflict — see below. Flagged, not resolved, per established precedent of surfacing rather than unilaterally fixing what's outside deployer's decision authority. |
+| 7 | Single feature theme | ✅ PASS | Both non-merge commits (`74a46b64a`, `fe59756f8`) cite `be-nn2m`; `assert_deploy_ancestry_scope` clean (rc=0), no `.claude/**` paths |
+
+### Criterion 6 — merge conflict with origin/main (real finding, not resolved here)
+
+`origin/main` carries 11 commits not in this deploy. Diff-overlap check found 2 files touched by
+both sides: `internal/storage/dolt/store.go` (auto-merges cleanly) and
+`internal/storage/dolt/git_remote_test.go` (**does not** — 8 real conflict hunks).
+
+Root cause: `main` independently picked up a *different* rewrite of the same shared git-remote
+test fixture via #5892 (`2240ee784`) and #5889 (`4daf88082`) — a host-local `dolt sql-server`
+design (`startLocalDoltServer`, `gitRemoteSetup.serverPort`, remote provisioned on the host).
+This deploy's fixture takes a container-based design instead (`gitRemoteSetup.dbName`, remote
+provisioned inside the shared testcontainer via bind-mount). Both rewrote the same
+`gitRemoteSetup` struct, `setupGitRemote`/`setupContainerGitRemote`, and several call sites, in
+mutually incompatible ways — confirmed via a throwaway `git merge --no-commit --no-ff
+origin/main` (aborted, no changes kept): struct-field-level conflicts (`dbName` vs `serverPort`,
+possibly both needed), a whole added function (`startLocalDoltServer`) only on `main`'s side, and
+divergent fixture-setup bodies (container-provisioned vs host-provisioned bare repo). This is not
+a mechanical/whitespace conflict — reconciling it requires engineering judgment from someone with
+context on both fixture designs (does the merged fixture need both `dbName` and `serverPort`? do
+the two provisioning strategies need to coexist or does one supersede the other?), which is
+outside the deployer's role and this session's authority to decide blind.
+
+**Not resolved here.** The deploy branch and PR carry the exact reviewed commit
+(`fe59756f8de2a0bcf7e7999fa32277fa72541d0e`), unmodified — attempting a conflict resolution would
+mean shipping code be-r2msq never reviewed. PR #5925 is confirmed via `gh pr view` to show
+`mergeable: CONFLICTING`, `mergeStateStatus: DIRTY` — this is visible and honest on the PR itself,
+not papered over. Flagged in the PR body and in bd notes for mayor/Jim to route to a rebase-aware
+builder (likely whoever owns be-9i0yq's broader SQL-routing investigation, since both fixture
+designs exist because of the same `hasCLIDatabase()`-false gap).
+
+This is a materially different situation from be-g3iz8's round (zero file overlap, no rebase
+needed) — not the same "clean" pattern, called out explicitly rather than reusing that verdict.
+
+The `.claude/**` denylist check is clean (covered by `assert_deploy_ancestry_scope`, rc=0).
+
+## Tests run on release branch
+
+Diff-owned test file: `internal/storage/dolt/git_remote_test.go` (also touches `store.go`,
+`internal/testutil/testdoltserver.go`).
+
+Independently re-ran be-r2msq's own `test_cmd` (full diff-owned file, all 18 functions) against a
+live Dolt/podman testcontainer:
+
+```
+cd internal/storage/dolt && env -u BEADS_DOLT_SERVER_PORT -u BEADS_DOLT_AUTO_START \
+  TMPDIR=$HOME/.gotmp GOTMPDIR=$HOME/.gotmp DOCKER_HOST=unix:///run/user/1000/podman/podman.sock \
+  TESTCONTAINERS_RYUK_DISABLED=true BEADS_TEST_ENV_RUN_DOLT=1 \
+  go test -tags=integration,gms_pure_go -count=1 -v \
+  -run '^TestGitRemote|^TestCreateIssueAfterPull|^TestSQLRemotePersistsAcrossExternalServerRestart|^TestCredentialCLIRoutingE2E$' .
+```
+
+| Test | Result | Time |
+|------|--------|------|
+| TestGitRemoteAdd | PASS | 1.11s |
+| TestGitRemotePushEmptyDB | PASS | 1.66s |
+| TestGitRemotePushWithData | PASS | 2.45s |
+| TestGitRemotePushIdempotent | PASS | 3.05s |
+| TestGitRemotePushIncremental | PASS | 2.26s |
+| TestGitRemoteClone | PASS | 2.00s |
+| TestGitRemotePull | PASS | 2.17s |
+| TestGitRemotePullWithLocalChanges | PASS | 2.30s |
+| TestGitRemoteRoundTripAllTables | PASS | 3.44s |
+| TestGitRemoteSpecialCharacters | PASS | 3.09s |
+| TestGitRemotePushPull | SKIP | 0.00s (be-9i0yq, mayor-waived) |
+| TestGitRemoteHasRemote | PASS | 6.11s |
+| TestGitRemotePushSkipsUserPrePushHook | SKIP | 0.00s (be-9i0yq, mayor-waived) |
+| TestGitRemoteSyncRoundTrip | PASS | 14.55s |
+| TestCreateIssueAfterPull | SKIP | 0.00s (be-9i0yq, mayor-waived) |
+| TestGitRemoteExternalServerRouting | PASS | 5.82s |
+| TestSQLRemotePersistsAcrossExternalServerRestart | PASS | 3.33s |
+| TestCredentialCLIRoutingE2E | PASS | 15.33s |
+
+`ok github.com/steveyegge/beads/internal/storage/dolt 74.398s` — 15 PASS, 0 FAIL, 3 SKIP, exact
+match to be-r2msq's recorded counts. The 3 SKIPs are the mayor-waived set (waiver_ref on
+be-r2msq: "diff-owned SKIP waived on be-r2msq notes ... conditional on be-9i0yq").
+
+Also: `gofmt -l .` clean. `go vet ./...` clean. `go build ./...` clean.
+
+### Policy/lint lane (criterion 3b)
+
+`make ci-pr-policy` fails solely on the `.githooks/commit-msg` BEGIN/END marker check — the
+established, repeatedly-reconfirmed non-issue (be-jy56/be-jygq, reconfirmed in be-p7dzx, be-y1jo,
+be-g3iz8; see `.gc` memory `reference_githooks_commit_msg_false_positive`). Not a repository file;
+a git-ignored per-session shim regenerated every session start. All other sub-checks
+(build-tag policy, go-install guidance, version-consistency) PASS.
+
+### Pre-PR check
+
+`gc beads-contributor pre-pr-check --remote-checks --title=... --body-file=...` run **before**
+`gh pr create` (proactively this round): 0 blockers, 1 warning (title/body cites `be-r2msq` not
+present in commits — expected noise, review-bead ids never appear in feature commits). Its
+mergeability check ("branch is 11 commits behind, <=25 OK") is commit-count-only and does **not**
+detect real content conflicts — it did not catch the criterion-6 finding above; that was found
+via a manual throwaway `git merge --no-commit` check, not by this tool.
+
+## Findings from reviews
+
+be-r2msq (beads/reviewer): PASS (round 2). No unresolved HIGH findings. 2 informational security
+notes (fixed shared bind-mount path; unquoted shell suffix in a test helper), both traced and
+judged non-exploitable — test-only code, fixed random-hex-only input.
+
+## Verdict
+
+**PASS, with an unresolved criterion-6 flag.** Deploy branch `deploy/be-2ym7w-gate` cut from
+verified commit `fe59756f8...`, pushed to `headfork`, PR #5925 opened against
+`gastownhall/beads:main` carrying the exact reviewed commit, unmodified. The reviewed code itself
+is correct, tested, and secure — what's not clean is a routine (if unusually substantive) merge
+conflict with unrelated concurrent work on `main`, which is a mergeability/rebase problem, not a
+defect in this deploy's content. Surfaced explicitly in the PR body, this gate file, and bd notes
+rather than silently resolved or silently hidden.
+
+`gastownhall/beads` is contributor-only for this rig (established repeatedly: be-vc1m, be-gd3v,
+be-79jh, be-krza3, be-pp7e, be-y1jo, be-g3iz8) — merge authority does not extend to an upstream
+repo this rig doesn't own. The deployer's job ends at the open PR; no functional merge-request is
+routed to mayor/mpr (be-2ym7w's own instruction text to do so is boilerplate that assumes
+maintainer status, inapplicable here per established precedent). Gate result reported to mayor
+per the bead's separate, applicable instruction to do so.


### PR DESCRIPTION
## Summary

Provisions a bare git remote inside the shared `dolt-sql-server` testcontainer (be-b81f Option D) via a bind-mounted host directory visible to both the test process and the container at the same path, plus a container `Exec` accessor for tests that need it directly. `TestGitRemoteSyncRoundTrip`'s clone step now clones server-side via `CALL DOLT_CLONE` over a raw SQL connection (`versioncontrolops.DoltClone`), mirroring `cmd/bd/bootstrap.go`'s existing `cloneViaServer` pattern for external servers.

## Test results (independently re-run against a live Dolt/podman container)

15 PASS, 0 FAIL, 3 SKIP — `ok github.com/steveyegge/beads/internal/storage/dolt 74.398s`.

The 3 SKIPs (`TestGitRemotePushPull`, `TestGitRemotePushSkipsUserPrePushHook`, `TestCreateIssueAfterPull`) are a known, architect-documented gap: this fixture's server-mode store never runs a local `dolt init`, so `hasCLIDatabase()` is always false and both Push and Pull structurally fall through to SQL-only routing (`CALL DOLT_PUSH` / `CALL DOLT_PULL`) instead of the CLI-routed path that GH#3724's hook-suppression fix covers. Tracked in be-9i0yq (open, P1) as a live correctness question for external-server deployments, not just a test-fixture artifact. These SKIPs were reviewed and blocked in round 1 for lacking a waiver, then explicitly waived by the mayor for this specific bead's fixture work only (narrow, dated, non-transferable — see review notes on be-r2msq).

## Review

Reviewed and passed (round 2) by beads/reviewer — round 1 request-changes was solely the diff-owned-SKIP/no-waiver gate; style, security, and acceptance-criteria coverage were already clean in round 1 and the commit is unchanged since. Full review notes: bead be-r2msq.

## Note for maintainers

This branch currently conflicts with `main` in `internal/storage/dolt/git_remote_test.go` — `main` has independently picked up a different rewrite of the same shared test fixture (`startLocalDoltServer`, a host-local sql-server design) via #5892/#5889, which overlaps this PR's container-based fixture (`dbName` field, container-side remote provisioning) in the same struct and several of the same functions. Reconciling the two needs someone with context on both fixture designs — flagging here rather than force-resolving blind.
