### PR TITLE
fix(cmd/bd): route backup URLs through the storage predicate

### DIFF
--- a/cmd/bd/backup.go
+++ b/cmd/bd/backup.go
@@ -24,7 +24,7 @@ and interoperability.
 Commands:
   bd backup init <path>    Set up a backup destination (filesystem or DoltHub)
   bd backup sync           Push to configured backup destination
-  bd backup restore [path] Restore from a backup directory
+  bd backup restore [path] Restore from a backup directory or remote URL
   bd backup remove         Remove backup destination
   bd backup status         Show backup status
 

--- a/cmd/bd/backup_dolt.go
+++ b/cmd/bd/backup_dolt.go
@@ -182,13 +182,11 @@ Run 'bd backup init <path>' first to configure a destination.`,
 }
 
 // resolveDoltBackupURL converts a user-provided path or URL into a Dolt backup URL.
-// Filesystem paths get resolved to absolute and prefixed with file://
-// URLs (https://, http://) are passed through as-is.
+// Recognized backup URLs (versioncontrolops.IsBackupURL) pass through unchanged;
+// anything else is treated as a filesystem path, resolved to absolute and
+// prefixed with file://.
 func resolveDoltBackupURL(raw string) string {
-	// DoltHub or other remote URLs — pass through
-	if strings.HasPrefix(raw, "https://") || strings.HasPrefix(raw, "http://") ||
-		strings.HasPrefix(raw, "file://") || strings.HasPrefix(raw, "aws://") ||
-		strings.HasPrefix(raw, "gs://") {
+	if versioncontrolops.IsBackupURL(raw) {
 		return raw
 	}
 

--- a/cmd/bd/backup_dolt_test.go
+++ b/cmd/bd/backup_dolt_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,46 +23,58 @@ func TestResolveDoltBackupURL(t *testing.T) {
 	// t.TempDir() is absolute and already cleaned on every platform.
 	absBackup := filepath.Join(t.TempDir(), "beads-backup")
 
+	// TODO(#6227): az:// is a valid Dolt backup/remote scheme, but this PR only fixes the s3:// stack. Do not add a green row for today's az:// local-file fallback here.
 	tests := []struct {
-		name      string
-		input     string
-		wantPfx   string // expected prefix
-		wantExact string // exact match (empty = use prefix check)
+		name  string
+		input string
+		want  string
+		// wantRel asserts structure instead of an exact value: cwd can move under a parallel test.
+		wantRel bool
 	}{
 		{
-			name:      "https URL passes through",
-			input:     "https://doltremoteapi.dolthub.com/user/repo",
-			wantExact: "https://doltremoteapi.dolthub.com/user/repo",
+			name:  "https URL passes through",
+			input: "https://doltremoteapi.dolthub.com/user/repo?region=auto",
+			want:  "https://doltremoteapi.dolthub.com/user/repo?region=auto",
 		},
 		{
-			name:      "http URL passes through",
-			input:     "http://localhost:50051/repo",
-			wantExact: "http://localhost:50051/repo",
+			name:  "http URL passes through",
+			input: "http://localhost:50051/repo?endpoint=local",
+			want:  "http://localhost:50051/repo?endpoint=local",
 		},
 		{
-			name:      "file:// URL passes through",
-			input:     "file:///tmp/backup",
-			wantExact: "file:///tmp/backup",
+			name:  "file URL passes through",
+			input: "file:///tmp/backup?version=1",
+			want:  "file:///tmp/backup?version=1",
 		},
 		{
-			name:      "aws:// URL passes through",
-			input:     "aws://[key:secret@]bucket/path",
-			wantExact: "aws://[key:secret@]bucket/path",
+			name:  "aws URL passes through",
+			input: "aws://key:secret@bucket/path?region=auto",
+			want:  "aws://key:secret@bucket/path?region=auto",
 		},
 		{
-			name:      "gs:// URL passes through",
-			input:     "gs://bucket/path",
-			wantExact: "gs://bucket/path",
+			name:  "bracketed aws URL passes through",
+			input: "aws://[key:secret@]bucket/path",
+			want:  "aws://[key:secret@]bucket/path",
 		},
 		{
-			name:      "absolute path gets file:// prefix",
-			input:     absBackup,
-			wantExact: "file://" + absBackup,
+			name:  "gs URL passes through",
+			input: "gs://bucket/path?endpoint=storage.example",
+			want:  "gs://bucket/path?endpoint=storage.example",
+		},
+		{
+			name:  "s3 URL passes through",
+			input: "s3://bucket/path?endpoint=https://minio.example&region=auto&path-style=true",
+			want:  "s3://bucket/path?endpoint=https://minio.example&region=auto&path-style=true",
+		},
+		{
+			name:  "absolute path gets file prefix",
+			input: absBackup,
+			want:  "file://" + absBackup,
 		},
 		{
 			name:    "relative path gets resolved and prefixed",
 			input:   "my-backup",
-			wantPfx: "file://",
+			wantRel: true,
 		},
 	}
 
@@ -69,14 +82,17 @@ func TestResolveDoltBackupURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := resolveDoltBackupURL(tt.input)
-			if tt.wantExact != "" {
-				if got != tt.wantExact {
-					t.Errorf("resolveDoltBackupURL(%q) = %q, want %q", tt.input, got, tt.wantExact)
+			if tt.wantRel {
+				wantSuffix := string(filepath.Separator) + "my-backup"
+				if !strings.HasPrefix(got, "file://") ||
+					!filepath.IsAbs(strings.TrimPrefix(got, "file://")) ||
+					!strings.HasSuffix(got, wantSuffix) {
+					t.Errorf("resolveDoltBackupURL(%q) = %q, want file:// plus an absolute path ending in %q", tt.input, got, wantSuffix)
 				}
-			} else if tt.wantPfx != "" {
-				if len(got) < len(tt.wantPfx) || got[:len(tt.wantPfx)] != tt.wantPfx {
-					t.Errorf("resolveDoltBackupURL(%q) = %q, want prefix %q", tt.input, got, tt.wantPfx)
-				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("resolveDoltBackupURL(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/cmd/bd/backup_dolt_test.go
+++ b/cmd/bd/backup_dolt_test.go
@@ -23,7 +23,9 @@ func TestResolveDoltBackupURL(t *testing.T) {
 	// t.TempDir() is absolute and already cleaned on every platform.
 	absBackup := filepath.Join(t.TempDir(), "beads-backup")
 
-	// TODO(#6227): az:// is a valid Dolt backup/remote scheme, but this PR only fixes the s3:// stack. Do not add a green row for today's az:// local-file fallback here.
+	// TODO(#6227): az:// is a valid Dolt backup/remote scheme, but this PR
+	// only fixes the s3:// stack. Do not add a green row for today's az://
+	// local-file fallback here.
 	tests := []struct {
 		name  string
 		input string

--- a/cmd/bd/backup_restore.go
+++ b/cmd/bd/backup_restore.go
@@ -11,16 +11,17 @@ import (
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
 	"github.com/steveyegge/beads/internal/ui"
 )
 
 var backupRestoreCmd = &cobra.Command{
-	Use:   "restore [path]",
+	Use:   "restore [directory-or-url]",
 	Short: "Restore database from a Dolt backup",
 	Long: `Restore the beads database from a Dolt-native backup.
 
 By default, reads from .beads/backup/ (or the configured backup directory).
