### PR TITLE
Add reverse-dependency-scoped test-selection tool

### DIFF
--- a/release-gates/be-g4zox-revdepscope-gate.md
+++ b/release-gates/be-g4zox-revdepscope-gate.md
@@ -1,0 +1,86 @@
+# Release gate — reverse-dependency-scoped test-selection tool (be-g4zox)
+
+- **Deploy bead:** be-g4zox (needs-deploy, routed beads/deployer, from:be-paugu)
+- **Build bead:** be-mv0ww.3.1 — tdd_red `5247ad94e`, tdd_green `95a142720`, shadow-mode harness `51750d3fa`
+- **Review bead:** be-paugu — verdict **PASS** (round 1), closed with reason `pass`
+- **Commit deployed:** `3cef8d53d89ea337bb1867142a9f04ec2505ff42` (post-rebase; reviewed source was `51750d3fa53fc567c8955e29bca5442f7f68ab9c`, identical tree, rebased onto current `origin/main` — see criterion 6)
+- **Source branch:** `builder/be-mv0ww.3.1` — provenance only, never a push target
+- **Related beads:** be-mv0ww.3 (parent design bead, architecture + empirical method-comparison), be-mv0ww.3.1 (this build), be-paugu (review)
+- **Deploy branch:** `deploy/be-paugu-gate` — name taken from be-g4zox's own explicit branch-name instruction (derived via `resolve_deploy_branch_target "be-paugu" <sha>`, which reduces to the same deterministic `deploy/<id>-gate` pattern)
+- **Push target:** `headfork` (`quad341/beads-sec003-contrib.git`) — `origin` push is disabled by design on this rig (`DISABLED-upstream-is-fetch-only-push-to-fork-and-PR`)
+- **PR:** (recorded below once opened)
+- **Evaluated:** 2026-08-21 by beads/deployer
+
+## Scope
+
+New CLI tool `scripts/ci/revdepscope` computes the reverse-dependency-scoped
+set of Go packages that need retesting for a given set of changed packages,
+using `go list -test -deps` (never a build-only or single-hop import scan —
+both were empirically proven on this repo to miss real callers). Includes a
+mandatory full-suite fallback when the scoped set exceeds a tunable fraction
+of all packages (default 50%), and a shadow-mode validation harness that
+diffs scoped output against full-suite ground truth on real commits. Per its
+own hard requirements, this tool is explicitly **not** wired into any
+deploy-gate criterion, CI requirement, or acceptable-command list — that
+remains out of scope pending a stronger shadow-mode validation sample.
+
+Diff is exactly 3 additive files under `scripts/ci/revdepscope/`, 557
+insertions, 0 deletions, 0 modifications elsewhere: `main.go`,
+`revdepscope_test.go`, `shadow-mode.sh`.
+
+Single feature theme: all 3 commits in the deploy range cite `be-mv0ww.3.1`,
+confirmed by `assert_deploy_ancestry_scope` (see criterion 6).
+
+## Gate criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 0 | Already merged? (pre-flight) | **NO** | `gh pr list -R gastownhall/beads --search "revdepscope"` (state all) → empty. `gh api repos/gastownhall/beads/commits/51750d3fa.../pulls` → empty. `git merge-base --is-ancestor 51750d3fa... origin/main` → not an ancestor. Proceeded. |
+| 1 | Review PASS present | **PASS** | be-paugu, `verdict: pass`, round 1, closed with reason `pass`. Reviewer ran independently in an isolated worktree at the true branch tip (caught and corrected a one-commit SHA-staleness issue in the build bead's own recorded metadata before reviewing — documented in be-paugu's notes). |
+| 2 | Acceptance criteria met | **PASS** | Independently re-verified against source, not just the reviewer's say-so. Read `main.go` directly: `go list -test -deps` at line 116 (not build-only, not single-hop); threshold fallback at lines 49-51, default 0.5, tunable via `REVDEPSCOPE_THRESHOLD` (line 150); no hand-maintained package lists anywhere — `allPackages`/`deps` computed fresh via `go list` every invocation; plain newline-delimited package-list output (lines 177-179), no new test runner. Read `revdepscope_test.go`: threshold boundary cases (exactly-at vs exceeding) and a real-repo smoke test against `internal/storage/schema` are present and exercised, not just table-driven synthetic cases. Read `shadow-mode.sh`: matches its own documented design — builds the binary, runs one ground-truth full-suite pass, samples N real `origin/main` commits, diffs scoped output against `FAILED_PACKAGES`, reports divergences; limitations (current-tree package resolution, single reused ground truth) honestly disclosed in its own header. Out-of-scope boundary independently confirmed: `deployer.md.tmpl` / `mol-deployer-gate.formula.toml` / be-mv0ww.1's gate criterion untouched — diffstat is exactly the 3 files above. |
+| 3 | Tests pass (diff-owned) | **PASS** | Re-ran the reviewer's exact documented command myself, independently, post-rebase: `go build ./scripts/ci/revdepscope/... && go vet ./scripts/ci/revdepscope/... && go test -v ./scripts/ci/revdepscope/...` → **17 PASS, 0 FAIL, 0 SKIP** (TestScope×8 subtests, TestScopeThresholdIsFractionOfAllPackagesNotReverseDepSet, TestParseThreshold×7 subtests, TestRealRepoSchemaChangeStaysScoped 10.80s real-repo smoke test) — identical count to the reviewer's own independent run. `gofmt -l scripts/ci/revdepscope/` clean. `go build ./...` (full module) clean, exit 0. |
+| 3a | Pre-existing-failure attribution | **N/A** | 0 FAIL — nothing to attribute. Diff is purely additive (3 new files, 0 modifications to existing files), so no pre-existing test could be affected. |
+| 3b | Policy / lint lane | **PASS (named exception)** | `make ci-pr-policy`: build-tag policy PASS, go-install guidance PASS, version-consistency FAILs solely on `.githooks/commit-msg` missing BEGIN/END BEADS INTEGRATION markers. Independently re-verified this file is **not a tracked repo file** (`git ls-files --error-unmatch` fails) and **is git-ignored** (`git check-ignore -v` → matches `.git/info/exclude:40`) — a per-session shim regenerated by `worktree-setup.sh`, not diff-related. Known environmental false positive, previously root-caused (be-jy56/be-jygq) and reconfirmed across be-p7dzx, be-y1jo, be-g3iz8, be-krza3; reconfirmed again here. `shellcheck scripts/ci/revdepscope/shadow-mode.sh`: only an info-level SC1091 (cannot follow the sourced `.buildflags` path outside `-x` mode) — same finding the reviewer documented, non-actionable. |
+| 4 | No open HIGH findings | **PASS** | Reviewer's OWASP-style walk: no findings (blocker/major/minor) across all 10 categories. Independently re-confirmed the injection-relevant claim myself by reading the source directly: all 3 `exec.Command` calls (`main.go:83,102,116`) use argv-array form, zero shell-string concatenation; `grep -nE 'eval |sh -c|bash -c|http\.(Get\|Post)'` across all 3 files → no matches. No new dependencies (stdlib only). No credentials/PII/network I/O in scope. |
+| 5 | Branch clean | **PASS** | `git status --short` empty after removing a stray `revdepscope` build artifact left by this gate's own independent `go build` run (not part of the diff — a local binary produced by the build command, `.gitignore`-eligible, never staged). |
+| 6 | Diverges cleanly from main | **PASS (self-rebase applied)** | Deploy SHA `51750d3fa` was 1 commit behind `origin/main` (`1617f3a85`, unrelated `storage/dolt/*.go` follow-up — no path overlap with `scripts/ci/revdepscope/`). `assert_deploy_ancestry_scope origin/main 51750d3fa... be-mv0ww.3.1` → rc=0 pre-rebase. `PUSH_REMOTE=headfork attempt_bounded_self_rebase deploy/be-paugu-gate main` → rc=0, `BEFORE_SHA=51750d3fa53fc567c8955e29bca5442f7f68ab9c`, `AFTER_SHA=3cef8d53d89ea337bb1867142a9f04ec2505ff42`, and — unlike the be-krza3/be-z3iuv precedent where this function's internal push was hardcoded to the disabled `origin` remote — its internal force-with-lease push against `headfork` **succeeded** this round (the canonical script now honours `$PUSH_REMOTE`, confirmed by reading `rebase-resolve-lib.sh:502,572` directly). Landing independently verified via `git ls-remote headfork refs/heads/deploy/be-paugu-gate` → `3cef8d53d...`, matching local `HEAD` exactly. `git merge-base HEAD origin/main` now equals `origin/main`'s own tip (`1617f3a85`) — zero divergence. `assert_safe_push_target deploy/be-paugu-gate` → rc=0. |
+| 7 | Single feature theme | **PASS** | All 3 commits (`tdd_red`, `tdd_green`, shadow-mode-harness) cite `be-mv0ww.3.1`; `assert_deploy_ancestry_scope` found no stray commits and no `.claude/**` paths. |
+
+## Branch recreation note (this round)
+
+This worktree's between-bead session-restart reset (`worktree-setup.sh
+--reset-main`) silently reset the local `deploy/be-paugu-gate` branch pointer
+back to `origin/main` before this gate's markdown/commit step had run in a
+prior incarnation of this session — confirmed via `git reflog show
+deploy/be-paugu-gate` (two entries only: branch-creation from `51750d3fa`,
+then a bare `reset: moving to origin/main`; no commit in between, so no work
+was lost). No remote copy existed yet (`git ls-remote fork/headfork/prhead`
+all empty for this branch name pre-recreation), so nothing was prematurely
+pushed either. Recreated cleanly via `resolve_deploy_branch_target "be-paugu"
+51750d3fa53fc567c8955e29bca5442f7f68ab9c` and re-ran every criterion fresh
+against the restored state before proceeding — same recovery pattern as
+be-krza3's own gate file documents for an analogous reset.
+
+## Push target
+
+`origin` (`gastownhall/beads`) denies push
+(`DISABLED-upstream-is-fetch-only-push-to-fork-and-PR` sentinel); `headfork`
+(`quad341/beads-sec003-contrib.git`) accepts. PR opens cross-repo against
+`gastownhall/beads:main` with head `quad341:deploy/be-paugu-gate`.
+
+## Merge authority
+
+`gastownhall/beads` is a contributor-only repo for this rig — no rig agent
+has merge access. Per established precedent (be-vc1m, be-gd3v, be-79jh,
+be-39ss, be-pp7e, be-r3ysh, be-krza3, be-2ym7w), the deployer's job ends at
+the open, verified PR. No merge-request is routed to mayor/mpr; gate result
+reported to mayor via mail.
+
+## Verdict
+
+**PASS 7/7 (1 N/A, 1 named environmental exception)** — branch recreated
+after a between-bead reset and re-verified from scratch, self-rebased cleanly
+onto current main (push succeeded, landing independently confirmed), tests
+and policy/lint independently re-run and matched against the reviewer's
+results, security scan independently reconfirmed. Proceeding to push + open
+PR.

--- a/scripts/ci/revdepscope/main.go
+++ b/scripts/ci/revdepscope/main.go
@@ -1,0 +1,180 @@
+// Command revdepscope computes the reverse-dependency-scoped set of Go
+// packages that need their tests re-run for a given set of changed
+// packages. See be-mv0ww.3's design (bd show be-mv0ww.3) for the full
+// rationale; FR-1 is why this uses `go list -test -deps` rather than a
+// build-only or single-hop import scan.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type scopeResult struct {
+	fullSuiteRequired bool
+	packages          []string
+}
+
+// scope returns the union of changedPackages and every package in
+// allPackages whose entry in deps (its go-list-test-deps closure, already
+// transitive) contains a changed package. deps[pkg] not containing pkg
+// itself is fine; changedPackages are unioned in explicitly.
+func scope(allPackages, changedPackages []string, deps map[string][]string, threshold float64) scopeResult {
+	changed := make(map[string]bool, len(changedPackages))
+	for _, pkg := range changedPackages {
+		changed[pkg] = true
+	}
+
+	result := make(map[string]bool, len(changed))
+	for pkg := range changed {
+		result[pkg] = true
+	}
+	for pkg, pkgDeps := range deps {
+		for _, dep := range pkgDeps {
+			if changed[dep] {
+				result[pkg] = true
+				break
+			}
+		}
+	}
+
+	if len(result) == 0 {
+		return scopeResult{}
+	}
+
+	if total := len(allPackages); total > 0 && float64(len(result))/float64(total) > threshold {
+		return scopeResult{fullSuiteRequired: true}
+	}
+
+	packages := make([]string, 0, len(result))
+	for pkg := range result {
+		packages = append(packages, pkg)
+	}
+	sort.Strings(packages)
+	return scopeResult{packages: packages}
+}
+
+// parseThreshold parses the configured threshold fraction. Empty means the
+// FR-3 default of 50%.
+func parseThreshold(raw string) (float64, error) {
+	if raw == "" {
+		return 0.5, nil
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid threshold %q: %w", raw, err)
+	}
+	if v <= 0 || v > 1 {
+		return 0, fmt.Errorf("threshold %q out of range: must be > 0 and <= 1", raw)
+	}
+	return v, nil
+}
+
+var cachedModulePath string
+
+func modulePath() (string, error) {
+	if cachedModulePath != "" {
+		return cachedModulePath, nil
+	}
+	out, err := exec.Command("go", "list", "-m").Output()
+	if err != nil {
+		return "", fmt.Errorf("go list -m: %w", err)
+	}
+	cachedModulePath = strings.TrimSpace(string(out))
+	return cachedModulePath, nil
+}
+
+// listAllPackages lists every package in the module. It uses the
+// module-qualified pattern (rather than "./...") so the result does not
+// depend on the caller's working directory — "./..." is relative to cwd,
+// which e.g. `go test` sets to the package's own source directory rather
+// than the module root.
+func listAllPackages() ([]string, error) {
+	mod, err := modulePath()
+	if err != nil {
+		return nil, err
+	}
+	pattern := mod + "/..."
+	out, err := exec.Command("go", "list", pattern).Output()
+	if err != nil {
+		return nil, fmt.Errorf("go list %s: %w", pattern, err)
+	}
+	return splitLines(string(out)), nil
+}
+
+// listTestDeps returns pkg's go-list-test-deps closure, filtered to
+// packages within this module (NFR-2: single-module scope).
+func listTestDeps(pkg string) ([]string, error) {
+	mod, err := modulePath()
+	if err != nil {
+		return nil, err
+	}
+	out, err := exec.Command("go", "list", "-test", "-deps", pkg).Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("go list -test -deps %s: %w: %s", pkg, err, string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("go list -test -deps %s: %w", pkg, err)
+	}
+	var internal []string
+	for _, line := range splitLines(string(out)) {
+		if line == mod || strings.HasPrefix(line, mod+"/") {
+			internal = append(internal, line)
+		}
+	}
+	return internal, nil
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: revdepscope <changed-package-import-path> [...]")
+		os.Exit(2)
+	}
+	changedPackages := os.Args[1:]
+
+	threshold, err := parseThreshold(os.Getenv("REVDEPSCOPE_THRESHOLD"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+
+	allPackages, err := listAllPackages()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	deps := make(map[string][]string, len(allPackages))
+	for _, pkg := range allPackages {
+		d, err := listTestDeps(pkg)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		deps[pkg] = d
+	}
+
+	res := scope(allPackages, changedPackages, deps, threshold)
+	if res.fullSuiteRequired {
+		fmt.Println("full suite required")
+		return
+	}
+	for _, pkg := range res.packages {
+		fmt.Println(pkg)
+	}
+}

--- a/scripts/ci/revdepscope/revdepscope_test.go
+++ b/scripts/ci/revdepscope/revdepscope_test.go
@@ -43,9 +43,13 @@ func TestScope(t *testing.T) {
 			allPackages:     []string{"schema", "dolt", "embeddeddolt", "uow", "unrelated"},
 			changedPackages: []string{"schema"},
 			deps: map[string][]string{
+				// go list -test -deps already returns each package's full
+				// transitive closure, so uow (which reaches schema via dolt)
+				// carries schema directly here too — the fixture mirrors that,
+				// not a one-hop import graph.
 				"dolt":         {"schema"},
 				"embeddeddolt": {"schema"},
-				"uow":          {"dolt"},
+				"uow":          {"dolt", "schema"},
 				"unrelated":    {"fmt"},
 			},
 			threshold:     0.9,
@@ -100,11 +104,15 @@ func TestScope(t *testing.T) {
 			wantPackages:  []string{"a", "b", "c", "d"},
 		},
 		{
-			name:            "caller reaching a changed package only through the supplied test-aware deps is scoped in",
-			allPackages:     []string{"schema", "domain_db"},
+			name: "caller reaching a changed package only through the supplied test-aware deps is scoped in",
+			allPackages: []string{
+				"schema", "domain_db",
+				"other1", "other2", "other3", "other4", "other5", "other6", "other7", "other8",
+			},
 			changedPackages: []string{"schema"},
 			deps: map[string][]string{
 				"domain_db": {"schema"},
+				"other1":    {"fmt"},
 			},
 			threshold:     0.9,
 			wantFullSuite: false,

--- a/scripts/ci/revdepscope/revdepscope_test.go
+++ b/scripts/ci/revdepscope/revdepscope_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestScope(t *testing.T) {
+	tests := []struct {
+		name            string
+		allPackages     []string
+		changedPackages []string
+		deps            map[string][]string
+		threshold       float64
+		wantFullSuite   bool
+		wantPackages    []string
+	}{
+		{
+			name:            "no changed packages yields empty scope",
+			allPackages:     []string{"a", "b", "c"},
+			changedPackages: nil,
+			deps:            map[string][]string{},
+			threshold:       0.5,
+			wantFullSuite:   false,
+			wantPackages:    nil,
+		},
+		{
+			name:            "changed leaf package with no callers scopes to itself",
+			allPackages:     []string{"leaf", "other1", "other2"},
+			changedPackages: []string{"leaf"},
+			deps: map[string][]string{
+				"other1": {"unrelated"},
+				"other2": {"unrelated"},
+			},
+			threshold:     0.5,
+			wantFullSuite: false,
+			wantPackages:  []string{"leaf"},
+		},
+		{
+			name:            "changed package pulls in direct and transitive test-aware callers",
+			allPackages:     []string{"schema", "dolt", "embeddeddolt", "uow", "unrelated"},
+			changedPackages: []string{"schema"},
+			deps: map[string][]string{
+				"dolt":         {"schema"},
+				"embeddeddolt": {"schema"},
+				"uow":          {"dolt"},
+				"unrelated":    {"fmt"},
+			},
+			threshold:     0.9,
+			wantFullSuite: false,
+			wantPackages:  []string{"dolt", "embeddeddolt", "schema", "uow"},
+		},
+		{
+			name:            "reverse-dep set at exactly the threshold fraction is scoped, not full suite",
+			allPackages:     []string{"a", "b", "c", "d"},
+			changedPackages: []string{"a"},
+			deps: map[string][]string{
+				"b": {"a"},
+			},
+			threshold:     0.5,
+			wantFullSuite: false,
+			wantPackages:  []string{"a", "b"},
+		},
+		{
+			name:            "reverse-dep set exceeding the threshold fraction requires full suite",
+			allPackages:     []string{"a", "b", "c", "d"},
+			changedPackages: []string{"a"},
+			deps: map[string][]string{
+				"b": {"a"},
+				"c": {"a"},
+			},
+			threshold:     0.5,
+			wantFullSuite: true,
+			wantPackages:  nil,
+		},
+		{
+			name:            "custom threshold changes the outcome for the same graph",
+			allPackages:     []string{"a", "b", "c", "d"},
+			changedPackages: []string{"a"},
+			deps: map[string][]string{
+				"b": {"a"},
+				"c": {"a"},
+			},
+			threshold:     0.8,
+			wantFullSuite: false,
+			wantPackages:  []string{"a", "b", "c"},
+		},
+		{
+			name:            "multiple changed packages union their reverse-dep sets and dedupe",
+			allPackages:     []string{"a", "b", "c", "d", "e"},
+			changedPackages: []string{"a", "d"},
+			deps: map[string][]string{
+				"b": {"a"},
+				"c": {"a", "d"},
+			},
+			threshold:     0.9,
+			wantFullSuite: false,
+			wantPackages:  []string{"a", "b", "c", "d"},
+		},
+		{
+			name:            "caller reaching a changed package only through the supplied test-aware deps is scoped in",
+			allPackages:     []string{"schema", "domain_db"},
+			changedPackages: []string{"schema"},
+			deps: map[string][]string{
+				"domain_db": {"schema"},
+			},
+			threshold:     0.9,
+			wantFullSuite: false,
+			wantPackages:  []string{"domain_db", "schema"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scope(tt.allPackages, tt.changedPackages, tt.deps, tt.threshold)
+			if got.fullSuiteRequired != tt.wantFullSuite {
+				t.Fatalf("fullSuiteRequired = %v, want %v", got.fullSuiteRequired, tt.wantFullSuite)
+			}
+			gotPkgs := append([]string(nil), got.packages...)
+			sort.Strings(gotPkgs)
+			wantPkgs := append([]string(nil), tt.wantPackages...)
+			sort.Strings(wantPkgs)
+			if !reflect.DeepEqual(gotPkgs, wantPkgs) {
+				t.Fatalf("packages = %v, want %v", gotPkgs, wantPkgs)
+			}
+		})
+	}
+}
+
+func TestScopeThresholdIsFractionOfAllPackagesNotReverseDepSet(t *testing.T) {
+	all := make([]string, 0, 20)
+	for i := 0; i < 20; i++ {
+		all = append(all, fmt.Sprintf("pkg%d", i))
+	}
+	deps := map[string][]string{}
+	for i := 1; i < 10; i++ {
+		deps[fmt.Sprintf("pkg%d", i)] = []string{"pkg0"}
+	}
+
+	got := scope(all, []string{"pkg0"}, deps, 0.5)
+	if got.fullSuiteRequired {
+		t.Fatalf("fullSuiteRequired = true for 10/20 (0.5, not exceeding threshold); want false")
+	}
+	if len(got.packages) != 10 {
+		t.Fatalf("packages = %v (len %d), want 10 packages (pkg0..pkg9)", got.packages, len(got.packages))
+	}
+}
+
+func TestParseThreshold(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    float64
+		wantErr bool
+	}{
+		{name: "empty uses default", raw: "", want: 0.5},
+		{name: "valid custom value", raw: "0.44", want: 0.44},
+		{name: "boundary value 1 is valid", raw: "1", want: 1},
+		{name: "not a number", raw: "not-a-number", wantErr: true},
+		{name: "zero is out of range", raw: "0", wantErr: true},
+		{name: "negative is out of range", raw: "-0.1", wantErr: true},
+		{name: "above 1 is out of range", raw: "1.5", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseThreshold(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseThreshold(%q) = %v, nil; want error", tt.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseThreshold(%q) unexpected error: %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseThreshold(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRealRepoSchemaChangeStaysScoped(t *testing.T) {
+	all, err := listAllPackages()
+	if err != nil {
+		t.Fatalf("listAllPackages: %v", err)
+	}
+	if len(all) == 0 {
+		t.Fatal("listAllPackages returned no packages")
+	}
+
+	const target = "github.com/steveyegge/beads/internal/storage/schema"
+	found := false
+	for _, pkg := range all {
+		if pkg == target {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Skipf("%s not present in this checkout; skipping real-repo smoke test", target)
+	}
+
+	deps := make(map[string][]string, len(all))
+	for _, pkg := range all {
+		d, err := listTestDeps(pkg)
+		if err != nil {
+			t.Fatalf("listTestDeps(%s): %v", pkg, err)
+		}
+		deps[pkg] = d
+	}
+
+	res := scope(all, []string{target}, deps, 0.9)
+	if res.fullSuiteRequired {
+		t.Fatalf("scope() reported full-suite-required for a single leaf-package change at threshold 0.9")
+	}
+	inScope := false
+	for _, pkg := range res.packages {
+		if pkg == target {
+			inScope = true
+			break
+		}
+	}
+	if !inScope {
+		t.Fatalf("scope() result %v does not contain the changed package itself (%s)", res.packages, target)
+	}
+	if len(res.packages) < 2 {
+		t.Fatalf("scope() result %v: expected at least one real test-aware caller of %s (e.g. dolt/embeddeddolt/uow), got only the package itself", res.packages, target)
+	}
+}

--- a/scripts/ci/revdepscope/shadow-mode.sh
+++ b/scripts/ci/revdepscope/shadow-mode.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Shadow-mode validation harness for revdepscope (FR-4 / be-mv0ww.3.1).
+#
+# revdepscope's output is not trusted for anything until it has run clean,
+# in shadow mode, against a real sample of commits — see be-mv0ww.3.1's
+# acceptance criteria. This script never wires revdepscope into a gate; it
+# only compares its output against a full-suite ground truth and reports
+# divergences for a human to read.
+#
+# For each of the last N real commits on origin/main, this:
+#   1. Computes that commit's actual changed Go packages (git diff vs its
+#      parent, resolved against the CURRENT tree — see Limitations below).
+#   2. Runs revdepscope on those changed packages.
+#   3. Checks that every package currently FAILing in a fresh full-suite
+#      ground-truth run (step 0, done once) is included in revdepscope's
+#      scoped set for that commit (or that "full suite required" was
+#      returned, which trivially covers everything).
+#
+# A "missed-failure divergence" means: a package fails in the full run, but
+# revdepscope's scoped set for some commit's changed packages did not
+# include it. That would mean a scoped CI run could have missed a real
+# failure — the exact risk this tool exists to avoid introducing.
+#
+# Limitations (read before trusting a clean run too far):
+#   - Changed-package resolution uses the CURRENT checkout, not each
+#     historical commit's own tree. A file/directory a historical commit
+#     touched but that has since been renamed or deleted resolves to
+#     nothing and that commit is skipped (reported, not silently dropped).
+#     Package structure is stable enough over a handful of recent commits
+#     for this to be a reasonable approximation, not a full historical
+#     replay.
+#   - Ground truth is one fresh full-suite run at current HEAD, reused for
+#     every sampled commit's comparison — not a per-commit historical full
+#     run. This is what makes the harness affordable to actually run.
+#   - If the ground-truth run has zero failures (the common case on a
+#     repo that keeps main green), every commit's divergence check is
+#     vacuously true. That is a real limitation of validating against green
+#     history, not a flaw in the check itself: see the posted results for
+#     how this run's ground truth came out and what that does and doesn't
+#     demonstrate.
+#
+# Usage:
+#   shadow-mode.sh [num_commits]
+#
+# num_commits defaults to 5 and samples the last N commits on origin/main.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+NUM_COMMITS="${1:-5}"
+if ! [[ "$NUM_COMMITS" =~ ^[0-9]+$ ]] || ((NUM_COMMITS < 1)); then
+    echo "num_commits must be a positive integer" >&2
+    exit 1
+fi
+
+cd "$REPO_ROOT"
+
+# shellcheck source=../../.buildflags
+source "$REPO_ROOT/.buildflags"
+
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+BIN="$BUILD_DIR/revdepscope"
+
+echo "Building revdepscope..." >&2
+go build -o "$BIN" ./scripts/ci/revdepscope
+
+echo "Ground truth: running the full suite at $(git rev-parse --short HEAD)..." >&2
+FULL_LOG="$BUILD_DIR/full-suite.log"
+set +e
+./scripts/test.sh 2>&1 | tee "$FULL_LOG"
+set -e
+
+mapfile -t FAILED_PACKAGES < <(awk '/^FAIL[[:space:]]/{print $2}' "$FULL_LOG" | sort -u)
+echo "" >&2
+echo "Ground truth: ${#FAILED_PACKAGES[@]} package(s) FAILing at HEAD" >&2
+
+mapfile -t COMMITS < <(git log origin/main -n "$NUM_COMMITS" --format=%H)
+
+echo ""
+echo "commit,changed_packages,scoped_result,divergence"
+
+DIVERGENCES=0
+for commit in "${COMMITS[@]}"; do
+    short="${commit:0:8}"
+
+    mapfile -t changed_files < <(git diff --name-only "${commit}^" "$commit" -- '*.go' 2>/dev/null || true)
+    if ((${#changed_files[@]} == 0)); then
+        echo "$short,(no .go changes),skipped,no"
+        continue
+    fi
+
+    mapfile -t changed_dirs < <(for f in "${changed_files[@]}"; do dirname "$f"; done | sort -u)
+    changed_pkgs=()
+    for dir in "${changed_dirs[@]}"; do
+        pkg="$(go list "./$dir" 2>/dev/null || true)"
+        [[ -n "$pkg" ]] && changed_pkgs+=("$pkg")
+    done
+    if ((${#changed_pkgs[@]} == 0)); then
+        echo "$short,(no packages resolvable in current tree),skipped,no"
+        continue
+    fi
+
+    scoped_output="$("$BIN" "${changed_pkgs[@]}" 2>/dev/null || echo "ERROR")"
+
+    if [[ "$scoped_output" == "full suite required" ]]; then
+        result="full suite required"
+        divergence="no"
+    elif [[ "$scoped_output" == "ERROR" ]]; then
+        result="ERROR running revdepscope"
+        divergence="yes"
+        DIVERGENCES=$((DIVERGENCES + 1))
+    else
+        pkg_count=$(printf '%s\n' "$scoped_output" | grep -c .)
+        result="${pkg_count} package(s)"
+        divergence="no"
+        for failed in "${FAILED_PACKAGES[@]:-}"; do
+            [[ -z "$failed" ]] && continue
+            if ! grep -qxF "$failed" <<<"$scoped_output"; then
+                divergence="yes"
+            fi
+        done
+        [[ "$divergence" == "yes" ]] && DIVERGENCES=$((DIVERGENCES + 1))
+    fi
+
+    echo "$short,\"${changed_pkgs[*]}\",\"$result\",$divergence"
+done
+
+echo ""
+if ((DIVERGENCES > 0)); then
+    echo "SHADOW MODE FAILED: $DIVERGENCES commit(s) showed a missed-failure divergence or error." >&2
+    exit 1
+fi
+echo "SHADOW MODE PASSED: 0 missed-failure divergences across ${#COMMITS[@]} sampled commit(s) (ground truth: ${#FAILED_PACKAGES[@]} FAILing package(s) at HEAD)." >&2


### PR DESCRIPTION
## What

Adds `scripts/ci/revdepscope`, a CLI tool that computes the reverse-dependency-scoped set of Go packages that need their tests re-run for a given set of changed packages.

## Why

Full-suite-every-time works but scales poorly as the package graph grows. This tool computes a scoped test set using `go list -test -deps` (the transitive test-and-runtime dependency closure), rather than a build-only or single-hop import scan — both of those were checked empirically against this repo and found to silently miss real callers.

## How it works

- For a set of changed packages, finds every package whose `go list -test -deps` closure includes one of them.
- Applies a mandatory fallback: if the scoped set exceeds a configurable fraction of all packages (default 50%, via `REVDEPSCOPE_THRESHOLD`), it reports "full suite required" instead of a package list — so a central/foundational package change doesn't produce a falsely-narrow scope.
- No hand-maintained package lists anywhere — everything is computed from the current package graph and the actual diff on each invocation.
- Output is a plain newline-delimited package list, consumable by the existing test-runner's package-argument convention.

A shadow-mode validation harness (`scripts/ci/revdepscope/shadow-mode.sh`) is included: it runs the tool against real historical commits alongside a full-suite ground-truth run and reports whether the scoped run would have missed any failure the full run caught. It has been run against a sample of real commits with zero missed-failure divergences.

**This tool's output is not wired into any CI gate or test-selection decision yet.** It ships as a standalone, independently-runnable tool pending a stronger shadow-mode validation sample (the initial sample's ground truth had no failing packages, which is a real limitation of validating against green history — documented in the harness's own comments).

## Testing

- `go test -v ./scripts/ci/revdepscope/...` — all tests pass, including a real-repo smoke test against this repo's own package graph.
- `gofmt`, `go vet`, and `shellcheck` all clean.
