### PR TITLE
fix(metrics): bound the send-metrics prune by the child's flush budget

### DIFF
--- a/internal/metrics/flusher.go
+++ b/internal/metrics/flusher.go
@@ -16,6 +16,10 @@ const (
 	flushTimeout = 30 * time.Second
 )
 
+// pruneQueueFn is PruneQueue behind a seam so tests can assert the prune is
+// handed the child's real budget — the property GH#5871 turned on.
+var pruneQueueFn = PruneQueue
+
 func RunSendMetrics() int {
 	dir, err := DataDir()
 	if err != nil {
@@ -23,11 +27,23 @@ func RunSendMetrics() int {
 		return 1
 	}
 
+	// The prune used to run before any context existed, so the expensive half
+	// of the child — a stat per queued file — had no deadline at all, and
+	// children on a backed-up spool were observed alive for ~15 minutes
+	// against this 30s advertised bound (GH#5871). Giving it a budget bounds
+	// the part that ran away. It does not make the child's total wall clock
+	// flushTimeout: the prune may still overrun (see PruneQueue, which
+	// finishes its listing when stopping would leave the queue unbounded),
+	// eventkit's own flush prologue lists the directory unbounded, and the
+	// prune's cap-unlink pass runs after the budget check that admitted it.
+	pruneCtx, cancelPrune := context.WithTimeout(context.Background(), flushTimeout)
+	defer cancelPrune()
+
 	// Bound the queue before flushing: TTL out stale batches and orphaned
 	// emitter temps, cap the rest drop-oldest (bd-ulfod: an unbounded queue
 	// reached 149k files / 1.1GB when emission outran the throttled drain).
 	// Out-of-band by construction — this child is already detached.
-	if dropped, freed := PruneQueue(dir, time.Now()); dropped > 0 {
+	if dropped, freed := pruneQueueFn(pruneCtx, dir, time.Now()); dropped > 0 {
 		fmt.Fprintf(os.Stderr, "send-metrics: pruned %d queued event file(s), freed %.1f MB\n",
 			dropped, float64(freed)/(1<<20))
 	}
@@ -47,10 +63,17 @@ func RunSendMetrics() int {
 		return 1
 	}
 
+	// The upload gets its own full budget rather than the prune's remainder.
+	// Sharing one would let a slow-but-successful prune hand the flush an
+	// already-spent context, so the child would prune, upload nothing, and
+	// exit 1 — and since a prune slow enough to do that is exactly what a
+	// backed-up spool produces, the uploads would never resume. Two budgets
+	// keep the two halves independent: neither can starve the other.
+	flushCtx, cancelFlush := context.WithTimeout(context.Background(), flushTimeout)
+	defer cancelFlush()
+
 	flusher := eventkit.NewFileFlusher(dir, ga)
-	ctx, cancel := context.WithTimeout(context.Background(), flushTimeout)
-	defer cancel()
-	if err := flusher.Flush(ctx); err != nil {
+	if err := flusher.Flush(flushCtx); err != nil {
 		fmt.Fprintf(os.Stderr, "send-metrics: flush: %v\n", err)
 		return 1
 	}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -286,3 +286,45 @@ func envContains(env []string, want string) bool {
 	}
 	return false
 }
+
+// TestRunSendMetricsPrunesUnderFlushDeadline is the GH#5871 ordering
+// regression. RunSendMetrics advertises a flushTimeout budget for the detached
+// child, but built the context only after the prune, so the prune — the
+// expensive half on a backed-up spool — ran with no deadline at all and the
+// advertised budget bounded nothing.
+func TestRunSendMetricsPrunesUnderFlushDeadline(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".beads", "eventsData"), 0o750); err != nil {
+		t.Fatalf("mkdir eventsData: %v", err)
+	}
+
+	var called, hasDeadline bool
+	var budget time.Duration
+	orig := pruneQueueFn
+	t.Cleanup(func() { pruneQueueFn = orig })
+	pruneQueueFn = func(ctx context.Context, dir string, now time.Time) (int, int64) {
+		called = true
+		if dl, ok := ctx.Deadline(); ok {
+			hasDeadline = true
+			budget = time.Until(dl)
+		}
+		return 0, 0
+	}
+
+	if _, err := Init("0.0.0-test", false, ""); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if code := RunSendMetrics(); code != 0 {
+		t.Fatalf("RunSendMetrics() = %d, want 0", code)
+	}
+	if !called {
+		t.Fatal("RunSendMetrics did not prune")
+	}
+	if !hasDeadline {
+		t.Fatal("RunSendMetrics ran the prune with a deadline-free context: the advertised flushTimeout budget does not bound the child's expensive half")
+	}
+	if budget <= 0 || budget > flushTimeout {
+		t.Errorf("prune context budget = %v, want (0, %v]", budget, flushTimeout)
+	}
+}

--- a/internal/metrics/prune.go
+++ b/internal/metrics/prune.go
@@ -1,6 +1,9 @@
 package metrics
 
 import (
+	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -30,6 +33,12 @@ const (
 	// one forever: no rename will come, and the flusher and the pending-check
 	// both ignore non-.evtq names, so only the prune ever reclaims them.
 	writeTempPrefix = ".write-"
+
+	// pruneChunkSize is how many directory entries the prune walks between
+	// budget checks. It matches the chunk hasQueuedEvents uses: big enough
+	// that the per-chunk check is noise, small enough that an expired
+	// deadline is honored within one chunk of stats.
+	pruneChunkSize = 64
 )
 
 // PruneQueue bounds the queued-event backlog in dir before a flush: event
@@ -47,8 +56,18 @@ const (
 // double-sent, the backlog just waits one more spawn interval. ENOENT
 // tolerance in eventkit's flush loop is the upstream fix (gastownhall/beads
 // GH#5649 lane).
-func PruneQueue(dir string, now time.Time) (dropped int, freed int64) {
-	return pruneQueue(dir, now, pruneTTL, maxQueueFiles, maxQueueBytes)
+//
+// The scan is bounded by ctx: it reads the directory in chunks and, once the
+// context is done, abandons the walk and keeps whatever it already deleted
+// (GH#5871 — the child advertises a flushTimeout budget, and a spool large
+// enough to matter is exactly the one whose per-entry stat walk outruns it).
+// The one exception is a pass that has deleted nothing when its budget runs
+// out: it finishes the listing anyway, because abandoning it there would also
+// skip the oldest-first caps and leave the queue with no bound applied at all
+// (see the walk below). That pass can outrun ctx; the walk is otherwise the
+// bounded half of a child that used to run ~15 minutes against a 30s budget.
+func PruneQueue(ctx context.Context, dir string, now time.Time) (dropped int, freed int64) {
+	return pruneQueue(ctx, dir, now, pruneTTL, maxQueueFiles, maxQueueBytes)
 }
 
 // queueEntry is one prune-eligible file in the queue directory.
@@ -58,45 +77,101 @@ type queueEntry struct {
 	size    int64
 }
 
+// dirChunkReader is the chunked-listing half of *os.File. It is a seam so a
+// test can inject a listing that fails part way through: a mid-listing read
+// error leaves a PARTIAL prefix, which must never reach the oldest-first cap
+// pass below.
+type dirChunkReader interface {
+	ReadDir(n int) ([]os.DirEntry, error)
+}
+
 // pruneQueue is PruneQueue with the knobs exposed for tests.
-func pruneQueue(dir string, now time.Time, ttl time.Duration, maxFiles int, maxBytes int64) (dropped int, freed int64) {
-	dirents, err := os.ReadDir(dir)
+func pruneQueue(ctx context.Context, dir string, now time.Time, ttl time.Duration, maxFiles int, maxBytes int64) (dropped int, freed int64) {
+	f, err := os.Open(dir) // #nosec G304 -- dir is the metrics DataDir, not user input
 	if err != nil {
 		// Missing/unreadable queue dir: nothing to prune.
 		return 0, 0
 	}
+	defer f.Close()
+	return pruneQueueFrom(ctx, f, dir, now, ttl, maxFiles, maxBytes)
+}
 
+// pruneQueueFrom is pruneQueue over an already-opened listing of dir.
+func pruneQueueFrom(ctx context.Context, r dirChunkReader, dir string, now time.Time, ttl time.Duration, maxFiles int, maxBytes int64) (dropped int, freed int64) {
 	var live []queueEntry // surviving .evtq batches, candidates for the caps
 	var liveBytes int64
-	for _, de := range dirents {
-		if de.IsDir() {
-			continue
+	truncated := false
+	for chunk := 0; ; chunk++ {
+		// One budget check per chunk, so the worst-case overrun is one
+		// chunk of stats rather than the whole spool. os.ReadDir is not
+		// usable here: it reads AND name-sorts every entry before the caller
+		// sees one, which on a backed-up queue is precisely the unbounded
+		// prologue this bounds (same reason hasQueuedEvents streams).
+		//
+		// Out of budget is not automatically "stop". A truncated walk cannot
+		// run the cap pass below, so a pass that also deleted nothing has
+		// applied NEITHER drain — and since the next child reopens the
+		// directory at offset zero, it would walk the same young prefix and
+		// stop in the same place, leaving the file/byte caps inert forever
+		// against exactly the young oversized spool they were added for
+		// (GH#5660). So the deadline stops the walk only once there is TTL
+		// progress to keep (or before the first chunk, where the caller
+		// handed over no budget at all and the queue may not even be large).
+		// The cost is disclosed: on a big all-young queue this child runs
+		// past its budget to the end of the listing, because that is the
+		// only pass in which the caps can fire.
+		if ctx.Err() != nil && (chunk == 0 || dropped > 0) {
+			truncated = true
+			break
 		}
-		name := de.Name()
-		isBatch := filepath.Ext(name) == queuedEventExt
-		isOrphanTemp := strings.HasPrefix(name, writeTempPrefix)
-		if !isBatch && !isOrphanTemp {
-			// Never touch the throttle marker, the flusher lock, or anything
-			// else that is not queue payload.
-			continue
-		}
-		fi, err := de.Info()
-		if err != nil {
-			// Vanished between ReadDir and Info (a concurrent flusher child
-			// uploads-and-deletes): already gone, nothing to do.
-			continue
-		}
-		if now.Sub(fi.ModTime()) > ttl {
-			if remove(filepath.Join(dir, name)) {
-				dropped++
-				freed += fi.Size()
+		dirents, readErr := r.ReadDir(pruneChunkSize)
+		for _, de := range dirents {
+			if de.IsDir() {
+				continue
 			}
-			continue
+			name := de.Name()
+			isBatch := filepath.Ext(name) == queuedEventExt
+			isOrphanTemp := strings.HasPrefix(name, writeTempPrefix)
+			if !isBatch && !isOrphanTemp {
+				// Never touch the throttle marker, the flusher lock, or anything
+				// else that is not queue payload.
+				continue
+			}
+			fi, err := de.Info()
+			if err != nil {
+				// Vanished between ReadDir and Info (a concurrent flusher child
+				// uploads-and-deletes): already gone, nothing to do.
+				continue
+			}
+			if now.Sub(fi.ModTime()) > ttl {
+				if remove(filepath.Join(dir, name)) {
+					dropped++
+					freed += fi.Size()
+				}
+				continue
+			}
+			if isBatch {
+				live = append(live, queueEntry{filepath.Join(dir, name), fi.ModTime(), fi.Size()})
+				liveBytes += fi.Size()
+			}
 		}
-		if isBatch {
-			live = append(live, queueEntry{filepath.Join(dir, name), fi.ModTime(), fi.Size()})
-			liveBytes += fi.Size()
+		if readErr != nil {
+			// io.EOF means the whole directory was listed and the caps below
+			// may run. Anything else ended the listing early, so what we
+			// hold is a prefix, not the queue: the cap pass must not see it.
+			if !errors.Is(readErr, io.EOF) {
+				truncated = true
+			}
+			break
 		}
+	}
+
+	if truncated {
+		// The caps are an oldest-first decision over the WHOLE queue; a
+		// partial listing cannot make it correctly, and guessing from a
+		// prefix would drop batches that are not actually the oldest. The
+		// TTL deletions above already stand.
+		return dropped, freed
 	}
 
 	if len(live) <= maxFiles && liveBytes <= maxBytes {

--- a/internal/metrics/prune_test.go
+++ b/internal/metrics/prune_test.go
@@ -1,6 +1,9 @@
 package metrics
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,7 +44,7 @@ func TestPruneTTLDropsStaleBatchesAndOrphanTemps(t *testing.T) {
 	writeQueueFile(t, dir, "young.evtq", 10, now.Add(-time.Hour))
 	writeQueueFile(t, dir, ".write-live", 10, now.Add(-time.Minute))
 
-	dropped, freed := pruneQueue(dir, now, 7*24*time.Hour, 100, 1<<20)
+	dropped, freed := pruneQueue(context.Background(), dir, now, 7*24*time.Hour, 100, 1<<20)
 	if dropped != 2 || freed != 20 {
 		t.Fatalf("dropped=%d freed=%d, want 2/20", dropped, freed)
 	}
@@ -62,7 +65,7 @@ func TestPruneCountCapDropsOldestFirst(t *testing.T) {
 		writeQueueFile(t, dir, "q"+string(rune('0'+i))+".evtq", 10,
 			now.Add(-time.Duration(5-i)*time.Minute))
 	}
-	dropped, _ := pruneQueue(dir, now, 7*24*time.Hour, 3, 1<<20)
+	dropped, _ := pruneQueue(context.Background(), dir, now, 7*24*time.Hour, 3, 1<<20)
 	if dropped != 2 {
 		t.Fatalf("dropped=%d, want 2", dropped)
 	}
@@ -87,7 +90,7 @@ func TestPruneByteCapDropsOldestFirst(t *testing.T) {
 	writeQueueFile(t, dir, "c.evtq", 400, now.Add(-time.Minute))
 
 	// 1000-byte cap: dropping only "a" (oldest) brings the total to 800.
-	dropped, freed := pruneQueue(dir, now, 7*24*time.Hour, 100, 1000)
+	dropped, freed := pruneQueue(context.Background(), dir, now, 7*24*time.Hour, 100, 1000)
 	if dropped != 1 || freed != 400 {
 		t.Fatalf("dropped=%d freed=%d, want 1/400", dropped, freed)
 	}
@@ -105,7 +108,7 @@ func TestPruneNeverTouchesMarkerOrLock(t *testing.T) {
 	writeQueueFile(t, dir, "eventkit.lock", 1, ancient)
 	writeQueueFile(t, dir, "unrelated.txt", 1, ancient)
 
-	dropped, _ := pruneQueue(dir, now, 7*24*time.Hour, 0, 0)
+	dropped, _ := pruneQueue(context.Background(), dir, now, 7*24*time.Hour, 0, 0)
 	if dropped != 0 {
 		t.Fatalf("dropped=%d, want 0", dropped)
 	}
@@ -131,7 +134,7 @@ func TestPruneCapNeverTakesYoungWriteTemps(t *testing.T) {
 		writeQueueFile(t, dir, "q"+string(rune('0'+i))+".evtq", 10,
 			now.Add(-time.Duration(10-i)*time.Hour))
 	}
-	dropped, _ := pruneQueue(dir, now, 7*24*time.Hour, 1, 1<<20)
+	dropped, _ := pruneQueue(context.Background(), dir, now, 7*24*time.Hour, 1, 1<<20)
 	if dropped != 3 {
 		t.Fatalf("dropped=%d, want 3 (oldest batches only)", dropped)
 	}
@@ -145,7 +148,7 @@ func TestPruneCapNeverTakesYoungWriteTemps(t *testing.T) {
 }
 
 func TestPruneMissingDirIsNoop(t *testing.T) {
-	dropped, freed := pruneQueue(filepath.Join(t.TempDir(), "nope"), time.Now(), time.Hour, 1, 1)
+	dropped, freed := pruneQueue(context.Background(), filepath.Join(t.TempDir(), "nope"), time.Now(), time.Hour, 1, 1)
 	if dropped != 0 || freed != 0 {
 		t.Fatalf("dropped=%d freed=%d, want 0/0", dropped, freed)
 	}
@@ -155,11 +158,226 @@ func TestPruneWithinCapsIsNoop(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Now()
 	writeQueueFile(t, dir, "a.evtq", 10, now.Add(-time.Minute))
-	dropped, _ := pruneQueue(dir, now, 7*24*time.Hour, 10, 1<<20)
+	dropped, _ := pruneQueue(context.Background(), dir, now, 7*24*time.Hour, 10, 1<<20)
 	if dropped != 0 {
 		t.Fatalf("dropped=%d, want 0", dropped)
 	}
 	if !names(t, dir)["a.evtq"] {
 		t.Fatal("in-cap file pruned")
+	}
+}
+
+// ctxExpiringAfter is a deadline context whose deadline falls part way through
+// the scan. It reports live for the first n consultations and expired from
+// then on, which makes "the budget ran out after n chunks" deterministic
+// without a timing race: pruneQueue consults the context once per directory
+// chunk, so n chunks are processed.
+//
+// Expiry flips every part of the context interface together — Err returns
+// DeadlineExceeded, Done is closed, Deadline moves into the past — and either
+// Err or Done counts as a consultation. A partial fake (Err only) would let a
+// future scan that waits on Done pass this test while production still walks
+// the whole spool. Not safe for concurrent use; the prune walk is sequential.
+type ctxExpiringAfter struct {
+	context.Context
+	state *expiryState
+}
+
+type expiryState struct {
+	remaining int
+	done      chan struct{}
+	expiredAt time.Time
+}
+
+// consult burns one consultation and reports whether the context is expired.
+func (c ctxExpiringAfter) consult() bool {
+	if c.state.remaining > 0 {
+		c.state.remaining--
+		return false
+	}
+	select {
+	case <-c.state.done:
+	default:
+		c.state.expiredAt = time.Now()
+		close(c.state.done)
+	}
+	return true
+}
+
+func (c ctxExpiringAfter) Err() error {
+	if c.consult() {
+		return context.DeadlineExceeded
+	}
+	return nil
+}
+
+func (c ctxExpiringAfter) Done() <-chan struct{} {
+	c.consult()
+	return c.state.done
+}
+
+func (c ctxExpiringAfter) Deadline() (time.Time, bool) {
+	select {
+	case <-c.state.done:
+		return c.state.expiredAt, true
+	default:
+		// Still live: a deadline far enough out that a budget computed from
+		// it is positive, as a real un-expired deadline context reports.
+		return time.Now().Add(time.Hour), true
+	}
+}
+
+func expiringAfter(chunks int) context.Context {
+	return ctxExpiringAfter{
+		Context: context.Background(),
+		state:   &expiryState{remaining: chunks, done: make(chan struct{})},
+	}
+}
+
+// seedExpired writes n past-TTL .evtq batches and returns their names.
+func seedExpired(t *testing.T, dir string, n int, now time.Time) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		writeQueueFile(t, dir, fmt.Sprintf("b%04d%s", i, queuedEventExt), 10, now.Add(-8*24*time.Hour))
+	}
+}
+
+// TestPruneQueueStopsOnExpiredContext is the GH#5871 regression: the prune the
+// send-metrics child runs before its flush must be bounded by the child's
+// advertised flushTimeout budget. With the budget already spent, the prune has
+// to return instead of walking (and lstat-ing) the whole spool — the walk that
+// kept observed children alive ~15 minutes against a 30s advertised budget.
+func TestPruneQueueStopsOnExpiredContext(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	const seeded = 200
+	seedExpired(t, dir, seeded, now)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	dropped, freed := pruneQueue(ctx, dir, now, 7*24*time.Hour, 10_000, 64<<20)
+	if dropped != 0 || freed != 0 {
+		t.Errorf("pruneQueue with an already-expired context = (%d dropped, %d freed), want (0, 0): the budget was gone before it started", dropped, freed)
+	}
+	if got := len(names(t, dir)); got != seeded {
+		t.Errorf("queue holds %d files after an out-of-budget prune, want all %d untouched", got, seeded)
+	}
+}
+
+// TestPruneQueueTruncatesAndStillMakesProgress pins the other half: once the
+// pass has TTL deletions to keep, expiring mid-scan must stop the scan (so the
+// walk stays inside its budget) yet keep those deletions, so the pass makes
+// forward progress instead of costing the queue nothing.
+func TestPruneQueueTruncatesAndStillMakesProgress(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	const seeded = 200
+	seedExpired(t, dir, seeded, now)
+
+	// One chunk of budget, then the deadline is spent.
+	dropped, _ := pruneQueue(expiringAfter(1), dir, now, 7*24*time.Hour, 10_000, 64<<20)
+	if dropped == 0 {
+		t.Errorf("pruneQueue dropped 0 of %d expired batches: a truncated prune must still make forward progress", seeded)
+	}
+	if dropped >= seeded {
+		t.Errorf("pruneQueue dropped %d of %d expired batches: it ran the whole spool after its budget expired", dropped, seeded)
+	}
+	if got := len(names(t, dir)); got != seeded-dropped {
+		t.Errorf("queue holds %d files, want %d (seeded %d - dropped %d)", got, seeded-dropped, seeded, dropped)
+	}
+}
+
+// seedYoung writes n in-TTL .evtq batches, newest first (b0000 is the
+// youngest), and returns the names in age order.
+func seedYoung(t *testing.T, dir string, n int, now time.Time) []string {
+	t.Helper()
+	out := make([]string, n)
+	for i := 0; i < n; i++ {
+		out[i] = fmt.Sprintf("b%04d%s", i, queuedEventExt)
+		writeQueueFile(t, dir, out[i], 10, now.Add(-time.Duration(i+1)*time.Minute))
+	}
+	return out
+}
+
+// TestPruneQueueCapsYoungPileWhenTTLMadeNoProgress pins the cap-skip livelock.
+// The caps are the only bound on a queue whose files are all inside the TTL —
+// exactly the 149k-file/1.1GB pile GH#5660 added them for. If the walk simply
+// gave up at its deadline, that pass would drop nothing (nothing is past TTL)
+// AND skip the cap pass (the listing is partial), the next spawn would reopen
+// the directory at offset 0 and repeat, and the file/byte bound would never
+// fire at all while emission kept appending. So: when the budget runs out with
+// zero TTL progress, finish the listing and let the caps run.
+func TestPruneQueueCapsYoungPileWhenTTLMadeNoProgress(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	const seeded = 200
+	const maxFiles = 10
+	byAge := seedYoung(t, dir, seeded, now)
+
+	// One chunk of budget, then the deadline is spent — with nothing past TTL
+	// for the first chunk (or any chunk) to have deleted.
+	dropped, _ := pruneQueue(expiringAfter(1), dir, now, 7*24*time.Hour, maxFiles, 64<<20)
+	if dropped == 0 {
+		t.Errorf("pruneQueue dropped 0 of %d young over-cap batches: the deadline skipped the cap pass, so neither drain ran and the next spawn repeats this pass from offset 0", seeded)
+	}
+	got := names(t, dir)
+	if len(got) > maxFiles {
+		t.Errorf("queue holds %d files, want at most maxFiles=%d", len(got), maxFiles)
+	}
+	// Whatever survives must be the youngest batches: the cap is an
+	// oldest-first decision over the whole listing.
+	for _, name := range byAge[maxFiles:] {
+		if got[name] {
+			t.Errorf("older batch %s survived while the cap was over: the cap pass did not see the whole listing", name)
+			break
+		}
+	}
+}
+
+// failAfterChunks serves n real directory chunks and then fails, standing in
+// for a listing that breaks mid-walk (I/O error, a dir that went away).
+type failAfterChunks struct {
+	r         dirChunkReader
+	remaining int
+}
+
+var errSimulatedReadDir = errors.New("simulated readdir failure")
+
+func (f *failAfterChunks) ReadDir(n int) ([]os.DirEntry, error) {
+	if f.remaining <= 0 {
+		return nil, errSimulatedReadDir
+	}
+	f.remaining--
+	return f.r.ReadDir(n)
+}
+
+// TestPruneQueueDoesNotCapOnPartialListing pins the fail-closed half. A
+// non-EOF read error ends the walk holding only a PREFIX of the queue. The
+// oldest-first caps cannot be decided from a prefix — dropping "the oldest of
+// what we happened to see" deletes batches that are not actually the oldest,
+// which is the mistake the truncation path exists to prevent (the os.ReadDir
+// implementation this replaced failed closed by returning 0, 0).
+func TestPruneQueueDoesNotCapOnPartialListing(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	const seeded = 200
+	seedYoung(t, dir, seeded, now)
+
+	f, err := os.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// One good chunk, then the listing breaks: everything seen so far is a
+	// prefix, and no cap decision may be made from it.
+	r := &failAfterChunks{r: f, remaining: 1}
+	dropped, freed := pruneQueueFrom(context.Background(), r, dir, now, 7*24*time.Hour, 10, 64<<20)
+	if dropped != 0 || freed != 0 {
+		t.Errorf("pruneQueue over a listing that failed mid-walk = (%d dropped, %d freed), want (0, 0): the caps ran over a partial prefix", dropped, freed)
+	}
+	if got := len(names(t, dir)); got != seeded {
+		t.Errorf("queue holds %d files after a failed listing, want all %d untouched", got, seeded)
 	}
 }

--- a/internal/metrics/spawn.go
+++ b/internal/metrics/spawn.go
@@ -148,7 +148,7 @@ func hasQueuedEvents(dir string, now time.Time) bool {
 // stamps it, so it can make a post-throttle window prune-only and delay (worst
 // case, if disabled traffic dominates, starve) the enabled stream's uploads.
 // This is design-tolerated latency, not a data-safety issue: enabled and
-// disabled children run the identical PruneQueue(dir, now), so a disabled prune
+// disabled children run the identical PruneQueue(ctx, dir, now), so a disabled prune
 // deletes exactly what an enabled one would; only upload cadence is affected,
 // which the 7d TTL / 5-min batching budget already absorbs.
 func touchFlushMarker(dir string) {


### PR DESCRIPTION
Refs #5871 — **partial. Please do not close #5871 on this PR.**

Thanks to @outdoorsea for the report and the forensics in #5871; the
process/file counts and the `bd version 1.1.0 (8e4e59d39)` datapoint are what
made the remaining defect findable.

## Scope: this is one of the three things #5871 describes

#5871 raises three claims. Only the third is still an open defect on `main`, and
this PR addresses only that one.

**(a) Unbounded `~/.beads/eventsData` spool — already fixed on `main`, not
touched here.** `6128bc017` (#5660, 2026-08-11) added
`internal/metrics/prune.go`: 7-day TTL, 10,000-file and 64 MiB drop-oldest caps,
run by the send-metrics child. The reporter's build predates it —
`git cat-file -e v1.1.0:internal/metrics/prune.go` fails, and `8e4e59d39` is
2026-07-03. The related spawn throttle (`.last-flush`, 5 min) landed in
`18c24a3ac` (#5646), also after that build. This PR deliberately does not touch
those bounds; picking different ones would be a retention-policy change the
maintainers already decided.

**(b) "A single global lock serialises all flushers" — the premise does not hold
on the code, so nothing is changed for it.** `eventkit`'s
`FileFlusher.Flush` uses `lock.TryLock()` and returns `nil` on
`fslock.ErrLocked` (`fileflusher.go`, ~lines 60–68 of
`eventkit@v0.0.0-20260611184414-99f5693e696a`). A losing flusher no-ops
immediately; it does not queue behind the winner. The suggested remedies in the
issue (elect a single flusher, shard into date buckets) would be redesigns aimed
at a serialization that is not happening.

**(c) The flusher's own non-termination — fixed here.**

## The defect

`RunSendMetrics` advertises a 30s budget for the detached child
(`flushTimeout`, `internal/metrics/flusher.go`), but built that context *after*
`PruneQueue` had already run:

```go
if dropped, freed := PruneQueue(dir, time.Now()); dropped > 0 { ... }   // no deadline
...
ctx, cancel := context.WithTimeout(context.Background(), flushTimeout)  // only now
```

The prune is the expensive half on a backed-up queue: `os.ReadDir` materializes
and name-sorts every dirent, then `de.Info()` stats each survivor
(`internal/metrics/prune.go`). So the work the budget was meant to cover ran
with no deadline at all — the advertised bound was decorative. A machine that
accumulated a large spool on a pre-#5660 build and then upgrades still gets
long-lived children on exactly this path.

This is a defect against the code's own stated intent. It needs no new knob, no
new constant, and changes no documented behavior — `docs/cli-reference/metrics.md`
states no prune or flush timing contract.

## The change

- Build a `flushTimeout` context at the top of `RunSendMetrics` and pass it to
  `PruneQueue`, so the prune runs under a budget instead of none.
- Give the flush its **own** fresh `flushTimeout` context rather than the
  prune's remainder. Sharing one would let a slow-but-successful prune hand the
  upload an already-spent context — the child would prune, upload nothing and
  exit 1 — and a prune slow enough to do that is exactly what a backed-up spool
  produces, so uploads would never resume. The two halves now have independent
  budgets and neither can starve the other.
- `pruneQueue` walks the directory in 64-entry chunks via `f.ReadDir(n)` instead
  of `os.ReadDir`, checking the budget once per chunk. That is the idiom
  `hasQueuedEvents` already uses in `internal/metrics/spawn.go`, and for the
  same stated reason (`os.ReadDir` "reads and sorts EVERY entry before the
  caller sees one").
- TTL deletions made before the budget expires stand.
- The oldest-first cap pass is **skipped** when the listing is partial — it is a
  decision over the whole queue, and a prefix cannot make it correctly. Partial
  means either a deadline that stopped the walk or a non-EOF read error that
  ended it, and both must fail closed the way `os.ReadDir`'s `return 0, 0` did.
- **The deadline does not stop a walk that has deleted nothing yet.** A pass
  that runs out of budget with `dropped == 0` finishes its listing. Otherwise
  neither drain would ever apply on the queue #5660's caps exist for: nothing is
  past TTL so the TTL half deletes zero, the partial listing skips the cap half,
  the next child reopens the directory at offset 0, walks the same young prefix
  and stops in the same place — while emission keeps appending. The cost is a
  child that outruns its budget in that case; see limitation 3.

Behavior on a healthy queue is unchanged.

## Tests

Five new tests in `internal/metrics`. Every one was confirmed red first, so the
failures are behavioral, not compile errors.

Red against `main` with the signature change alone applied (`ctx` threaded but
ignored):

- `TestPruneQueueStopsOnExpiredContext` — an already-expired context must leave
  all 200 seeded expired batches alone. Before: `(200 dropped, 2000 freed)`.
- `TestPruneQueueTruncatesAndStillMakesProgress` — expiring mid-scan must stop
  the scan yet keep the deletions already made. Before: `dropped 200 of 200`.
- `TestRunSendMetricsPrunesUnderFlushDeadline` — the prune must receive a
  context that carries a deadline. Before: "ran the prune with a deadline-free
  context".

Red against the naive bounded walk (deadline always stops the walk; a read error
leaves `truncated` false) — these two pin the ways a bounded prune can be worse
than no prune:

- `TestPruneQueueCapsYoungPileWhenTTLMadeNoProgress` — 200 young batches, a
  10-file cap, budget gone after one chunk. Before: `pruneQueue dropped 0 of 200
  young over-cap batches` / `queue holds 200 files, want at most maxFiles=10`.
  That is the cap-skip livelock: neither drain runs, and the next spawn repeats
  the same pass from offset 0. The other two truncation tests cannot catch it —
  they seed expired batches, so their TTL half always makes progress.
- `TestPruneQueueDoesNotCapOnPartialListing` — the listing fails after one chunk.
  Before: `(54 dropped, 540 freed), want (0, 0)` / `queue holds 146 files after a
  failed listing, want all 200 untouched`. Those 54 were the oldest of the first
  64 dirents, not the oldest of the queue: a cap decision made from a prefix,
  which is the mistake `os.ReadDir`'s `return 0, 0` never made.

The seven existing `prune_test.go` tests are otherwise untouched — the only edit
to each is a `context.Background()` first argument
(`TestPruneTTLDropsStaleBatchesAndOrphanTemps`, `TestPruneCountCapDropsOldestFirst`,
`TestPruneByteCapDropsOldestFirst`, `TestPruneNeverTouchesMarkerOrLock`,
`TestPruneCapNeverTakesYoungWriteTemps`, `TestPruneMissingDirIsNoop`,
`TestPruneWithinCapsIsNoop`). `go test ./internal/metrics/...`, `gofmt -l`,
`go vet` and `golangci-lint run` are clean.

## Limitations — please read before merging

1. **This does not close #5871.** It fixes the termination half only. The
   reporter's headline symptom (254–280 concurrent children, millions of queued
   files) is addressed, if at all, by #5660 and #5646 — both of which postdate
   their build. I have not verified whether the reporter still reproduces
   anything on current `main`; asking them to retest would be worthwhile
   independently of this PR.
2. **eventkit's flush prologue is still unbounded.** `FileFlusher.Flush` calls
   `os.ReadDir(f.dir)` before its per-entry `ctx.Err()` check, so the upload half
   still materializes the whole directory before the deadline can bite. That is
   in `github.com/dolthub/eventkit`, not this repo, and is out of scope here.
3. **`flushTimeout` still does not bound the child's wall clock, and this PR
   does not claim it does.** It bounds the stat walk that previously had no
   deadline at all, with one deliberate exception: a prune that has deleted
   nothing when its budget expires keeps walking to the end of the listing, so
   on a large all-young over-cap spool the walk (and the cap unlink pass that
   follows it) runs past 30s. Bounding it there instead would disable both
   drains on precisely that queue, which is worse. Two further paths are
   unbounded and untouched: eventkit's `os.ReadDir` flush prologue (limitation
   2), and the cap unlink pass, which is admitted by a budget check taken
   before it starts. So the honest summary is *the runaway walk is bounded
   except where bounding it would disable #5660's caps*, not *the child now
   always finishes in 30s*.
4. **A truncated prune does TTL work only, never cap work.** When the walk stops
   early — a deadline reached after some TTL progress, or a read error — that
   run applies no caps, because a cap is an oldest-first decision over the whole
   queue and a prefix cannot make it. The caps then only take effect on a run
   that completes its listing; the exception in limitation 3 guarantees such a
   run happens *once the TTL half stops making progress*. Until then, a queue
   that yields TTL deletions on every pass keeps truncating and keeps skipping
   the caps — that is still forward progress (the TTL drain runs), but it is not
   a completed listing. One state remains where neither drain runs: a directory
   listing that fails persistently mid-walk leaves `dropped == 0` with no caps
   applied. That is not a regression — the previous `os.ReadDir` returned
   `(0, 0)` on the same error — but it is not fixed here either. The alternative
   (capping from a prefix) drops batches that may not be the oldest.
5. **Prune and flush get separate 30s budgets** (one each, not one shared), so a
   long prune no longer changes `RunSendMetrics`'s exit code: as before this PR,
   a slow prune followed by a successful flush returns 0. The cost is that the
   child's worst-case wall clock is now two budgets rather than one.
6. **Deleting while the directory handle is mid-read.** The streaming form
   removes entries during the walk, and POSIX leaves it unspecified whether
   not-yet-read entries removed in the meantime are still returned. `PruneQueue`
   is already documented as lock-free and race-tolerant and re-runs on every
   spawn, so a skipped entry is caught next time — but this is more exposed than
   the previous `os.ReadDir` snapshot.
7. **Not reproduced at the reporter's scale.** The tests use 200 files and a
   synthetic context, not a multi-million-file spool. I have not benchmarked the
   ~15-minute pathology directly; the claim this PR makes is *termination*, not a
   measured speedup, and I have deliberately not claimed a memory win.
8. **Two test seams were added.** `var pruneQueueFn = PruneQueue` in `flusher.go`
   lets the deadline-propagation test observe the context, mirroring the existing
   `var scanQueue = hasQueuedEvents` seam in `spawn.go`. `pruneQueueFrom` takes a
   one-method `dirChunkReader` instead of the `*os.File` so a test can inject a
   listing that fails mid-walk — there is no portable way to make a real
   directory read fail after N entries, and without it the fail-closed path has
   no test. Happy to drop either (and its test) if you would rather not carry the
   indirection.
9. **`PruneQueue`'s signature changed.** It is package-internal
   (`internal/metrics`, one production caller), but if you prefer a non-breaking
   `PruneQueueContext` variant that is a cheap switch.

## Related

- #5933 (open) reaps exited send-metrics children. Disjoint files
  (`spawn.go`, `spawn_reap_test.go`); no conflict with this PR.
- #5660 / `6128bc017` introduced the prune this PR bounds.
- #5649 lane: ENOENT tolerance in eventkit's flush loop, referenced by the
  existing `PruneQueue` doc comment.