-Optionally specify a path to a directory containing a Dolt backup.
+Optionally specify a directory containing a Dolt backup or a remote backup URL.
 
 This restores a full database backup created by 'bd backup sync' or an
 equivalent Dolt backup. JSONL files produced by 'bd export' are issue exports,
@@ -28,7 +29,7 @@ not restore targets for this command.
 
 Use --force to overwrite an existing database with the backup contents.
 
-The database must already be initialized (run 'bd init' first if needed).
+Restore requires a freshly initialized database. Run 'bd init' first if needed.
 To initialize and restore in one step, use: bd init && bd backup restore`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -55,8 +56,10 @@ To initialize and restore in one step, use: bd init && bd backup restore`,
 			}
 		}
 
-		if err := validateBackupRestoreDir(dir); err != nil {
-			return err
+		if !versioncontrolops.IsBackupURL(dir) {
+			if err := validateBackupRestoreDir(dir); err != nil {
+				return err
+			}
 		}
 
 		force, _ := cmd.Flags().GetBool("force")

--- a/cmd/bd/backup_restore_url_test.go
+++ b/cmd/bd/backup_restore_url_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+var errBackupRestoreReachedStorage = errors.New("backup restore reached storage")
+
+type backupRestoreRecordingStore struct {
+	storage.DoltStorage
+	restoreCalls  int
+	restoreSource string
+}
+
+func (s *backupRestoreRecordingStore) BackupAdd(context.Context, string, string) error { return nil }
+func (s *backupRestoreRecordingStore) BackupSync(context.Context, string) error        { return nil }
+func (s *backupRestoreRecordingStore) BackupRemove(context.Context, string) error      { return nil }
+func (s *backupRestoreRecordingStore) BackupDatabase(context.Context, string) error    { return nil }
+func (s *backupRestoreRecordingStore) RestoreDatabase(_ context.Context, source string, _ bool) error {
+	s.restoreCalls++
+	s.restoreSource = source
+	return errBackupRestoreReachedStorage
+}
+func (s *backupRestoreRecordingStore) Commit(context.Context, string) error { return nil }
+
+var _ storage.BackupStore = (*backupRestoreRecordingStore)(nil)
+
+func TestBackupRestoreCommandRoutesBackupURLToStorage(t *testing.T) {
+	oldStore := store
+	oldRootCtx := rootCtx
+	oldProxiedServerMode := proxiedServerMode
+	t.Cleanup(func() {
+		store = oldStore
+		rootCtx = oldRootCtx
+		proxiedServerMode = oldProxiedServerMode
+	})
+
+	fake := &backupRestoreRecordingStore{}
+	store = fake
+	rootCtx = context.Background()
+	proxiedServerMode = false
+
+	const source = "s3://bucket/path?endpoint=https://minio.example&region=auto&path-style=true"
+	err := backupRestoreCmd.RunE(backupRestoreCmd, []string{source})
+	if !errors.Is(err, errBackupRestoreReachedStorage) {
+		t.Fatalf("backup restore error = %v, want storage error", err)
+	}
+	if fake.restoreCalls != 1 {
+		t.Fatalf("RestoreDatabase calls = %d, want 1", fake.restoreCalls)
+	}
+	if fake.restoreSource != source {
+		t.Fatalf("RestoreDatabase source = %q, want %q", fake.restoreSource, source)
+	}
+}
+
+func TestBackupRestoreCommandKeepsDirectoryValidation(t *testing.T) {
+	oldStore := store
+	oldRootCtx := rootCtx
+	oldProxiedServerMode := proxiedServerMode
+	t.Cleanup(func() {
+		store = oldStore
+		rootCtx = oldRootCtx
+		proxiedServerMode = oldProxiedServerMode
+	})
+
+	fake := &backupRestoreRecordingStore{}
+	store = fake
+	rootCtx = context.Background()
+	proxiedServerMode = false
+
+	source := filepath.Join(t.TempDir(), "missing")
+	err := backupRestoreCmd.RunE(backupRestoreCmd, []string{source})
+	want := fmt.Sprintf("backup directory not found: %s\nRun 'bd backup' first to create a backup", source)
+	if err == nil || err.Error() != want {
+		t.Fatalf("backup restore error = %q, want %q", err, want)
+	}
+	if fake.restoreCalls != 0 {
+		t.Fatalf("RestoreDatabase calls = %d, want 0", fake.restoreCalls)
+	}
+}

--- a/cmd/bd/backup_restore_url_test.go
+++ b/cmd/bd/backup_restore_url_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -14,18 +16,23 @@ var errBackupRestoreReachedStorage = errors.New("backup restore reached storage"
 
 type backupRestoreRecordingStore struct {
 	storage.DoltStorage
+	restoreErr    error
 	restoreCalls  int
 	restoreSource string
+	backupAddURL  string
 }
 
-func (s *backupRestoreRecordingStore) BackupAdd(context.Context, string, string) error { return nil }
-func (s *backupRestoreRecordingStore) BackupSync(context.Context, string) error        { return nil }
-func (s *backupRestoreRecordingStore) BackupRemove(context.Context, string) error      { return nil }
-func (s *backupRestoreRecordingStore) BackupDatabase(context.Context, string) error    { return nil }
+func (s *backupRestoreRecordingStore) BackupAdd(_ context.Context, _ string, url string) error {
+	s.backupAddURL = url
+	return nil
+}
+func (s *backupRestoreRecordingStore) BackupSync(context.Context, string) error     { return nil }
+func (s *backupRestoreRecordingStore) BackupRemove(context.Context, string) error   { return nil }
+func (s *backupRestoreRecordingStore) BackupDatabase(context.Context, string) error { return nil }
 func (s *backupRestoreRecordingStore) RestoreDatabase(_ context.Context, source string, _ bool) error {
 	s.restoreCalls++
 	s.restoreSource = source
-	return errBackupRestoreReachedStorage
+	return s.restoreErr
 }
 func (s *backupRestoreRecordingStore) Commit(context.Context, string) error { return nil }
 
@@ -41,7 +48,7 @@ func TestBackupRestoreCommandRoutesBackupURLToStorage(t *testing.T) {
 		proxiedServerMode = oldProxiedServerMode
 	})
 
-	fake := &backupRestoreRecordingStore{}
+	fake := &backupRestoreRecordingStore{restoreErr: errBackupRestoreReachedStorage}
 	store = fake
 	rootCtx = context.Background()
 	proxiedServerMode = false
@@ -69,7 +76,7 @@ func TestBackupRestoreCommandKeepsDirectoryValidation(t *testing.T) {
 		proxiedServerMode = oldProxiedServerMode
 	})
 
