### PR TITLE
fix(storage): stop counts and ready folding a broken wisp plane into zero

### DIFF
--- a/internal/storage/domain/db/issue_search_counts.go
+++ b/internal/storage/domain/db/issue_search_counts.go
@@ -103,7 +103,7 @@ func (r *issueSQLRepositoryImpl) searchUnionWithCounts(ctx context.Context, quer
 		return domain.SearchCountsPage{}, fmt.Errorf("search union with counts (hydrate issues): %w", err)
 	}
 	wispsByID, err := r.fetchCountsByIDs(ctx, page.wispIDs, wispsFilterTables, true, hydrationFor(filter))
-	if err != nil && !dberrors.IsTableNotExist(err) {
+	if err != nil && !missingOptionalWispTable(err) {
 		return domain.SearchCountsPage{}, fmt.Errorf("search union with counts (hydrate wisps): %w", err)
 	}
 

--- a/internal/storage/domain/db/issue_search_counts_missing_table_test.go
+++ b/internal/storage/domain/db/issue_search_counts_missing_table_test.go
@@ -1,0 +1,92 @@
+package db
+
+import (
+	"errors"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// unionCountsOverBrokenWispPlane drives the counted union to the point where
+// it hydrates the wisp rows, and fails that hydration with hydrateErr.
+//
+// The union leg is not where the breakage shows. Its FROM is plan.FromSQL,
+// which carries no lease join and reads neither labels nor comments, so the
+// union query itself succeeds on a database missing `leases`, `wisp_labels`
+// or `wisp_comments` and returns wisp ids. Only fetchCountsByIDs renders the
+// counts mega-query -- which adds sqlbuild.LeaseJoin, hydrates labels, and
+// LEFT JOINs the comment-count subquery (sqlbuild/counts.go:198) -- so it is
+// the first query to see the breakage, and tolerating it drops every wisp
+// from the counted page behind a nil error. This is the counts twin of
+// unionOverBrokenWispPlane in issue_search_missing_table_test.go.
+func unionCountsOverBrokenWispPlane(t *testing.T, hydrateErr error) (sqlmock.Sqlmock, domain.SearchCountsPage, error) {
+	t.Helper()
+	mock, repo := newMockRepo(t)
+	mock.ExpectQuery(`SELECT 1 FROM wisp_dependencies LIMIT 1`).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery("UNION ALL").WillReturnRows(
+		sqlmock.NewRows([]string{"id", "src"}).AddRow("bd-w1", "w"))
+	mock.ExpectQuery(`(?s)FROM wisps`).WillReturnError(hydrateErr)
+
+	page, err := repo.searchAcrossIssuesAndWispsWithCounts(t.Context(), "", types.IssueFilter{})
+	return mock, page, err
+}
+
+// TestSearchCountsUnionBrokenWispPlaneIsAnError is the counted-page twin of
+// TestSearchUnionBrokenWispPlaneIsAnError. `bd search --counts` and every
+// store-shaped caller that projects counts ran through this path, and a wisp
+// hydration that failed because a table the wisp plane does not own had gone
+// missing was answered as "there are no wisps".
+//
+// The assertion is errors.Is against the primed driver error, not a substring
+// of the message: the query text names the joined tables, so a substring check
+// would pass on any error that merely echoes the query.
+func TestSearchCountsUnionBrokenWispPlaneIsAnError(t *testing.T) {
+	for _, missing := range []string{"wisp_labels", "wisp_comments", "leases"} {
+		t.Run(missing, func(t *testing.T) {
+			gone := missingTable(missing)
+			_, page, err := unionCountsOverBrokenWispPlane(t, gone)
+			if err == nil {
+				t.Fatalf("counted search hid a broken wisp plane, returning %d rows", len(page.Items))
+			}
+			if !errors.Is(err, gone) {
+				t.Fatalf("error is not the missing-%s failure: %v", missing, err)
+			}
+		})
+	}
+}
+
+// TestSearchCountsUnionMissingWispPlaneIsNotAnError is the control the
+// tightened guard must keep: the wisp plane's own tables are the ones a
+// database may legitimately not have. Over-tightening to "never tolerate"
+// passes the assertions above and fails here.
+func TestSearchCountsUnionMissingWispPlaneIsNotAnError(t *testing.T) {
+	for _, table := range []string{"wisps", "wisp_dependencies"} {
+		t.Run(table, func(t *testing.T) {
+			mock, page, err := unionCountsOverBrokenWispPlane(t, missingTable(table))
+			if err != nil {
+				t.Fatalf("counted search errored on a database with no %s: %v", table, err)
+			}
+			if len(page.Items) != 0 {
+				t.Fatalf("got %d rows, want 0", len(page.Items))
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet sql expectations: %v", err)
+			}
+		})
+	}
+}
+
+// TestSearchCountsUnionUnrelatedErrorPropagates is the second control: the
+// tolerance must not be a blanket catch in either direction.
+func TestSearchCountsUnionUnrelatedErrorPropagates(t *testing.T) {
+	boom := errors.New("connection refused")
+	if _, _, err := unionCountsOverBrokenWispPlane(t, boom); !errors.Is(err, boom) {
+		t.Fatalf("counted search did not propagate a failed hydration: %v", err)
+	}
+}

--- a/internal/storage/embeddeddolt/counts_missing_table_test.go
+++ b/internal/storage/embeddeddolt/counts_missing_table_test.go
@@ -1,0 +1,120 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// seedCountsPlane puts one durable issue and one wisp in the store so both
+// legs of every count have something to find. The wisp is what keeps the
+// wisps-table probe from short-circuiting the merge, so the query that reads
+// the rest of the wisp plane is actually reached.
+func seedCountsPlane(t *testing.T, te *testEnv, prefix string) {
+	t.Helper()
+	wisp := &types.Issue{
+		ID:        prefix + "-wisp",
+		Title:     "ephemeral bead",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := te.store.CreateIssue(t.Context(), wisp, "tester"); err != nil {
+		t.Fatalf("CreateIssue wisp: %v", err)
+	}
+	durable := &types.Issue{
+		ID:        prefix + "-issue",
+		Title:     "durable bead",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := te.store.CreateIssue(t.Context(), durable, "tester"); err != nil {
+		t.Fatalf("CreateIssue durable: %v", err)
+	}
+}
+
+// TestCountsWithMissingWispPlaneTables is the end-to-end twin of
+// TestSearchWithMissingWispPlaneTables for the counting and ready-work reads.
+// It runs against a real database rather than a mock, so it pins one of the
+// tables named in the sqlmock guards -- wisp_labels, the only one this test
+// renames -- as a table these queries genuinely read: renaming it away is
+// enough to break a counted read, and the blanket tolerance answered that
+// broken database with a durable-only number and no error. The other names in
+// the guards (leases, wisp_comments) are argued from the query builders, not
+// pinned end-to-end here; see the PR's Limitations.
+func TestCountsWithMissingWispPlaneTables(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	// wisp_labels is not a wisp-plane table a database may legitimately lack:
+	// a store that has wisps but no wisp_labels is broken, and every count
+	// below reads it -- the counts mega-query hydrates labels, and grouping by
+	// label queries it directly.
+	t.Run("missing_wisp_labels_is_an_error", func(t *testing.T) {
+		te := newTestEnv(t, "cwl")
+		seedCountsPlane(t, te, "cwl")
+		te.assertRowExists(t, t.Context(), "wisps", "cwl-wisp")
+		te.exec(t, t.Context(), "RENAME TABLE wisp_labels TO wisp_labels_renamed_away")
+
+		if got, err := te.store.SearchIssuesWithCounts(t.Context(), "", types.IssueFilter{}); err == nil {
+			t.Errorf("SearchIssuesWithCounts hid a broken wisp plane, returning %d rows", len(got))
+		}
+		if got, err := te.store.GetReadyWorkWithCounts(t.Context(), types.WorkFilter{IncludeDeferred: true}); err == nil {
+			t.Errorf("GetReadyWorkWithCounts hid a broken wisp plane, returning %d rows", len(got))
+		}
+		if got, err := te.store.CountIssuesByGroup(t.Context(), types.IssueFilter{}, "label"); err == nil {
+			t.Errorf("CountIssuesByGroup(label) hid a broken wisp plane, returning %v", got)
+		}
+	})
+
+	// The control the tightened guard must keep: a pre-migration database has
+	// no wisps table at all, and a count over it really does have no wisps to
+	// add. Over-tightening to "never tolerate" passes every assertion above
+	// and fails here.
+	t.Run("missing_wisps_table_is_a_durable_only_answer", func(t *testing.T) {
+		te := newTestEnv(t, "cwt")
+		seedCountsPlane(t, te, "cwt")
+		te.exec(t, t.Context(), "RENAME TABLE wisps TO wisps_renamed_away")
+
+		n, err := te.store.CountIssues(t.Context(), "", types.IssueFilter{})
+		if err != nil {
+			t.Fatalf("CountIssues on a database with no wisp plane: %v", err)
+		}
+		if n != 1 {
+			t.Fatalf("CountIssues = %d, want 1 (the durable issue)", n)
+		}
+		counts, err := te.store.CountIssuesByGroup(t.Context(), types.IssueFilter{}, "label")
+		if err != nil {
+			t.Fatalf("CountIssuesByGroup(label) on a database with no wisp plane: %v", err)
+		}
+		if counts["(no labels)"] != 1 {
+			t.Fatalf("CountIssuesByGroup(label) = %v, want one unlabelled durable issue", counts)
+		}
+	})
+
+	// The second control: wisp_dependencies is genuinely optional and its
+	// absence must stay invisible to a plain count.
+	//
+	// This does not pin the tolerance set, and is not meant to: a plain
+	// COUNT(*) over wisps never reads the dependency table, so it stays green
+	// whatever missingOptionalWispTable is tightened to. What pins the
+	// wisp_dependencies entry is the sqlmock control in
+	// issueops/counts_missing_table_test.go, which drives the failure through
+	// the guard directly. This one proves the end-to-end count still answers.
+	t.Run("missing_wisp_dependencies_is_invisible", func(t *testing.T) {
+		te := newTestEnv(t, "cwd")
+		seedCountsPlane(t, te, "cwd")
+		te.exec(t, t.Context(), "RENAME TABLE wisp_dependencies TO wisp_dependencies_renamed_away")
+
+		n, err := te.store.CountIssues(t.Context(), "", types.IssueFilter{})
+		if err != nil {
+			t.Fatalf("CountIssues with no wisp_dependencies table: %v", err)
+		}
+		if n != 2 {
+			t.Fatalf("CountIssues = %d, want 2 (the durable issue and the wisp)", n)
+		}
+	})
+}

--- a/internal/storage/issueops/count.go
+++ b/internal/storage/issueops/count.go
@@ -16,7 +16,7 @@ import (
 func CountIssuesInTx(ctx context.Context, tx DBTX, query string, filter types.IssueFilter) (int, error) {
 	if filter.Ephemeral != nil && *filter.Ephemeral {
 		wispCount, err := countTableInTx(ctx, tx, query, filter, WispsFilterTables)
-		if err != nil && !isTableNotExistError(err) {
+		if err != nil && !missingOptionalWispTable(err) {
 			return 0, fmt.Errorf("count wisps (ephemeral filter): %w", err)
 		}
 		if wispCount > 0 {
@@ -61,7 +61,7 @@ func CountIssuesInTx(ctx context.Context, tx DBTX, query string, filter types.Is
 	// selector: the four the flag accepts are artifacts, conventions, pollution
 	// and validate, and the cross-table check runs in the default sweep.)
 	wispCount, wispErr := countTableInTx(ctx, tx, query, filter, WispsFilterTables)
-	if wispErr != nil && !isTableNotExistError(wispErr) {
+	if wispErr != nil && !missingOptionalWispTable(wispErr) {
 		return 0, fmt.Errorf("count wisps (merge): %w", wispErr)
 	}
 	return count + wispCount, nil
@@ -77,7 +77,7 @@ func CountIssuesInTx(ctx context.Context, tx DBTX, query string, filter types.Is
 func CountIssuesByGroupInTx(ctx context.Context, tx DBTX, filter types.IssueFilter, groupBy string) (map[string]int, error) {
 	if filter.Ephemeral != nil && *filter.Ephemeral {
 		wispCounts, err := countGroupForTablesInTx(ctx, tx, filter, groupBy, WispsFilterTables)
-		if err != nil && !isTableNotExistError(err) {
+		if err != nil && !missingOptionalWispTable(err) {
 			return nil, fmt.Errorf("count wisps by %s (ephemeral filter): %w", groupBy, err)
 		}
 		total := 0
@@ -113,7 +113,7 @@ func CountIssuesByGroupInTx(ctx context.Context, tx DBTX, filter types.IssueFilt
 	// Merge wisps counts when the caller hasn't opted out (same semantics as
 	// CountIssuesInTx / SearchIssuesInTx; the two tables never share an ID).
 	wispCounts, wispErr := countGroupForTablesInTx(ctx, tx, filter, groupBy, WispsFilterTables)
-	if wispErr != nil && !isTableNotExistError(wispErr) {
+	if wispErr != nil && !missingOptionalWispTable(wispErr) {
 		return nil, fmt.Errorf("count wisps by %s (merge): %w", groupBy, wispErr)
 	}
 	for k, v := range wispCounts {

--- a/internal/storage/issueops/counts_missing_table_test.go
+++ b/internal/storage/issueops/counts_missing_table_test.go
@@ -1,0 +1,325 @@
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// countsEntryPoint is one read path that answers a count (or a counted page)
+// by merging the wisp plane into the durable one. Every one of them used to
+// classify *any* table-not-exist error from its wisp query as "there are no
+// wisps", which is only true for the tables a database may legitimately not
+// have. The wisp queries reach past those: the counts mega-query's FROM
+// carries sqlbuild.LeaseJoin, and hydration reads wisp_labels.
+//
+// prime installs the query expectations for one run, with wispErr returned by
+// the wisp leg; run drives the entry point and renders the answer so a
+// tolerating path reports what it silently produced rather than just "nil".
+type countsEntryPoint struct {
+	name string
+	// missing lists the tables this entry point's wisp query can actually be
+	// broken by, and the three lists below are deliberately not the same.
+	// Every form reaches wisp_labels, through filter subqueries or the
+	// by-label grouping. Beyond that the reach is the FROM clause's: the
+	// plain COUNT(*) forms (countTableInTx, countByColumnInTx) build
+	// `SELECT COUNT(*) FROM <wisps> [WHERE ...]` and nothing else, so they
+	// stop there; searchTableInTxT adds sqlbuild.LeaseJoin, so leases joins
+	// the list; and only the counts mega-query also LEFT JOINs the comment
+	// table (sqlbuild/counts.go:198, the sole non-test use of
+	// FilterTables.Comments), so wisp_comments is reachable there alone.
+	missing       []string
+	prime         func(mock sqlmock.Sqlmock, wispErr error)
+	run           func(ctx context.Context, tx *sql.Tx) (string, error)
+	wantTolerated string
+}
+
+func scalarCountRows(n int) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"count"}).AddRow(n)
+}
+
+func groupRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"k", "n"}).AddRow("open", 1)
+}
+
+// emptyCountsRows stands in for a counts mega-query that matched nothing.
+// scanCountsRowsInTx never scans a column here, so the narrow column set is
+// enough and the test does not have to restate the mega-query's projection.
+func emptyCountsRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"id"})
+}
+
+// wispPlaneAndLeases is the reach of a wide wisp projection: label subqueries
+// plus the lease overlay searchTableInTxT adds (search.go:381).
+var wispPlaneAndLeases = []string{"wisp_labels", "leases"}
+
+// countsMegaQueryTables is the reach of sqlbuild.SearchCountsSQL, which is
+// wispPlaneAndLeases plus the comment-count LEFT JOIN at
+// sqlbuild/counts.go:198. Only the three entry points that render the counts
+// mega-query can be broken by wisp_comments; the plain COUNT(*) forms never
+// name it.
+var countsMegaQueryTables = []string{"wisp_labels", "wisp_comments", "leases"}
+
+var countsEntryPoints = []countsEntryPoint{
+	{
+		name:    "CountIssuesInTx/ephemeral",
+		missing: []string{"wisp_labels"},
+		prime: func(mock sqlmock.Sqlmock, wispErr error) {
+			mock.ExpectQuery(`SELECT COUNT\(\*\) FROM wisps`).WillReturnError(wispErr)
+			// Only the tolerating path reaches the durable table. Priming it
+			// makes the untightened behaviour a clean answer rather than an
+			// unexpected-query error that would read like a pass.
+			mock.ExpectQuery(`SELECT COUNT\(\*\) FROM issues`).WillReturnRows(scalarCountRows(1))
+		},
+		run: func(ctx context.Context, tx *sql.Tx) (string, error) {
+			n, err := CountIssuesInTx(ctx, tx, "", types.IssueFilter{Ephemeral: boolPtr(true)})
+			return fmt.Sprintf("count=%d", n), err
+		},
+		wantTolerated: "count=1",
+	},
+	{
+		name:    "CountIssuesInTx/merge",
+		missing: []string{"wisp_labels"},
+		prime: func(mock sqlmock.Sqlmock, wispErr error) {
+			mock.ExpectQuery(`SELECT COUNT\(\*\) FROM issues`).WillReturnRows(scalarCountRows(1))
+			mock.ExpectQuery(`SELECT COUNT\(\*\) FROM wisps`).WillReturnError(wispErr)
+		},
+		run: func(ctx context.Context, tx *sql.Tx) (string, error) {
+			n, err := CountIssuesInTx(ctx, tx, "", types.IssueFilter{})
+			return fmt.Sprintf("count=%d", n), err
+		},
+		wantTolerated: "count=1",
+	},
+	{
+		name:    "CountIssuesByGroupInTx/ephemeral",
+		missing: []string{"wisp_labels"},
+		prime: func(mock sqlmock.Sqlmock, wispErr error) {
+			mock.ExpectQuery(`(?s)FROM wisps.*GROUP BY status`).WillReturnError(wispErr)
+			mock.ExpectQuery(`(?s)FROM issues.*GROUP BY status`).WillReturnRows(groupRows())
+		},
+		run: func(ctx context.Context, tx *sql.Tx) (string, error) {
+			m, err := CountIssuesByGroupInTx(ctx, tx, types.IssueFilter{Ephemeral: boolPtr(true)}, "status")
+			return fmt.Sprintf("groups=%v", m), err
+		},
+		wantTolerated: "groups=map[open:1]",
+	},
+	{
+		name:    "CountIssuesByGroupInTx/merge",
+		missing: []string{"wisp_labels"},
+		prime: func(mock sqlmock.Sqlmock, wispErr error) {
+			mock.ExpectQuery(`(?s)FROM issues.*GROUP BY status`).WillReturnRows(groupRows())
+			mock.ExpectQuery(`(?s)FROM wisps.*GROUP BY status`).WillReturnError(wispErr)
+		},
+		run: func(ctx context.Context, tx *sql.Tx) (string, error) {
+			m, err := CountIssuesByGroupInTx(ctx, tx, types.IssueFilter{}, "status")
+			return fmt.Sprintf("groups=%v", m), err
+		},
+		wantTolerated: "groups=map[open:1]",
+	},
+	{
+		name:    "SearchIssuesWithCountsInTx/ephemeral",
+		missing: countsMegaQueryTables,
+		prime: func(mock sqlmock.Sqlmock, wispErr error) {
+			mock.ExpectQuery(`SELECT 1 FROM wisp_dependencies LIMIT 1`).
+				WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+			mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).
+				WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+			mock.ExpectQuery(`(?s)FROM wisps i`).WillReturnError(wispErr)
+			mock.ExpectQuery(`(?s)FROM issues i`).WillReturnRows(emptyCountsRows())
+		},
+		run: func(ctx context.Context, tx *sql.Tx) (string, error) {
+			out, err := SearchIssuesWithCountsInTx(ctx, tx, "", types.IssueFilter{Ephemeral: boolPtr(true)})
+			return fmt.Sprintf("rows=%d", len(out)), err
+		},
+		wantTolerated: "rows=0",
+	},
+	{
+		name:    "SearchIssuesWithCountsInTx/merge",
+		missing: countsMegaQueryTables,
+		prime: func(mock sqlmock.Sqlmock, wispErr error) {
+			mock.ExpectQuery(`SELECT 1 FROM wisp_dependencies LIMIT 1`).
+				WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+			mock.ExpectQuery(`(?s)FROM issues i`).WillReturnRows(emptyCountsRows())
+			mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).
+				WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+			mock.ExpectQuery(`(?s)FROM wisps i`).WillReturnError(wispErr)
+		},
+		run: func(ctx context.Context, tx *sql.Tx) (string, error) {
+			out, err := SearchIssuesWithCountsInTx(ctx, tx, "", types.IssueFilter{})
+			return fmt.Sprintf("rows=%d", len(out)), err
+		},
+		wantTolerated: "rows=0",
+	},
+	{
+		name:    "GetReadyWorkWithCountsInTx",
+		missing: countsMegaQueryTables,
+		prime: func(mock sqlmock.Sqlmock, wispErr error) {
+			mock.ExpectQuery(`SELECT 1 FROM wisp_dependencies LIMIT 1`).
+				WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+			mock.ExpectQuery(`(?s)FROM issues i`).WillReturnRows(emptyCountsRows())
+			mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).
+				WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+			mock.ExpectQuery(`(?s)FROM wisps i`).WillReturnError(wispErr)
+		},
+		run: func(ctx context.Context, tx *sql.Tx) (string, error) {
+			out, err := GetReadyWorkWithCountsInTx(ctx, tx, readyFilter())
+			return fmt.Sprintf("rows=%d", len(out)), err
+		},
+		wantTolerated: "rows=0",
+	},
+	{
+		name:    "CountReadyWorkInTx",
+		missing: []string{"wisp_labels"},
+		prime: func(mock sqlmock.Sqlmock, wispErr error) {
+			mock.ExpectQuery(`SELECT 1 FROM wisp_dependencies LIMIT 1`).
+				WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+			mock.ExpectQuery(`SELECT COUNT\(\*\) FROM issues`).WillReturnRows(scalarCountRows(1))
+			mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).
+				WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+			mock.ExpectQuery(`SELECT COUNT\(\*\) FROM wisps`).WillReturnError(wispErr)
+		},
+		run: func(ctx context.Context, tx *sql.Tx) (string, error) {
+			n, err := CountReadyWorkInTx(ctx, tx, readyFilter())
+			return fmt.Sprintf("count=%d", n), err
+		},
+		wantTolerated: "count=1",
+	},
+	{
+		name:    "GetReadyWorkInTx/unbounded",
+		missing: wispPlaneAndLeases,
+		prime: func(mock sqlmock.Sqlmock, wispErr error) {
+			mock.ExpectQuery(`SELECT id FROM issues`).WillReturnRows(sqlmock.NewRows([]string{"id"}))
+			mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).
+				WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+			mock.ExpectQuery(`(?s)FROM wisps`).WillReturnError(wispErr)
+		},
+		run: func(ctx context.Context, tx *sql.Tx) (string, error) {
+			out, err := GetReadyWorkInTx(ctx, tx, readyFilter())
+			return fmt.Sprintf("rows=%d", len(out)), err
+		},
+		wantTolerated: "rows=0",
+	},
+	{
+		name:    "GetReadyWorkInTx/paged",
+		missing: []string{"wisp_labels"},
+		prime: func(mock sqlmock.Sqlmock, wispErr error) {
+			mock.ExpectQuery(`SELECT id FROM issues`).WillReturnRows(sqlmock.NewRows([]string{"id"}))
+			mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).
+				WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+			mock.ExpectQuery(`(?s)FROM wisps`).WillReturnError(wispErr)
+		},
+		run: func(ctx context.Context, tx *sql.Tx) (string, error) {
+			filter := readyFilter()
+			filter.Limit = 5
+			out, err := GetReadyWorkInTx(ctx, tx, filter)
+			return fmt.Sprintf("rows=%d", len(out)), err
+		},
+		wantTolerated: "rows=0",
+	},
+}
+
+// readyFilter keeps the ready-work predicate builder query-free
+// (IncludeDeferred skips the deferred-parent scan, and no ParentID means no
+// descendant walk) so each expectation below belongs to the path under test.
+func readyFilter() types.WorkFilter {
+	return types.WorkFilter{IncludeDeferred: true}
+}
+
+// TestCountsBrokenWispPlaneIsAnError is the counts/ready twin of
+// TestSearchInTxBrokenWispPlaneIsAnError: a wisp query that failed because a
+// table it reads but the wisp plane does not own has gone missing was reported
+// as "no wisps", so `bd count`, `bd count --by-*`, `bd search --counts` and
+// `bd ready` answered a durable-only number over a broken database and told
+// the caller nothing.
+//
+// The assertion is errors.Is against the primed driver error rather than a
+// substring of the message: the query text names the joined tables, so a
+// substring check would pass on any error that merely echoes the query.
+func TestCountsBrokenWispPlaneIsAnError(t *testing.T) {
+	for _, tc := range countsEntryPoints {
+		for _, missing := range tc.missing {
+			t.Run(tc.name+"/"+missing, func(t *testing.T) {
+				_, mock, tx := beginMockTx(t)
+				gone := tableNotFound(missing)
+				tc.prime(mock, gone)
+
+				got, err := tc.run(context.Background(), tx)
+				if err == nil {
+					t.Fatalf("%s succeeded with no %s table, answering %s", tc.name, missing, got)
+				}
+				if !errors.Is(err, gone) {
+					t.Fatalf("%s: error is not the missing-%s failure: %v", tc.name, missing, err)
+				}
+			})
+		}
+	}
+}
+
+// TestCountsMissingWispPlaneIsNotAnError is the control the tightened guard
+// must keep green: a pre-migration database has no wisp plane at all, and a
+// count over it really does have no wisps to add. Over-tightening to "never
+// tolerate" passes every must-error assertion above and fails here.
+func TestCountsMissingWispPlaneIsNotAnError(t *testing.T) {
+	for _, tc := range countsEntryPoints {
+		for _, table := range []string{"wisps", "wisp_dependencies"} {
+			t.Run(tc.name+"/"+table, func(t *testing.T) {
+				_, mock, tx := beginMockTx(t)
+				tc.prime(mock, tableNotFound(table))
+
+				got, err := tc.run(context.Background(), tx)
+				if err != nil {
+					t.Fatalf("%s errored on a database with no %s: %v", tc.name, table, err)
+				}
+				if got != tc.wantTolerated {
+					t.Fatalf("%s answered %s, want %s", tc.name, got, tc.wantTolerated)
+				}
+				if err := mock.ExpectationsWereMet(); err != nil {
+					t.Fatalf("%s: unmet sql expectations: %v", tc.name, err)
+				}
+			})
+		}
+	}
+}
+
+// TestCountsUnrelatedErrorPropagates is the second control: the tolerance must
+// not be a blanket catch in either direction. A deadlock or a dropped
+// connection was never a missing table and must still reach the caller.
+func TestCountsUnrelatedErrorPropagates(t *testing.T) {
+	for _, tc := range countsEntryPoints {
+		t.Run(tc.name, func(t *testing.T) {
+			_, mock, tx := beginMockTx(t)
+			boom := errors.New("connection refused")
+			tc.prime(mock, boom)
+
+			if _, err := tc.run(context.Background(), tx); !errors.Is(err, boom) {
+				t.Fatalf("%s did not propagate a failed wisp query: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestCountsHealthyPlaneStillMerges is the GH#4387 parity control: on a
+// database whose wisp plane is intact, both legs answer and the merged number
+// is unchanged by the tightening.
+func TestCountsHealthyPlaneStillMerges(t *testing.T) {
+	_, mock, tx := beginMockTx(t)
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM issues`).WillReturnRows(scalarCountRows(3))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM wisps`).WillReturnRows(scalarCountRows(2))
+
+	n, err := CountIssuesInTx(context.Background(), tx, "", types.IssueFilter{})
+	if err != nil {
+		t.Fatalf("CountIssuesInTx over a healthy database: %v", err)
+	}
+	if n != 5 {
+		t.Fatalf("CountIssuesInTx = %d, want 5 (3 issues + 2 wisps)", n)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -179,7 +179,7 @@ func getReadyWispsInTx(ctx context.Context, tx DBTX, filter types.WorkFilter, de
 		wispFilter.Limit = 0
 		wisps, err := searchTableInTxT(ctx, tx, "", wispFilter, WispsFilterTables, issueProjection)
 		if err != nil {
-			if isTableNotExistError(err) {
+			if missingOptionalWispTable(err) {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("search wisps (ready work): %w", err)
@@ -193,7 +193,7 @@ func getReadyWispsInTx(ctx context.Context, tx DBTX, filter types.WorkFilter, de
 	for offset := 0; len(ready) < filter.Limit; offset += pageSize {
 		pageIDs, err := queryReadyWispIssueIDPage(ctx, tx, wispFilter, !filter.IncludeDeferred, orderBy, pageSize, offset)
 		if err != nil {
-			if isTableNotExistError(err) {
+			if missingOptionalWispTable(err) {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("search wisps (ready work): %w", err)

--- a/internal/storage/issueops/ready_work_counts.go
+++ b/internal/storage/issueops/ready_work_counts.go
@@ -59,7 +59,7 @@ func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.Wo
 	}
 	wisps, err := runReadyCountsInTx(ctx, tx, WispsFilterTables, filter.Limit, wispPreds, true, readyHydrationFor(filter))
 	if err != nil {
-		if isTableNotExistError(err) {
+		if missingOptionalWispTable(err) {
 			return finishReadyWorkWithCounts(out, filter)
 		}
 		return nil, err
@@ -239,7 +239,7 @@ func CountReadyWorkInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilter
 	}
 	wispCount, err := countReadyPredicateInTx(ctx, tx, "wisps", wispPreds.whereSQL, wispPreds.whereArgs)
 	if err != nil {
-		if isTableNotExistError(err) {
+		if missingOptionalWispTable(err) {
 			return issueCount, nil
 		}
 		return 0, fmt.Errorf("count ready work: wisps: %w", err)

--- a/internal/storage/issueops/search_counts.go
+++ b/internal/storage/issueops/search_counts.go
@@ -23,7 +23,7 @@ func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, f
 		}
 		if !empty && wispDepsExist {
 			wisps, err := runFilterSearchQueryInTx(ctx, tx, query, filter, WispsFilterTables, true)
-			if err != nil && !isTableNotExistError(err) {
+			if err != nil && !missingOptionalWispTable(err) {
 				return nil, err
 			}
 			if len(wisps) > 0 {
@@ -66,7 +66,7 @@ func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, f
 
 	wisps, err := runFilterSearchQueryInTx(ctx, tx, query, filter, WispsFilterTables, true)
 	if err != nil {
-		if isTableNotExistError(err) {
+		if missingOptionalWispTable(err) {
 			return finishSearchIssuesWithCounts(out, filter)
 		}
 		return nil, err


### PR DESCRIPTION
Fixes #5873.

## What was wrong

Every count and ready-work read that merges the wisp plane classified **any**
table-not-exist error from its wisp query as "there are no wisps". That is only
true for the tables a database may legitimately not have. The wisp queries
reach past those: the counts mega-query's FROM carries `sqlbuild.LeaseJoin`
(`internal/storage/sqlbuild/counts.go:256`), hydration reads `wisp_labels`, and
grouping by label queries `wisp_labels` directly. So a database that *has* a
wisp plane but is missing one of the tables that plane depends on was answered
with a durable-only number and a `nil` error — the live wisp rows were dropped
and nothing said so.

Measured on a real embedded-Dolt store seeded with one durable issue and one
wisp, with `wisp_labels` renamed away (`internal/storage/embeddeddolt/counts_missing_table_test.go`,
run against the pre-fix tree):

```
SearchIssuesWithCounts hid a broken wisp plane, returning 1 rows
GetReadyWorkWithCounts hid a broken wisp plane, returning 1 rows
CountIssuesByGroup(label) hid a broken wisp plane, returning map[(no labels):1]
```

All three returned a `nil` error. The wisp is simply gone.

That database shape is not hypothetical — beads' own repair path manufactures
it. `ensureWispTablesForMixedBlockedRecompute`
(`internal/storage/schema/migration_repairs.go:200-222`) recreates `wisps` and
`wisp_dependencies` at migration 0047 on a drifted clone and creates neither
`wisp_labels` nor `wisp_comments`; in the main series `wisp_labels` is created
only by `migrations/0021_create_wisp_auxiliary.up.sql`, which has no repair
counterpart. `cli_migrations.go:126-133` names exactly this shape as
**#4695/#4176** — "the main cursor arrives at-latest with the wisp tables never
synced (they are `dolt_ignored`, so a clone can simply not have them), and
0047's repair recreates only `wisps` and `wisp_dependencies`" — and
`schema_test.go:1183` stages a live database with no `wisp_comments` for the
same reason.

## What changed

The eleven sites below now classify through `missingOptionalWispTable`, the
helper #5932 added to both stacks, which is keyed on the name of the table that
actually went missing (`sqlbuild.OptionalWispTable`: `wisps`,
`wisp_dependencies`) rather than on "some table was missing". Line numbers are
against `b7175be22ec0133dd5495c7e0163bf4edcca5374`:

| file | lines | entry point |
|---|---|---|
| `internal/storage/issueops/count.go` | 19, 64, 80, 116 | `CountIssuesInTx`, `CountIssuesByGroupInTx` (ephemeral + merge each) |
| `internal/storage/issueops/search_counts.go` | 26, 69 | `SearchIssuesWithCountsInTx` (ephemeral + merge) |
| `internal/storage/issueops/ready_work_counts.go` | 62, 242 | `GetReadyWorkWithCountsInTx`, `CountReadyWorkInTx` |
| `internal/storage/issueops/ready_work.go` | 182, 196 | `getReadyWispsInTx` (unbounded + paged) |
| `internal/storage/domain/db/issue_search_counts.go` | 106 | `searchUnionWithCounts` wisp hydration |

No new classification helper is introduced. This mirrors #5932's layout rather
than inventing a parallel mechanism, so the two stacks cannot drift on what a
missing table means.

## Relationship to #5932, and a correction to the issue's premise

#5932 ("stop reporting a broken wisp plane as an empty one in search", merged
2026-08-21T23:58:44Z) did the search half and added the seam this PR uses:
`sqlbuild.OptionalWispTable` plus a `missingOptionalWispTable` in each of
`issueops` and `domain/db`. It deliberately did not touch `count.go`,
`search_counts.go`, `ready_work*.go` or `issue_search_counts.go`. This PR is
the sibling half.

One correction, offered gently because the defect the issue reports is real and
was found before the symptom was: **the repro as stated did not reproduce when
the issue was filed.** The issue describes counts answering `0` while `bd list`
on the same database errors. At filing time the search side was blanket-tolerant
too, so `bd list` was *also* silently empty and both halves agreed, wrongly.
The reason is a stacked-PR race: #5805 merged at 2026-08-20T03:40:39Z into base
`fix/get-issue-leases-tolerance`, not into `main`, and its merge commit
`5cde7c5` is still not an ancestor of `main` today. The issue was filed
2026-08-20T03:42:24Z, about two minutes later, against a `main` that had never
received #5805's content.

The disagreement the issue describes became real when #5932 landed on
2026-08-21. So this PR **creates** count/list agreement rather than restoring
it: after it, both halves error on a broken wisp plane, matching what
`GetIssueInTx` has done since #5804. Worth stating plainly so nobody goes
looking for a pre-#5932 commit where the two disagreed.

Two smaller notes on the issue's site list:

- `internal/storage/domain/db/issue_search_counts.go:218` is **not** a defect
  and is left alone. It sits inside `optionalTableExists`, whose query is
  `SELECT 1 FROM %s LIMIT 1` over exactly one table, so a table-not-exist error
  there names precisely the table being probed. The check is correctly scoped;
  tightening it would be wrong.
- Four sites the issue did not list are fixed here: `ready_work_counts.go:62`
  and `:242`, and `ready_work.go:182` and `:196`. `bd ready` had the same hole
  as `bd count`.

## Tests

Three files, mirroring #5932's style:

- `internal/storage/issueops/counts_missing_table_test.go` — sqlmock, ten entry
  points × the tables each one's wisp query can actually be broken by.
- `internal/storage/domain/db/issue_search_counts_missing_table_test.go` —
  sqlmock, the counted union's wisp hydration (the counts twin of #5932's
  `unionOverBrokenWispPlane`).
- `internal/storage/embeddeddolt/counts_missing_table_test.go` — end-to-end
  against a real store, breaking the plane with `RENAME TABLE`.

Assertions are `errors.Is` against the primed driver error, not a substring of
the message: the query text names the joined tables, so a substring check would
pass on any error that merely echoes the query.

Four controls separate "narrowed the tolerance" from "removed it":

1. **`wisps` missing** (pre-migration database) → still a durable-only answer,
   `nil` error.
2. **`wisp_dependencies` missing** → still invisible, `nil` error.
3. **Healthy plane** → merged count unchanged (`TestCountsHealthyPlaneStillMerges`
   pins 3 issues + 2 wisps = 5, the GH#4387 parity contract).
4. **Unrelated failure** (a dropped connection) → still propagates, so the
   tolerance is not a blanket catch in the other direction either.

Controls 1, 2 and 4 run for every entry point in the sqlmock table. Control 3
is pinned on one entry point only, `CountIssuesInTx` — a healthy plane never
enters the `err != nil` branch, so swapping the classifier cannot change
cardinality on the others, but the pin itself is single-point.

Over-tightening to "never tolerate" passes every must-error assertion and fails
controls 1 and 2.

Pre-fix, with only the test files added, the new tests are red: 17 failing
subtests in `issueops`, 3 in `domain/db`, and the three embedded-Dolt
assertions quoted above. Post-fix they pass.

What was run locally, precisely: the two packages whose source this change
edits (`issueops`, `domain/db`) pass, as do `sqlbuild`, `dberrors` and `domain`
alongside them and `./internal/storage/dbproxy/...` (all five subpackages). The
change's only other file is a new test in `embeddeddolt`, covered below.
`./internal/storage/...`
was **not** run as a whole tree, because `internal/storage/uow` hangs on this
machine: under `-timeout 3m` it dies with `panic: test timed out after 3m0s`,
`FAIL github.com/steveyegge/beads/internal/storage/uow 180.835s`, with the
stuck goroutine in `dbproxy/proxy.forkExecChild`. That is pre-existing and not
attributable to this change — with all five changed source files reverted to
their parent content it fails identically (`180.872s`, same goroutine).
`./cmd/bd/...` was likewise not run locally; the change is confined to storage
read paths, but CLI-level coverage is CI's to confirm.

## Limitations, stated up front

- **This is an observable behaviour change, and which table breaks which
  command differs.** `bd count` and `bd count --by-*` (`CountIssuesInTx`,
  `CountIssuesByGroupInTx`), `bd ready`'s ready total (`CountReadyWorkInTx`,
  reached from `cmd/bd/ready.go:195` via `ReadyCounter`), and the **paged** arm
  of the bare `GetReadyWorkInTx` now error only on a missing `wisp_labels`; the
  **unbounded** arm of that same bare `GetReadyWorkInTx` (`cmd/bd/ready.go:220`,
  `:481`) errors on `wisp_labels` or `leases`, because only that arm carries the
  lease overlay; and only the three counts mega-query entry points — `SearchIssuesWithCountsInTx`,
  `GetReadyWorkWithCountsInTx` (`bd ready --json` at `cmd/bd/ready.go:181`, plus
  the proxied ready and search routes), and the `domain/db` counted union — can
  also break on a missing `wisp_comments`. Before, each returned a durable-only
  number and a `nil` error. That is the direction `GetIssueInTx` took in #5804
  and search took in #5932, and it leaves the GH#4387 count/list
  cardinality-parity contract intact on healthy and on pre-migration databases. It is still a change, not a pure fix. Note
  that on `main` today #5932 already makes `bd list` / `bd search` error on
  exactly that database (`internal/storage/embeddeddolt/search_missing_table_test.go:50-60`),
  so this PR extends an already-merged policy rather than introducing one.
- **The sqlmock tests exercise the guard, not the query's ability to produce
  that error.** They inject the driver error into the wisp leg. What proves the
  tables are genuinely reachable is the embedded-Dolt test — and that test
  renames exactly one table, so it proves it for `wisp_labels` only. The other
  two names in the guards are argued from the query builders, not pinned
  end-to-end here: `leases` because `searchTableInTxT` (`search.go:381`) and the
  counts mega-query (`sqlbuild/counts.go:256`) both put `LeaseJoin` in the FROM,
  and `wisp_comments` because the mega-query LEFT JOINs the comment-count
  subquery at `sqlbuild/counts.go:198`.
- **The three lists of reachable tables in the sqlmock table are deliberately
  different, and follow the FROM clause.** `FilterTables.Comments` has exactly
  one non-test use in the tree — `sqlbuild/counts.go:198` — so only the three
  entry points that render the counts mega-query
  (`SearchIssuesWithCountsInTx` ×2, `GetReadyWorkWithCountsInTx`, plus the
  `domain/db` counted union, which reaches it through `fetchCountsByIDs`) can be
  broken by a missing `wisp_comments`. The plain `COUNT(*)` forms
  (`countTableInTx`, `countByColumnInTx`) build `SELECT COUNT(*) FROM <wisps>`
  and a WHERE clause and nothing else; `GetReadyWorkInTx`'s unbounded arm adds
  only the lease overlay. That is where the first bullet's map comes from.
- **The end-to-end `wisp_dependencies` control does not exercise the guard.** A
  plain `COUNT(*)` over `wisps` never reads the dependency table, so it stays
  green whatever `missingOptionalWispTable` is tightened to. The sqlmock control
  is what pins that entry. The test comment says so at the point of the
  assertion.
- **The embedded-Dolt test is `//go:build cgo` and gated on
  `BEADS_TEST_EMBEDDED_DOLT=1`,** so it is skipped in a default run. It was run
  locally in both directions (red before, green after).
- **Not fixed here: `ready_work.go:555`.** In
  `getChildrenOfDeferredParentsInTx`'s loop over
  `{dependencies, wisp_dependencies} × {issues, wisps}`, that guard tests only
  `depTable`, so at `(wisp_dependencies, issues)` a missing durable `issues`
  table is swallowed as though the wisp plane were absent. Its neighbours are
  correctly scoped and left alone, alongside `issue_search_counts.go:218`:
  `:530` and `:599` each run a single-table query, so a table-not-exist error
  names the table probed, and `:558` is reachable only once the
  `(dependencies, issues)` pass has succeeded — so `dependencies` exists and the
  error really is the missing `wisps`. `:555` is a different failure class —
  wrong-name gating, not blanket tolerance — with no repro attached, so it is
  left for a follow-up rather than widened into this PR.
- The disjoint-table invariant that `CountIssuesInTx` documents at `count.go:54`
  is untouched. This PR changes only how a failed wisp query is classified.
- **Not addressed here: the issue's fourth item.** #5873 also notes that
  `internal/storage/issueops/journal.go:385`'s
  `optionalBlockedTable(candidate.issueTable) && isTableNotExistError(err)`
  branch is effectively dead after #5804. That is a dead-code cleanup rather
  than a misclassification, it is in a write path rather than a count path, and
  removing it would need its own reasoning about `getIssueFromTableInTx`'s
  callers — so it is left out of scope here despite the `Fixes #5873` keyword.

Thanks to @bee-ghosttrack for the report — the four extra sites came out of
chasing down the pattern it pointed at.
