### PR TITLE
fix(list): stop truncation hint padding a blank TTY line

### DIFF
--- a/cmd/bd/list_output.go
+++ b/cmd/bd/list_output.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"text/template"
 
 	"github.com/steveyegge/beads/internal/types"
@@ -18,8 +19,23 @@ func printTruncationHint(truncated bool, effectiveLimit int) {
 	if !truncated || effectiveLimit <= 0 || !ui.IsStderrTerminal() {
 		return
 	}
-	msg := fmt.Sprintf("\nShowing %d issues; more results matched but were hidden by --limit. Use --limit 0 for all, or --limit N to raise the cap.\n", effectiveLimit)
-	fmt.Fprint(os.Stderr, ui.RenderWarn(msg))
+	fmt.Fprint(os.Stderr, formatTruncationHint(effectiveLimit))
+}
+
+func truncationHintText(effectiveLimit int) string {
+	return fmt.Sprintf("Showing %d issues; more results matched but were hidden by --limit. Use --limit 0 for all, or --limit N to raise the cap.", effectiveLimit)
+}
+
+func formatTruncationHint(effectiveLimit int) string {
+	return composeTruncationHint(ui.RenderWarn, truncationHintText(effectiveLimit))
+}
+
+// composeTruncationHint keeps newlines outside the renderer. lipgloss pads
+// blank lines to the widest-line width (alignTextHorizontal shortAmount =
+// widestLine - lineWidth) and drops the trailing newline (GH#5685).
+func composeTruncationHint(render func(string) string, text string) string {
+	rendered := strings.TrimRight(render(text), " \t\r\n")
+	return "\n" + rendered + "\n"
 }
 
 func outputDotFormat(out io.Writer, issues []*types.Issue, depsByIssueID map[string][]*types.Dependency) error {

--- a/cmd/bd/list_output_test.go
+++ b/cmd/bd/list_output_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"regexp"
 	"strings"
 	"testing"
 
+	lipgloss "charm.land/lipgloss/v2"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -165,5 +167,105 @@ func TestOutputFormattedListWithNoEdgesDoesNotWrite(t *testing.T) {
 	}
 	if writer.writes != 0 {
 		t.Fatalf("zero-edge output made %d writes, want 0", writer.writes)
+	}
+}
+
+func TestFormatTruncationHintExactBytes(t *testing.T) {
+	t.Parallel()
+
+	got := formatTruncationHint(2)
+	plain := stripANSIForTest(got)
+	const want = "\nShowing 2 issues; more results matched but were hidden by --limit. Use --limit 0 for all, or --limit N to raise the cap.\n"
+	if plain != want {
+		t.Fatalf("truncation hint bytes differ\ngot:\n%q\nwant:\n%q", plain, want)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatal("truncation hint missing trailing newline")
+	}
+	if strings.HasSuffix(got, "\n\n") {
+		t.Fatal("truncation hint ended with a double newline")
+	}
+	assertNoWhitespaceOnlyLine(t, plain)
+
+	got10 := stripANSIForTest(formatTruncationHint(10))
+	if !strings.Contains(got10, "Showing 10 issues;") {
+		t.Fatalf("limit interpolation missing: %q", got10)
+	}
+	if strings.HasPrefix(got10, "\n\n") {
+		t.Fatalf("leading double newline: %q", got10)
+	}
+}
+
+func TestComposeTruncationHintRejectsLipglossBlankLinePadding(t *testing.T) {
+	t.Parallel()
+
+	// Empty lipgloss Style (props==0) is identity — the colorless test
+	// default, and why RenderWarn("\n"+text+"\n") did not catch GH#5685.
+	// Foreground sets props so alignTextHorizontal pads blank lines to
+	// the widest-line width (not terminal width; no PTY required).
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	render := func(s string) string { return style.Render(s) }
+	text := truncationHintText(2)
+
+	buggy := render("\n" + text + "\n")
+	got := composeTruncationHint(render, text)
+
+	buggyPlain := stripANSIForTest(buggy)
+	gotPlain := stripANSIForTest(got)
+
+	padWidth := whitespaceOnlyLineWidth(buggyPlain)
+	if padWidth == 0 {
+		t.Fatalf("fixture: styled Render of newline-wrapped text should pad a blank line; got %q", buggyPlain)
+	}
+	if padWidth != len(text) {
+		t.Fatalf("lipgloss pad width = %d, want hint length %d (widest-line width, not terminal width)\nbuggy=%q", padWidth, len(text), buggyPlain)
+	}
+	widest := widestNonBlankLineWidth(buggyPlain)
+	if padWidth != widest {
+		t.Fatalf("lipgloss pad width = %d, want widest-line width %d\nbuggy=%q", padWidth, widest, buggyPlain)
+	}
+
+	assertNoWhitespaceOnlyLine(t, gotPlain)
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("composeTruncationHint missing trailing newline: %q", got)
+	}
+	if strings.HasSuffix(got, "\n\n") {
+		t.Fatal("composeTruncationHint ended with a double newline")
+	}
+	if got == buggy {
+		t.Fatalf("composeTruncationHint still uses newline-inside-Render bytes:\n%q", got)
+	}
+}
+
+func stripANSIForTest(s string) string {
+	return regexp.MustCompile(`\x1b\[[0-9;]*m`).ReplaceAllString(s, "")
+}
+
+func whitespaceOnlyLineWidth(s string) int {
+	width := 0
+	for _, line := range strings.Split(s, "\n") {
+		if line != "" && strings.TrimSpace(line) == "" && len(line) > width {
+			width = len(line)
+		}
+	}
+	return width
+}
+
+func widestNonBlankLineWidth(s string) int {
+	width := 0
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) != "" && len(line) > width {
+			width = len(line)
+		}
+	}
+	return width
+}
+
+func assertNoWhitespaceOnlyLine(t *testing.T, s string) {
+	t.Helper()
+	for i, line := range strings.Split(s, "\n") {
+		if line != "" && strings.TrimSpace(line) == "" {
+			t.Fatalf("whitespace-only line at index %d (len=%d): %q", i, len(line), line)
+		}
 	}
 }


