### PR TITLE
fix(storage): stop recommending an inert config.yaml key for a missing prefix (#5916)

### DIFF
--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -524,7 +524,7 @@ func ReadConfigPrefix(ctx context.Context, tx DBTX) (string, error) {
 		underscoreYamlPrefix := strings.TrimSpace(config.GetString("issue_prefix"))
 		debug.Logf("Debug: missing config.issue_prefix in database (err=%v, db value=%q, yaml issue-prefix=%q, yaml issue_prefix=%q)\n",
 			err, configPrefix, yamlPrefix, underscoreYamlPrefix)
-		return "", fmt.Errorf("%w: issue_prefix config is missing (run 'bd init --prefix <prefix>' for a new project, or 'bd bootstrap' to clone an existing remote; if using config.yaml, use key 'issue-prefix', not 'issue_prefix')", storage.ErrNotInitialized)
+		return "", fmt.Errorf("%w: issue_prefix config is missing (run 'bd init --prefix <prefix>' for a new project, or 'bd bootstrap' to clone an existing remote; this check reads the database's config table, so adding 'issue-prefix' to config.yaml does not satisfy it)", storage.ErrNotInitialized)
 	} else if err != nil {
 		return "", fmt.Errorf("failed to get config: %w", err)
 	}

--- a/internal/storage/issueops/helpers_test.go
+++ b/internal/storage/issueops/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -289,7 +290,7 @@ func TestReadConfigPrefix(t *testing.T) {
 		}
 	})
 
