### PR TITLE
fix(storage): stop reporting a broken wisp plane as an empty one in search (re-land of #5805)

### DIFF
--- a/internal/storage/domain/db/issue_search.go
+++ b/internal/storage/domain/db/issue_search.go
@@ -26,10 +26,20 @@ var (
 	wispsFilterTables  = sqlbuild.WispsFilterTables
 )
 
+// missingOptionalWispTable reports whether err is the absence of a wisp-plane
+// table a database may legitimately not have. A wisp search touches more than
+// that: its FROM clause carries sqlbuild.LeaseJoin and its hydration reads
+// wisp_labels, so a blanket table-not-exist check reports a broken database as
+// an empty wisp plane and silently drops live rows from the result.
+func missingOptionalWispTable(err error) bool {
+	name, ok := dberrors.MissingTableName(err)
+	return ok && sqlbuild.OptionalWispTable(name)
+}
+
 func (r *issueSQLRepositoryImpl) searchAcrossIssuesAndWisps(ctx context.Context, query string, filter types.IssueFilter) (domain.SearchPage, error) {
 	if filter.Ephemeral != nil && *filter.Ephemeral {
 		page, err := r.searchTable(ctx, query, filter, wispsFilterTables)
-		if err != nil && !dberrors.IsTableNotExist(err) {
+		if err != nil && !missingOptionalWispTable(err) {
 			return domain.SearchPage{}, fmt.Errorf("search wisps (ephemeral filter): %w", err)
 		}
 		if len(page.Items) > 0 {
@@ -105,7 +115,7 @@ func (r *issueSQLRepositoryImpl) searchUnion(ctx context.Context, query string, 
 		return domain.SearchPage{}, fmt.Errorf("search union (hydrate issues): %w", err)
 	}
 	wispsByID, err := r.fetchIssuesByIDs(ctx, page.wispIDs, wispsFilterTables, filter)
-	if err != nil && !dberrors.IsTableNotExist(err) {
+	if err != nil && !missingOptionalWispTable(err) {
 		return domain.SearchPage{}, fmt.Errorf("search union (hydrate wisps): %w", err)
 	}
 

--- a/internal/storage/domain/db/issue_search_missing_table_test.go
+++ b/internal/storage/domain/db/issue_search_missing_table_test.go
@@ -7,6 +7,7 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	mysql "github.com/go-sql-driver/mysql"
 
+	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -71,5 +72,88 @@ func TestSearchAcrossEphemeralMissingWispPlaneIsEmpty(t *testing.T) {
 				t.Fatalf("unmet sql expectations: %v", err)
 			}
 		})
+	}
+}
+
+// TestSearchAcrossEphemeralUnrelatedErrorPropagates is the second control, the
+// one that pins the tolerance from the other side: a guard that fails open on
+// any error it cannot parse a table name out of would still pass every test
+// above.
+func TestSearchAcrossEphemeralUnrelatedErrorPropagates(t *testing.T) {
+	mock, repo := newMockRepo(t)
+	boom := errors.New("connection refused")
+	mock.ExpectQuery("FROM wisps").WillReturnError(boom)
+
+	_, err := repo.searchAcrossIssuesAndWisps(t.Context(), "", ephemeralFilter())
+	if !errors.Is(err, boom) {
+		t.Fatalf("search did not propagate a failed wisps query: %v", err)
+	}
+}
+
+// unionOverBrokenWispPlane primes the merged UNION path up to the point where
+// it hydrates the wisp rows, then fails that hydration with hydrateErr.
+//
+// The union leg is where the two stacks diverge. Its FROM clause is
+// plan.FromSQL, which carries no lease join and reads no labels, so the union
+// query itself succeeds against a database missing `leases` or `wisp_labels`
+// and returns wisp ids. Only fetchIssuesByIDs adds sqlbuild.LeaseJoin and
+// hydrates labels, so that is the first query to see the breakage -- and
+// tolerating it there drops every wisp from a merged search behind a nil
+// error, which is the exact silent-row-loss this guard exists to stop.
+func unionOverBrokenWispPlane(t *testing.T, hydrateErr error) (sqlmock.Sqlmock, domain.SearchPage, error) {
+	t.Helper()
+	mock, repo := newMockRepo(t)
+	mock.ExpectQuery("SELECT 1 FROM wisps").WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery("UNION ALL").WillReturnRows(
+		sqlmock.NewRows([]string{"id", "src"}).AddRow("bd-w1", "w"))
+	mock.ExpectQuery("FROM wisps").WillReturnError(hydrateErr)
+
+	page, err := repo.searchAcrossIssuesAndWisps(t.Context(), "", types.IssueFilter{})
+	return mock, page, err
+}
+
+// TestSearchUnionBrokenWispPlaneIsAnError is the merged-path twin of
+// TestSearchAcrossEphemeralBrokenWispPlaneIsAnError. The ephemeral branch is
+// reachable only with an explicit filter; the union is what an ordinary
+// `bd list` runs, so this is the guard most searches actually depend on.
+func TestSearchUnionBrokenWispPlaneIsAnError(t *testing.T) {
+	for _, missing := range []string{"wisp_labels", "leases"} {
+		t.Run(missing, func(t *testing.T) {
+			gone := missingTable(missing)
+			_, _, err := unionOverBrokenWispPlane(t, gone)
+			if !errors.Is(err, gone) {
+				t.Fatalf("merged search hid a broken wisp plane: %v", err)
+			}
+		})
+	}
+}
+
+// TestSearchUnionMissingWispPlaneIsEmpty is the control for the union path: a
+// table the wisp plane genuinely owns can be absent, and the merged search
+// still answers -- one row short, without an error.
+func TestSearchUnionMissingWispPlaneIsEmpty(t *testing.T) {
+	for _, table := range []string{"wisps", "wisp_dependencies"} {
+		t.Run(table, func(t *testing.T) {
+			mock, page, err := unionOverBrokenWispPlane(t, missingTable(table))
+			if err != nil {
+				t.Fatalf("merged search errored on a database with no wisp plane: %v", err)
+			}
+			if len(page.Items) != 0 {
+				t.Fatalf("got %d rows, want 0", len(page.Items))
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet sql expectations: %v", err)
+			}
+		})
+	}
+}
+
+// TestSearchUnionUnrelatedErrorPropagates is the union path's fail-open
+// control.
+func TestSearchUnionUnrelatedErrorPropagates(t *testing.T) {
+	boom := errors.New("connection refused")
+	_, _, err := unionOverBrokenWispPlane(t, boom)
+	if !errors.Is(err, boom) {
+		t.Fatalf("merged search did not propagate a failed hydration: %v", err)
 	}
 }

--- a/internal/storage/domain/db/issue_search_missing_table_test.go
+++ b/internal/storage/domain/db/issue_search_missing_table_test.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"errors"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	mysql "github.com/go-sql-driver/mysql"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func missingTable(table string) error {
+	return &mysql.MySQLError{Number: 1146, Message: "table not found: " + table}
+}
+
+func ephemeralFilter() types.IssueFilter {
+	on := true
+	return types.IssueFilter{Ephemeral: &on}
+}
+
+func newMockRepo(t *testing.T) (sqlmock.Sqlmock, *issueSQLRepositoryImpl) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return mock, &issueSQLRepositoryImpl{runner: db}
+}
+
+// TestSearchAcrossEphemeralBrokenWispPlaneIsAnError mirrors the issueops guard
+// on the domain/db stack: the two must agree on what a missing table means, or
+// the same query answers differently depending on which stack served it.
+func TestSearchAcrossEphemeralBrokenWispPlaneIsAnError(t *testing.T) {
+	for _, missing := range []string{"wisp_labels", "leases"} {
+		t.Run(missing, func(t *testing.T) {
+			mock, repo := newMockRepo(t)
+			gone := missingTable(missing)
+			mock.ExpectQuery("FROM wisps").WillReturnError(gone)
+			mock.ExpectQuery("SELECT 1 FROM wisps").WillReturnError(missingTable("wisps"))
+			mock.ExpectQuery("FROM issues").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+			_, err := repo.searchAcrossIssuesAndWisps(t.Context(), "", ephemeralFilter())
+			if !errors.Is(err, gone) {
+				t.Fatalf("search hid a broken wisp plane: %v", err)
+			}
+		})
+	}
+}
+
+// TestSearchAcrossEphemeralMissingWispPlaneIsEmpty is the control: a
+// pre-migration database has no wisp plane, and searching it for wisps
+// really does match nothing.
+func TestSearchAcrossEphemeralMissingWispPlaneIsEmpty(t *testing.T) {
+	for _, table := range []string{"wisps", "wisp_dependencies"} {
+		t.Run(table, func(t *testing.T) {
+			mock, repo := newMockRepo(t)
+			mock.ExpectQuery("FROM wisps").WillReturnError(missingTable(table))
+			mock.ExpectQuery("SELECT 1 FROM wisps").WillReturnError(missingTable("wisps"))
+			mock.ExpectQuery("FROM issues").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+			page, err := repo.searchAcrossIssuesAndWisps(t.Context(), "", ephemeralFilter())
+			if err != nil {
+				t.Fatalf("search errored on a database with no wisp plane: %v", err)
+			}
+			if len(page.Items) != 0 {
+				t.Fatalf("got %d rows, want 0", len(page.Items))
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet sql expectations: %v", err)
+			}
+		})
+	}
+}

--- a/internal/storage/embeddeddolt/search_missing_table_test.go
+++ b/internal/storage/embeddeddolt/search_missing_table_test.go
@@ -89,6 +89,13 @@ func TestSearchWithMissingWispPlaneTables(t *testing.T) {
 
 	// The second control: wisp_dependencies is genuinely optional and its
 	// absence must stay invisible to a plain search.
+	//
+	// It does not pin the tolerance set, and it is not meant to: a search that
+	// does not ask for dependencies never reads the table, so this stays green
+	// whatever missingOptionalWispTable is tightened to. What pins the
+	// wisp_dependencies entry is the sqlmock control in
+	// issueops/search_missing_table_test.go, which drives the failure through
+	// the guard directly. This one proves the end-to-end query still answers.
 	t.Run("missing_wisp_dependencies_is_invisible", func(t *testing.T) {
 		te := newTestEnv(t, "wd2")
 		seed(t, te, "wd2")

--- a/internal/storage/embeddeddolt/search_missing_table_test.go
+++ b/internal/storage/embeddeddolt/search_missing_table_test.go
@@ -1,0 +1,105 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func ephemeralOnly() *bool { b := true; return &b }
+
+func searchIDs(t *testing.T, te *testEnv, filter types.IssueFilter) ([]string, error) {
+	t.Helper()
+	got, err := te.store.SearchIssues(t.Context(), "", filter)
+	ids := make([]string, 0, len(got))
+	for _, issue := range got {
+		ids = append(ids, issue.ID)
+	}
+	return ids, err
+}
+
+// TestSearchWithMissingWispPlaneTables pins which missing tables a wisp search
+// may treat as "no wisps" and which it must report. The wisp query and its
+// label hydration span more tables than the wisp plane owns, and folding all
+// of them into an empty result set drops live rows from an ordinary list with
+// no error to show for it.
+func TestSearchWithMissingWispPlaneTables(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	seed := func(t *testing.T, te *testEnv, prefix string) {
+		t.Helper()
+		wisp := &types.Issue{
+			ID: prefix + "-wisp", Title: "ephemeral bead", Status: types.StatusOpen,
+			Priority: 2, IssueType: types.TypeTask, Ephemeral: true,
+		}
+		if err := te.store.CreateIssue(t.Context(), wisp, "tester"); err != nil {
+			t.Fatalf("CreateIssue wisp: %v", err)
+		}
+		durable := &types.Issue{
+			ID: prefix + "-issue", Title: "durable bead", Status: types.StatusOpen,
+			Priority: 2, IssueType: types.TypeTask,
+		}
+		if err := te.store.CreateIssue(t.Context(), durable, "tester"); err != nil {
+			t.Fatalf("CreateIssue durable: %v", err)
+		}
+	}
+
+	// A missing wisp_labels is not the wisp plane being absent, it is the wisp
+	// plane being broken. assertRowExists is the control: the wisp is present
+	// while the search is answering that there is nothing there.
+	t.Run("missing_wisp_labels_is_an_error_not_an_empty_result", func(t *testing.T) {
+		te := newTestEnv(t, "wl2")
+		seed(t, te, "wl2")
+		te.exec(t, t.Context(), "RENAME TABLE wisp_labels TO wisp_labels_renamed_away")
+		te.assertRowExists(t, t.Context(), "wisps", "wl2-wisp")
+
+		if ids, err := searchIDs(t, te, types.IssueFilter{Ephemeral: ephemeralOnly()}); err == nil {
+			t.Fatalf("ephemeral search returned %v with no error and no wisp_labels table", ids)
+		}
+		if ids, err := searchIDs(t, te, types.IssueFilter{}); err == nil {
+			t.Fatalf("merged search returned %v with no error and no wisp_labels table", ids)
+		}
+	})
+
+	// The control the tolerance exists for: a pre-migration database has no
+	// wisp plane at all, and a search of it really does match no wisps.
+	t.Run("missing_wisps_table_is_an_empty_result", func(t *testing.T) {
+		te := newTestEnv(t, "wt2")
+		seed(t, te, "wt2")
+		te.exec(t, t.Context(), "RENAME TABLE wisps TO wisps_renamed_away")
+
+		ids, err := searchIDs(t, te, types.IssueFilter{Ephemeral: ephemeralOnly()})
+		if err != nil {
+			t.Fatalf("ephemeral search on a database with no wisp plane: %v", err)
+		}
+		if len(ids) != 0 {
+			t.Fatalf("ephemeral search returned %v, want none", ids)
+		}
+
+		ids, err = searchIDs(t, te, types.IssueFilter{})
+		if err != nil {
+			t.Fatalf("merged search on a database with no wisp plane: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != "wt2-issue" {
+			t.Fatalf("merged search returned %v, want just the durable issue", ids)
+		}
+	})
+
+	// The second control: wisp_dependencies is genuinely optional and its
+	// absence must stay invisible to a plain search.
+	t.Run("missing_wisp_dependencies_is_invisible", func(t *testing.T) {
+		te := newTestEnv(t, "wd2")
+		seed(t, te, "wd2")
+		te.exec(t, t.Context(), "RENAME TABLE wisp_dependencies TO wisp_dependencies_renamed_away")
+
+		ids, err := searchIDs(t, te, types.IssueFilter{Ephemeral: ephemeralOnly()})
+		if err != nil {
+			t.Fatalf("ephemeral search with no wisp_dependencies: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != "wd2-wisp" {
+			t.Fatalf("ephemeral search returned %v, want just the wisp", ids)
+		}
+	})
+}

--- a/internal/storage/issueops/blocked.go
+++ b/internal/storage/issueops/blocked.go
@@ -17,7 +17,7 @@ type blockingDepRecord struct {
 }
 
 func optionalBlockedTable(table string) bool {
-	return table == "wisps" || table == "wisp_dependencies"
+	return sqlbuild.OptionalWispTable(table)
 }
 
 func loadBlockingDepsForIssueIDsInTx(ctx context.Context, tx DBTX, depTables []string, issueIDs []string) ([]blockingDepRecord, error) {

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -155,6 +156,16 @@ func hydrateIssueLabelsAndDeps(ctx context.Context, tx DBTX, tables FilterTables
 	return nil
 }
 
+// missingOptionalWispTable reports whether err is the absence of a wisp-plane
+// table a database may legitimately not have. A wisp search touches more than
+// that: its FROM clause carries sqlbuild.LeaseJoin and its hydration reads
+// wisp_labels, so a blanket table-not-exist check reports a broken database as
+// an empty wisp plane and silently drops live rows from the result.
+func missingOptionalWispTable(err error) bool {
+	name, ok := dberrors.MissingTableName(err)
+	return ok && sqlbuild.OptionalWispTable(name)
+}
+
 // searchInTx is the shared wisp-merge wrapper. Ephemeral routing, the
 // empty-wisps probe, the issues+wisps queries, and overlap detection live
 // here once. Both SearchIssuesInTx and SearchIssueIDsInTx use this body —
@@ -163,7 +174,7 @@ func searchInTx[T any](ctx context.Context, tx DBTX, query string, filter types.
 	// Route ephemeral-only queries to wisps table.
 	if filter.Ephemeral != nil && *filter.Ephemeral {
 		results, err := searchTableInTxT(ctx, tx, query, filter, WispsFilterTables, proj)
-		if err != nil && !isTableNotExistError(err) {
+		if err != nil && !missingOptionalWispTable(err) {
 			return nil, fmt.Errorf("search wisps (ephemeral filter): %w", err)
 		}
 		if len(results) > 0 {
@@ -218,7 +229,7 @@ func searchInTx[T any](ctx context.Context, tx DBTX, query string, filter types.
 			return results, nil
 		}
 		wispResults, wispErr := searchTableInTxT(ctx, tx, query, filter, WispsFilterTables, proj)
-		if wispErr != nil && !isTableNotExistError(wispErr) {
+		if wispErr != nil && !missingOptionalWispTable(wispErr) {
 			return nil, fmt.Errorf("search wisps (merge): %w", wispErr)
 		}
 		if len(wispResults) > 0 {

--- a/internal/storage/issueops/search_missing_table_test.go
+++ b/internal/storage/issueops/search_missing_table_test.go
@@ -1,0 +1,128 @@
+package issueops
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	mysql "github.com/go-sql-driver/mysql"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func tableNotFound(table string) error {
+	return &mysql.MySQLError{Number: 1146, Message: "table not found: " + table}
+}
+
+type searchEntryPoint struct {
+	name string
+	run  func(context.Context, DBTX, string, types.IssueFilter) (int, error)
+}
+
+var searchEntryPoints = []searchEntryPoint{
+	{
+		name: "SearchIssuesInTx",
+		run: func(ctx context.Context, tx DBTX, q string, f types.IssueFilter) (int, error) {
+			out, err := SearchIssuesInTx(ctx, tx, q, f)
+			return len(out), err
+		},
+	},
+	{
+		name: "SearchIssueIDsInTx",
+		run: func(ctx context.Context, tx DBTX, q string, f types.IssueFilter) (int, error) {
+			out, err := SearchIssueIDsInTx(ctx, tx, q, f)
+			return len(out), err
+		},
+	},
+}
+
+// TestSearchInTxEphemeralBrokenWispPlaneIsAnError pins the tolerance to the
+// wisp-plane tables a database may legitimately not have. The ephemeral branch
+// runs the wisps query as its only query, so its table-not-exist check is the
+// last word on what the caller is told: a table the wisp query reads but the
+// wisp plane does not own -- wisp_labels during hydration, leases through
+// sqlbuild.LeaseJoin -- was answered as "there are no wisps".
+//
+// The assertion is errors.Is against the primed driver error, not a substring
+// of the message: the query text names the joined tables, so a substring check
+// passes on any error that merely echoes the query.
+func TestSearchInTxEphemeralBrokenWispPlaneIsAnError(t *testing.T) {
+	for _, missing := range []string{"wisp_labels", "leases"} {
+		for _, tc := range searchEntryPoints {
+			t.Run(missing+"/"+tc.name, func(t *testing.T) {
+				_, mock, tx := beginMockTx(t)
+				gone := tableNotFound(missing)
+				mock.ExpectQuery("FROM wisps").WillReturnError(gone)
+				// Only the tolerating path reaches the issues plane. Priming it
+				// makes the untightened behaviour a clean "0 rows, nil error"
+				// rather than an unexpected-query error that reads like a pass.
+				mock.ExpectQuery("FROM issues").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+				n, err := tc.run(context.Background(), tx, "", types.IssueFilter{Ephemeral: boolPtr(true)})
+				if err == nil {
+					t.Fatalf("search succeeded with no %s table, returning %d rows", missing, n)
+				}
+				if !errors.Is(err, gone) {
+					t.Fatalf("error is not the missing-%s failure: %v", missing, err)
+				}
+			})
+		}
+	}
+}
+
+// TestSearchInTxEphemeralMissingWispPlaneIsEmpty is the control the tightened
+// guard must keep: a pre-migration database has no wisp plane, and a search of
+// it really does match no wisps. Over-tightening to "never tolerate" passes
+// every must-error assertion above and fails here.
+func TestSearchInTxEphemeralMissingWispPlaneIsEmpty(t *testing.T) {
+	for _, table := range []string{"wisps", "wisp_dependencies"} {
+		t.Run(table, func(t *testing.T) {
+			_, mock, tx := beginMockTx(t)
+			mock.ExpectQuery("FROM wisps").WillReturnError(tableNotFound(table))
+			mock.ExpectQuery("FROM issues").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+			out, err := SearchIssueIDsInTx(context.Background(), tx, "", types.IssueFilter{Ephemeral: boolPtr(true)})
+			if err != nil {
+				t.Fatalf("search errored on a database with no wisp plane: %v", err)
+			}
+			if len(out) != 0 {
+				t.Fatalf("got %d rows, want 0", len(out))
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet sql expectations: %v", err)
+			}
+		})
+	}
+}
+
+// TestSearchInTxEphemeralUnrelatedErrorPropagates is the second control: the
+// tolerance must not be a blanket catch in either direction.
+func TestSearchInTxEphemeralUnrelatedErrorPropagates(t *testing.T) {
+	_, mock, tx := beginMockTx(t)
+	boom := errors.New("connection refused")
+	mock.ExpectQuery("FROM wisps").WillReturnError(boom)
+
+	_, err := SearchIssueIDsInTx(context.Background(), tx, "", types.IssueFilter{Ephemeral: boolPtr(true)})
+	if !errors.Is(err, boom) {
+		t.Fatalf("search did not propagate a failed wisps query: %v", err)
+	}
+}
+
+// TestSearchInTxMergeBrokenWispPlaneIsAnError covers the merge branch: the
+// issues leg has already succeeded there, so the swallowed wisp failure is not
+// re-raised by anything downstream and the caller gets a short list.
+func TestSearchInTxMergeBrokenWispPlaneIsAnError(t *testing.T) {
+	_, mock, tx := beginMockTx(t)
+	gone := tableNotFound("wisp_labels")
+	mock.ExpectQuery("FROM issues").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("bd-1"))
+	mock.ExpectQuery("SELECT 1 FROM wisps").WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery("FROM wisps").WillReturnError(gone)
+
+	_, err := SearchIssueIDsInTx(context.Background(), tx, "", types.IssueFilter{})
+	if !errors.Is(err, gone) {
+		t.Fatalf("merged search hid a broken wisp plane: %v", err)
+	}
+}

--- a/internal/storage/sqlbuild/sqlbuild.go
+++ b/internal/storage/sqlbuild/sqlbuild.go
@@ -27,6 +27,14 @@ var (
 	WispsFilterTables  = FilterTables{Main: "wisps", Labels: "wisp_labels", Dependencies: "wisp_dependencies", Comments: "wisp_comments"}
 )
 
+// OptionalWispTable reports whether name is a wisp-plane table a database may
+// legitimately not have, which is the set a wisp query may treat as "no wisps"
+// rather than a failure. Both stacks read it so the two cannot disagree about
+// what a missing table means.
+func OptionalWispTable(name string) bool {
+	return strings.EqualFold(name, "wisps") || strings.EqualFold(name, "wisp_dependencies")
+}
+
 // DepTargetExpr resolves a dependency row's target across the three
 // mutually-exclusive target columns.
 const DepTargetExpr = "COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)"

--- a/internal/storage/sqlbuild/sqlbuild_test.go
+++ b/internal/storage/sqlbuild/sqlbuild_test.go
@@ -433,3 +433,22 @@ func TestBuildReadyWorkWhereStatusFilter(t *testing.T) {
 		})
 	}
 }
+
+// TestOptionalWispTable pins the set a wisp query may treat as "no wisps".
+// leases and wisp_labels are joined or hydrated by that query but are not the
+// wisp plane being absent, so tolerating them turns a broken database into an
+// empty result.
+func TestOptionalWispTable(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"wisps", "wisp_dependencies", "WISPS"} {
+		if !OptionalWispTable(name) {
+			t.Errorf("OptionalWispTable(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"leases", "wisp_labels", "issues", "labels", "", "wisp"} {
+		if OptionalWispTable(name) {
+			t.Errorf("OptionalWispTable(%q) = true, want false", name)
+		}
+	}
+}


### PR DESCRIPTION
Re-lands the content of #5805, which reports `MERGED` but never reached `main`.

## Why this PR exists

#5805 was opened with `base` set to the head branch of #5804
(`fix/get-issue-leases-tolerance`), not `main`. #5804 merged to `main` at
`d44d399bdbdb`; five seconds later #5805 merged into that now-orphaned branch.
Both PRs show `MERGED`, but only #5804's content is on `main`. Nor did CI flag
it: #5805 does carry 15 green/skipped checks, but they are the 13 "Historical …
→ candidate" migration checks and friends — the **main test suite never ran on
it**, because its base was not `main`. (#5804, by contrast, ran the full set:
build, conformance, 15 test shards.) So the one signal that would have caught
the mistake is exactly the one a non-`main` base suppresses.

Verified before re-landing, with a control:

| site | at `main` before this PR |
| --- | --- |
| `internal/storage/issueops/search.go:166` | unchanged (`isTableNotExistError`) |
| `internal/storage/issueops/search.go:221` | unchanged |
| `internal/storage/domain/db/issue_search.go:32` | unchanged (`dberrors.IsTableNotExist`) |
| `internal/storage/domain/db/issue_search.go:108` | unchanged |
| `search_missing_table_test.go` (×3) | absent |
| `issueops/search.go` itself | **present** — the control proving the probe works |

`5ce6374f29ae` cherry-picks onto `main` cleanly (one auto-merge in `blocked.go`).
`070a3c55648a` is deliberately **not** included: it is #5804's commit and its
content is already on `main`.

## The bug being fixed

A wisp search is tolerant of a missing wisp plane — a pre-migration database has
no `wisps` table and really does match no wisps. That tolerance was written as a
blanket `IsTableNotExist`, but a wisp search touches more than the wisp plane:
its `FROM` clause carries `sqlbuild.LeaseJoin`, and hydration reads
`wisp_labels`. So a database that was *broken* rather than *pre-migration* —
missing `leases`, missing `wisp_labels` — was reported as an empty wisp plane,
and live rows were dropped from the result with a nil error.

The tolerance is now scoped to the tables the wisp plane actually owns, via one
shared predicate both stacks read so they cannot disagree:

```go
func OptionalWispTable(name string) bool {
    return strings.EqualFold(name, "wisps") || strings.EqualFold(name, "wisp_dependencies")
}
```

`issueops.optionalBlockedTable` now delegates to it instead of carrying its own
copy of the same two names.

## Tests and their controls

Over-tightening this guard to "never tolerate" passes every *must-error*
assertion, so the must-error tests alone cannot tell a correct fix from a
regression. Each direction has a control:

- `TestSearchInTxEphemeralBrokenWispPlaneIsAnError` — missing `wisp_labels` or
  `leases` must surface. Asserted with `errors.Is` against the primed driver
  error, **not** a message substring: the query text names the joined tables, so
  a substring check passes on any error that merely echoes the query.
- `TestSearchInTxEphemeralMissingWispPlaneIsEmpty` — **control**: a
  pre-migration database with no `wisps` / `wisp_dependencies` still returns
  empty, not an error.
- `TestSearchInTxEphemeralUnrelatedErrorPropagates` — **control**: the tolerance
  is not a blanket catch in the other direction either.
- `TestSearchInTxMergeBrokenWispPlaneIsAnError` — the merge branch, where the
  issues leg already succeeded so nothing downstream re-raises the swallowed
  wisp failure and the caller just gets a short list.

## Mutation, re-run on this branch

Reverting `missingOptionalWispTable` to the old blanket `isTableNotExistError`:

```
--- FAIL: TestSearchInTxEphemeralBrokenWispPlaneIsAnError
--- PASS: TestSearchInTxEphemeralMissingWispPlaneIsEmpty      <- control
--- PASS: TestSearchInTxEphemeralUnrelatedErrorPropagates     <- control
--- FAIL: TestSearchInTxMergeBrokenWispPlaneIsAnError
```

Exactly the two must-error tests red, both controls green.

## Gates

`go build ./...`, `go vet` on the four touched packages, and
`go test ./internal/storage/{issueops,domain/db,sqlbuild}/...` all pass on this
branch.

## Review follow-ups (not in this PR)

Two independent review lenses converged on the same residual: the identical
blanket-tolerance bug shape survives at the sibling *count* sites
(`issueops/search_counts.go:26,69`, `domain/db/issue_search_counts.go:106`,
`issueops/count.go:19,64,80,116`), and `missingOptionalWispTable` still
empties the whole result when only `wisp_dependencies` is absent rather than
degrading dependency hydration. Both are pre-existing and out of scope for a
faithful re-land of already-approved content; filed as **ga-e14j1**.

Fixes ga-47zl2.