### PR DESCRIPTION

Fixes #5685.

## What

`bd list` with an active `--limit` prints its truncation hint by feeding
`"\n<text>\n"` through `ui.RenderWarn`. lipgloss treats that as a block:
the surrounding blank lines get padded to the width of the hint line (120
columns) and the trailing newline is dropped. On a TTY that produces a whitespace-only line above the
hint and leaves the shell prompt on the same line as a run of trailing
spaces — the `cat -A` shape @ccope reported.

The fix keeps the newlines outside `RenderWarn`: render the one-line hint,
trim lipgloss's trailing padding, then wrap it in plain `\n`s.

## Test plan

- Scoped tests (BEADS_* stripped, TMPDIR/GOTMPDIR in mktemp, CGO_ENABLED=0):

  `go test -tags gms_pure_go -count=1 -run 'TestFormatTruncationHint|TestComposeTruncationHint|TestOutputFormattedList' ./cmd/bd`

  Result: `ok github.com/steveyegge/beads/cmd/bd 2.710s`. `TestFormatTruncationHintExactBytes` checks the colorless helper bytes. `TestComposeTruncationHintRejectsLipglossBlankLinePadding` constructs `lipgloss.NewStyle().Foreground(...)` so `alignTextHorizontal` pads blank lines to the hint's widest-line width (120 columns for this message — not terminal width).
- Mutation (same command, `-run TestComposeTruncationHintRejectsLipglossBlankLinePadding` only): revert `composeTruncationHint` to `return render("\n"+text+"\n")` → FAIL:

  ```
  --- FAIL: TestComposeTruncationHintRejectsLipglossBlankLinePadding (0.00s)
      list_output_test.go:228: whitespace-only line at index 0 (len=120): "                                                                                                                        "
  FAIL
  FAIL	github.com/steveyegge/beads/cmd/bd	6.097s
  ```

  Restore trim-then-wrap → PASS (`ok github.com/steveyegge/beads/cmd/bd 2.710s`).
- PTY repro with a real binary (`script(1)`, `CLICOLOR_FORCE=1`, isolated workspace, 3 issues, `--limit 2`): before — hint bracketed by two colored lines padded to the hint's 120-column width, final line missing its newline; after — one colored hint line with a real trailing newline. Not re-run this round (the styled unit test is the regression that was vacuous before).
- `BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint` not re-run this round. Full `./cmd/bd` suite not run (Docker-gated per repo docs).
