### PR TITLE
fix(doltremote): treat s3:// as a native Dolt remote scheme

### DIFF
--- a/internal/doltremote/remote.go
+++ b/internal/doltremote/remote.go
@@ -1,6 +1,9 @@
 package doltremote
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 // NativeSchemes are URL schemes that Dolt understands natively and should not
 // be converted through FromGitURL.
@@ -9,6 +12,7 @@ var NativeSchemes = []string{
 	"file://",
 	"aws://",
 	"gs://",
+	"s3://",
 	"git+https://",
 	"git+ssh://",
 	"git+http://",
@@ -62,31 +66,21 @@ func FromGitURL(url string) string {
 	return "git+" + url
 }
 
+var scpStyleGitURLPattern = regexp.MustCompile(`^(?:[a-zA-Z0-9._-]+@[a-zA-Z0-9][a-zA-Z0-9._-]*|[a-zA-Z0-9][a-zA-Z0-9._-]*\.[a-zA-Z0-9._-]*):[^\x00-\x1f\x7f]+$`)
+
 // isSCPStyleGitURL reports whether url looks like an SCP-style git remote:
-// either the classic user form (git@host:path) or the user-less form
-// (host:path). The user-less form is only recognized when the pre-colon
-// token looks like a hostname (contains a ".") so that dotless tokens such
-// as a Windows drive letter ("C:foo") are not mistaken for a host.
+// user@host:path, or host:path when the pre-colon token contains a "." so a
+// Windows drive letter ("C:foo") is not mistaken for a host. Anything that
+// carries a "://" scheme is never SCP-style, whatever else it contains, so a
+// query or path with "@" in it cannot turn an s3:// URL into a git remote.
 //
-// Known limitation: git itself also accepts dotless SSH config aliases in
-// this position (e.g. "github:org/repo.git", "localhost:repo.git"), which
-// the "." check above rejects. Those origins pass through unconverted and
-// won't canonically match an equivalent git+ssh://alias/... or
-// user@alias:path Dolt remote. This is a deliberate trade-off to keep
-// isWindowsDrivePath's single-letter-drive check from being the only guard
-// against misreading "C:foo" as a host; widening the rule (e.g. following
-// git's own convention of treating anything host:path as SCP-style unless
-// the pre-colon token is a single-letter drive) is tracked as a follow-up
-// rather than fixed here.
+// Known limitations: git also accepts dotless SSH config aliases
+// ("github:org/repo.git"); those pass through unconverted and will not
+// canonically match an equivalent git+ssh:// form. User and host are limited
+// to [a-zA-Z0-9._-], so non-ASCII userinfo and IDN hosts are not recognized
+// either.
 func isSCPStyleGitURL(url string) bool {
-	idx := strings.Index(url, ":")
-	if idx <= 0 || strings.Contains(url[:idx], "/") {
-		return false
-	}
-	if strings.Contains(url, "@") {
-		return true
-	}
-	return strings.Contains(url[:idx], ".")
+	return !strings.Contains(url, "://") && scpStyleGitURLPattern.MatchString(url)
 }
 
 // CanonicalForComparison returns a form of url suitable for equality checks

--- a/internal/doltremote/remote.go
+++ b/internal/doltremote/remote.go
@@ -20,7 +20,7 @@ var NativeSchemes = []string{
 }
 
 // Normalize converts a remote URL to a Dolt-compatible format.
-// Dolt-native URLs (dolthub://, file://, aws://, gs://, git+...) are returned
+// Dolt-native URLs (dolthub://, file://, aws://, gs://, s3://, git+...) are returned
 // as-is. Git URLs (https://, ssh://, git@...) are converted via FromGitURL.
 // Unknown schemes are returned as-is and let dolt clone decide.
 func Normalize(url string) string {

--- a/internal/doltremote/remote_invariant_test.go
+++ b/internal/doltremote/remote_invariant_test.go
@@ -1,0 +1,24 @@
+package doltremote_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/doltremote"
+	"github.com/steveyegge/beads/internal/remotecache"
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+)
+
+func TestS3RemotePreservesInternalBoundaries(t *testing.T) {
+	// The "@" in the path is what the old SCP heuristic tripped on.
+	const raw = "s3://bucket/team@prod/db?endpoint=https://acct.r2.example&region=auto&path-style=true"
+
+	if err := remotecache.ValidateRemoteURL(raw); err != nil {
+		t.Fatalf("ValidateRemoteURL(%q): %v", raw, err)
+	}
+	if got := doltremote.Normalize(raw); got != raw {
+		t.Errorf("Normalize(%q) = %q, want unchanged", raw, got)
+	}
+	if doltutil.IsGitProtocolURL(raw) {
+		t.Errorf("IsGitProtocolURL(%q) = true, want false", raw)
+	}
+}

--- a/internal/doltremote/remote_test.go
+++ b/internal/doltremote/remote_test.go
@@ -1,0 +1,47 @@
+package doltremote
+
+import "testing"
+
+func TestIsSCPStyleGitURLRecognizesValidForms(t *testing.T) {
+	tests := []string{
+		"git@github.com:org/repo.git",
+		"deploy@myserver.com:beads/data",
+		"git@github:org/repo.git",
+		"github.com:org/repo.git",
+		// Dots in the user token are inside the accepted charset.
+		"user.name@host.com:path",
+	}
+
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			if !isSCPStyleGitURL(raw) {
+				t.Errorf("isSCPStyleGitURL(%q) = false, want true", raw)
+			}
+		})
+	}
+}
+
+func TestIsSCPStyleGitURLRejectsNonSCPInputs(t *testing.T) {
+	tests := []string{
+		"s3://bucket/team@prod/beads",
+		"s3://bucket/db?endpoint=https://minio.local/api@v1",
+		`C:\Users\alice\beads`,
+		"C:/Users/alice/beads",
+		// Empty path. The "@" alone used to classify this as SCP-style; the
+		// anchored grammar requires at least one path character.
+		"git@host.com:",
+		// Non-ASCII userinfo is outside [a-zA-Z0-9._-]; the URL passes
+		// through unconverted instead of being rewritten to git+ssh://.
+		"usér@host.com:path",
+		// IDN host, same charset limit.
+		"git@bücher.example:repo",
+	}
+
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			if isSCPStyleGitURL(raw) {
+				t.Errorf("isSCPStyleGitURL(%q) = true, want false", raw)
+			}
+		})
+	}
+}

