### PR TITLE
fix(storage): key the deferred-parent table gate on which table is missing

### DIFF
--- a/internal/storage/domain/db/ready_work.go
+++ b/internal/storage/domain/db/ready_work.go
@@ -103,7 +103,13 @@ func (r *issueSQLRepositoryImpl) descendantsOfFutureDeferredParents(ctx context.
 		`, e.depTable, e.issueTable, e.targetCol)
 		rows, err := r.runner.QueryContext(ctx, q)
 		if err != nil {
-			if dberrors.IsTableNotExist(err) {
+			// Each edge joins a dependency table to an issue table. Only one of
+			// the four pairs is entirely durable, but three of them name at
+			// least one required table. Classified by error class alone this
+			// swallowed the edges naming a missing dependencies or issues and
+			// let the rest answer, returning an incomplete set of deferred
+			// children with a nil error.
+			if missingOptionalWispTable(err) {
 				continue
 			}
 			return nil, fmt.Errorf("deferred parents: %s/%s: %w", e.depTable, e.issueTable, err)

--- a/internal/storage/domain/db/ready_work_missing_table_test.go
+++ b/internal/storage/domain/db/ready_work_missing_table_test.go
@@ -1,0 +1,122 @@
+package db
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+func deferredParentProbeRegex(issueTable string) string {
+	return `SELECT 1 FROM ` + issueTable + ` WHERE defer_until IS NOT NULL AND defer_until > UTC_TIMESTAMP\(\) LIMIT 1`
+}
+
+func deferredEdgeRegex(e deferredParentEdge) string {
+	return `SELECT dep\.issue_id\s+FROM ` + e.depTable + ` dep\s+JOIN ` + e.issueTable +
+		` parent ON parent\.id = dep\.` + e.targetCol
+}
+
+func noDeferredChildren() *sqlmock.Rows { return sqlmock.NewRows([]string{"issue_id"}) }
+
+// TestDeferredParentEdgesBrokenDurablePlaneIsAnError is the domain/db twin of
+// the issueops guard on the same join. `descendantsOfFutureDeferredParents`
+// walks four (dependency table, issue table) pairs, and three of the four name
+// a table every beads database must have. Its gate classified the error class
+// alone with no plane guard at all, and it continues rather than aborting, so
+// the edges naming a missing `dependencies` or `issues` were swallowed one by
+// one while the remaining two answered: a nil error over an incomplete set of
+// deferred children. For a missing `dependencies` that reaches the user --
+// ready work hands back the child of a deferred parent, pinned end-to-end in
+// embeddeddolt/ready_work_missing_table_test.go. For a missing `issues` the
+// walk swallows it the same way, but the ready-work union reads `issues`
+// downstream and fails there anyway, so nothing is handed back on that route.
+//
+// Each case below scripts the surviving edges empty, so the answer here is no
+// children at all -- that is this test's setup, not the shape of the defect.
+//
+// The two stacks must agree on what a missing table means, or the same query
+// answers differently depending on which one served it.
+//
+// The assertion is errors.Is against the primed driver error, not a substring
+// of the message: the query text names both joined tables, so a substring
+// check would pass on any error that merely echoes the query.
+func TestDeferredParentEdgesBrokenDurablePlaneIsAnError(t *testing.T) {
+	for _, missing := range []string{"dependencies", "issues"} {
+		t.Run(missing, func(t *testing.T) {
+			mock, repo := newMockRepo(t)
+			gone := missingTable(missing)
+			mock.ExpectQuery(deferredParentProbeRegex("issues")).
+				WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+			for _, e := range deferredParentEdges {
+				if e.depTable == missing || e.issueTable == missing {
+					mock.ExpectQuery(deferredEdgeRegex(e)).WillReturnError(gone)
+					continue
+				}
+				mock.ExpectQuery(deferredEdgeRegex(e)).WillReturnRows(noDeferredChildren())
+			}
+
+			got, err := repo.getChildrenOfDeferredParents(t.Context())
+			if err == nil {
+				t.Fatalf("a missing %s table was excused as an absent wisp plane, answering %v", missing, got)
+			}
+			if !errors.Is(err, gone) {
+				t.Fatalf("error is not the missing-%s failure: %v", missing, err)
+			}
+		})
+	}
+}
+
+// TestDeferredParentEdgesMissingWispPlaneIsNotAnError is the control the
+// narrowed gate must keep green: `wisps` and `wisp_dependencies` are the two
+// tables a database may legitimately not have, and the surviving edges still
+// carry deferred children. Over-tightening to "never tolerate" passes the
+// assertions above and fails here.
+func TestDeferredParentEdgesMissingWispPlaneIsNotAnError(t *testing.T) {
+	for _, missing := range []string{"wisps", "wisp_dependencies"} {
+		t.Run(missing, func(t *testing.T) {
+			mock, repo := newMockRepo(t)
+			mock.ExpectQuery(deferredParentProbeRegex("issues")).
+				WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+			for _, e := range deferredParentEdges {
+				if e.depTable == missing || e.issueTable == missing {
+					mock.ExpectQuery(deferredEdgeRegex(e)).WillReturnError(missingTable(missing))
+					continue
+				}
+				mock.ExpectQuery(deferredEdgeRegex(e)).WillReturnRows(
+					sqlmock.NewRows([]string{"issue_id"}).AddRow(e.depTable + "/" + e.issueTable))
+			}
+
+			got, err := repo.getChildrenOfDeferredParents(t.Context())
+			if err != nil {
+				t.Fatalf("deferred-parent walk errored on a database with no %s: %v", missing, err)
+			}
+			var want []string
+			for _, e := range deferredParentEdges {
+				if e.depTable != missing && e.issueTable != missing {
+					want = append(want, e.depTable+"/"+e.issueTable)
+				}
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("children = %v, want %v", got, want)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet sql expectations: %v", err)
+			}
+		})
+	}
+}
+
+// TestDeferredParentEdgesUnrelatedErrorPropagates is the second control: the
+// tolerance must not be a blanket catch in either direction.
+func TestDeferredParentEdgesUnrelatedErrorPropagates(t *testing.T) {
+	mock, repo := newMockRepo(t)
+	boom := errors.New("connection refused")
+	mock.ExpectQuery(deferredParentProbeRegex("issues")).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery(deferredEdgeRegex(deferredParentEdges[0])).WillReturnError(boom)
+
+	if _, err := repo.getChildrenOfDeferredParents(t.Context()); !errors.Is(err, boom) {
+		t.Fatalf("a failed deferred-parent edge did not propagate: %v", err)
+	}
+}

--- a/internal/storage/embeddeddolt/ready_work_missing_table_test.go
+++ b/internal/storage/embeddeddolt/ready_work_missing_table_test.go
@@ -1,0 +1,155 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/dberrors"
+	"github.com/steveyegge/beads/internal/storage/domain/db"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// seedDeferredParentPlane puts a future-deferred parent, a child hanging off it
+// by a parent-child edge, and one unrelated free issue into the store. Ready
+// work must return the free issue and withhold the child: its parent is not
+// workable yet, so neither is it.
+func seedDeferredParentPlane(t *testing.T, te *testEnv, prefix string) {
+	t.Helper()
+	ctx := t.Context()
+	deferUntil := time.Now().Add(24 * time.Hour).UTC()
+
+	parent := &types.Issue{
+		ID:         prefix + "-parent",
+		Title:      "deferred parent",
+		Status:     types.StatusOpen,
+		Priority:   2,
+		IssueType:  types.TypeTask,
+		DeferUntil: &deferUntil,
+	}
+	if err := te.store.CreateIssue(ctx, parent, "tester"); err != nil {
+		t.Fatalf("CreateIssue parent: %v", err)
+	}
+	for _, id := range []string{prefix + "-child", prefix + "-free"} {
+		issue := &types.Issue{
+			ID:        id,
+			Title:     id,
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", id, err)
+		}
+	}
+	dep := &types.Dependency{
+		IssueID:     prefix + "-child",
+		DependsOnID: prefix + "-parent",
+		Type:        types.DepParentChild,
+	}
+	if err := te.store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("AddDependency: %v", err)
+	}
+}
+
+// readyWorkIDs drives the domain/db repository straight over an embedded
+// connection. *sql.DB satisfies db.Runner (domain/db/runner.go:8-12), so the
+// repository can be built without the uow stack -- which is what makes this
+// end-to-end test possible at all.
+func readyWorkIDs(t *testing.T, te *testEnv) ([]string, error) {
+	t.Helper()
+	ctx := context.Background()
+	raw, cleanup, err := embeddeddolt.OpenSQL(ctx, te.dataDir, te.database, "main")
+	if err != nil {
+		t.Fatalf("OpenSQL: %v", err)
+	}
+	defer func() { _ = cleanup() }()
+
+	page, err := db.NewIssueSQLRepository(raw).GetReadyWork(ctx, types.WorkFilter{})
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(page.Items))
+	for _, issue := range page.Items {
+		ids = append(ids, issue.ID)
+	}
+	return ids, nil
+}
+
+// TestReadyWorkWithMissingDeferredParentTables is the end-to-end twin of the
+// sqlmock guards on domain/db's deferred-parent walk, and the one test on this
+// PR that separates base from fix against a real database.
+//
+// The walk joins a dependency table to an issue table over four pairs, and
+// three of the four name a table every beads database must have. The gate
+// tolerated any table-not-exist error and continued, so renaming `dependencies`
+// away, holding the other three tables present, swallows edges 1 and 2 while
+// edges 3 and 4 answer. Ready work came back with a nil error and the child of
+// a deferred parent in it, because the walk that would have excluded the child
+// returned an incomplete set.
+//
+// `issues` gets no case here on purpose. The walk swallows it the same way, but
+// the ready-work union reads `issues` downstream and fails there regardless, so
+// renaming it away cannot separate base from fix at this surface. See the PR's
+// Limitations.
+func TestReadyWorkWithMissingDeferredParentTables(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	t.Run("missing_dependencies_is_an_error", func(t *testing.T) {
+		te := newTestEnv(t, "rwd")
+		seedDeferredParentPlane(t, te, "rwd")
+		te.assertRowExists(t, t.Context(), "issues", "rwd-parent")
+		te.exec(t, t.Context(), "RENAME TABLE dependencies TO dependencies_renamed_away")
+
+		ids, err := readyWorkIDs(t, te)
+		if err == nil {
+			t.Fatalf("ready work answered over a database with no dependencies table, returning %v", ids)
+		}
+		// Not a substring check: "wisp_dependencies" contains "dependencies",
+		// so a substring assertion cannot tell apart the two tables this test
+		// exists to tell apart. IsMissingTable matches the whole name.
+		if !dberrors.IsMissingTable(err, "dependencies") {
+			t.Fatalf("error is not the missing-dependencies failure: %v", err)
+		}
+	})
+
+	// The fixture control: a broken seed -- a child that was never actually
+	// blocked by its parent -- passes the assertion above and fails here.
+	t.Run("healthy_plane_withholds_deferred_child", func(t *testing.T) {
+		te := newTestEnv(t, "rwh")
+		seedDeferredParentPlane(t, te, "rwh")
+
+		ids, err := readyWorkIDs(t, te)
+		if err != nil {
+			t.Fatalf("ready work over a healthy database: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != "rwh-free" {
+			t.Fatalf("ready work = %v, want [rwh-free] (the deferred parent's child must be withheld)", ids)
+		}
+	})
+
+	// The over-tightening control, and the reason it renames rather than
+	// leaving the database healthy: a healthy schema raises no table-not-exist
+	// error at all, so the gate is never consulted and a "never tolerate"
+	// narrowing would sail through. `wisps` is one of the two tables a database
+	// may legitimately lack, so its absence must still leave the walk running
+	// and the deferred child withheld. Narrow the tolerance too far and edge 2
+	// (dependencies/wisps) errors out instead of being skipped, and this
+	// reddens.
+	t.Run("missing_wisps_still_withholds_deferred_child", func(t *testing.T) {
+		te := newTestEnv(t, "rww")
+		seedDeferredParentPlane(t, te, "rww")
+		te.exec(t, t.Context(), "RENAME TABLE wisps TO wisps_renamed_away")
+
+		ids, err := readyWorkIDs(t, te)
+		if err != nil {
+			t.Fatalf("ready work over a database with no wisps table: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != "rww-free" {
+			t.Fatalf("ready work = %v, want [rww-free] (the deferred parent's child must still be withheld)", ids)
+		}
+	})
+}

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -552,10 +553,15 @@ func getChildrenOfDeferredParentsInTx(ctx context.Context, tx DBTX) ([]string, e
 				  AND parent.defer_until > UTC_TIMESTAMP()
 			`, depTable, issueTable, targetCol))
 			if err != nil {
-				if depTable == "wisp_dependencies" && isTableNotExistError(err) {
+				// This FROM names two tables at once, so the gate has to key on
+				// which one the driver reports missing. The wisp plane is the
+				// only half a database may legitimately lack; keyed on the error
+				// class alone, the tolerance written for it also excused a
+				// missing dependencies or issues on the same leg.
+				if optionalBlockedTable(depTable) && dberrors.IsMissingTable(err, depTable) {
 					break
 				}
-				if issueTable == "wisps" && isTableNotExistError(err) {
+				if optionalBlockedTable(issueTable) && dberrors.IsMissingTable(err, issueTable) {
 					continue
 				}
 				return nil, fmt.Errorf("deferred parents: get deferred children from %s/%s: %w", depTable, issueTable, err)

--- a/internal/storage/issueops/ready_work_missing_table_test.go
+++ b/internal/storage/issueops/ready_work_missing_table_test.go
@@ -1,0 +1,148 @@
+package issueops
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+func noChildren() *sqlmock.Rows { return sqlmock.NewRows([]string{"issue_id"}) }
+
+func childRows(ids ...string) *sqlmock.Rows {
+	rows := sqlmock.NewRows([]string{"issue_id"})
+	for _, id := range ids {
+		rows.AddRow(id)
+	}
+	return rows
+}
+
+func deferredParentFound() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"1"}).AddRow(1)
+}
+
+// TestGetChildrenOfDeferredParentsInTx_MissingIssuesIsNotExcusedByWispDependencies
+// is the ready-work twin of #5942's counts guards, on the one join this
+// package walks whose FROM names two tables at once:
+//
+//	FROM <dependencies|wisp_dependencies> dep
+//	JOIN <issues|wisps> parent ON parent.id = dep.<target>
+//
+// The tolerance is written for the wisp plane, the two tables a database may
+// legitimately not have. Keyed on the error class alone it also fires on the
+// leg's other table, so a missing `issues` -- a table no beads database is
+// allowed to be without -- surfacing on a wisp_dependencies leg was read as
+// "this database has no wisp_dependencies", which breaks the inner loop and
+// so skips the one leg left in the walk, behind a nil error.
+//
+// On a statically corrupt schema neither arm is ever in range, so what this
+// pins is the gate's contract rather than a reachable product bug: a missing
+// `issues` fails at the `:530` probe before the walk starts, and a missing
+// `dependencies` fails on leg 1 (dependencies/issues). Both confirmed by
+// executing them against embedded Dolt -- identical errors on base and on the
+// fix. The domain/db twin has no such shield.
+//
+// The assertion is errors.Is against the primed driver error rather than a
+// substring of the message: the query text names both joined tables, so a
+// substring check would pass on any error that merely echoes the query.
+func TestGetChildrenOfDeferredParentsInTx_MissingIssuesIsNotExcusedByWispDependencies(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	gone := tableNotFound("issues")
+	mock.ExpectQuery(deferredParentProbeRegex("issues")).WillReturnRows(deferredParentFound())
+	mock.ExpectQuery(deferredChildrenQueryRegex("dependencies", "issues")).WillReturnRows(noChildren())
+	mock.ExpectQuery(deferredChildrenQueryRegex("dependencies", "wisps")).WillReturnRows(noChildren())
+	mock.ExpectQuery(deferredChildrenQueryRegex("wisp_dependencies", "issues")).WillReturnError(gone)
+
+	got, err := getChildrenOfDeferredParentsInTx(context.Background(), tx)
+	if err == nil {
+		t.Fatalf("a missing issues table was excused as an absent wisp plane, answering %v", got)
+	}
+	if !errors.Is(err, gone) {
+		t.Fatalf("error is not the missing-issues failure: %v", err)
+	}
+}
+
+// TestGetChildrenOfDeferredParentsInTx_MissingDependenciesIsNotExcusedByWisps
+// is the same defect reached through the other half of the gate. Here the leg
+// is dependencies/wisps, so the wisps tolerance is the one in range, and a
+// missing `dependencies` was skipped as an absent wisp plane -- the run then
+// walked the remaining legs and returned whatever they held, again behind a
+// nil error.
+func TestGetChildrenOfDeferredParentsInTx_MissingDependenciesIsNotExcusedByWisps(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	gone := tableNotFound("dependencies")
+	mock.ExpectQuery(deferredParentProbeRegex("issues")).WillReturnRows(deferredParentFound())
+	mock.ExpectQuery(deferredChildrenQueryRegex("dependencies", "issues")).WillReturnRows(noChildren())
+	mock.ExpectQuery(deferredChildrenQueryRegex("dependencies", "wisps")).WillReturnError(gone)
+	// Only the untightened path reaches these. Priming them keeps the old
+	// behaviour a clean nil-error answer rather than an unexpected-query
+	// failure, which would read like a pass for the wrong reason.
+	mock.ExpectQuery(deferredChildrenQueryRegex("wisp_dependencies", "issues")).WillReturnRows(noChildren())
+	mock.ExpectQuery(deferredChildrenQueryRegex("wisp_dependencies", "wisps")).WillReturnRows(noChildren())
+
+	got, err := getChildrenOfDeferredParentsInTx(context.Background(), tx)
+	if err == nil {
+		t.Fatalf("a missing dependencies table was excused as an absent wisp plane, answering %v", got)
+	}
+	if !errors.Is(err, gone) {
+		t.Fatalf("error is not the missing-dependencies failure: %v", err)
+	}
+}
+
+// TestGetChildrenOfDeferredParentsInTx_IgnoresMissingWispsTable is the control
+// the narrowed gate must keep green: `wisps` is one of the two tables the
+// tolerance was written for, and a database that never migrated the wisp plane
+// still has deferred children on the surviving legs -- here dependencies/issues
+// and wisp_dependencies/issues, one durable and one mixed. Over-tightening to
+// "never tolerate" passes both assertions above and fails here.
+func TestGetChildrenOfDeferredParentsInTx_IgnoresMissingWispsTable(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	mock.ExpectQuery(deferredParentProbeRegex("issues")).WillReturnRows(deferredParentFound())
+	mock.ExpectQuery(deferredChildrenQueryRegex("dependencies", "issues")).
+		WillReturnRows(childRows("child-from-dependencies-issues"))
+	mock.ExpectQuery(deferredChildrenQueryRegex("dependencies", "wisps")).
+		WillReturnError(tableNotFound("wisps"))
+	mock.ExpectQuery(deferredChildrenQueryRegex("wisp_dependencies", "issues")).
+		WillReturnRows(childRows("child-from-wisp-dependencies-issues"))
+	mock.ExpectQuery(deferredChildrenQueryRegex("wisp_dependencies", "wisps")).
+		WillReturnError(tableNotFound("wisps"))
+
+	got, err := getChildrenOfDeferredParentsInTx(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("getChildrenOfDeferredParentsInTx errored on a database with no wisps table: %v", err)
+	}
+	want := []string{"child-from-dependencies-issues", "child-from-wisp-dependencies-issues"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("children = %v, want %v", got, want)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+// TestGetChildrenOfDeferredParentsInTx_UnrelatedErrorPropagates is the second
+// control: the tolerance must not become a blanket catch in either direction.
+// A dropped connection was never a missing table and must still reach the
+// caller.
+func TestGetChildrenOfDeferredParentsInTx_UnrelatedErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	boom := errors.New("connection refused")
+	mock.ExpectQuery(deferredParentProbeRegex("issues")).WillReturnRows(deferredParentFound())
+	mock.ExpectQuery(deferredChildrenQueryRegex("dependencies", "issues")).WillReturnRows(noChildren())
+	mock.ExpectQuery(deferredChildrenQueryRegex("dependencies", "wisps")).WillReturnRows(noChildren())
+	mock.ExpectQuery(deferredChildrenQueryRegex("wisp_dependencies", "issues")).WillReturnError(boom)
+
+	if _, err := getChildrenOfDeferredParentsInTx(context.Background(), tx); !errors.Is(err, boom) {
+		t.Fatalf("a failed deferred-parent join did not propagate: %v", err)
+	}
+}


### PR DESCRIPTION
Reported by @bee-ghosttrack in #5943. Follow-up to #5942, and it uses the same
helpers that PR introduced.

**Up front, so the scope is not overstated:** of the two sites this changes, the
live swallow is on `domain/db` — demonstrated end-to-end against embedded Dolt,
and shipped with the test that pins it. The `issueops` site the issue names is a
mis-scoped gate I could not get to misbehave; executing it gives identical
errors on base and on the fix, so that half is defensive. Both are labelled
below.

## What was wrong

The deferred-parent walk is the one read in this area whose `FROM` names two
tables at once:

```
FROM <dependencies|wisp_dependencies> dep
JOIN <issues|wisps> parent ON parent.id = dep.<target>
```

Four legs. Only one is entirely durable, but three of them join a table no
beads database is allowed to be without. Both stacks tolerated a
table-not-exist error here for the wisp plane — the two tables a database may
legitimately not have. domain/db keyed that tolerance on the error *class*
alone; issueops keyed it on the loop variable. Neither keyed it on which table
the driver named, so a missing required table on the same statement was covered
too.

**`domain/db/ready_work.go:106` (`descendantsOfFutureDeferredParents`) — live.**
No plane guard at all: *any* table-not-exist error was excused — and the gate
`continue`s rather than aborting, so the walk goes on to the remaining edges.
It is statically reachable on either durable table, by routes with different
preconditions. `deferredParentEdges` (`:58-63`) is `{dependencies,issues}`,
`{dependencies,wisps}`, `{wisp_dependencies,issues}`, `{wisp_dependencies,wisps}`.

For a missing `dependencies` — the weaker walk-start precondition, since the
wisp plane need not exist for the walk to begin: any future-deferred row in
`issues` satisfies `anyFutureDeferredParent` (`:83`) normally, so the walk runs.
Holding the other three tables present, edges 1 and 2 error on the missing
`dependencies` and are swallowed; edges 3 and 4 answer.

For a missing `issues`: `:83` probes `["issues","wisps"]` and excuses the
missing `issues` there too, so it falls through to `wisps` — the walk runs only
if `wisps` exists *and* holds a future-deferred row. Edges 1 and 3 are then
swallowed and edges 2 and 4 answer. If `wisps` is absent or has no such row,
`:83` returns false and the walk never runs at all.

Either way exactly two of the four edges are lost and the walk returns a `nil`
error over an **incomplete** set. What reaches the user differs by route. For a
missing `dependencies` it reaches them: on base, ready work answers with a nil
error and the child of a deferred parent in the result — executed, not argued,
and now pinned by a test. For a missing `issues` the walk swallows it
identically, but the ready-work union reads `issues` downstream and fails there
regardless, so nothing is handed back on the path exercised; that route is a
swallowed error, not a wrong answer.

**`issueops/ready_work.go:555,558` — defensive.** This guarded on the loop
variable rather than the named table, so a missing `issues` surfacing on a
`wisp_dependencies` leg matched the `wisp_dependencies` arm, and a missing
`dependencies` surfacing on a `wisps` leg matched the `wisps` arm. But on a
statically corrupt schema neither arm is ever in range: a missing `issues` fails
at the `:530` probe before the walk starts, and a missing `dependencies` fails
on leg 1 (`dependencies`/`issues`). Executing both against embedded Dolt gives
byte-identical errors on base and on the fix, so this half is a gate-contract
fix, not a user-visible one. See Limitations.

## The fix

Classify through the identity-aware helpers already in the tree:
`dberrors.IsMissingTable` paired with the existing `optionalBlockedTable`
predicate on the issueops side (the `missingOptionalIssueTable` shape from
`get_issue.go:43`), and `missingOptionalWispTable` on the domain/db side. Each
arm now fires only when the driver names the optional table that arm was written
for.

Both stacks change together on purpose. They serve the same query, and #5942 left
them agreeing on what a missing table means; fixing one alone reintroduces
exactly the drift that PR called out.

## Sibling sweep

Grepped `internal/storage/issueops/` and `internal/storage/domain/` for the same
shape — a not-exist gate that checks error class but not table identity — and
traced the hits back to the statements their errors came from — to fix-grade
depth for the four settled below, more lightly for the rest.

**Verified correctly scoped, deliberately unchanged:** `issueops/ready_work.go:530`
and `:599` both read exactly one table (`SELECT 1 FROM %s …`, `SELECT issue_id
FROM %s …`), so the error there names precisely the table probed — the same
reasoning by which #5942 left `domain/db/issue_search_counts.go:218` blanket. The
third stack is fine too: `dolt/queries.go:217`
(`DoltStore.getChildrenOfDeferredParents`) deliberately uses separate
single-table queries (GH#1190) and has no tolerance gate at all — errors
propagate.

The sweep also turned up 18 further sites in the same or an adjacent class,
none of them touched here. That inventory does not belong in the merge
description for a four-line predicate change, and I have not proven it to the
depth I proved these — happy to file it as a tracking issue on request.

## Tests

sqlmock in each stack, driving the gate leg by leg. Assertions are `errors.Is`
against the primed driver error, not a substring — the query text names both
joined tables, so a substring check would pass on any error that merely echoes
the query.

issueops has two arms and two assertions, and they map one-to-one: reverting
either arm alone reddens exactly that one, checked by mutating the arms
independently. domain/db has a single gate, so its two cases (missing
`dependencies`, missing `issues`) both bear on that one predicate.

Controls separate narrowing the tolerance from removing it. The new issueops
file carries two — a database with no `wisps`, and an unrelated `connection
refused` that must still propagate; the missing-`wisp_dependencies` control is
the pre-existing `IgnoresMissingWispDependenciesTable`, which is unchanged and
still passes, as is the healthy-plane test beside it. The new domain/db file
carries all three itself.

On top of those, an **end-to-end test against embedded Dolt** pins the live
half. It seeds a future-deferred parent, a parent-child edge, and one free
issue, renames `dependencies` away, and drives `GetReadyWork` through
`db.NewIssueSQLRepository` over an embedded connection — `*sql.DB` satisfies
`db.Runner` (`domain/db/runner.go:8-12`), so no uow stack and no Docker are
involved. On base it returns a nil error and `[rwd-child rwd-free]`, handing
back the child of a deferred parent; on the fix it errors naming
`dependencies`. It carries both kinds of control, which do different jobs: a
healthy database catches a broken fixture but cannot catch over-tightening —
it raises no table-not-exist error, so the gate is never consulted — while
renaming `wisps` away does catch it, since the walk must still run and still
withhold the deferred child. Deleting the tolerance outright reddens the
`wisps` case and leaves the healthy one green, which is how each control's job
was confirmed rather than assumed. Follows the embedded-Dolt precedent #5942
set.

## Verification

`CGO_ENABLED=0 go test -tags gms_pure_go -count=1 ./internal/storage/issueops/...
./internal/storage/domain/...` — all packages pass. `go build -tags gms_pure_go
./...` clean. `golangci-lint run --config=.golangci.yml --build-tags=gms_pure_go
--new-from-merge-base=origin/main ./...` — 0 issues.

The end-to-end test runs under `BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 go test
-tags gms_pure_go ./internal/storage/embeddeddolt/`, and is skipped without that
env var, the way the package's embedded-Dolt tests are gated.

## Limitations

- **No end-to-end test pins the issueops half, and none can at this surface.**
  Executed rather than argued: driving `GetReadyWork` through the issueops stack
  with `dependencies` renamed away, and again with `issues` renamed away, gives
  byte-identical errors on base and on this branch — leg 1 propagates in the
  first case, the `:530` probe in the second. So an embedded test there would
  pass with or without the change. That is the evidence for the defensive label.
  Separating the two would need the required table to become visible as missing
  at a leg *after* the first, i.e. a schema changing under an open transaction; I
  could not construct that, which is not the same as saying it cannot happen.
  The issueops tests are therefore sqlmock contract tests on the gate.
- **The `issues` route on domain/db is masked for every filter, not just the one
  probed.** The walk swallows it exactly as it swallows `dependencies`, but
  `getReadyWorkIDPage` appends the `issues` subquery unconditionally — only the
  `wisps` leg sits behind a guard — and the filter reaches only the WHERE clause,
  never the FROM, which carries `issues` as a literal. So the union's `issues`
  read cannot be skipped, and base and fix agree at this surface for any filter.
  Only the `dependencies` route is user-visible, and that is the one the
  end-to-end test pins. This one is read off the construction rather than
  executed — you cannot run "every filter", so it is inference from code, not a
  probe — and it covers `GetReadyWork`/`GetReadyWorkWithCounts` on this stack; I
  did not audit whether some other entry point elsewhere reaches a
  deferred-parent walk without a union.
- **Lint is not version-identical to CI.** CI pins v2.10.1; I ran 2.12.2, with an
  isolated cache. I also planted a deliberate `misspell` violation in the changed
  source file to confirm the linter was really reading it rather than passing
  blind — it was flagged, so the clean run is genuine.

Fixes #5943.