-	fake := &backupRestoreRecordingStore{}
+	fake := &backupRestoreRecordingStore{restoreErr: errBackupRestoreReachedStorage}
 	store = fake
 	rootCtx = context.Background()
 	proxiedServerMode = false
@@ -82,5 +89,51 @@ func TestBackupRestoreCommandKeepsDirectoryValidation(t *testing.T) {
 	}
 	if fake.restoreCalls != 0 {
 		t.Fatalf("RestoreDatabase calls = %d, want 0", fake.restoreCalls)
+	}
+}
+
+func TestBackupRestoreCommandRegistersBackupURLAfterRestore(t *testing.T) {
+	oldStore := store
+	oldRootCtx := rootCtx
+	oldProxiedServerMode := proxiedServerMode
+	t.Cleanup(func() {
+		store = oldStore
+		rootCtx = oldRootCtx
+		proxiedServerMode = oldProxiedServerMode
+	})
+
+	// A successful restore re-registers the source as the backup remote and
+	// saves .beads/dolt-backup.json via beads.FindBeadsDir, so point BEADS_DIR
+	// at a throwaway workspace (embeddeddolt/ is the marker FindBeadsDir
+	// accepts) rather than whatever .beads is ambient.
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDir, "embeddeddolt"), 0o700); err != nil {
+		t.Fatalf("create workspace marker: %v", err)
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+
+	fake := &backupRestoreRecordingStore{}
+	store = fake
+	rootCtx = context.Background()
+	proxiedServerMode = false
+
+	const source = "s3://bucket/path?endpoint=https://minio.example&region=auto&path-style=true"
+	if err := backupRestoreCmd.RunE(backupRestoreCmd, []string{source}); err != nil {
+		t.Fatalf("backup restore error = %v, want nil", err)
+	}
+	if fake.backupAddURL != source {
+		t.Fatalf("BackupAdd url = %q, want %q", fake.backupAddURL, source)
+	}
+
+	data, err := os.ReadFile(filepath.Join(beadsDir, "dolt-backup.json"))
+	if err != nil {
+		t.Fatalf("read saved backup config: %v", err)
+	}
+	var cfg doltBackupConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal saved backup config: %v", err)
+	}
+	if cfg.BackupURL != source {
+		t.Fatalf("saved backup_url = %q, want %q", cfg.BackupURL, source)
 	}
 }

