### PR TITLE
fix(metrics): reap detached send-metrics flush children

### DIFF
--- a/internal/metrics/spawn.go
+++ b/internal/metrics/spawn.go
@@ -189,10 +189,33 @@ func MaybeSpawnFlusher() {
 	// env + user-global config (see resolveMetricsEndpoint in cmd/bd) and mark
 	// the child as the flusher so it cannot recurse.
 	cmd.Env = flusherChildEnv(os.Environ(), Endpoint())
-	if err := cmd.Start(); err != nil {
+	if _, err := startDetached(cmd); err != nil {
 		return
 	}
-	_ = cmd.Process.Release()
+}
+
+// startDetached starts cmd and reaps it in a background goroutine. The
+// returned pid is captured before any handle release so callers can observe
+// the child even if a future change clears cmd.Process.Pid.
+//
+// os/exec requires Wait after a successful Start. The previous
+// cmd.Process.Release() path dropped the Go handle without waitpid, so an
+// exited child stayed a zombie for the parent's remaining lifetime. In
+// current shipped code every flusher spawn happens in a process-exit tail
+// (see CloseAndFlush callers), so that window is typically milliseconds —
+// but any long-lived caller added later would accumulate zombies
+// unboundedly. This addresses the missing-reap half of GH#5900's
+// hypothesis only; the live, CPU-consuming children reported there are a
+// separate concern. A parent that exits before Wait completes leaves the
+// child to init, which reaps it. Either way the child is never left as Z
+// under this process.
+func startDetached(cmd *exec.Cmd) (int, error) {
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+	pid := cmd.Process.Pid
+	go func() { _ = cmd.Wait() }()
+	return pid, nil
 }
 
 // flusherChildEnv returns a copy of env with the metrics endpoint pinned to

--- a/internal/metrics/spawn_reap_test.go
+++ b/internal/metrics/spawn_reap_test.go
@@ -1,0 +1,89 @@
+package metrics
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStartDetachedReapsExitedChild is the GH#5900 regression: a child that
+// exits while the parent stays alive must be waitpid'd, not left as a zombie.
+// The helper re-execs this test binary and exits immediately; startDetached
+// must reap it so `ps` never reports STAT Z under this process.
+func TestStartDetachedReapsExitedChild(t *testing.T) {
+	if os.Getenv("BD_TEST_FLUSHER_HELPER") == "1" {
+		// Stay alive long enough for the parent to observe a live pid.
+		// An instant-exit helper can vanish from `ps` before the first
+		// poll, which looks identical to a successful reap and would
+		// false-pass the old cmd.Process.Release() path.
+		time.Sleep(500 * time.Millisecond)
+		os.Exit(0)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestStartDetachedReapsExitedChild$") //nolint:gosec // test binary re-exec
+	cmd.Env = append(os.Environ(), "BD_TEST_FLUSHER_HELPER=1")
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	pid, err := startDetached(cmd)
+	if err != nil {
+		t.Fatalf("startDetached: %v", err)
+	}
+	if pid <= 0 {
+		t.Fatalf("startDetached pid = %d, want > 0", pid)
+	}
+
+	if runtime.GOOS == "windows" {
+		// Zombie STAT is a Unix process-table property. Still start the
+		// child so startDetached's Wait path is exercised, then return.
+		time.Sleep(400 * time.Millisecond)
+		return
+	}
+
+	seenLive := false
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		st, alive := unixProcStat(pid)
+		if strings.Contains(st, "Z") {
+			t.Fatalf("child pid %d became a zombie (stat=%q); startDetached did not reap", pid, st)
+		}
+		if alive {
+			seenLive = true
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		if !seenLive {
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		return
+	}
+	st, alive := unixProcStat(pid)
+	if !seenLive {
+		t.Fatalf("child pid %d never appeared in ps (alive=%v stat=%q)", pid, alive, st)
+	}
+	t.Fatalf("child pid %d still present after 3s (alive=%v stat=%q); startDetached did not reap", pid, alive, st)
+}
+
+// unixProcStat returns the `ps` STAT field for pid. alive is false when ps
+// finds no such process (reaped and gone). On Windows, ps is unavailable so
+// this reports not-alive after a short grace; the Wait goroutine is still
+// the resource-release path under test.
+func unixProcStat(pid int) (stat string, alive bool) {
+	if runtime.GOOS == "windows" {
+		return "", false
+	}
+	out, err := exec.Command("ps", "-o", "stat=", "-p", strconv.Itoa(pid)).CombinedOutput()
+	if err != nil {
+		return "", false
+	}
+	st := strings.TrimSpace(string(out))
+	if st == "" || strings.HasPrefix(st, "STAT") {
+		return "", false
+	}
+	return st, true
+}


### PR DESCRIPTION
## Summary

`internal/metrics/spawn.go` spawned the detached `send-metrics` telemetry-flush
child with `cmd.Start()` followed by `cmd.Process.Release()` and no `Wait` — a
violation of the documented `os/exec` contract, which leaves each exited flush
child as a zombie for the parent's remaining lifetime.

**Honest scope:** in current shipped code every flusher spawn sits in a
process-exit tail (`CloseAndFlush` is called only from the `main.go` post-run
tail and the `CheckReadonly` exit path), so that zombie window is typically
milliseconds and bounded — the parent exits, init reaps. The unbounded case
arises only if a long-lived caller is ever added. This PR fixes the contract
violation and hardens that future path.

**This is a partial response to #5900, not a fix for it.** The reporter
hypothesized "spawn-and-detach with no matching wait/reap, AND/OR the flusher
never reaches its own exit condition." This PR addresses the first half only.
The dominant reported symptoms — live, CPU-burning `send-metrics` processes
reparented to PID 1, and `~/.beads/eventsData` at ~4.8M files — cannot be
caused by a missing `waitpid` (a zombie consumes no CPU) and point at the
flusher's own exit condition under a huge backlog. That remains open;
**please do not close #5900 on merge** (commit uses `Refs`, not `Fixes`).

## The change

After a successful `Start`, reap with `cmd.Wait()` in a background goroutine;
`Release()` is removed. The caller still returns as soon as `Start` succeeds.

- **Unchanged:** detach semantics — this is *not* a session detach (no
  `Setsid`/`Setpgid`); the child stays in the parent's process group exactly as
  before. No change to spawn rate, child argv, or `flusherChildEnv`.
- **Windows:** the old `Release()` path did close the process handle, so there
  was no Windows leak; the new code closes it via `Wait` instead — same
  end-state through the contract-conformant path.
- **Cost:** one goroutine per spawn, alive until that child exits. If a
  `send-metrics` child hangs, its goroutine hangs with it — bounded by child
  lifetime.
- **Short-lived CLI parents:** the parent may exit before `Wait` runs; the
  child is re-parented and reaped by init, as before (stated in the code
  comment).

## Test

`spawn_reap_test.go` adds `TestStartDetachedReapsExitedChild`, a real
regression test on Unix (not a not-crash test):

- helper child (`BD_TEST_FLUSHER_HELPER=1`) stays alive 500ms so the test first
  observes it live — an instant-exit child would false-pass the old `Release()`
  path;
- fails if `ps -o stat=` ever reports `Z` for the child;
- requires observed-live → gone within a 3s deadline (never-seen and
  still-present both fail).

Against the old `Start`+`Release` code the test fails with
`became a zombie (stat="Z"); startDetached did not reap` — verified by
mutation (reverting the reap in an overlay).

**Disclosed limitations:** on Windows the test only smoke-runs the `Wait`
goroutine (zombie STAT is Unix-only), so a Windows-only regression would not be
caught. Two theoretical flake modes, both failing safe (false FAILURE, never
false pass): a kernel-transient `Z` between exit and `waitpid`, and a heavily
loaded machine missing the 500ms live window entirely.

## Test evidence

`CGO_ENABLED=0 -tags gms_pure_go`: `go build ./internal/...` OK;
`go test -count=1 ./internal/metrics/...` → `ok ... 1.041s` (no skips).

## Credit

Report and root-cause hypotheses by @pcresswell in #5900.