-	t.Run("missing config row has actionable key naming hint", func(t *testing.T) {
+	t.Run("missing config row names the commands that initialize the prefix", func(t *testing.T) {
 		t.Parallel()
 
 		db, mock, err := sqlmock.New()
@@ -319,12 +320,56 @@ func TestReadConfigPrefix(t *testing.T) {
 		msg := err.Error()
 		if !containsAll(msg,
 			"issue_prefix config is missing",
-			"issue-prefix",
-			"not 'issue_prefix'",
+			"bd init --prefix",
+			"bd bootstrap",
 		) {
-			t.Fatalf("ReadConfigPrefix error missing key naming guidance: %s", msg)
+			t.Fatalf("ReadConfigPrefix error missing actionable recovery commands: %s", msg)
 		}
 	})
+}
+
+// TestReadConfigPrefixDoesNotRecommendInertYAMLKey pins GH#5916: the message
+// used to tell an operator to "use key 'issue-prefix', not 'issue_prefix'" in
+// config.yaml, but this gate only ever reads the database's config table. The
+// YAML key is SET here and the gate still fails, so the recommendation sent
+// operators to commit a tracked field that changes nothing and misleads the
+// next reader.
+//
+// Not parallel: it initializes and mutates the process-global viper config.
+// BEADS_TEST_IGNORE_REPO_CONFIG keeps the checkout's own tracked config.yaml
+// out of the picture, so only the value injected below is in effect.
+func TestReadConfigPrefixDoesNotRecommendInertYAMLKey(t *testing.T) {
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+	defer config.ResetForTesting()
+	config.Set("issue-prefix", "skills")
+
+	if got := config.GetString("issue-prefix"); got != "skills" {
+		t.Fatalf("precondition: config.GetString(issue-prefix) = %q, want %q — the assertions below would be vacuous", got, "skills")
+	}
+
+	_, mock, tx := beginMockTx(t)
+	mock.ExpectQuery("SELECT value FROM config WHERE `key` = \\?").
+		WithArgs("issue_prefix").
+		WillReturnRows(sqlmock.NewRows([]string{"value"}))
+
+	_, err := ReadConfigPrefix(context.Background(), tx)
+	if err == nil {
+		t.Fatal("ReadConfigPrefix() returned nil error, want error: the YAML key must not satisfy this gate")
+	}
+	if !errors.Is(err, storage.ErrNotInitialized) {
+		t.Fatalf("ReadConfigPrefix error = %v, want ErrNotInitialized", err)
+	}
+
+	msg := err.Error()
+	if strings.Contains(msg, "use key 'issue-prefix'") {
+		t.Fatalf("ReadConfigPrefix recommends a config.yaml key that does not satisfy it: %s", msg)
+	}
+	if !containsAll(msg, "bd init --prefix", "bd bootstrap") {
+		t.Fatalf("ReadConfigPrefix error missing actionable recovery commands: %s", msg)
+	}
 }
 
 func containsAll(s string, parts ...string) bool {


### PR DESCRIPTION
## Summary

`ReadConfigPrefix` gates issue creation on the database's `config` table row
`issue_prefix`. When that row is missing or empty, its error told the operator:

> if using config.yaml, use key 'issue-prefix', not 'issue_prefix'

That recommendation cannot satisfy the gate. `internal/storage/issueops/helpers.go:519-532`
queries only `SELECT value FROM config WHERE \`key\` = 'issue_prefix'`
(`helpers.go:521`). The YAML value is read just above the error
(`helpers.go:523-524`) purely to populate the `debug.Logf` diagnostic on
`helpers.go:525-526` — it is never returned and never consulted by the gate. So adding `issue-prefix:` to `.beads/config.yaml` leaves
the check failing with the exact same message that recommended it.

The cost is not only a wasted step: following the advice commits a tracked
configuration field that changes nothing and misleads the next reader of the
file. That is the reporter's core objection, and it is correct.

What actually satisfies the gate is the database row, written by the lifecycle
commands the message already named — `bd init --prefix <prefix>` or
`bd bootstrap`. Notably there is *no* config.yaml key that satisfies it, which
is consistent with the repo's existing stance: `bd config set` explicitly
refuses both `issue_prefix` and `issue-prefix`
(`cmd/bd/config.go:1059`, `rejectProtectedConfigKey`) on the grounds that the
prefix is owned by a lifecycle command rather than the config plane.

## The change

One error string, in `internal/storage/issueops/helpers.go:527`. The misleading
dash-vs-underscore clause is replaced with a statement of where the check
actually reads from:

> this check reads the database's config table, so adding 'issue-prefix' to
> config.yaml does not satisfy it

The `bd init --prefix` / `bd bootstrap` guidance and the
`issue_prefix config is missing` prefix are kept verbatim, so no other assertion
against this message moves.

**No resolution behavior changes.** This deliberately does not make config.yaml
satisfy the gate. Doing so would change prefix-resolution semantics at the
storage layer and contradict the design intent recorded in
`issueops/workspaceconfig.go:5-15` and `cmd/bd/config.go:1051-1061`;
that is a maintainer call, not a bug fix. This PR only stops the message from
recommending a step that provably does nothing.

Worth noting for scope: YAML `issue-prefix` is not inert *everywhere* — front
doors overlay it for `--id` prefix validation via `overlayYAMLPrefix`
(`cmd/bd/create_deps.go:249-254`). It is inert specifically for satisfying this
initialization gate, and the new wording is scoped to that claim.

## Test

`TestReadConfigPrefixDoesNotRecommendInertYAMLKey` in
`internal/storage/issueops/helpers_test.go`.

It sets the recommended YAML key to a real value (`config.Set("issue-prefix", "skills")`,
guarded by a precondition assertion so it cannot pass vacuously), mocks the
config-table query returning no rows, and asserts two things:

1. `ReadConfigPrefix` still returns `storage.ErrNotInitialized` — proving the
   recommended key does not satisfy the gate;
2. the resulting message does not contain `use key 'issue-prefix'` — the fix.

The test is deliberately **not** parallel: it initializes and mutates the
process-global viper config. It follows the existing pattern in this package
(`TestMergeMetadataInTxSchemaValidation`, `metadata_test.go:59-67`), using
`t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")` so the checkout's own tracked
`config.yaml` cannot influence the result, plus `defer config.ResetForTesting()`.
Being serial, it completes before the package's parallel tests resume, so it
does not race them on global config state.

The pre-existing sibling subtest was renamed from
`missing config row has actionable key naming hint` to
`missing config row names the commands that initialize the prefix`, and its
assertion changed from pinning the misleading text (`"issue-prefix"`,
`"not 'issue_prefix'"`) to pinning the actionable commands (`bd init --prefix`,
`bd bootstrap`). That subtest was pinning the defect; it had to move.

## Test evidence

Build and tests run with the repo's pure-Go configuration
(`CGO_ENABLED=0`, `-tags gms_pure_go`, per `engdocs/ICU-POLICY.md`).

`go build -tags gms_pure_go ./...` — exit 0, no output.

Scoped package, verbatim:

```
--- PASS: TestReadConfigPrefixDoesNotRecommendInertYAMLKey (0.05s)
--- PASS: TestReadConfigPrefix (0.00s)
    --- PASS: TestReadConfigPrefix/returns_trimmed_prefix (0.00s)
    --- PASS: TestReadConfigPrefix/missing_config_row_names_the_commands_that_initialize_the_prefix (0.00s)
PASS
ok  	github.com/steveyegge/beads/internal/storage/issueops	0.630s
```

Whole package and the config package it depends on:

```
ok  	github.com/steveyegge/beads/internal/storage/issueops	1.600s
ok  	github.com/steveyegge/beads/internal/config	5.156s
```

`gofmt -l internal/storage/issueops/` — clean. `go vet` — clean.

**Mutation check.** Reverting only `helpers.go` (keeping both tests) makes the
new test fail, verbatim:

```
    helpers_test.go:368: ReadConfigPrefix recommends a config.yaml key that does not satisfy it: database not initialized: issue_prefix config is missing (run 'bd init --prefix <prefix>' for a new project, or 'bd bootstrap' to clone an existing remote; if using config.yaml, use key 'issue-prefix', not 'issue_prefix')
--- FAIL: TestReadConfigPrefixDoesNotRecommendInertYAMLKey (0.05s)
--- PASS: TestReadConfigPrefix (0.00s)
    --- PASS: TestReadConfigPrefix/returns_trimmed_prefix (0.00s)
    --- PASS: TestReadConfigPrefix/missing_config_row_names_the_commands_that_initialize_the_prefix (0.00s)
FAIL	github.com/steveyegge/beads/internal/storage/issueops	0.633s
```

Note that the renamed sibling subtest passes under both the fixed and reverted
message (the old text also contained `bd init --prefix` and `bd bootstrap`), so
the new test is the sole gate on this change. That is stated rather than
implied.

### Limitations, disclosed

- `internal/storage/embeddeddolt/create_issue_test.go:251` also asserts against
  this error, but that file is `//go:build cgo` and is therefore excluded under
  the mandated `CGO_ENABLED=0` build — **it was not executed here**. It asserts
  only the substring `issue_prefix config is missing`, which this change
  preserves verbatim, so it should be unaffected; that is reasoning, not a
  test run.
- No end-to-end `bd create` reproduction was performed. The defect is verified
  by reading the gate and by a unit test that sets the recommended key and shows
  the gate still rejects it. The reporter supplied the end-to-end symptom.
- Drafted against `origin/main` at `1617f3a85`, then rebased onto `e7894732e`
  after `origin/main` advanced by two commits (#5932, #5935) mid-work. The
  rebase was conflict-free. Every result above — build, both package runs,
  `gofmt`/`go vet`, and the mutation check — was **re-run on the `e7894732e`
  base**, and the line numbers cited above were re-derived from that tip. The
  two new commits touch other files in `internal/storage/issueops` (and files
  outside the package) but leave `helpers.go` and `helpers_test.go`
  byte-identical. The exported patch
  additionally passes `git apply --check` (and `--3way`) against a clean
  checkout at `e7894732e`.

## Credit the reporter

Reported by **@ncljesus** in #5916, with an accurate diagnosis: "The gate reads
the database's `config` table, not the file, so the file key is inert." The
observation that the suggestion leads an operator to commit a field into tracked
configuration that changes nothing and misleads the next reader is what set the
scope of this fix. The reporter also linked the related #5913.
