### PR TITLE
fix(schema): read dolt_ignore before writing it

### DIFF
--- a/internal/storage/schema/dolt_ignore_seed_test.go
+++ b/internal/storage/schema/dolt_ignore_seed_test.go
@@ -1,0 +1,159 @@
+package schema
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// A fenced wire client holds SELECT on dolt_ignore and nothing else, so the
+// seed must issue ZERO statements against a database whose patterns are all
+// already registered. sqlmock in ordered mode fails any Exec that was not
+// expected, which is exactly the shape the fence produces at the wire: the
+// old unconditional `INSERT IGNORE` died here with
+//
+//	command denied to user 'bd_lego_pilot_op'@'%'
+//
+// and took `bd init --server --external` with it.
+func TestSeedDoltIgnorePatternsWritesNothingWhenAllPatternsPresent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	const mainVersion = 63
+	expectIgnorePatternSeedNoop(mock, mainVersion)
+
+	changed, err := seedDoltIgnorePatterns(context.Background(), db)
+	if err != nil {
+		t.Fatalf("seedDoltIgnorePatterns() error = %v, want nil (a correctly seeded database must be readable through a fence that grants no write on dolt_ignore)", err)
+	}
+	if changed {
+		t.Fatal("seedDoltIgnorePatterns() reported changed=true on a fully seeded database")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+// The heal path still works: an under-seeded database (the out-of-band
+// table-copy case migration 0019/0028 cannot reach) gets exactly the missing
+// rows written, and nothing else.
+func TestSeedDoltIgnorePatternsWritesOnlyTheMissingPatterns(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	const mainVersion = 63
+	candidates := expectedIgnoreSeedCandidates(mainVersion)
+	if len(candidates) < 3 {
+		t.Fatalf("expected at least 3 seed candidates at v%d, got %d", mainVersion, len(candidates))
+	}
+	present := candidates[:len(candidates)-2]
+	missing := candidates[len(candidates)-2:]
+
+	expectIgnoreSeedProbe(mock, mainVersion, present)
+	for _, pattern := range missing {
+		mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO dolt_ignore VALUES (?, true)")).
+			WithArgs(pattern).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+	}
+
+	changed, err := seedDoltIgnorePatterns(context.Background(), db)
+	if err != nil {
+		t.Fatalf("seedDoltIgnorePatterns() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("seedDoltIgnorePatterns() reported changed=false after seeding missing patterns")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+// A genuinely fresh database has no dolt_ignore table yet — the first INSERT
+// creates it. A failing probe must therefore degrade to the blind write, not
+// to "everything is present". That path only ever runs as the privileged
+// opener that is about to create the schema.
+func TestSeedDoltIgnorePatternsSeedsWhenTheTableDoesNotExistYet(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	// No schema_migrations either: the cursor probe reports it absent, so
+	// version-gated patterns are skipped and only the canonical set is asserted.
+	expectCursorProbe(mock, "schema_migrations", false)
+	args := make([]driver.Value, 0, len(doltIgnorePatterns))
+	for _, pattern := range doltIgnorePatterns {
+		args = append(args, pattern)
+	}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT pattern FROM dolt_ignore WHERE pattern IN (")).
+		WithArgs(args...).
+		WillReturnError(errors.New("table not found: dolt_ignore"))
+	for _, pattern := range doltIgnorePatterns {
+		mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO dolt_ignore VALUES (?, true)")).
+			WithArgs(pattern).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+	}
+
+	changed, err := seedDoltIgnorePatterns(context.Background(), db)
+	if err != nil {
+		t.Fatalf("seedDoltIgnorePatterns() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("seedDoltIgnorePatterns() reported changed=false on a fresh database")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+// The presence probe asks the database, not Go, whether a pattern is a
+// duplicate — so a row stored in another case under the default
+// case-insensitive collation counts as present, exactly as INSERT IGNORE
+// would have treated it.
+func TestSeedDoltIgnorePatternsHonoursStoredCasing(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	const mainVersion = 63
+	candidates := expectedIgnoreSeedCandidates(mainVersion)
+	shouty := make([]string, 0, len(candidates))
+	for _, pattern := range candidates {
+		shouty = append(shouty, upperASCII(pattern))
+	}
+	expectIgnoreSeedProbe(mock, mainVersion, shouty)
+
+	changed, err := seedDoltIgnorePatterns(context.Background(), db)
+	if err != nil {
+		t.Fatalf("seedDoltIgnorePatterns() error = %v", err)
+	}
+	if changed {
+		t.Fatal("seedDoltIgnorePatterns() re-seeded patterns the database already reported as present")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func upperASCII(s string) string {
+	b := []byte(s)
+	for i, c := range b {
+		if c >= 'a' && c <= 'z' {
+			b[i] = c - 32
+		}
+	}
+	return string(b)
+}

--- a/internal/storage/schema/dolt_ignore_seed_test.go
+++ b/internal/storage/schema/dolt_ignore_seed_test.go
@@ -148,6 +148,66 @@ func TestSeedDoltIgnorePatternsHonoursStoredCasing(t *testing.T) {
 	}
 }
 
+// A partial read must degrade to the documented blind write, not to "these
+// first patterns are present". If the presence probe SELECT succeeds but the
+// row stream errors partway (an iteration error only rows.Err() reveals), the
+// half-filled result cannot be trusted: on the very SELECT/DML-only fence this
+// seed supports, misclassifying an already-registered pattern as missing draws
+// a spurious INSERT IGNORE that is itself command-denied. The seed must discard
+// the partial read and re-assert every candidate on the privileged opener,
+// exactly as a query-level failure degrades.
+func TestSeedDoltIgnorePatternsDegradesToBlindWriteOnPartialRead(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	const mainVersion = 63
+	candidates := expectedIgnoreSeedCandidates(mainVersion)
+	const failAt = 2
+	if len(candidates) <= failAt {
+		t.Fatalf("expected more than %d seed candidates at v%d, got %d", failAt, mainVersion, len(candidates))
+	}
+
+	// The probe reports the cursor, the main version, then returns rows for the
+	// candidates but errors mid-stream: rows 0..failAt-1 scan cleanly, then the
+	// stream fails, leaving present partially populated.
+	expectCursorProbe(mock, "schema_migrations", true)
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", mainVersion)
+	args := make([]driver.Value, 0, len(candidates))
+	rows := sqlmock.NewRows([]string{"pattern"})
+	for _, pattern := range candidates {
+		args = append(args, pattern)
+		rows.AddRow(pattern)
+	}
+	rows.RowError(failAt, errors.New("connection reset mid-read"))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT pattern FROM dolt_ignore WHERE pattern IN (")).
+		WithArgs(args...).
+		WillReturnRows(rows)
+
+	// Every candidate must be (re)asserted, in order: the partial map is
+	// discarded, so the seed blind-writes the full set. Under the unguarded
+	// loop only the post-error subset would be written, and ordered sqlmock
+	// would reject the first mismatched INSERT.
+	for _, pattern := range candidates {
+		mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO dolt_ignore VALUES (?, true)")).
+			WithArgs(pattern).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+	}
+
+	changed, err := seedDoltIgnorePatterns(context.Background(), db)
+	if err != nil {
+		t.Fatalf("seedDoltIgnorePatterns() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("seedDoltIgnorePatterns() reported changed=false after a partial read forced a blind write")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations (a partial read must discard the probe and re-assert every pattern): %v", err)
+	}
+}
+
 func upperASCII(s string) string {
 	b := []byte(s)
 	for i, c := range b {

--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"regexp"
 	"strings"
@@ -295,37 +296,58 @@ func TestMigrateUpSkipsSeedCommitWhenNothingChanged(t *testing.T) {
 	}
 }
 
-// expectIgnorePatternSeed mocks the unconditional dolt_ignore pattern seed
-// MigrateUp runs before anything else, with every pattern actually inserted
-// (RowsAffected=1: an under-seeded database). mainVersion is what the seed's
-// cursor probe reports; version-gated patterns (events, >= 0062) are only
-// expected when it qualifies them.
-func expectIgnorePatternSeed(mock sqlmock.Sqlmock, mainVersion int) {
-	expectIgnorePatternSeedRows(mock, mainVersion, 1)
-}
-
-// expectIgnorePatternSeedNoop mocks the seed on a healthy database: every
-// INSERT IGNORE hits an existing row (RowsAffected=0), nothing changes.
-func expectIgnorePatternSeedNoop(mock sqlmock.Sqlmock, mainVersion int) {
-	expectIgnorePatternSeedRows(mock, mainVersion, 0)
-}
-
-func expectIgnorePatternSeedRows(mock sqlmock.Sqlmock, mainVersion int, rowsAffected int64) {
-	for _, pattern := range doltIgnorePatterns {
-		mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO dolt_ignore VALUES (?, true)")).
-			WithArgs(pattern).
-			WillReturnResult(sqlmock.NewResult(0, rowsAffected))
-	}
-	expectCursorProbe(mock, "schema_migrations", true)
-	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", mainVersion)
+// expectedIgnoreSeedCandidates is the pattern set the seed asserts at a given
+// main cursor: the canonical set plus the version-gated ones that qualify.
+func expectedIgnoreSeedCandidates(mainVersion int) []string {
+	candidates := append([]string(nil), doltIgnorePatterns...)
 	for _, gated := range versionGatedDoltIgnorePatterns {
 		if mainVersion < gated.minMainVersion {
 			continue
 		}
-		mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO dolt_ignore VALUES (?, true)")).
-			WithArgs(gated.pattern).
-			WillReturnResult(sqlmock.NewResult(0, rowsAffected))
+		candidates = append(candidates, gated.pattern)
 	}
+	return candidates
+}
+
+// expectIgnoreSeedProbe mocks the seed's read half: the cursor probe that
+// decides the version-gated patterns, then the single presence SELECT.
+// alreadyPresent is what dolt_ignore reports back.
+func expectIgnoreSeedProbe(mock sqlmock.Sqlmock, mainVersion int, alreadyPresent []string) {
+	expectCursorProbe(mock, "schema_migrations", true)
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", mainVersion)
+	args := make([]driver.Value, 0, len(doltIgnorePatterns)+len(versionGatedDoltIgnorePatterns))
+	for _, pattern := range expectedIgnoreSeedCandidates(mainVersion) {
+		args = append(args, pattern)
+	}
+	rows := sqlmock.NewRows([]string{"pattern"})
+	for _, pattern := range alreadyPresent {
+		rows.AddRow(pattern)
+	}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT pattern FROM dolt_ignore WHERE pattern IN (")).
+		WithArgs(args...).
+		WillReturnRows(rows)
+}
+
+// expectIgnorePatternSeed mocks the dolt_ignore pattern seed MigrateUp runs
+// before anything else on an UNDER-SEEDED database: the probe finds nothing,
+// so every pattern is inserted (RowsAffected=1). mainVersion is what the
+// seed's cursor probe reports; version-gated patterns (events, >= 0062) are
+// only expected when it qualifies them.
+func expectIgnorePatternSeed(mock sqlmock.Sqlmock, mainVersion int) {
+	expectIgnoreSeedProbe(mock, mainVersion, nil)
+	for _, pattern := range expectedIgnoreSeedCandidates(mainVersion) {
+		mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO dolt_ignore VALUES (?, true)")).
+			WithArgs(pattern).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+	}
+}
+
+// expectIgnorePatternSeedNoop mocks the seed on a healthy database: the probe
+// finds every pattern already registered, so NO statement is issued at all.
+// This is the shape a fenced wire client must produce — it holds no write
+// grant on dolt_ignore, so an INSERT here is an error, not a no-op.
+func expectIgnorePatternSeedNoop(mock sqlmock.Sqlmock, mainVersion int) {
+	expectIgnoreSeedProbe(mock, mainVersion, expectedIgnoreSeedCandidates(mainVersion))
 }
 
 func expectOnePendingMigration(t *testing.T, mock sqlmock.Sqlmock) {

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -356,7 +356,9 @@ func doltIgnoreSeedCandidates(ctx context.Context, db DBConn) []string {
 // A read failure is not fatal: dolt_ignore does not exist on a never-migrated
 // database (the first INSERT creates it), and that path is privileged by
 // construction. Treat the probe as "nothing present" and let the writes run,
-// which is exactly the pre-read behavior.
+// which is exactly the pre-read behavior. A partial read (the query succeeds
+// but iteration fails partway) degrades identically: the half-filled result is
+// discarded so it can never misclassify a registered pattern as missing.
 func missingDoltIgnorePatterns(ctx context.Context, db DBConn, candidates []string) []string {
 	present := make(map[string]bool, len(candidates))
 	placeholders := make([]string, len(candidates))
@@ -367,14 +369,32 @@ func missingDoltIgnorePatterns(ctx context.Context, db DBConn, candidates []stri
 	}
 	query := "SELECT pattern FROM dolt_ignore WHERE pattern IN (" + strings.Join(placeholders, ", ") + ")"
 	if rows, err := db.QueryContext(ctx, query, args...); err == nil {
+		readErr := false
 		for rows.Next() {
 			var stored string
 			if err := rows.Scan(&stored); err != nil {
+				readErr = true
 				break
 			}
 			present[strings.ToLower(stored)] = true
 		}
+		// rows.Err() surfaces an iteration failure that rows.Next() swallowed;
+		// a Scan error above is tracked separately because rows.Err() does not
+		// report it. Either way the read did not complete.
+		if err := rows.Err(); err != nil {
+			readErr = true
+		}
 		_ = rows.Close()
+		// A partial read must not drive the write decision. If iteration failed
+		// partway, present is half-filled, so a genuinely-registered pattern
+		// would be misclassified as missing and draw a spurious INSERT IGNORE —
+		// the exact command-denied write this seed exists to avoid on a
+		// SELECT/DML-only fence. Discard the partial map so a partial read
+		// degrades to the same "nothing present" blind-write as a query-level
+		// failure, which only ever runs on the privileged opener.
+		if readErr {
+			present = nil
+		}
 	}
 	missing := make([]string, 0, len(candidates))
 	for _, pattern := range candidates {

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -374,7 +374,7 @@ func missingDoltIgnorePatterns(ctx context.Context, db DBConn, candidates []stri
 			}
 			present[strings.ToLower(stored)] = true
 		}
-		rows.Close()
+		_ = rows.Close()
 	}
 	missing := make([]string, 0, len(candidates))
 	for _, pattern := range candidates {

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -321,42 +321,14 @@ var versionGatedDoltIgnorePatterns = []struct {
 	{"events", 62}, // 0062_events_dolt_ignore (bd-red8u)
 }
 
-// seedDoltIgnorePatterns idempotently asserts the canonical dolt_ignore
-// patterns and reports whether it actually changed anything. INSERT IGNORE
-// leaves existing rows untouched, so a healthy database sees no working-set
-// change and an explicit operator override (pattern present with
-// ignored=false) is respected. On an under-seeded database the new rows land
-// in the working set and take effect immediately; who commits them depends on
-// the pass: when migration work is needed, MigrateUp exempts dolt_ignore from
-// the pre-existing-dirty guards as pass-owned state (same treatment as the
-// aux-rekey tables) and stageSchemaTables commits it with the pass; on the
-// no-work short-circuit, MigrateUp commits the seed itself in a scoped,
-// labeled commit (keyed off the changed return value) so the heal converges
-// in one pass instead of riding along inside an unrelated later commit.
-func seedDoltIgnorePatterns(ctx context.Context, db DBConn) (bool, error) {
-	changed := false
-	seedOne := func(pattern string) error {
-		res, err := db.ExecContext(ctx, "INSERT IGNORE INTO dolt_ignore VALUES (?, true)", pattern)
-		if err != nil {
-			return fmt.Errorf("seeding dolt_ignore pattern %q: %w", pattern, err)
-		}
-		// A RowsAffected error degrades to changed=false for that row: the
-		// seed then stays an uncommitted working-set diff swept up by the
-		// next commit, exactly the pre-scoped-commit behavior.
-		if n, raErr := res.RowsAffected(); raErr == nil && n > 0 {
-			changed = true
-		}
-		return nil
-	}
-	for _, pattern := range doltIgnorePatterns {
-		if err := seedOne(pattern); err != nil {
-			return changed, err
-		}
-	}
-	// Version-gated patterns seed only once the main cursor proves the flip
-	// migration applied. The cursor table may not exist yet (first-ever run,
-	// before mainSource.migrate bootstraps it): treat that as version 0 and
-	// skip — the flip migration registers its own pattern when it applies.
+// doltIgnoreSeedCandidates is the pattern set this open should assert: the
+// canonical patterns plus any version-gated pattern the main cursor
+// qualifies. The cursor table may not exist yet (first-ever run, before
+// mainSource.migrate bootstraps it): treat that as version 0 and skip the
+// gated ones — the flip migration registers its own pattern when it applies.
+func doltIgnoreSeedCandidates(ctx context.Context, db DBConn) []string {
+	candidates := make([]string, 0, len(doltIgnorePatterns)+len(versionGatedDoltIgnorePatterns))
+	candidates = append(candidates, doltIgnorePatterns...)
 	mainVersion, err := mainSource.currentVersion(ctx, db)
 	if err != nil {
 		mainVersion = 0
@@ -365,8 +337,92 @@ func seedDoltIgnorePatterns(ctx context.Context, db DBConn) (bool, error) {
 		if mainVersion < gated.minMainVersion {
 			continue
 		}
-		if err := seedOne(gated.pattern); err != nil {
-			return changed, err
+		candidates = append(candidates, gated.pattern)
+	}
+	return candidates
+}
+
+// missingDoltIgnorePatterns reports which candidates have no row in
+// dolt_ignore yet, i.e. exactly the ones an INSERT IGNORE would actually
+// insert. The probe is a single `WHERE pattern IN (...)` so the equality that
+// decides it is the COLUMN's own collation — the same comparison the primary
+// key uses to swallow an INSERT IGNORE — rather than Go string equality
+// guessing at it. The returned values are the STORED spellings, which under a
+// case-insensitive collation may differ in case from the candidate, so they
+// are matched back case-insensitively; the candidate set has no two entries
+// that collide under case folding, and under a case-sensitive collation the
+// database only ever returns exact matches, so the fold cannot mis-attribute.
+//
+// A read failure is not fatal: dolt_ignore does not exist on a never-migrated
+// database (the first INSERT creates it), and that path is privileged by
+// construction. Treat the probe as "nothing present" and let the writes run,
+// which is exactly the pre-read behavior.
+func missingDoltIgnorePatterns(ctx context.Context, db DBConn, candidates []string) []string {
+	present := make(map[string]bool, len(candidates))
+	placeholders := make([]string, len(candidates))
+	args := make([]any, len(candidates))
+	for i, pattern := range candidates {
+		placeholders[i] = "?"
+		args[i] = pattern
+	}
+	query := "SELECT pattern FROM dolt_ignore WHERE pattern IN (" + strings.Join(placeholders, ", ") + ")"
+	if rows, err := db.QueryContext(ctx, query, args...); err == nil {
+		for rows.Next() {
+			var stored string
+			if err := rows.Scan(&stored); err != nil {
+				break
+			}
+			present[strings.ToLower(stored)] = true
+		}
+		rows.Close()
+	}
+	missing := make([]string, 0, len(candidates))
+	for _, pattern := range candidates {
+		if present[strings.ToLower(pattern)] {
+			continue
+		}
+		missing = append(missing, pattern)
+	}
+	return missing
+}
+
+// seedDoltIgnorePatterns idempotently asserts the canonical dolt_ignore
+// patterns and reports whether it actually changed anything.
+//
+// It READS before it writes, and issues no statement at all for a pattern
+// that is already registered. That is not an optimization: the store is
+// opened by every client, including a wire client coming through the hosted
+// or box fence, whose operator grant is deliberately SELECT/DML-on-data-only.
+// A blind `INSERT IGNORE` is a write for privilege purposes even when it
+// changes nothing, so the unconditional form made a correctly-seeded database
+// un-openable through a fence, and the only way to open it was to grant
+// INSERT on dolt_ignore — which lets a wire client register a pattern for
+// `issues` and silently stop its own writes from ever being committed. The
+// read costs one round trip and removes the need for that grant.
+//
+// The write path is unchanged where a write is genuinely owed: INSERT IGNORE
+// leaves existing rows untouched, so an explicit operator override (pattern
+// present with ignored=false) is respected even in the race where the probe
+// missed it. On an under-seeded database the new rows land in the working set
+// and take effect immediately; who commits them depends on the pass: when
+// migration work is needed, MigrateUp exempts dolt_ignore from the
+// pre-existing-dirty guards as pass-owned state (same treatment as the
+// aux-rekey tables) and stageSchemaTables commits it with the pass; on the
+// no-work short-circuit, MigrateUp commits the seed itself in a scoped,
+// labeled commit (keyed off the changed return value) so the heal converges
+// in one pass instead of riding along inside an unrelated later commit.
+func seedDoltIgnorePatterns(ctx context.Context, db DBConn) (bool, error) {
+	changed := false
+	for _, pattern := range missingDoltIgnorePatterns(ctx, db, doltIgnoreSeedCandidates(ctx, db)) {
+		res, err := db.ExecContext(ctx, "INSERT IGNORE INTO dolt_ignore VALUES (?, true)", pattern)
+		if err != nil {
+			return changed, fmt.Errorf("seeding dolt_ignore pattern %q: %w", pattern, err)
+		}
+		// A RowsAffected error degrades to changed=false for that row: the
+		// seed then stays an uncommitted working-set diff swept up by the
+		// next commit, exactly the pre-scoped-commit behavior.
+		if n, raErr := res.RowsAffected(); raErr == nil && n > 0 {
+			changed = true
 		}
 	}
 	return changed, nil


### PR DESCRIPTION
`seedDoltIgnorePatterns` ran `INSERT IGNORE` for every canonical pattern on
*every* store open — including opens by a wire client through a fence, and
including a database where all the rows were already present and correct.

`INSERT IGNORE` needs the INSERT privilege whether or not it changes a row, so
a fenced operator user — granted DML on the data tables and nothing else —
could not open a healthy store at all:

```
failed to initialize schema: schema migration: seeding dolt_ignore pattern
'ignored_schema_migrations': Error 1105 (HY000): command denied to user
```

The seed now probes first with a single `SELECT` over exactly the candidate
patterns and writes only what is missing, so a correct store costs one read and
zero writes. The presence test is `WHERE pattern IN (...)`, which decides
equality under the *column's* collation — the same comparison the primary key
uses to swallow an `INSERT IGNORE` — rather than Go string equality guessing at
it; stored spellings are matched back case-insensitively.

Chosen over gating the seed on the opener's identity: the engine has no
trustworthy signal for "I am the migrating identity" at this layer, and a
read-first seed needs none. It still writes on a genuinely fresh store, where
`dolt_ignore` does not exist yet and the probe fails — that path is privileged
by construction, and the failure degrades to the old blind write rather than to
"everything is present".

The alternative considered and rejected was to `GRANT INSERT ON <db>.dolt_ignore`
to the fenced user. That would let a wire client register an ignore pattern for
`issues`, after which its own writes stop being staged and committed while every
statement still returns success — silent data loss.

## Tests

`internal/storage/schema/dolt_ignore_seed_test.go` covers the fenced case (zero
statements issued when everything is present — sqlmock's ordered mode fails any
unexpected Exec, which is the shape the fence produces at the wire), the heal
case (only the missing rows written), the fresh-database case (probe fails,
blind write still runs), and stored-casing matching.

Mutation-verified: restoring the unconditional write makes
`TestSeedDoltIgnorePatternsWritesNothingWhenAllPatternsPresent` fail.

`go test ./internal/storage/schema/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)