--- a/internal/doltremote/remote_test.go
+++ b/internal/doltremote/remote_test.go
@@ -1,6 +1,9 @@
 package doltremote
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestIsSCPStyleGitURLRecognizesValidForms(t *testing.T) {
 	tests := []string{
@@ -30,6 +33,11 @@ func TestIsSCPStyleGitURLRejectsNonSCPInputs(t *testing.T) {
 		// Empty path. The "@" alone used to classify this as SCP-style; the
 		// anchored grammar requires at least one path character.
 		"git@host.com:",
+		// Dotless host with the only "@" after the colon. The "@" alone used
+		// to classify these as SCP-style (host:pa@th -> git+ssh://host/pa@th);
+		// the anchored grammar wants user@host or a dotted host before the colon.
+		"host:pa@th",
+		"alias:repo@v1",
 		// Non-ASCII userinfo is outside [a-zA-Z0-9._-]; the URL passes
 		// through unconverted instead of being rewritten to git+ssh://.
 		"usér@host.com:path",
@@ -41,6 +49,30 @@ func TestIsSCPStyleGitURLRejectsNonSCPInputs(t *testing.T) {
 		t.Run(raw, func(t *testing.T) {
 			if isSCPStyleGitURL(raw) {
 				t.Errorf("isSCPStyleGitURL(%q) = true, want false", raw)
+			}
+		})
+	}
+}
+
+func TestNativeSchemesContainsEachNativeScheme(t *testing.T) {
+	tests := []string{
+		"dolthub://",
+		"file://",
+		"aws://",
+		"gs://",
+		// s3 URLs must take the native fast path rather than survive
+		// Normalize by falling through past the git heuristics.
+		"s3://",
+		"git+https://",
+		"git+ssh://",
+		"git+http://",
+		"git+file://",
+	}
+
+	for _, scheme := range tests {
+		t.Run(scheme, func(t *testing.T) {
+			if !slices.Contains(NativeSchemes, scheme) {
+				t.Errorf("slices.Contains(NativeSchemes, %q) = false, want true", scheme)
 			}
 		})
 	}


### PR DESCRIPTION
**Layer**: internal (`internal/doltremote`) only. **Diff**: 3 files, +121/-24 (`remote.go` +18/-24, the rest is two test files). Two commits on current main: the fix (`6d749bb92`, the head you approved) and the round-2 follow-up (`7cb918ebb`), folded in from #6345.

---

## What

Add `s3://` to `NativeSchemes` and stop the SCP-style heuristic from treating
any `@` in a URL as a git remote.

## Why

Dolt merged S3-compatible `s3://` remotes (AWS S3, Cloudflare R2, MinIO) in
dolthub/dolt#11571. Before bd's dolt dependency catches up, two scheme-handling
bugs in stock beads need fixing, both provable today.

**Bug 1: `s3://` is not in `NativeSchemes`.** A plain `s3://bucket/db` survives
`Normalize` only because it falls through every branch unchanged. That works by
accident, and the accident ends at bug 2.

**Bug 2: the SCP heuristic treats any `@` as an SCP-style git remote.**
`isSCPStyleGitURL` matched on `strings.Contains(url, "@")`, so a valid s3 URL
with `@` in its path is rewritten into a bogus git remote:

```
Normalize("s3://bucket/team@prod/beads")  ->  "git+ssh://s3///bucket/team@prod/beads"
```

Dolt's s3 URLs carry routing in the query string
(`?endpoint=...&region=...&path-style=true`), which makes `@` in URLs more
likely.

**Changes**

- Add `"s3://"` to `NativeSchemes` (s3 only). `az://` has the same gap (#3101
  added it to the validator and credential maps but not here); that is tracked
  in #6227 and deliberately not folded into this PR.
- Anchor SCP detection: a string is SCP-style only when it has no `://` scheme
  and matches a `user@host:path` grammar. Every currently valid SCP form is
  pinned by a positive regression table that passes before and after the
  change.
- Cross-surface invariant test: an s3 URL with `@` in its path and routing in
  its query is accepted by the remotecache validator, returned byte-for-byte by
  `Normalize`, and classified false by `IsGitProtocolURL`. On main's
  `remote.go` it fails (`Normalize` rewrites it to `git+ssh://s3///...`).
- Round-2 follow-up (`7cb918ebb`): `TestNativeSchemesContainsEachNativeScheme`
  asserts every entry of `NativeSchemes`, so deleting the `s3://` line fails
  its `s3://` subtest; `host:pa@th` and `alias:repo@v1` are reject rows; and
  `s3://` is in the `Normalize` doc comment.

**Behavior notes**

Three inputs classify differently than before, beyond the s3 fix. Each is
pinned by a row in `TestIsSCPStyleGitURLRejectsNonSCPInputs`:

- The malformed empty-path form `git@host.com:` used to classify as SCP-style
  on the `@` alone; it now classifies false.
- User and host must be `[a-zA-Z0-9._-]`, so non-ASCII userinfo or IDN hosts
  (`usér@host.com:path`, `git@bücher.example:repo`) no longer classify as
  SCP-style. They pass through `Normalize` unconverted, and
  `CanonicalForComparison` will not match them against an equivalent
  `git+ssh://` form.
- A dotless pre-colon token with `@` only after the colon (`host:pa@th`,
  `alias:repo@v1`) used to classify as SCP-style on the `@` alone and normalize
  to `git+ssh://host/pa@th`. It now passes through unchanged, so the
  dotless-alias limitation applies uniformly instead of exempting aliases with
  an `@` in the path. Such a remote no longer matches its `git+ssh://`
  equivalent under `CanonicalForComparison`.

The dotless-SSH-alias limitation itself (hosts without a dot still require
the `user@` form) is unchanged and stays documented on the function.

## Verification

- `go test ./internal/doltremote/... ./internal/remotecache/... -count=1`: ok.
- `make test`: exit 0, 98 packages ok, 0 failures (macOS, go 1.26.5, `gms_pure_go`, CGO on).
- `make ci-pr-lint` with `BD_LINT_NEW_FROM_MERGE_BASE=origin/main` (the form
  the PR lane runs): 0 issues on the native and Windows lanes.
- Red/green: with `origin/main`'s `internal/doltremote/remote.go` dropped into
  this tree and the same test files, six subtests fail
  (`s3://bucket/team@prod/beads`,
  `s3://bucket/db?endpoint=https://minio.local/api@v1`, `git@host.com:`,
  `usér@host.com:path`, `git@bücher.example:repo`, and
  `TestS3RemotePreservesInternalBoundaries`); all pass with this branch's
  `remote.go`. The five-row positive SCP table passes on both.
- Second commit: with `"s3://"` removed from `NativeSchemes` only the `s3://`
  subtest fails; the two dotless-alias rows fail on `origin/main`'s `remote.go`.

Existing tests: additions only, zero modified assertions.

