### PR TITLE
fix(setup/claude): keep settings.json's trailing newline and skip no-op rewrites

### DIFF
--- a/cmd/bd/setup/claude.go
+++ b/cmd/bd/setup/claude.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -68,6 +69,28 @@ func legacyProjectSettingsPath(base string) string {
 
 func globalSettingsPath(home string) string {
 	return filepath.Join(home, ".claude", "settings.json")
+}
+
+// marshalSettings renders a Claude settings map as two-space-indented JSON
+// with the trailing newline json.MarshalIndent omits, so the file stays
+// POSIX-clean and byte-stable across runs.
+func marshalSettings(settings map[string]interface{}) ([]byte, error) {
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+// writeSettingsIfChanged writes data to path only when it differs from what is
+// already on disk. GH#5693: bd init / bd setup claude marshalled and wrote
+// settings.json on every run, so a no-op run still churned the file's mtime
+// and — because MarshalIndent emits no trailing newline — silently stripped it.
+func writeSettingsIfChanged(env claudeEnv, path string, data []byte) error {
+	if existing, err := env.readFile(path); err == nil && bytes.Equal(existing, data) {
+		return nil
+	}
+	return env.writeFile(path, data)
 }
 
 func claudeAgentsEnv(env claudeEnv) agentsEnv {
@@ -277,13 +300,13 @@ func installClaude(env claudeEnv, global bool, stealth bool) error {
 		}
 	}
 
-	data, err := json.MarshalIndent(settings, "", "  ")
+	data, err := marshalSettings(settings)
 	if err != nil {
 		_, _ = fmt.Fprintf(env.stderr, "Error: marshal settings: %v\n", err)
 		return err
 	}
 
-	if err := env.writeFile(settingsPath, data); err != nil {
+	if err := writeSettingsIfChanged(env, settingsPath, data); err != nil {
 		_, _ = fmt.Fprintf(env.stderr, "Error: write settings: %v\n", err)
 		return err
 	}
@@ -300,8 +323,8 @@ func installClaude(env claudeEnv, global bool, stealth bool) error {
 							removeHookCommand(legacyHooks, "SessionStart", v)
 							removeHookCommand(legacyHooks, "PreCompact", v)
 						}
-						if migrated, marshalErr := json.MarshalIndent(legacySettings, "", "  "); marshalErr == nil {
-							if writeErr := env.writeFile(legacyPath, migrated); writeErr == nil {
+						if migrated, marshalErr := marshalSettings(legacySettings); marshalErr == nil {
+							if writeErr := writeSettingsIfChanged(env, legacyPath, migrated); writeErr == nil {
 								_, _ = fmt.Fprintf(env.stdout, "✓ Migrated hooks from %s\n", legacyPath)
 							}
 						}
@@ -473,13 +496,13 @@ func removeClaude(env claudeEnv, global bool) error {
 				removeHookCommand(hooks, "PreCompact", v)
 			}
 
-			data, err = json.MarshalIndent(settings, "", "  ")
+			data, err = marshalSettings(settings)
 			if err != nil {
 				_, _ = fmt.Fprintf(env.stderr, "Error: marshal settings: %v\n", err)
 				return err
 			}
 
-			if err := env.writeFile(settingsPath, data); err != nil {
+			if err := writeSettingsIfChanged(env, settingsPath, data); err != nil {
 				_, _ = fmt.Fprintf(env.stderr, "Error: write settings: %v\n", err)
 				return err
 			}
@@ -497,8 +520,8 @@ func removeClaude(env claudeEnv, global bool) error {
 						removeHookCommand(legacyHooks, "SessionStart", v)
 						removeHookCommand(legacyHooks, "PreCompact", v)
 					}
-					if migrated, marshalErr := json.MarshalIndent(legacySettings, "", "  "); marshalErr == nil {
-						_ = env.writeFile(legacyPath, migrated)
+					if migrated, marshalErr := marshalSettings(legacySettings); marshalErr == nil {
+						_ = writeSettingsIfChanged(env, legacyPath, migrated)
 					}
 				}
 			}

--- a/cmd/bd/setup/claude.go
+++ b/cmd/bd/setup/claude.go
@@ -83,7 +83,7 @@ func marshalSettings(settings map[string]interface{}) ([]byte, error) {
 }
 
 // writeSettingsIfChanged writes data to path only when it differs from what is
-// already on disk. GH#5693: bd init / bd setup claude marshalled and wrote
+// already on disk. GH#5693: bd init / bd setup claude marshaled and wrote
 // settings.json on every run, so a no-op run still churned the file's mtime
 // and — because MarshalIndent emits no trailing newline — silently stripped it.
 func writeSettingsIfChanged(env claudeEnv, path string, data []byte) error {

--- a/cmd/bd/setup/claude_test.go
+++ b/cmd/bd/setup/claude_test.go
@@ -1655,3 +1655,207 @@ func TestRemoveClaudeRedirectCleansStaleClaudeBlock(t *testing.T) {
 		t.Fatalf("AGENTS.md should still contain its beads block after remove:\n%s", agentsData)
 	}
 }
+
+// countingClaudeEnv wraps env.writeFile with a per-path write counter so tests
+// can assert that an unchanged settings file is not rewritten.
+func countingClaudeEnv(env claudeEnv, counts map[string]int) claudeEnv {
+	inner := env.writeFile
+	env.writeFile = func(path string, data []byte) error {
+		counts[path]++
+		return inner(path, data)
+	}
+	return env
+}
+
+func assertTrailingNewline(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Errorf("%s should end with a trailing newline, got %q", path, tailOf(data))
+	}
+}
+
+func tailOf(data []byte) string {
+	if len(data) > 24 {
+		return string(data[len(data)-24:])
+	}
+	return string(data)
+}
+
+// GH#5693: bd setup claude must leave settings.json POSIX-clean (trailing
+// newline) instead of stripping the newline json.MarshalIndent omits.
+func TestInstallClaudeSettingsEndsWithTrailingNewline(t *testing.T) {
+	t.Run("project", func(t *testing.T) {
+		env, _, _ := newClaudeTestEnv(t)
+		if err := installClaude(env, false, false); err != nil {
+			t.Fatalf("installClaude: %v", err)
+		}
+		assertTrailingNewline(t, projectSettingsPath(env.projectDir))
+	})
+	t.Run("global", func(t *testing.T) {
+		env, _, _ := newClaudeTestEnv(t)
+		if err := installClaude(env, true, false); err != nil {
+			t.Fatalf("installClaude: %v", err)
+		}
+		assertTrailingNewline(t, globalSettingsPath(env.homeDir))
+	})
+}
+
+// GH#5693: a second bd setup claude with nothing to change must not rewrite
+// settings.json.
+func TestInstallClaudeSkipsRewriteWhenSettingsUnchanged(t *testing.T) {
+	env, _, _ := newClaudeTestEnv(t)
+	counts := map[string]int{}
+	env = countingClaudeEnv(env, counts)
+	settingsPath := projectSettingsPath(env.projectDir)
+
+	if err := installClaude(env, false, false); err != nil {
+		t.Fatalf("first installClaude: %v", err)
+	}
+	if counts[settingsPath] != 1 {
+		t.Fatalf("first install should write settings once, got %d", counts[settingsPath])
+	}
+	before, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+
+	if err := installClaude(env, false, false); err != nil {
+		t.Fatalf("second installClaude: %v", err)
+	}
+	if got := counts[settingsPath]; got != 1 {
+		t.Errorf("second install rewrote unchanged settings: %d total writes, want 1", got)
+	}
+	after, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("re-read settings: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Errorf("second install changed settings content:\nbefore=%q\nafter=%q", before, after)
+	}
+}
+
+// GH#5693: the same two properties must hold for the removeClaude write path,
+// which marshals and writes settings.json through a separate call site.
+func TestRemoveClaudeSettingsNewlineAndSkipsUnchangedRewrite(t *testing.T) {
+	env, _, _ := newClaudeTestEnv(t)
+	counts := map[string]int{}
+	env = countingClaudeEnv(env, counts)
+	settingsPath := projectSettingsPath(env.projectDir)
+
+	if err := installClaude(env, false, false); err != nil {
+		t.Fatalf("installClaude: %v", err)
+	}
+	writesAfterInstall := counts[settingsPath]
+
+	if err := removeClaude(env, false); err != nil {
+		t.Fatalf("first removeClaude: %v", err)
+	}
+	assertTrailingNewline(t, settingsPath)
+	writesAfterRemove := counts[settingsPath]
+	if writesAfterRemove != writesAfterInstall+1 {
+		t.Fatalf("first remove should write settings once, got %d writes (install left %d)",
+			writesAfterRemove-writesAfterInstall, writesAfterInstall)
+	}
+
+	if err := removeClaude(env, false); err != nil {
+		t.Fatalf("second removeClaude: %v", err)
+	}
+	if got := counts[settingsPath]; got != writesAfterRemove {
+		t.Errorf("second remove rewrote unchanged settings: %d writes, want %d", got, writesAfterRemove)
+	}
+}
+
+// GH#5693: the legacy settings.local.json migration writes are the two other
+// marshal-and-write call sites in this file; they strip the newline too.
+func TestClaudeLegacySettingsWritesEndWithNewline(t *testing.T) {
+	legacyWithBeadsHook := func() map[string]interface{} {
+		return map[string]interface{}{
+			"hooks": map[string]interface{}{
+				"SessionStart": []interface{}{
+					map[string]interface{}{
+						"matcher": "",
+						"hooks": []interface{}{
+							map[string]interface{}{"type": "command", "command": "bd prime"},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// The second install writes settings.local.json zero times, but not via
+	// writeSettingsIfChanged: installClaude's migration block is guarded by
+	// hasBeadsHooks(legacyPath), which is false once the first install has
+	// migrated the hooks away, so the block is skipped outright. That guard is
+	// also why the skip inside writeSettingsIfChanged is unreachable on this
+	// call site — whenever the guard passes, removeHookCommand strips a hook
+	// that hasBeadsHooks just matched, so the marshalled bytes always differ.
+	// What this subtest pins is therefore the user-visible property (a repeat
+	// bd setup claude leaves settings.local.json alone) plus the newline, not
+	// the no-op-skip helper.
+	t.Run("install migration then no further legacy writes", func(t *testing.T) {
+		env, _, _ := newClaudeTestEnv(t)
+		counts := map[string]int{}
+		env = countingClaudeEnv(env, counts)
+		legacyPath := legacyProjectSettingsPath(env.projectDir)
+		writeSettings(t, legacyPath, legacyWithBeadsHook())
+
+		if err := installClaude(env, false, false); err != nil {
+			t.Fatalf("first installClaude: %v", err)
+		}
+		if hasBeadsHooks(legacyPath) {
+			t.Fatal("legacy beads hooks should have been migrated away")
+		}
+		assertTrailingNewline(t, legacyPath)
+		writesAfterFirst := counts[legacyPath]
+		if writesAfterFirst != 1 {
+			t.Fatalf("first install should write legacy settings once, got %d", writesAfterFirst)
+		}
+		before, err := os.ReadFile(legacyPath)
+		if err != nil {
+			t.Fatalf("read legacy settings: %v", err)
+		}
+
+		if err := installClaude(env, false, false); err != nil {
+			t.Fatalf("second installClaude: %v", err)
+		}
+		if got := counts[legacyPath]; got != writesAfterFirst {
+			t.Errorf("second install rewrote migrated legacy settings: %d writes, want %d", got, writesAfterFirst)
+		}
+		after, err := os.ReadFile(legacyPath)
+		if err != nil {
+			t.Fatalf("re-read legacy settings: %v", err)
+		}
+		if !bytes.Equal(before, after) {
+			t.Errorf("second install changed legacy settings content:\nbefore=%q\nafter=%q", before, after)
+		}
+	})
+
+	t.Run("remove cleanup", func(t *testing.T) {
+		env, _, _ := newClaudeTestEnv(t)
+		counts := map[string]int{}
+		env = countingClaudeEnv(env, counts)
+		legacyPath := legacyProjectSettingsPath(env.projectDir)
+		writeSettings(t, legacyPath, legacyWithBeadsHook())
+
+		if err := removeClaude(env, false); err != nil {
+			t.Fatalf("first removeClaude: %v", err)
+		}
+		assertTrailingNewline(t, legacyPath)
+		writesAfterFirst := counts[legacyPath]
+		if writesAfterFirst != 1 {
+			t.Fatalf("first remove should write legacy settings once, got %d", writesAfterFirst)
+		}
+
+		if err := removeClaude(env, false); err != nil {
+			t.Fatalf("second removeClaude: %v", err)
+		}
+		if got := counts[legacyPath]; got != writesAfterFirst {
+			t.Errorf("second remove rewrote unchanged legacy settings: %d writes, want %d", got, writesAfterFirst)
+		}
+	})
+}

--- a/cmd/bd/setup/claude_test.go
+++ b/cmd/bd/setup/claude_test.go
@@ -1793,7 +1793,7 @@ func TestClaudeLegacySettingsWritesEndWithNewline(t *testing.T) {
 	// migrated the hooks away, so the block is skipped outright. That guard is
 	// also why the skip inside writeSettingsIfChanged is unreachable on this
 	// call site — whenever the guard passes, removeHookCommand strips a hook
-	// that hasBeadsHooks just matched, so the marshalled bytes always differ.
+	// that hasBeadsHooks just matched, so the marshaled bytes always differ.
 	// What this subtest pins is therefore the user-visible property (a repeat
 	// bd setup claude leaves settings.local.json alone) plus the newline, not
 	// the no-op-skip helper.


### PR DESCRIPTION
Fixes #5693.

## Problem

`bd setup claude` builds the Claude settings map, renders it with
`json.MarshalIndent`, and writes it **unconditionally**. `MarshalIndent` emits no
trailing newline, so every invocation both:

1. strips the trailing newline from `.claude/settings.json`, and
2. rewrites the file even when no hook changed.

`bd init` calls into the same path and then `git add`s the file
(`cmd/bd/init.go:2163`, `cmd/bd/init_proxied_server.go:634`), so the strip
surfaces as a staged diff with no semantic content.

## The duplication

The marshal-then-write pattern occurs at **four** call sites in
`cmd/bd/setup/claude.go` (line numbers at `b7175be`):

| Line | Function | File written |
| --- | --- | --- |
| 280 | `installClaude` | `settings.json` |
| 303 | `installClaude` (legacy migration) | `settings.local.json` |
| 476 | `removeClaude` | `settings.json` |
| 500 | `removeClaude` (legacy cleanup) | `settings.local.json` |

The issue cites two of them. Fixing only those would have left the bug live in
the legacy-migration writes, so this PR routes all four through two helpers:
`marshalSettings` appends the newline, and `writeSettingsIfChanged` compares
against the bytes already on disk and returns early when they match.

## Tests

Four tests were added to `claude_test.go` and confirmed RED on `b7175be` before
the fix (temp paths and `(0.00s)` timings elided):

```
--- FAIL: TestInstallClaudeSettingsEndsWithTrailingNewline/project
    .../project/.claude/settings.json should end with a trailing newline, got ": \"\"\n      }\n    ]\n  }\n}"
--- FAIL: TestInstallClaudeSettingsEndsWithTrailingNewline/global
    .../home/.claude/settings.json should end with a trailing newline, got ": \"\"\n      }\n    ]\n  }\n}"
--- FAIL: TestInstallClaudeSkipsRewriteWhenSettingsUnchanged
    second install rewrote unchanged settings: 2 total writes, want 1
--- FAIL: TestRemoveClaudeSettingsNewlineAndSkipsUnchangedRewrite
    .../settings.json should end with a trailing newline, got "{\n  \"hooks\": {}\n}"
    second remove rewrote unchanged settings: 3 writes, want 2
--- FAIL: TestClaudeLegacySettingsWritesEndWithNewline/install_migration_then_no_further_legacy_writes
    .../settings.local.json should end with a trailing newline, got "{\n  \"hooks\": {}\n}"
--- FAIL: TestClaudeLegacySettingsWritesEndWithNewline/remove_cleanup
    .../settings.local.json should end with a trailing newline, got "{\n  \"hooks\": {}\n}"
    second remove rewrote unchanged legacy settings: 2 writes, want 1
```

The no-op assertions count writes by wrapping `claudeEnv.writeFile`, so they
fail on a redundant write even when the bytes are identical.

**What the install-migration subtest does and does not pin.** Its second-install
write-count assertion passes on `b7175be` too, and the subtest is named and
commented to say so. `installClaude`'s legacy block is guarded by
`hasBeadsHooks(legacyPath)`, which is false once the first install has migrated
the hooks away, so the second install skips the block outright rather than
reaching the helper. That same guard makes `writeSettingsIfChanged`'s skip
branch unreachable on this call site: whenever the guard passes,
`removeHookCommand` strips a hook that `hasBeadsHooks` just matched on the same
exact-string set, so the marshalled bytes always differ. The subtest therefore
pins the user-visible property — a repeat `bd setup claude` leaves
`settings.local.json` byte-identical and untouched — and the trailing newline,
which is the assertion that is RED on `b7175be`. The no-op skip itself is pinned
by the three other tests, on the call sites where it is reachable.

## Limitations, disclosed

- **Scope is `claude.go` only.** `cmd/bd/setup/gemini.go:146` and `:253` carry
  the identical pattern for the Gemini settings file and are **not** fixed here.
  I kept this PR to the file the issue names. A follow-up can reuse
  `marshalSettings` as-is — it takes only the settings map — but **not**
  `writeSettingsIfChanged`, whose signature is
  `writeSettingsIfChanged(env claudeEnv, path string, data []byte)`
  (`cmd/bd/setup/claude.go:89`) and so is hard-wired to `claudeEnv`.
  `geminiEnv` (`gemini.go:28-36`) is a separate type with the same shape, so
  the follow-up needs either a small shared interface over the
  `readFile`/`writeFile` pair or a Gemini twin of the helper.
- **Two behaviour changes beyond the newline**, both consequences of not writing
  when nothing changed:
  - *Symlinked settings files.* `atomicWriteFile` refuses to write through a
    symlink (`cmd/bd/setup/utils.go:22-23`). Today `bd setup claude` against a
    symlinked `.claude/settings.json` always fails that way, because the write is
    unconditional. With the skip it fails only when a change is actually needed.
    No existing test covers that path; I believe not erroring on a run with
    nothing to write is the better behaviour, but flagging it rather than burying
    it.
  - *File permissions.* `atomicWriteFile` writes to a temp file, `os.Chmod`s it
    to the default `0644` and renames it over the target
    (`cmd/bd/setup/utils.go:34-37,66-74`); the settings call sites pass no
    explicit mode. So today every run normalizes a hand-`chmod`ed
    `settings.json` back to `0644`. After this change a steady-state no-op run
    no longer does. The first run after upgrading still writes once to repair the
    newline, and that write still normalizes the mode; only subsequent no-op runs
    leave it alone. Stating it as a behaviour change rather than a defect — a
    tool that writes nothing arguably should not be resetting the file's mode.
- **Mtime is no longer bumped** on no-op runs. I found no code keyed on the
  settings file's mtime.
- The first run after this change still rewrites the file once, to add the
  missing newline. That is the repair, and it is idempotent afterwards.
- **Test scope:** `go test -count=1 ./cmd/bd/setup/` passes (with `CGO_ENABLED=0
  -tags gms_pure_go`), as do `gofmt -l` and `go vet` on the touched files. I did
  not run `./cmd/bd/...` or the `uow` suites, which hang without Docker in my
  environment.

Reported by @maphew — the diagnosis and both suggested fixes are his; this PR
adds the two legacy call sites and the regression tests.
