### PR TITLE
fix(ready): stop offering epics as claimable work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`bd ready` no longer offers an epic as claimable work beside its own open
+  children** (GH#5583). An epic is a container: its real work lives in the
+  children, which already appear on their own, so listing the parent next to
+  them sent an agent at the container record and cost it a cycle discovering
+  there was nothing there to do. `epic` now joins `merge-request`, `gate`,
+  `molecule`, `rig`, and the infra wisp types in the default ready-work type
+  exclusions, so the bare `bd ready` — the documented entry point — no longer
+  needs `--exclude-type epic` bolted on. `bd list` is unchanged, and
+  `bd ready --type epic` still returns epics, since an explicit `--type` skips
+  the default exclusions entirely.
+
 - **`bd show` labels `created_by` as `Created by:`, not `Owner:`** (be-ss66).
   The text view rendered `created_by` under a label naming a different
   concept. `owner` is a separate field holding a separate value — the git

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -22,7 +22,7 @@ var readyCmd = &cobra.Command{
 	Short: "Show ready work (open, no active blockers)",
 	Long: `Show ready work (open issues with no active blockers).
 
-Excludes in_progress, blocked, deferred, and hooked issues. This uses the
+Excludes in_progress, blocked, deferred, and hooked issues, as well as epics. This uses the
 GetReadyWork API which applies blocker-aware semantics to find truly claimable work.
 
 Note: 'bd list --ready' uses the same blocker-aware ready-work semantics.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -6761,7 +6761,7 @@ bd orphans [flags]
 
 Show ready work (open issues with no active blockers).
 
-Excludes in_progress, blocked, deferred, and hooked issues. This uses the
+Excludes in_progress, blocked, deferred, and hooked issues, as well as epics. This uses the
 GetReadyWork API which applies blocker-aware semantics to find truly claimable work.
 
 Note: 'bd list --ready' uses the same blocker-aware ready-work semantics.

--- a/docs/cli-reference/ready.md
+++ b/docs/cli-reference/ready.md
@@ -9,7 +9,7 @@ Generated from `bd help --doc ready`.
 
 Show ready work (open issues with no active blockers).
 
-Excludes in_progress, blocked, deferred, and hooked issues. This uses the
+Excludes in_progress, blocked, deferred, and hooked issues, as well as epics. This uses the
 GetReadyWork API which applies blocker-aware semantics to find truly claimable work.
 
 Note: 'bd list --ready' uses the same blocker-aware ready-work semantics.

--- a/internal/storage/domain/db/ready_work_test.go
+++ b/internal/storage/domain/db/ready_work_test.go
@@ -119,6 +119,12 @@ func (s *testSuite) readyExcludesDefaultTypes() {
 	message.IssueType = types.TypeMessage
 	s.Require().NoError(r.Insert(s.Ctx(), message, "tester", domain.InsertIssueOpts{}))
 
+	// GH#5583: an epic is a container whose work lives in its children, so it
+	// must not be offered as claimable work beside them.
+	epic := newTestIssue("bd-rdy-dt-epic", "epic")
+	epic.IssueType = types.TypeEpic
+	s.Require().NoError(r.Insert(s.Ctx(), epic, "tester", domain.InsertIssueOpts{}))
+
 	task := newTestIssue("bd-rdy-dt-task", "task")
 	s.Require().NoError(r.Insert(s.Ctx(), task, "tester", domain.InsertIssueOpts{}))
 
@@ -130,6 +136,13 @@ func (s *testSuite) readyExcludesDefaultTypes() {
 	s.NotContains(got, "bd-rdy-dt-gate")
 	s.NotContains(got, "bd-rdy-dt-rig")
 	s.NotContains(got, "bd-rdy-dt-message")
+	s.NotContains(got, "bd-rdy-dt-epic")
+
+	// --type is the opt-in escape hatch: it skips the default exclusions
+	// entirely, so asking for epics by name still returns them.
+	out, err = r.GetReadyWork(s.Ctx(), types.WorkFilter{Type: string(types.TypeEpic)})
+	s.Require().NoError(err)
+	s.Contains(issueIDsFrom(out), "bd-rdy-dt-epic")
 }
 
 func (s *testSuite) readyFilterByPriority() {

--- a/internal/storage/sqlbuild/ready.go
+++ b/internal/storage/sqlbuild/ready.go
@@ -13,11 +13,15 @@ import (
 // default, plus any caller extras (deduped, empty entries dropped). Infra types
 // stay hidden from ready work, and rig identity beads are also hidden even
 // though they are durable issues rather than infra wisps.
+//
+// Epics are also excluded because all of the claimable work lives in their
+// children, and that work can be split across multiple agents.
 func ReadyWorkExcludeTypes(extra []types.IssueType) []types.IssueType {
 	out := []types.IssueType{
 		types.IssueType("merge-request"),
 		types.TypeGate,
 		types.TypeMolecule,
+		types.TypeEpic,
 		types.IssueType("rig"),
 	}
 	for _, t := range domain.DefaultInfraTypes() {

--- a/internal/storage/sqlbuild/sqlbuild_test.go
+++ b/internal/storage/sqlbuild/sqlbuild_test.go
@@ -130,7 +130,7 @@ func TestReadyWorkExcludeTypes(t *testing.T) {
 		}
 		seen[typ] = true
 	}
-	for _, want := range []types.IssueType{"merge-request", types.TypeGate, types.TypeMolecule, "agent", "rig", "role", "message"} {
+	for _, want := range []types.IssueType{"merge-request", types.TypeGate, types.TypeMolecule, types.TypeEpic, "agent", "rig", "role", "message"} {
 		if !seen[want] {
 			t.Errorf("default exclude list missing %q", want)
 		}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -2136,7 +2136,7 @@ type WorkFilter struct {
 	IncludeEphemeral bool
 
 	// Type exclusion: exclude issues with these types from results.
-	// Appended to the default exclusion list (merge-request, gate, molecule, etc.).
+	// Appended to the default exclusion list (merge-request, gate, molecule, epic, etc.).
 	// When Type is set, ExcludeTypes is ignored (explicit type inclusion wins).
 	ExcludeTypes []IssueType
 

--- a/scripts/bench-ready-indexes/main.go
+++ b/scripts/bench-ready-indexes/main.go
@@ -184,7 +184,7 @@ func buildQueries(ctx context.Context, db *sql.DB) ([]queryCase, error) {
 WHERE status IN ('open','in_progress')
 AND (pinned = 0 OR pinned IS NULL)
 AND (ephemeral = 0 OR ephemeral IS NULL)
-AND id IN (SELECT id FROM issues WHERE issue_type NOT IN ('merge-request','gate','molecule','message','agent','role','rig'))
+AND id IN (SELECT id FROM issues WHERE issue_type NOT IN ('merge-request','gate','molecule','epic','message','agent','role','rig'))
 AND assignee = 'example-org--control-dispatcher'
 AND (defer_until IS NULL OR defer_until <= UTC_TIMESTAMP())
 ORDER BY priority ASC, created_at DESC, id ASC
@@ -196,7 +196,7 @@ LIMIT 100`,
 WHERE status IN ('open','in_progress')
 AND (pinned = 0 OR pinned IS NULL)
 AND (ephemeral = 0 OR ephemeral IS NULL)
-AND id IN (SELECT id FROM issues WHERE issue_type NOT IN ('merge-request','gate','molecule','message','agent','role','rig'))
+AND id IN (SELECT id FROM issues WHERE issue_type NOT IN ('merge-request','gate','molecule','epic','message','agent','role','rig'))
 AND (assignee IS NULL OR assignee = '')
 AND (defer_until IS NULL OR defer_until <= UTC_TIMESTAMP())
 AND JSON_UNQUOTE(JSON_EXTRACT(metadata, '$."route.routed_to"')) = 'example-org/control-dispatcher'


### PR DESCRIPTION
## What
Fixes #5583 by adding epics to `ReadyWorkExcludeTypes`

## Why

An epic is a container: the claimable work lives in its children, which already surface on their own. Listing the parent next to them sent an agent at the container record and cost it a cycle discovering there was nothing there to do.

epic now joins merge-request, gate, molecule, rig, and the infra wisp types in ReadyWorkExcludeTypes -- the single list both storage stacks share -- so the bare `bd ready`, the documented entry point, no longer needs `--exclude-type epic` bolted on.

Also syncs the hand-copied ready SQL in scripts/bench-ready-indexes so the index benchmark keeps measuring the query that actually ships.


## Verification
I manually ran a few bd commands to confirm the behavior works as expected:
 - `bd ready` no longer includes epics.
 - `bd ready --type epic` still returns epics.
 - `bd list` is unchanged