--- a/internal/storage/dolt/restore_source_test.go
+++ b/internal/storage/dolt/restore_source_test.go
@@ -1,0 +1,79 @@
+package dolt
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
+)
+
+func TestRestoreDatabaseRoutesBackupURLWithoutStat(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	const source = "s3://backup-bucket/beads"
+	mock.ExpectExec("CALL DOLT_BACKUP('restore', ?, ?)").
+		WithArgs(source, "beads").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	store := &DoltStore{database: "beads"}
+	err = store.restoreDatabase(t.Context(), source, false, func(time.Duration) (*sql.DB, error) {
+		return db, nil
+	})
+	if err != nil {
+		t.Fatalf("RestoreDatabase: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestRestoreDatabaseKeepsDirectorySourceBehavior(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	source := t.TempDir()
+	want, err := versioncontrolops.DirToFileURL(source)
+	if err != nil {
+		t.Fatalf("DirToFileURL(%q): %v", source, err)
+	}
+	mock.ExpectExec("CALL DOLT_BACKUP('restore', ?, ?)").
+		WithArgs(want, "beads").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	store := &DoltStore{database: "beads"}
+	err = store.restoreDatabase(t.Context(), source, false, func(time.Duration) (*sql.DB, error) {
+		return db, nil
+	})
+	if err != nil {
+		t.Fatalf("RestoreDatabase: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestRestoreDatabaseStatsDirectorySource(t *testing.T) {
+	source := t.TempDir() + "/missing"
+	store := &DoltStore{database: "beads"}
+	err := store.restoreDatabase(t.Context(), source, false, func(time.Duration) (*sql.DB, error) {
+		t.Fatal("RestoreDatabase opened a connection for a missing directory")
+		return nil, nil
+	})
+	if err == nil {
+		t.Fatal("RestoreDatabase returned nil for a missing directory")
+	}
+	if !strings.Contains(err.Error(), "backup source does not exist") {
+		t.Fatalf("RestoreDatabase error %q does not report a missing backup source", err)
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1338,22 +1338,20 @@ func (s *DoltStore) BackupDatabase(ctx context.Context, dir string) error {
 	return nil
 }
 
-// RestoreDatabase restores the database from a Dolt backup at dir.
+// RestoreDatabase restores the database from a local backup directory or a
+// backup URL accepted by DOLT_BACKUP (see versioncontrolops.ResolveBackupSource).
 // When force is true, an existing database is overwritten.
-func (s *DoltStore) RestoreDatabase(ctx context.Context, dir string, force bool) error {
-	info, err := os.Stat(dir)
-	if err != nil {
-		return fmt.Errorf("backup source does not exist: %w", err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("backup source is not a directory: %s", dir)
-	}
+func (s *DoltStore) RestoreDatabase(ctx context.Context, source string, force bool) error {
+	return s.restoreDatabase(ctx, source, force, s.oneShotConn)
+}
 
-	backupURL, err := versioncontrolops.DirToFileURL(dir)
+func (s *DoltStore) restoreDatabase(ctx context.Context, source string, force bool, openConn func(time.Duration) (*sql.DB, error)) error {
+	backupURL, err := versioncontrolops.ResolveBackupSource(source)
 	if err != nil {
 		return err
 	}
-	db, err := s.oneShotConn(0)
+
+	db, err := openConn(0)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1296,7 +1296,9 @@ func (s *DoltStore) BackupRemove(ctx context.Context, name string) error {
 }
 
 // BackupDatabase registers dir as a file:// Dolt backup remote and syncs
-// the full database to it, preserving complete commit history.
+// the full database to it, preserving complete commit history. It stays
+// directory-only on purpose: backup to a remote URL goes through BackupAdd
+// and BackupSync, while RestoreDatabase accepts a directory or a URL.
 func (s *DoltStore) BackupDatabase(ctx context.Context, dir string) error {
 	info, err := os.Stat(dir)
 	if err != nil {

--- a/internal/storage/embeddeddolt/restore_source_test.go
+++ b/internal/storage/embeddeddolt/restore_source_test.go
@@ -1,0 +1,49 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A backup URL must reach DOLT_BACKUP unchanged instead of being stat'ed as a
+// directory. A file:// URL whose path sits under a regular file is
+// deterministic: Dolt cannot create that directory (root included), the
+// restore fails, and the error carries versioncontrolops.BackupRestore's
+// "restore from backup <url>" wrapper, which proves the URL was passed to
+// CALL DOLT_BACKUP('restore', ...) byte-for-byte.
+func TestRestoreDatabaseRoutesBackupURLWithoutStat(t *testing.T) {
+	env := newTestEnv(t, "test")
+	blocker := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blocker, nil, 0o600); err != nil {
+		t.Fatalf("write %q: %v", blocker, err)
+	}
+	source := "file://" + filepath.Join(blocker, "backup")
+
+	err := env.store.RestoreDatabase(t.Context(), source, false)
+	if err == nil {
+		t.Fatalf("RestoreDatabase(%q) returned nil for a backup that cannot exist", source)
+	}
+	if !strings.Contains(err.Error(), "restore from backup "+source) {
+		t.Fatalf("RestoreDatabase error %q does not show the URL reaching DOLT_BACKUP unchanged", err)
+	}
+	if strings.Contains(err.Error(), "backup source does not exist") {
+		t.Fatalf("RestoreDatabase stat'ed a backup URL: %v", err)
+	}
+}
+
+func TestRestoreDatabaseStatsDirectorySource(t *testing.T) {
+	env := newTestEnv(t, "test")
+	source := filepath.Join(t.TempDir(), "missing")
+
+	err := env.store.RestoreDatabase(t.Context(), source, false)
+	if err == nil {
+		t.Fatal("RestoreDatabase returned nil for a missing directory")
+	}
+	if !strings.Contains(err.Error(), "backup source does not exist") {
+		t.Fatalf("RestoreDatabase error %q does not report a missing backup source", err)
+	}
+}

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -765,19 +765,11 @@ func (s *EmbeddedDoltStore) BackupDatabase(ctx context.Context, dir string) erro
 	})
 }
 
-// RestoreDatabase restores the database from a Dolt backup at dir.
-// The dir must exist locally and contain a valid Dolt backup.
+// RestoreDatabase restores the database from a local backup directory or a
+// backup URL accepted by DOLT_BACKUP (see versioncontrolops.ResolveBackupSource).
 // When force is true, an existing database is overwritten.
-func (s *EmbeddedDoltStore) RestoreDatabase(ctx context.Context, dir string, force bool) error {
-	info, err := os.Stat(dir)
-	if err != nil {
-		return fmt.Errorf("backup source does not exist: %w", err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("backup source is not a directory: %s", dir)
-	}
-
-	backupURL, err := versioncontrolops.DirToFileURL(dir)
+func (s *EmbeddedDoltStore) RestoreDatabase(ctx context.Context, source string, force bool) error {
+	backupURL, err := versioncontrolops.ResolveBackupSource(source)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -727,7 +727,9 @@ func (s *EmbeddedDoltStore) BackupRemove(ctx context.Context, name string) error
 
 // BackupDatabase registers dir as a file:// Dolt backup remote and syncs
 // the database to it. The dir must exist locally. This preserves full Dolt
-// commit history.
+// commit history. It stays directory-only on purpose: backup to a remote URL
+// goes through BackupAdd and BackupSync, while RestoreDatabase accepts a
+// directory or a URL.
 func (s *EmbeddedDoltStore) BackupDatabase(ctx context.Context, dir string) error {
 	info, err := os.Stat(dir)
 	if err != nil {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -851,9 +851,12 @@ type BackupStore interface {
 	// BackupDatabase registers dir as a file:// Dolt backup remote and syncs
 	// the full database to it, preserving complete commit history.
 	BackupDatabase(ctx context.Context, dir string) error
-	// RestoreDatabase restores the database from a Dolt backup at dir.
+	// RestoreDatabase restores the database from a Dolt backup at source, which
+	// is either a local backup directory or a backup URL that DOLT_BACKUP accepts
+	// (versioncontrolops.IsBackupURL). Implementations must not require the source
+	// to exist on the local filesystem when it is a URL.
 	// When force is true, the existing database is dropped before restoring.
-	RestoreDatabase(ctx context.Context, dir string, force bool) error
+	RestoreDatabase(ctx context.Context, source string, force bool) error
 }
 
 // ReadyWorkCounter sizes the total ready-work count for a filter without

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -849,7 +849,9 @@ type BackupStore interface {
 	BackupSync(ctx context.Context, name string) error
 	BackupRemove(ctx context.Context, name string) error
 	// BackupDatabase registers dir as a file:// Dolt backup remote and syncs
-	// the full database to it, preserving complete commit history.
+	// the full database to it, preserving complete commit history. It stays
+	// directory-only on purpose: backup to a remote URL goes through BackupAdd
+	// and BackupSync, while RestoreDatabase accepts a directory or a URL.
 	BackupDatabase(ctx context.Context, dir string) error
 	// RestoreDatabase restores the database from a Dolt backup at source, which
 	// is either a local backup directory or a backup URL that DOLT_BACKUP accepts

--- a/internal/storage/versioncontrolops/backup.go
+++ b/internal/storage/versioncontrolops/backup.go
@@ -3,6 +3,7 @@ package versioncontrolops
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -54,6 +55,49 @@ func DirToFileURL(dir string) (string, error) {
 		return "", fmt.Errorf("resolve absolute path: %w", err)
 	}
 	return "file://" + abs, nil
+}
+
+// backupSchemes are the URL schemes DOLT_BACKUP accepts as a destination or
+// restore source. Deliberately not doltremote.NativeSchemes: that list is the
+// clone/push vocabulary, excludes the http(s) backups bd already supports and
+// includes git+ schemes that are not backup targets.
+// az:// is a valid Dolt scheme (dbfactory/az.go) but is missing here and in
+// NativeSchemes alike; tracked in #6227.
+var backupSchemes = map[string]bool{
+	"http": true, "https": true, "file": true, "aws": true, "gs": true, "s3": true,
+}
+
+// IsBackupURL reports whether raw carries a scheme DOLT_BACKUP accepts. It
+// classifies by scheme token only (everything before the first "://",
+// lowercased) and does not validate the URL: Go 1.25.2+ url.Parse rejects
+// Dolt's bracketed aws://[dynamo_table:bucket]/db form (Dolt itself carries a
+// shim for it, earl.ParseRawWithAWSSupport), so parse-validity is the wrong
+// signal. URL validity stays Dolt's job.
+func IsBackupURL(raw string) bool {
+	sep := strings.Index(raw, "://")
+	if sep <= 0 {
+		return false
+	}
+	return backupSchemes[strings.ToLower(raw[:sep])]
+}
+
+// ResolveBackupSource turns a restore source into the URL passed to
+// DOLT_BACKUP('restore', ...). Recognized backup URLs pass through unchanged
+// and are never stat'ed; anything else must be an existing local directory
+// and is converted with DirToFileURL. The error strings are load-bearing:
+// the resolver and store tests assert them.
+func ResolveBackupSource(source string) (string, error) {
+	if IsBackupURL(source) {
+		return source, nil
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		return "", fmt.Errorf("backup source does not exist: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("backup source is not a directory: %s", source)
+	}
+	return DirToFileURL(source)
 }
 
 // ExtractAddressConflictName parses the conflicting remote name from a Dolt

--- a/internal/storage/versioncontrolops/backup.go
+++ b/internal/storage/versioncontrolops/backup.go
@@ -38,14 +38,40 @@ func BackupRemove(ctx context.Context, db DBConn, name string) error {
 func BackupRestore(ctx context.Context, db DBConn, url, dbName string, force bool) error {
 	if force {
 		if _, err := db.ExecContext(ctx, "CALL DOLT_BACKUP('restore', '--force', ?, ?)", url, dbName); err != nil {
-			return fmt.Errorf("restore from backup %s: %w", url, err)
+			return fmt.Errorf("restore from backup %s: %w", redactBackupURL(url), err)
 		}
 	} else {
 		if _, err := db.ExecContext(ctx, "CALL DOLT_BACKUP('restore', ?, ?)", url, dbName); err != nil {
-			return fmt.Errorf("restore from backup %s: %w", url, err)
+			return fmt.Errorf("restore from backup %s: %w", redactBackupURL(url), err)
 		}
 	}
 	return nil
+}
+
+// redactBackupURL strips the parts of a backup URL that can carry credentials
+// before BackupRestore quotes it in an error: userinfo (aws://key:secret@...)
+// and the query and fragment (s3 URLs carry signed parameters there). Scheme,
+// host and path stay. Plain string operations rather than url.Parse, which
+// rejects Dolt's bracketed aws://[dynamo_table:bucket]/db form (see
+// IsBackupURL). Only the wrapper's copy of the URL is redacted; the wrapped
+// Dolt error text is not rewritten.
+func redactBackupURL(source string) string {
+	sep := strings.Index(source, "://")
+	if sep < 0 {
+		return source
+	}
+	rest := source[sep+len("://"):]
+	if cut := strings.IndexAny(rest, "?#"); cut >= 0 {
+		rest = rest[:cut]
+	}
+	authority := rest
+	if slash := strings.Index(rest, "/"); slash >= 0 {
+		authority = rest[:slash]
+	}
+	if at := strings.LastIndex(authority, "@"); at >= 0 {
+		rest = rest[at+1:]
+	}
+	return source[:sep+len("://")] + rest
 }
 
 // DirToFileURL resolves dir to an absolute path and returns a file:// URL.
@@ -69,16 +95,20 @@ var backupSchemes = map[string]bool{
 
 // IsBackupURL reports whether raw carries a scheme DOLT_BACKUP accepts. It
 // classifies by scheme token only (everything before the first "://",
-// lowercased) and does not validate the URL: Go 1.25.2+ url.Parse rejects
+// case-sensitive) and does not validate the URL: Go 1.25.2+ url.Parse rejects
 // Dolt's bracketed aws://[dynamo_table:bucket]/db form (Dolt itself carries a
 // shim for it, earl.ParseRawWithAWSSupport), so parse-validity is the wrong
-// signal. URL validity stays Dolt's job.
+// signal. URL validity stays Dolt's job. Everything downstream matches
+// case-sensitively too: Dolt's dbfactory registry, remotecache and
+// doltremote all key on the lowercase scheme, so S3:// falls through to the
+// directory path and its clearer "backup source does not exist" error
+// instead of a Dolt internal error.
 func IsBackupURL(raw string) bool {
 	sep := strings.Index(raw, "://")
 	if sep <= 0 {
 		return false
 	}
-	return backupSchemes[strings.ToLower(raw[:sep])]
+	return backupSchemes[raw[:sep]]
 }
 
 // ResolveBackupSource turns a restore source into the URL passed to

--- a/internal/storage/versioncontrolops/backup_test.go
+++ b/internal/storage/versioncontrolops/backup_test.go
@@ -2,6 +2,9 @@ package versioncontrolops
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -41,6 +44,84 @@ func TestExtractAddressConflictName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ExtractAddressConflictName(tt.err); got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsBackupURL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "http", raw: "http://backup.example/beads", want: true},
+		{name: "https", raw: "https://backup.example/beads", want: true},
+		{name: "file", raw: "file:///var/backups/beads", want: true},
+		{name: "aws", raw: "aws://backup-bucket/beads", want: true},
+		{name: "bracketed aws", raw: "aws://[dolt_table:my_bucket]/db", want: true},
+		{name: "gs", raw: "gs://backup-bucket/beads", want: true},
+		{name: "s3", raw: "s3://backup-bucket/beads", want: true},
+		{name: "git ssh", raw: "git+ssh://git@example.com/org/repo.git", want: false},
+		{name: "git https", raw: "git+https://example.com/org/repo.git", want: false},
+		{name: "relative path", raw: "backups/beads", want: false},
+		{name: "absolute path", raw: "/var/backups/beads", want: false},
+		{name: "empty", raw: "", want: false},
+		{name: "scp style", raw: "git@example.com:org/repo.git", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsBackupURL(tt.raw); got != tt.want {
+				t.Errorf("IsBackupURL(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveBackupSource(t *testing.T) {
+	dir := t.TempDir()
+	dirURL, err := DirToFileURL(dir)
+	if err != nil {
+		t.Fatalf("DirToFileURL(%q): %v", dir, err)
+	}
+	file := filepath.Join(dir, "not-a-directory")
+	if err := os.WriteFile(file, nil, 0o600); err != nil {
+		t.Fatalf("write %q: %v", file, err)
+	}
+
+	tests := []struct {
+		name    string
+		source  string
+		want    string
+		wantErr string
+	}{
+		// A URL whose path does not exist locally: a stat would fail, so a
+		// verbatim return proves the URL was never stat'ed.
+		{name: "s3 URL passes through without stat", source: "s3://backup-bucket/beads", want: "s3://backup-bucket/beads"},
+		{name: "bracketed aws URL passes through", source: "aws://[dolt_table:my_bucket]/db", want: "aws://[dolt_table:my_bucket]/db"},
+		{name: "existing directory converts to file URL", source: dir, want: dirURL},
+		{name: "missing directory", source: filepath.Join(dir, "missing"), wantErr: "backup source does not exist"},
+		{name: "regular file", source: file, wantErr: "backup source is not a directory"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveBackupSource(tt.source)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ResolveBackupSource(%q) = %q, want error containing %q", tt.source, got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ResolveBackupSource(%q) error %q does not contain %q", tt.source, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveBackupSource(%q): %v", tt.source, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveBackupSource(%q) = %q, want %q", tt.source, got, tt.want)
 			}
 		})
 	}

--- a/internal/storage/versioncontrolops/backup_test.go
+++ b/internal/storage/versioncontrolops/backup_test.go
@@ -1,6 +1,9 @@
 package versioncontrolops
 
 import (
+	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -62,6 +65,7 @@ func TestIsBackupURL(t *testing.T) {
 		{name: "bracketed aws", raw: "aws://[dolt_table:my_bucket]/db", want: true},
 		{name: "gs", raw: "gs://backup-bucket/beads", want: true},
 		{name: "s3", raw: "s3://backup-bucket/beads", want: true},
+		{name: "uppercase scheme", raw: "S3://bucket/db", want: false},
 		{name: "git ssh", raw: "git+ssh://git@example.com/org/repo.git", want: false},
 		{name: "git https", raw: "git+https://example.com/org/repo.git", want: false},
 		{name: "relative path", raw: "backups/beads", want: false},
@@ -103,6 +107,7 @@ func TestResolveBackupSource(t *testing.T) {
 		{name: "existing directory converts to file URL", source: dir, want: dirURL},
 		{name: "missing directory", source: filepath.Join(dir, "missing"), wantErr: "backup source does not exist"},
 		{name: "regular file", source: file, wantErr: "backup source is not a directory"},
+		{name: "uppercase scheme is stat'ed as a path", source: "S3://bucket/db", wantErr: "backup source does not exist"},
 	}
 
 	for _, tt := range tests {
@@ -122,6 +127,78 @@ func TestResolveBackupSource(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Fatalf("ResolveBackupSource(%q) = %q, want %q", tt.source, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedactBackupURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{name: "userinfo", source: "aws://key:secret@bucket/db", want: "aws://bucket/db"},
+		{name: "signed query", source: "s3://bucket/db?X-Amz-Signature=abc&endpoint=https://minio.local", want: "s3://bucket/db"},
+		{name: "fragment", source: "s3://bucket/db#frag", want: "s3://bucket/db"},
+		{name: "user and query", source: "s3://user@bucket/db?x=1", want: "s3://bucket/db"},
+		{name: "bracketed aws", source: "aws://[dynamo-table:bucket]/db", want: "aws://[dynamo-table:bucket]/db"},
+		{name: "file URL", source: "file:///var/backups/x", want: "file:///var/backups/x"},
+		{name: "plain path", source: "/var/backups/x", want: "/var/backups/x"},
+		{name: "clean URL", source: "s3://bucket/db", want: "s3://bucket/db"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redactBackupURL(tt.source); got != tt.want {
+				t.Errorf("redactBackupURL(%q) = %q, want %q", tt.source, got, tt.want)
+			}
+		})
+	}
+}
+
+// failingConn fails every statement so BackupRestore's error wrapper can be
+// inspected.
+type failingConn struct {
+	err error
+}
+
+func (c *failingConn) ExecContext(context.Context, string, ...any) (sql.Result, error) {
+	return nil, c.err
+}
+
+func (c *failingConn) QueryContext(context.Context, string, ...any) (*sql.Rows, error) {
+	return nil, errStubConn
+}
+
+func (c *failingConn) QueryRowContext(context.Context, string, ...any) *sql.Row {
+	return nil
+}
+
+// A failed restore must not echo credentials a user put in the URL: userinfo
+// and signed query parameters both reach BackupRestore verbatim because
+// ResolveBackupSource passes URLs through untouched.
+func TestBackupRestoreRedactsURLInError(t *testing.T) {
+	tests := []struct {
+		name  string
+		force bool
+	}{
+		{name: "restore", force: false},
+		{name: "force restore", force: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := &failingConn{err: errors.New("dolt: restore failed")}
+			err := BackupRestore(context.Background(), conn, "aws://key:secret@bucket/db", "beads", tt.force)
+			if err == nil {
+				t.Fatal("BackupRestore returned nil for a failing statement")
+			}
+			if !strings.Contains(err.Error(), "restore from backup aws://bucket/db") {
+				t.Fatalf("BackupRestore error %q does not carry the redacted URL", err)
+			}
+			if strings.Contains(err.Error(), "secret") {
+				t.Fatalf("BackupRestore error %q leaks the credential", err)
 			}
 		})
 	}


### PR DESCRIPTION
**Base**: `backup-restore-urls` (#5949). **Layer**: application (`cmd/bd`) only. **Diff of this PR's increment**: 5 files, +200/-42, two commits on top of #5949's two: the `cmd/bd` change (`803cba453`, the approved `874c53da9` replayed onto #5949's new head, content-identical under `git range-diff`) and the round-2 follow-up (`4662e4c35`), folded in from #6347.

---

## What

`bd backup init` and `bd backup restore` now recognize the same backup URLs the storage layer does. `bd backup init s3://bucket/path` stores the URL as given instead of a local `file://` path, and `bd backup restore <url>` hands the URL to storage instead of failing directory validation.

## Why

Two command-path bugs, both reproducible in stock beads. dolthub/dolt#11571 shipped in dolt v2.3.2, so `s3://` stores are a supported backup destination once bd's dolt dependency catches up (#5952).

**Bug 1: `bd backup init s3://bucket/path` silently becomes a local file URL.** `resolveDoltBackupURL` had a hand-maintained prefix list (`https`, `http`, `file`, `aws`, `gs`); anything else fell to `filepath.Abs`:

```
bd backup init s3://bucket/backups
  -> stores backup URL "file:///current/dir/s3:/bucket/backups"
```

No error, wrong destination, discovered at restore time.

**Bug 2: `bd backup restore <url>` dies at directory validation** before the storage layer, which accepts URLs as of #5949, is ever called.

## Changes

- `resolveDoltBackupURL` delegates to `versioncontrolops.IsBackupURL`, the predicate `RestoreDatabase` itself uses in both stores, so init, restore and storage agree on the accepted schemes (`http`, `https`, `file`, `aws`, `gs`, `s3`). Recognized URLs pass through unchanged; anything else keeps today's path handling (`~` expansion, `filepath.Abs`, `file://` prefix). The doc comment says so.
- `bd backup restore` skips directory validation only for recognized backup URLs and passes the raw URL to storage. Directory sources keep today's validation and error text.
- Help text: restore takes a directory or a remote backup URL, and requires a freshly initialized database.
- `az://` is a valid Dolt scheme (`dbfactory/az.go`) that is missing from this predicate and from `doltremote.NativeSchemes` alike. It is tracked in #6227 and not added here; the test table carries a `TODO(#6227)` instead of a row that would pin today's `az://` local-file fallback as correct.

## Tests

- `TestResolveDoltBackupURL` asserts exact output (previously a prefix check) for all six predicate schemes with query strings preserved byte for byte, for the bracketed `aws://[key:secret@]bucket/path` form, and for an absolute path. One exception: the relative-path row asserts structure (`file://` prefix, absolute path, `/my-backup` suffix) rather than a `filepath.Abs`-derived exact value, because that value depends on the process cwd inside a `t.Parallel()` test and any concurrent `os.Chdir` in the package would make it flake. The comment explaining why the absolute fixture is `t.TempDir()` rather than a POSIX literal (Windows, #4923) is back verbatim.
- `TestBackupRestoreCommandRoutesBackupURLToStorage`: an s3 URL reaches `RestoreDatabase` unchanged, with no stat. `TestBackupRestoreCommandKeepsDirectoryValidation`: a missing directory still fails with the existing "backup directory not found" text before storage is called.
- `TestBackupRestoreCommandRegistersBackupURLAfterRestore` (follow-up): the fake `RestoreDatabase` succeeds, and the URL reaching `BackupAdd` and the `backup_url` saved to `.beads/dolt-backup.json` both equal the s3 URL byte for byte, under the `BEADS_DIR` isolation `backup_status_test.go` uses. With the post-restore step handing `"file://" + dir` to `registerBackupRemote` it fails; the other tests never reach that step. The `TODO(#6227)` comment is rewrapped to the file's width.
- Red/green: with `cmd/bd/backup_dolt.go` and `cmd/bd/backup_restore.go` reverted to #5949's head, `TestResolveDoltBackupURL/s3_URL_passes_through` and `TestBackupRestoreCommandRoutesBackupURLToStorage` fail with the two bugs above, mangled `https:/` in the query string included. On this head they pass.

## Verification

```
CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go test ./cmd/bd/... -run 'TestResolveDoltBackupURL|TestBackupRestoreCommand' -count=1 -v
CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go test ./cmd/bd/... -count=1 -timeout 25m
go build ./... && go vet ./cmd/bd/...
make test
BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint
```

All green locally (go 1.26.5, darwin/arm64, golangci-lint v2.10.1; the lint wrapper is scoped to the merge base the way the PR lane runs it). The Cross-Version Smoke red from the first round was present on `main` at the time; that workflow has been green on `main` since `40b323245`.

## Stacking

This branch carries the fixed #5949 commit (`versioncontrolops.IsBackupURL` and `ResolveBackupSource`, both stores) and this PR is the `cmd/bd` increment on top of it: four commits, #5949's two, then the `cmd/bd` change, then its follow-up. With #5949's embedded-store fix, `bd backup restore s3://...` reaches `DOLT_BACKUP` in embedded mode as well. #5952 stacks on this branch.

