### PR TITLE
fix(storage): accept remote backup URLs in RestoreDatabase (server + embedded)

### DIFF
--- a/internal/storage/dolt/restore_source_test.go
+++ b/internal/storage/dolt/restore_source_test.go
@@ -1,0 +1,79 @@
+package dolt
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
+)
+
+func TestRestoreDatabaseRoutesBackupURLWithoutStat(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	const source = "s3://backup-bucket/beads"
+	mock.ExpectExec("CALL DOLT_BACKUP('restore', ?, ?)").
+		WithArgs(source, "beads").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	store := &DoltStore{database: "beads"}
+	err = store.restoreDatabase(t.Context(), source, false, func(time.Duration) (*sql.DB, error) {
+		return db, nil
+	})
+	if err != nil {
+		t.Fatalf("RestoreDatabase: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestRestoreDatabaseKeepsDirectorySourceBehavior(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	source := t.TempDir()
+	want, err := versioncontrolops.DirToFileURL(source)
+	if err != nil {
+		t.Fatalf("DirToFileURL(%q): %v", source, err)
+	}
+	mock.ExpectExec("CALL DOLT_BACKUP('restore', ?, ?)").
+		WithArgs(want, "beads").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	store := &DoltStore{database: "beads"}
+	err = store.restoreDatabase(t.Context(), source, false, func(time.Duration) (*sql.DB, error) {
+		return db, nil
+	})
+	if err != nil {
+		t.Fatalf("RestoreDatabase: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestRestoreDatabaseStatsDirectorySource(t *testing.T) {
+	source := t.TempDir() + "/missing"
+	store := &DoltStore{database: "beads"}
+	err := store.restoreDatabase(t.Context(), source, false, func(time.Duration) (*sql.DB, error) {
+		t.Fatal("RestoreDatabase opened a connection for a missing directory")
+		return nil, nil
+	})
+	if err == nil {
+		t.Fatal("RestoreDatabase returned nil for a missing directory")
+	}
+	if !strings.Contains(err.Error(), "backup source does not exist") {
+		t.Fatalf("RestoreDatabase error %q does not report a missing backup source", err)
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1338,22 +1338,20 @@ func (s *DoltStore) BackupDatabase(ctx context.Context, dir string) error {
 	return nil
 }
 
-// RestoreDatabase restores the database from a Dolt backup at dir.
+// RestoreDatabase restores the database from a local backup directory or a
+// backup URL accepted by DOLT_BACKUP (see versioncontrolops.ResolveBackupSource).
 // When force is true, an existing database is overwritten.
-func (s *DoltStore) RestoreDatabase(ctx context.Context, dir string, force bool) error {
-	info, err := os.Stat(dir)
-	if err != nil {
-		return fmt.Errorf("backup source does not exist: %w", err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("backup source is not a directory: %s", dir)
-	}
+func (s *DoltStore) RestoreDatabase(ctx context.Context, source string, force bool) error {
+	return s.restoreDatabase(ctx, source, force, s.oneShotConn)
+}
 
-	backupURL, err := versioncontrolops.DirToFileURL(dir)
+func (s *DoltStore) restoreDatabase(ctx context.Context, source string, force bool, openConn func(time.Duration) (*sql.DB, error)) error {
+	backupURL, err := versioncontrolops.ResolveBackupSource(source)
 	if err != nil {
 		return err
 	}
-	db, err := s.oneShotConn(0)
+
+	db, err := openConn(0)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1296,7 +1296,9 @@ func (s *DoltStore) BackupRemove(ctx context.Context, name string) error {
 }
 
 // BackupDatabase registers dir as a file:// Dolt backup remote and syncs
-// the full database to it, preserving complete commit history.
+// the full database to it, preserving complete commit history. It stays
+// directory-only on purpose: backup to a remote URL goes through BackupAdd
+// and BackupSync, while RestoreDatabase accepts a directory or a URL.
 func (s *DoltStore) BackupDatabase(ctx context.Context, dir string) error {
 	info, err := os.Stat(dir)
 	if err != nil {

--- a/internal/storage/embeddeddolt/restore_source_test.go
+++ b/internal/storage/embeddeddolt/restore_source_test.go
@@ -1,0 +1,49 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A backup URL must reach DOLT_BACKUP unchanged instead of being stat'ed as a
+// directory. A file:// URL whose path sits under a regular file is
+// deterministic: Dolt cannot create that directory (root included), the
+// restore fails, and the error carries versioncontrolops.BackupRestore's
+// "restore from backup <url>" wrapper, which proves the URL was passed to
+// CALL DOLT_BACKUP('restore', ...) byte-for-byte.
+func TestRestoreDatabaseRoutesBackupURLWithoutStat(t *testing.T) {
+	env := newTestEnv(t, "test")
+	blocker := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blocker, nil, 0o600); err != nil {
+		t.Fatalf("write %q: %v", blocker, err)
+	}
+	source := "file://" + filepath.Join(blocker, "backup")
+
+	err := env.store.RestoreDatabase(t.Context(), source, false)
+	if err == nil {
+		t.Fatalf("RestoreDatabase(%q) returned nil for a backup that cannot exist", source)
+	}
+	if !strings.Contains(err.Error(), "restore from backup "+source) {
+		t.Fatalf("RestoreDatabase error %q does not show the URL reaching DOLT_BACKUP unchanged", err)
+	}
+	if strings.Contains(err.Error(), "backup source does not exist") {
+		t.Fatalf("RestoreDatabase stat'ed a backup URL: %v", err)
+	}
+}
+
+func TestRestoreDatabaseStatsDirectorySource(t *testing.T) {
+	env := newTestEnv(t, "test")
+	source := filepath.Join(t.TempDir(), "missing")
+
+	err := env.store.RestoreDatabase(t.Context(), source, false)
+	if err == nil {
+		t.Fatal("RestoreDatabase returned nil for a missing directory")
+	}
+	if !strings.Contains(err.Error(), "backup source does not exist") {
+		t.Fatalf("RestoreDatabase error %q does not report a missing backup source", err)
+	}
+}

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -765,19 +765,11 @@ func (s *EmbeddedDoltStore) BackupDatabase(ctx context.Context, dir string) erro
 	})
 }
 
-// RestoreDatabase restores the database from a Dolt backup at dir.
-// The dir must exist locally and contain a valid Dolt backup.
+// RestoreDatabase restores the database from a local backup directory or a
+// backup URL accepted by DOLT_BACKUP (see versioncontrolops.ResolveBackupSource).
 // When force is true, an existing database is overwritten.
-func (s *EmbeddedDoltStore) RestoreDatabase(ctx context.Context, dir string, force bool) error {
-	info, err := os.Stat(dir)
-	if err != nil {
-		return fmt.Errorf("backup source does not exist: %w", err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("backup source is not a directory: %s", dir)
-	}
-
-	backupURL, err := versioncontrolops.DirToFileURL(dir)
+func (s *EmbeddedDoltStore) RestoreDatabase(ctx context.Context, source string, force bool) error {
+	backupURL, err := versioncontrolops.ResolveBackupSource(source)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -727,7 +727,9 @@ func (s *EmbeddedDoltStore) BackupRemove(ctx context.Context, name string) error
 
 // BackupDatabase registers dir as a file:// Dolt backup remote and syncs
 // the database to it. The dir must exist locally. This preserves full Dolt
-// commit history.
+// commit history. It stays directory-only on purpose: backup to a remote URL
+// goes through BackupAdd and BackupSync, while RestoreDatabase accepts a
+// directory or a URL.
 func (s *EmbeddedDoltStore) BackupDatabase(ctx context.Context, dir string) error {
 	info, err := os.Stat(dir)
 	if err != nil {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -851,9 +851,12 @@ type BackupStore interface {
 	// BackupDatabase registers dir as a file:// Dolt backup remote and syncs
 	// the full database to it, preserving complete commit history.
 	BackupDatabase(ctx context.Context, dir string) error
-	// RestoreDatabase restores the database from a Dolt backup at dir.
+	// RestoreDatabase restores the database from a Dolt backup at source, which
+	// is either a local backup directory or a backup URL that DOLT_BACKUP accepts
+	// (versioncontrolops.IsBackupURL). Implementations must not require the source
+	// to exist on the local filesystem when it is a URL.
 	// When force is true, the existing database is dropped before restoring.
-	RestoreDatabase(ctx context.Context, dir string, force bool) error
+	RestoreDatabase(ctx context.Context, source string, force bool) error
 }
 
 // ReadyWorkCounter sizes the total ready-work count for a filter without

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -849,7 +849,9 @@ type BackupStore interface {
 	BackupSync(ctx context.Context, name string) error
 	BackupRemove(ctx context.Context, name string) error
 	// BackupDatabase registers dir as a file:// Dolt backup remote and syncs
-	// the full database to it, preserving complete commit history.
+	// the full database to it, preserving complete commit history. It stays
+	// directory-only on purpose: backup to a remote URL goes through BackupAdd
+	// and BackupSync, while RestoreDatabase accepts a directory or a URL.
 	BackupDatabase(ctx context.Context, dir string) error
 	// RestoreDatabase restores the database from a Dolt backup at source, which
 	// is either a local backup directory or a backup URL that DOLT_BACKUP accepts

--- a/internal/storage/versioncontrolops/backup.go
+++ b/internal/storage/versioncontrolops/backup.go
@@ -3,6 +3,7 @@ package versioncontrolops
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -54,6 +55,49 @@ func DirToFileURL(dir string) (string, error) {
 		return "", fmt.Errorf("resolve absolute path: %w", err)
 	}
 	return "file://" + abs, nil
+}
+
+// backupSchemes are the URL schemes DOLT_BACKUP accepts as a destination or
+// restore source. Deliberately not doltremote.NativeSchemes: that list is the
+// clone/push vocabulary, excludes the http(s) backups bd already supports and
+// includes git+ schemes that are not backup targets.
+// az:// is a valid Dolt scheme (dbfactory/az.go) but is missing here and in
+// NativeSchemes alike; tracked in #6227.
+var backupSchemes = map[string]bool{
+	"http": true, "https": true, "file": true, "aws": true, "gs": true, "s3": true,
+}
+
+// IsBackupURL reports whether raw carries a scheme DOLT_BACKUP accepts. It
+// classifies by scheme token only (everything before the first "://",
+// lowercased) and does not validate the URL: Go 1.25.2+ url.Parse rejects
+// Dolt's bracketed aws://[dynamo_table:bucket]/db form (Dolt itself carries a
+// shim for it, earl.ParseRawWithAWSSupport), so parse-validity is the wrong
+// signal. URL validity stays Dolt's job.
+func IsBackupURL(raw string) bool {
+	sep := strings.Index(raw, "://")
+	if sep <= 0 {
+		return false
+	}
+	return backupSchemes[strings.ToLower(raw[:sep])]
+}
+
+// ResolveBackupSource turns a restore source into the URL passed to
+// DOLT_BACKUP('restore', ...). Recognized backup URLs pass through unchanged
+// and are never stat'ed; anything else must be an existing local directory
+// and is converted with DirToFileURL. The error strings are load-bearing:
+// the resolver and store tests assert them.
+func ResolveBackupSource(source string) (string, error) {
+	if IsBackupURL(source) {
+		return source, nil
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		return "", fmt.Errorf("backup source does not exist: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("backup source is not a directory: %s", source)
+	}
+	return DirToFileURL(source)
 }
 
 // ExtractAddressConflictName parses the conflicting remote name from a Dolt

--- a/internal/storage/versioncontrolops/backup.go
+++ b/internal/storage/versioncontrolops/backup.go
@@ -38,14 +38,40 @@ func BackupRemove(ctx context.Context, db DBConn, name string) error {
 func BackupRestore(ctx context.Context, db DBConn, url, dbName string, force bool) error {
 	if force {
 		if _, err := db.ExecContext(ctx, "CALL DOLT_BACKUP('restore', '--force', ?, ?)", url, dbName); err != nil {
-			return fmt.Errorf("restore from backup %s: %w", url, err)
+			return fmt.Errorf("restore from backup %s: %w", redactBackupURL(url), err)
 		}
 	} else {
 		if _, err := db.ExecContext(ctx, "CALL DOLT_BACKUP('restore', ?, ?)", url, dbName); err != nil {
-			return fmt.Errorf("restore from backup %s: %w", url, err)
+			return fmt.Errorf("restore from backup %s: %w", redactBackupURL(url), err)
 		}
 	}
 	return nil
+}
+
+// redactBackupURL strips the parts of a backup URL that can carry credentials
+// before BackupRestore quotes it in an error: userinfo (aws://key:secret@...)
+// and the query and fragment (s3 URLs carry signed parameters there). Scheme,
+// host and path stay. Plain string operations rather than url.Parse, which
+// rejects Dolt's bracketed aws://[dynamo_table:bucket]/db form (see
+// IsBackupURL). Only the wrapper's copy of the URL is redacted; the wrapped
+// Dolt error text is not rewritten.
+func redactBackupURL(source string) string {
+	sep := strings.Index(source, "://")
+	if sep < 0 {
+		return source
+	}
+	rest := source[sep+len("://"):]
+	if cut := strings.IndexAny(rest, "?#"); cut >= 0 {
+		rest = rest[:cut]
+	}
+	authority := rest
+	if slash := strings.Index(rest, "/"); slash >= 0 {
+		authority = rest[:slash]
+	}
+	if at := strings.LastIndex(authority, "@"); at >= 0 {
+		rest = rest[at+1:]
+	}
+	return source[:sep+len("://")] + rest
 }
 
 // DirToFileURL resolves dir to an absolute path and returns a file:// URL.
@@ -69,16 +95,20 @@ var backupSchemes = map[string]bool{
 
 // IsBackupURL reports whether raw carries a scheme DOLT_BACKUP accepts. It
 // classifies by scheme token only (everything before the first "://",
-// lowercased) and does not validate the URL: Go 1.25.2+ url.Parse rejects
+// case-sensitive) and does not validate the URL: Go 1.25.2+ url.Parse rejects
 // Dolt's bracketed aws://[dynamo_table:bucket]/db form (Dolt itself carries a
 // shim for it, earl.ParseRawWithAWSSupport), so parse-validity is the wrong
-// signal. URL validity stays Dolt's job.
+// signal. URL validity stays Dolt's job. Everything downstream matches
+// case-sensitively too: Dolt's dbfactory registry, remotecache and
+// doltremote all key on the lowercase scheme, so S3:// falls through to the
+// directory path and its clearer "backup source does not exist" error
+// instead of a Dolt internal error.
 func IsBackupURL(raw string) bool {
 	sep := strings.Index(raw, "://")
 	if sep <= 0 {
 		return false
 	}
-	return backupSchemes[strings.ToLower(raw[:sep])]
+	return backupSchemes[raw[:sep]]
 }
 
 // ResolveBackupSource turns a restore source into the URL passed to

--- a/internal/storage/versioncontrolops/backup_test.go
+++ b/internal/storage/versioncontrolops/backup_test.go
@@ -2,6 +2,9 @@ package versioncontrolops
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -41,6 +44,84 @@ func TestExtractAddressConflictName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ExtractAddressConflictName(tt.err); got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsBackupURL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "http", raw: "http://backup.example/beads", want: true},
+		{name: "https", raw: "https://backup.example/beads", want: true},
+		{name: "file", raw: "file:///var/backups/beads", want: true},
+		{name: "aws", raw: "aws://backup-bucket/beads", want: true},
+		{name: "bracketed aws", raw: "aws://[dolt_table:my_bucket]/db", want: true},
+		{name: "gs", raw: "gs://backup-bucket/beads", want: true},
+		{name: "s3", raw: "s3://backup-bucket/beads", want: true},
+		{name: "git ssh", raw: "git+ssh://git@example.com/org/repo.git", want: false},
+		{name: "git https", raw: "git+https://example.com/org/repo.git", want: false},
+		{name: "relative path", raw: "backups/beads", want: false},
+		{name: "absolute path", raw: "/var/backups/beads", want: false},
+		{name: "empty", raw: "", want: false},
+		{name: "scp style", raw: "git@example.com:org/repo.git", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsBackupURL(tt.raw); got != tt.want {
+				t.Errorf("IsBackupURL(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveBackupSource(t *testing.T) {
+	dir := t.TempDir()
+	dirURL, err := DirToFileURL(dir)
+	if err != nil {
+		t.Fatalf("DirToFileURL(%q): %v", dir, err)
+	}
+	file := filepath.Join(dir, "not-a-directory")
+	if err := os.WriteFile(file, nil, 0o600); err != nil {
+		t.Fatalf("write %q: %v", file, err)
+	}
+
+	tests := []struct {
+		name    string
+		source  string
+		want    string
+		wantErr string
+	}{
+		// A URL whose path does not exist locally: a stat would fail, so a
+		// verbatim return proves the URL was never stat'ed.
+		{name: "s3 URL passes through without stat", source: "s3://backup-bucket/beads", want: "s3://backup-bucket/beads"},
+		{name: "bracketed aws URL passes through", source: "aws://[dolt_table:my_bucket]/db", want: "aws://[dolt_table:my_bucket]/db"},
+		{name: "existing directory converts to file URL", source: dir, want: dirURL},
+		{name: "missing directory", source: filepath.Join(dir, "missing"), wantErr: "backup source does not exist"},
+		{name: "regular file", source: file, wantErr: "backup source is not a directory"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveBackupSource(tt.source)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ResolveBackupSource(%q) = %q, want error containing %q", tt.source, got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ResolveBackupSource(%q) error %q does not contain %q", tt.source, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveBackupSource(%q): %v", tt.source, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveBackupSource(%q) = %q, want %q", tt.source, got, tt.want)
 			}
 		})
 	}

--- a/internal/storage/versioncontrolops/backup_test.go
+++ b/internal/storage/versioncontrolops/backup_test.go
@@ -1,6 +1,9 @@
 package versioncontrolops
 
 import (
+	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -62,6 +65,7 @@ func TestIsBackupURL(t *testing.T) {
 		{name: "bracketed aws", raw: "aws://[dolt_table:my_bucket]/db", want: true},
 		{name: "gs", raw: "gs://backup-bucket/beads", want: true},
 		{name: "s3", raw: "s3://backup-bucket/beads", want: true},
+		{name: "uppercase scheme", raw: "S3://bucket/db", want: false},
 		{name: "git ssh", raw: "git+ssh://git@example.com/org/repo.git", want: false},
 		{name: "git https", raw: "git+https://example.com/org/repo.git", want: false},
 		{name: "relative path", raw: "backups/beads", want: false},
@@ -103,6 +107,7 @@ func TestResolveBackupSource(t *testing.T) {
 		{name: "existing directory converts to file URL", source: dir, want: dirURL},
 		{name: "missing directory", source: filepath.Join(dir, "missing"), wantErr: "backup source does not exist"},
 		{name: "regular file", source: file, wantErr: "backup source is not a directory"},
+		{name: "uppercase scheme is stat'ed as a path", source: "S3://bucket/db", wantErr: "backup source does not exist"},
 	}
 
 	for _, tt := range tests {
@@ -122,6 +127,78 @@ func TestResolveBackupSource(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Fatalf("ResolveBackupSource(%q) = %q, want %q", tt.source, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedactBackupURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{name: "userinfo", source: "aws://key:secret@bucket/db", want: "aws://bucket/db"},
+		{name: "signed query", source: "s3://bucket/db?X-Amz-Signature=abc&endpoint=https://minio.local", want: "s3://bucket/db"},
+		{name: "fragment", source: "s3://bucket/db#frag", want: "s3://bucket/db"},
+		{name: "user and query", source: "s3://user@bucket/db?x=1", want: "s3://bucket/db"},
+		{name: "bracketed aws", source: "aws://[dynamo-table:bucket]/db", want: "aws://[dynamo-table:bucket]/db"},
+		{name: "file URL", source: "file:///var/backups/x", want: "file:///var/backups/x"},
+		{name: "plain path", source: "/var/backups/x", want: "/var/backups/x"},
+		{name: "clean URL", source: "s3://bucket/db", want: "s3://bucket/db"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redactBackupURL(tt.source); got != tt.want {
+				t.Errorf("redactBackupURL(%q) = %q, want %q", tt.source, got, tt.want)
+			}
+		})
+	}
+}
+
+// failingConn fails every statement so BackupRestore's error wrapper can be
+// inspected.
+type failingConn struct {
+	err error
+}
+
+func (c *failingConn) ExecContext(context.Context, string, ...any) (sql.Result, error) {
+	return nil, c.err
+}
+
+func (c *failingConn) QueryContext(context.Context, string, ...any) (*sql.Rows, error) {
+	return nil, errStubConn
+}
+
+func (c *failingConn) QueryRowContext(context.Context, string, ...any) *sql.Row {
+	return nil
+}
+
+// A failed restore must not echo credentials a user put in the URL: userinfo
+// and signed query parameters both reach BackupRestore verbatim because
+// ResolveBackupSource passes URLs through untouched.
+func TestBackupRestoreRedactsURLInError(t *testing.T) {
+	tests := []struct {
+		name  string
+		force bool
+	}{
+		{name: "restore", force: false},
+		{name: "force restore", force: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := &failingConn{err: errors.New("dolt: restore failed")}
+			err := BackupRestore(context.Background(), conn, "aws://key:secret@bucket/db", "beads", tt.force)
+			if err == nil {
+				t.Fatal("BackupRestore returned nil for a failing statement")
+			}
+			if !strings.Contains(err.Error(), "restore from backup aws://bucket/db") {
+				t.Fatalf("BackupRestore error %q does not carry the redacted URL", err)
+			}
+			if strings.Contains(err.Error(), "secret") {
+				t.Fatalf("BackupRestore error %q leaks the credential", err)
 			}
 		})
 	}


### PR DESCRIPTION
**Base**: main. **Layer**: storage (`internal/storage/versioncontrolops`, both `BackupStore` implementations). **Diff**: 7 files, +389/-30. No `cmd/bd` changes. Two commits on current main: the fix (`0447b0b70`, the head you approved) and the round-2 follow-up (`a1f0a7aaa`), folded in from #6346.

---

## What

`RestoreDatabase` now accepts a backup URL as its source in both the server-mode store (`internal/storage/dolt`) and the embedded store (`internal/storage/embeddeddolt`). A recognised URL is handed to `DOLT_BACKUP('restore', ...)` unchanged; a local directory keeps today's validation, `file://` conversion and error text.

## Why

`bd backup` can point at remote destinations, but restore cannot read from them. Both `RestoreDatabase` implementations stat their source, require a directory, convert it to a `file://` URL, and only then call the URL-capable `BackupRestore` procedure. Stock repro, identical in both modes:

```
RestoreDatabase(ctx, "s3://bucket/backups/db", false)
  -> "backup source does not exist: stat s3:/...: no such file or directory"
```

The URL never reaches Dolt. dolthub/dolt#11571 shipped in dolt v2.3.2, so `s3://` stores (AWS S3, Cloudflare R2, MinIO) are now a supported backup destination, and a backup you can sync to but not restore from is the dangerous kind.

The first round of this PR fixed only the server-mode store. Review finding 1 pointed out that the embedded store, `bd`'s default backend, carried the same block. That is why the predicate and the directory fallback now live in one place both stores share, instead of being hoisted into each store separately.

## Changes

- `internal/storage/versioncontrolops/backup.go` gains two functions next to `BackupRestore` and `DirToFileURL`:
  - `IsBackupURL(raw)` classifies by scheme token (everything before the first `://`, case-sensitive like `remotecache`, `doltremote` and Dolt's registry) against the schemes `DOLT_BACKUP` accepts: `http, https, file, aws, gs, s3`. Two deliberate non-choices, both pinned by tests:
    - Not `url.Parse`. Go 1.25.2 and later reject Dolt's bracketed `aws://[dynamo_table:bucket]/db` form as an invalid host, and Dolt carries its own shim for exactly that (`earl.ParseRawWithAWSSupport`), so parse-validity is the wrong classification signal. URL validity stays Dolt's job.
    - Not `doltremote.NativeSchemes`. That list is the clone/push vocabulary: it excludes the `http(s)` backups `bd` already supports and includes `git+` schemes that are not backup targets.
  - `ResolveBackupSource(source)` returns a recognised URL unchanged and never stats it; anything else must be an existing local directory and goes through the existing stat, `IsDir` check and `DirToFileURL`, with error strings byte-identical to what both stores returned before.
- Both stores delegate to `ResolveBackupSource`, so each `RestoreDatabase` is the resolver call plus `BackupRestore`. `versioncontrolops` is already imported by both stores and by `cmd/bd`, so no new import edge appears, and in particular no `embeddeddolt -> storage/dolt` edge. The server store keeps the `restoreDatabase(ctx, source, force, openConn)` seam the sqlmock tests use. The first round's `internal/storage/dolt/backup_url.go` is deleted.
- `storage.BackupStore.RestoreDatabase` doc comment now says the source is a local backup directory or a backup URL that `DOLT_BACKUP` accepts, and that implementations must not require a URL to exist on the local filesystem. The parameter is renamed from `dir` to `source`.
- `az://` is a valid Dolt scheme (`dbfactory/az.go`) and is missing from `backupSchemes` and from `doltremote.NativeSchemes` alike. It is tracked in #6227 and deliberately not folded in here; the comment on `backupSchemes` says so.
- Round-2 follow-up (`a1f0a7aaa`): `BackupRestore` interpolates a redacted source into its `restore from backup %s` error (scheme, host and path kept; userinfo, query and fragment dropped), so `aws://key:secret@bucket/db` is reported as `aws://bucket/db`. The helper is string-based because `url.Parse` on go 1.26.5 rejects the bracketed aws form outright; the wrapped Dolt error text is not rewritten. `IsBackupURL` matches case-sensitively, so `S3://bucket/db` takes the directory path and fails with `backup source does not exist`, as on main. `BackupDatabase`'s doc comment, on the interface and both stores, says it stays directory-only because backup to a URL goes through `BackupAdd` and `BackupSync`.

## Tests

- `versioncontrolops/backup_test.go`: `TestIsBackupURL`, the 14-row truth table (all six schemes, uppercase `S3://`, bracketed aws, git schemes, bare and relative paths, scp-style, empty string), and `TestResolveBackupSource` (s3 and bracketed aws URLs returned verbatim with no stat, `S3://` stat'ed as a path, an existing directory converts to the `DirToFileURL` value, a missing directory and a regular file return the existing error strings).
- `dolt/restore_source_test.go` (renamed from `backup_url_test.go`): the three sqlmock tests proving a raw s3 URL reaches `CALL DOLT_BACKUP('restore', ?, ?)` with no stat, that a directory source still converts, and that a missing directory still fails with the existing error before any connection is opened.
- `embeddeddolt/restore_source_test.go` (new): a `file://` URL whose path sits under a regular file (so Dolt cannot create it on any platform, root included) is passed to `DOLT_BACKUP` unchanged. This is asserted through `BackupRestore`'s `restore from backup <url>` wrapper, which only appears once the URL has reached the procedure. Against the reviewed head's embedded implementation this test fails with `backup source does not exist: stat file://...`, the error this PR removes. The missing-directory case still returns that error.

- `versioncontrolops/backup_test.go` (follow-up): `TestRedactBackupURL` (8 rows) and `TestBackupRestoreRedactsURLInError` (plain and `--force` paths, so both error sites are covered). With both call sites passing the raw URL, the latter fails with `restore from backup aws://key:secret@bucket/db: ...`.

The real network restore stays covered end to end by #5952's `TestS3MinioEmbeddedBackupRestore`.

## Verification

```
CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go test ./internal/storage/versioncontrolops/... ./internal/storage/dolt/... ./internal/storage/embeddeddolt/... -run 'IsBackupURL|ResolveBackupSource|RestoreDatabase' -count=1 -v
./scripts/test.sh ./internal/storage/... ./cmd/bd/...
make test
BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint
go build ./... && go vet ./internal/storage/...
```

All green locally (go 1.26.5, darwin/arm64, golangci-lint v2.10.1; the lint wrapper is scoped to the merge base the way the PR lane runs it). Rebased on `main` at `c0d8da42d`; the Cross-Version Smoke red from the first round was present on `main` at the time and that workflow has been green on `main` since `40b323245`.

## Stacking

#5950 is stacked on this branch and retargets its two `cmd/bd` call sites to `versioncontrolops.IsBackupURL`. #5952 no longer carries a restore change.

