### PR TITLE
docs(config): document audit.enabled in configuration reference

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -82,7 +82,7 @@ These keys must live in `config.yaml`, not the database, because they are read b
 
 The full namespaces routed to YAML are:
 
-`routing.*`, `sync.*`, `git.*`, `directory.*`, `repos.*`, `external_projects.*`, `validation.*`, `lint.*`, `hierarchy.*`, `ai.*`, `backup.*`, `export.*`, `dolt.*`, `federation.*`, `metrics.*`, `list.*`
+`routing.*`, `sync.*`, `git.*`, `directory.*`, `repos.*`, `external_projects.*`, `validation.*`, `lint.*`, `hierarchy.*`, `ai.*`, `backup.*`, `export.*`, `dolt.*`, `federation.*`, `metrics.*`, `list.*`, `audit.*`, `storage-class.*`
 
 `lint.*` holds lint settings: `lint.sections.<type>` is a comma-separated, additive list of sections that `bd lint` additionally requires for issues of that type (built-in required sections still apply; unset means no behavior change).
 
@@ -124,6 +124,7 @@ Any key whose name contains `api_key`, `api-key`, `secret`, `token`, or `passwor
 | `backup.interval` | — | `BD_BACKUP_INTERVAL` | `15m` | Minimum time between auto-backups |
 | `backup.git-push` | — | — | `false` | Auto-push backup repo |
 | `backup.git-repo` | — | `BD_BACKUP_GIT_REPO` | (none) | Backup git repo URL; when set, backups go to a `backup/` directory inside that repo |
+| `audit.enabled` | — | `BD_AUDIT_ENABLED` | `false` | Enable the optional JSONL interaction sidecar at `.beads/interactions.jsonl`, written by `bd audit record` / `bd audit label`. While disabled, `bd init` does not create the file and `bd audit record` / `bd audit label` refuse to write. Issue history is always recorded in the database either way — see `bd history <id> --events` |
 | `export.auto` | — | — | `false` | Refresh `.beads/issues.jsonl` export after every write; not cross-machine sync |
 | `export.path` | — | — | `issues.jsonl` | Output filename relative to `.beads/` |
 | `export.interval` | — | — | `60s` | Minimum time between auto-exports |


### PR DESCRIPTION
## Summary

Addresses part (2) of #5904. Part (1) — the generated `bd audit` page still saying `.beads/interactions.jsonl` "is intended to be versioned in git" after #4688 made the sidecar opt-in — is a real defect, but its cause is the docs release pin, not this tree; see below. Part (2) is a real gap: `audit.enabled` and `BD_AUDIT_ENABLED` appear nowhere under `docs/` at the tip, so `bd audit --help` is the only way to discover the key.

## What changed

`docs/reference/configuration.md`, two edits (+2/-1):

1. An `audit.enabled` row in the Tool-Level Settings (config.yaml) table (`configuration.md:127`), after the `backup.*` rows. That table is clustered by namespace, not alphabetised (`hierarchy.*` → `backup.*` → `export.*` → `import.*` → `routing.*` → `list.*`), so a new namespace has no sorted slot to take. Happy to move it.
2. `audit.*` and `storage-class.*` added to the "full list of namespaces routed to YAML" (`configuration.md:85`) — with both, that list and `IsYamlOnlyKey`'s prefix list (`internal/config/yaml_config.go:118`) are the same 18 namespaces in the same order, which is what makes "full" true. `storage-class.*` gets no table row: the list is a completeness claim about those prefixes, while the table documents individual keys, and no `storage-class` key appears on the page.

No generated file is touched, and `Last reviewed: 2026-07-10` is left alone: `scripts/check-doc-freshness.sh` (run in CI at `scripts/ci/pr-policy.sh:110`) lists `configuration.md` at `:22` against a 90-day default (`:15`), the marker is 42 days old, and there is no bump-on-edit rule — bumping it would assert a page review this PR did not do. (Sibling PR #4697 bumps it to 2026-07-29 while adding a section here; the check passes either way.)

Docs-only; no build or test run.

## How the new text was verified

All against `origin/main` @ `b7175be2`:

| Claim in the new row | Evidence |
|---|---|
| key `audit.enabled`, default `false` | `internal/config/config.go:245` — `v.SetDefault("audit.enabled", false)` |
| `BD_AUDIT_ENABLED` override | `internal/audit/audit.go:67-72` — `Enabled()` checks `os.LookupEnv("BD_AUDIT_ENABLED")` first, then `config.GetBool("audit.enabled")` |
| path `.beads/interactions.jsonl` | `internal/audit/audit.go:21` — `FileName = "interactions.jsonl"` |
| written by `bd audit record` / `bd audit label` | both subcommands call `audit.AppendIfEnabled`: `cmd/bd/audit.go:103` (in `auditRecordCmd`, declared `:46`) and `cmd/bd/audit.go:146` (in `auditLabelCmd`, declared `:120`) |
| both refuse to write while disabled | `internal/audit/audit.go:158-160` — `AppendIfEnabled` returns `audit JSONL sidecar is disabled; set audit.enabled=true or BD_AUDIT_ENABLED=1 …` instead of appending. The claim rests on those two call sites: ungated `audit.Append` still exists and is used elsewhere (`internal/compact/haiku.go:101`), so the gate is a property of the subcommands, not the package |
| `bd init` does not create it while disabled | `cmd/bd/init_embedded_test.go:358-360` — asserts absence, "created only when audit.enabled is true" |
| `bd history <id> --events` is a real invocation | `cmd/bd/history.go:133` — `historyCmd.Flags().BoolVar(&historyEvents, "events", false, "Show database audit events instead of commit snapshots")` |
| belongs in the config.yaml table and in the namespace list | `internal/config/yaml_config.go:118` — `IsYamlOnlyKey`'s prefix list contains both `"audit."` and `"storage-class."` |

One clause is attributed rather than independently verified: "Issue history is always recorded in the database either way" is bd's own documented contract — `auditCmd.Long` (`cmd/bd/audit.go:38-39`), the `Enabled()` doc comment (`internal/audit/audit.go:64-66`), and the commented `audit:` block in the generated `config.yaml` template (`cmd/bd/init_templates.go:63-67`). I did not trace the events-journal write path myself.

## Why the audit page is not touched

It is generated, and `docs/cli-docs.pin` pins the generator to **v1.2.2**; the pin file's header states the policy — the published site describes the latest *release*, not main's source. The page is accurate for the release it documents:

- `v1.2.2:cmd/bd/audit.go:34` still carries "This file is intended to be versioned in git and used for:".
- `git merge-base --is-ancestor 64a136d5 v1.2.2` fails — #4688 is not in v1.2.2, and `audit.enabled` exists nowhere in that tag.
- The reporter's own footer says every observation was reproduced against a local `bd` 1.2.2 install — exactly the release that page documents.

The page corrects itself on the next pin bump: `auditCmd.Long` on main (`cmd/bd/audit.go:32-43`) has already dropped the offending sentence; it now reads, in part:

> This optional JSONL sidecar is disabled by default. Enable it with:
> `bd config set audit.enabled true`
> Issue history is always recorded in the database and is visible with `bd history <id> --events`.

So regenerating past #4688 emits the corrected text with no source edit; #5906 tracks the pin. Hand-editing it would also fail `scripts/check-cli-docs-drift.sh`, whose `GEN_PATHSPECS` (`:73-75`) covers `docs/CLI_REFERENCE.md`, `docs/cli-reference`, and `docs/docs.json` — not `docs/reference/configuration.md`, the hand-maintained file this PR edits.

## Out of scope

- `audit.` is missing from `recognizedConfigPrefixes` (`cmd/bd/config.go:971-977`), so `bd config set audit.enabled true` — the exact invocation `bd audit --help` tells you to run — prints an unrecognized-key warning even though the setting takes effect. `list.` has the identical gap. `cmd/bd/config.go:1029` already documents this failure mode for `events-journal`. One-line Go fix, filed separately.
- `plugins/beads/skills/beads/commands/audit.md` omits that the sidecar is opt-in, and claims `bd dolt push` puts `.beads/interactions.jsonl` in a commit allowlist. `git grep -n interactions.jsonl` over the whole tree at `b7175be2` returns 34 hits in 17 files; the only one pairing the file with an allowlist is that skill doc itself (`:26`), and no Go push path names it. The nearest real artifact is `cmd/bd/doctor/tracked_runtime.go:18`, which deliberately excludes the file from doctor's tracked-runtime patterns. Left alone — that skill's `CLAUDE.md` says CLI documentation must not be duplicated there.

## Credit

Reported and investigated by @treystout in #5904.
