### PR TITLE
test(dolt): make git-protocol CLI/SQL routing and Pull's silent-staleness failure mode observable

### DIFF
--- a/internal/storage/dolt/route_logging_integration_test.go
+++ b/internal/storage/dolt/route_logging_integration_test.go
@@ -3,9 +3,7 @@
 package dolt
 
 import (
-	"bytes"
 	"context"
-	"log"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -75,19 +73,20 @@ func TestPushPullLogCLIRouteForGitProtocolRemote(t *testing.T) {
 	store.remote = "origin"
 	store.branch = "main"
 
-	var logBuf bytes.Buffer
-	prevOutput := log.Writer()
-	log.SetOutput(&logBuf)
-	defer log.SetOutput(prevOutput)
-
-	if err := store.Push(ctx); err == nil {
+	// captureRouteLog (route_logging_test.go) swaps os.Stderr and debug's
+	// verbose flag, both process-global: this test must never gain t.Parallel.
+	var pushErr, pullErr error
+	logged := captureRouteLog(t, func() {
+		pushErr = store.Push(ctx)
+		pullErr = store.Pull(ctx)
+	})
+	if pushErr == nil {
 		t.Fatalf("Push against a nonexistent git+file:// target should fail (route logging is under test, not transfer success)")
 	}
-	if err := store.Pull(ctx); err == nil {
+	if pullErr == nil {
 		t.Fatalf("Pull against a nonexistent git+file:// target should fail (route logging is under test, not transfer success)")
 	}
 
-	logged := logBuf.String()
 	if !strings.Contains(logged, "dolt push route: CLI") {
 		t.Fatalf("Push over a git+file:// (git-protocol) remote did not log taking the CLI route; got log:\n%s", logged)
 	}

--- a/internal/storage/dolt/route_logging_integration_test.go
+++ b/internal/storage/dolt/route_logging_integration_test.go
@@ -1,0 +1,100 @@
+//go:build integration
+
+package dolt
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/testutil"
+)
+
+// TestPushPullLogCLIRouteForGitProtocolRemote is the RED companion for the
+// other side of be-9i0yq.2 item 2: a git-protocol-scheme remote must make
+// Push/Pull log the CLI route, distinguishable from the file:// SQL route
+// proven by TestPushPullLogSQLRouteForFileRemote (route_logging_test.go).
+//
+// This test needs a store with its own local, CLI-accessible .dolt
+// directory. Plain New() with no ServerHost/ServerPort resolves to a client
+// of the suite's shared test server (testmain_test.go), which runs inside a
+// Docker container mounting only its own /var/lib/dolt volume — so that
+// store's CLIDir() is "" and hasCLIDatabase() is false, and CLI routing can
+// never be constructed there (be-9i0yq.2 review, round 1: the test always
+// self-skipped). startLocalDoltServer (git_remote_test.go) instead gives
+// this store its own on-disk database on this process's filesystem, the
+// same arrangement TestGitRemoteEmbeddedPushPull uses.
+//
+// The remote points at a local path that does not exist. git+file:// keeps
+// the whole exchange on the local filesystem, so the dolt subprocess fails
+// fast instead of risking a DNS/network hang -- appropriate here because this
+// test is about the route DECISION, which is logged before the subprocess
+// ever runs, not about a successful transfer. Push/Pull are expected to
+// return an error; only the log line is under test.
+func TestPushPullLogCLIRouteForGitProtocolRemote(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	doltDir := t.TempDir()
+	serverPort, stopServer := startLocalDoltServer(t, doltDir)
+	defer stopServer()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	dbName := uniqueTestDBName(t)
+	store, err := New(ctx, &Config{
+		Path:            doltDir,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      serverPort,
+		ServerUser:      "root",
+		AutoStart:       false,
+		CommitterName:   "test",
+		CommitterEmail:  "test@example.com",
+		Database:        dbName,
+		CreateIfMissing: true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer store.Close()
+
+	if store.CLIDir() == "" || !store.hasCLIDatabase() {
+		t.Fatalf("local-server store should have its own CLI-accessible database; CLIDir=%q hasCLIDatabase=%v", store.CLIDir(), store.hasCLIDatabase())
+	}
+
+	remoteURL := "git+file://" + filepath.Join(doltDir, "nonexistent-git-remote")
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_REMOTE('add', 'origin', ?)", remoteURL); err != nil {
+		t.Fatalf("add remote: %v", err)
+	}
+	store.remote = "origin"
+	store.branch = "main"
+
+	var logBuf bytes.Buffer
+	prevOutput := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(prevOutput)
+
+	if err := store.Push(ctx); err == nil {
+		t.Fatalf("Push against a nonexistent git+file:// target should fail (route logging is under test, not transfer success)")
+	}
+	if err := store.Pull(ctx); err == nil {
+		t.Fatalf("Pull against a nonexistent git+file:// target should fail (route logging is under test, not transfer success)")
+	}
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "dolt push route: CLI") {
+		t.Fatalf("Push over a git+file:// (git-protocol) remote did not log taking the CLI route; got log:\n%s", logged)
+	}
+	if !strings.Contains(logged, "dolt pull route: CLI") {
+		t.Fatalf("Pull over a git+file:// (git-protocol) remote did not log taking the CLI route; got log:\n%s", logged)
+	}
+	if strings.Contains(logged, "route: SQL") {
+		t.Fatalf("a git-protocol remote should never take the SQL route, but the log claims it did:\n%s", logged)
+	}
+}

--- a/internal/storage/dolt/route_logging_test.go
+++ b/internal/storage/dolt/route_logging_test.go
@@ -1,0 +1,147 @@
+package dolt
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPushPullLogSQLRouteForFileRemote is part of the RED coverage for
+// be-9i0yq.2 item 2: prepareCLIRouteForGitProtocol and its siblings
+// (store.go ~3554-3609) decide CLI-vs-SQL routing silently -- nothing in the
+// push/pull path says which one ran. A file:// remote is not git protocol,
+// so both Push and Pull take the SQL route (see the "Local file:// pulls
+// intentionally stay on the SQL path" comment on pullTransportReporting):
+// that route decision must be discoverable from the log for a real
+// Push/Pull call, without reading source to find out.
+func TestPushPullLogSQLRouteForFileRemote(t *testing.T) {
+	skipIfNoDolt(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	tmpDir := t.TempDir()
+	dbName := uniqueTestDBName(t)
+
+	store, err := New(ctx, &Config{
+		Path:            tmpDir,
+		CommitterName:   "test",
+		CommitterEmail:  "test@example.com",
+		Database:        dbName,
+		CreateIfMissing: true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer store.Close()
+
+	if _, err := store.db.ExecContext(ctx, "CREATE TABLE route_log_marker (id INT PRIMARY KEY)"); err != nil {
+		t.Fatalf("create marker table: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_ADD('-A')"); err != nil {
+		t.Fatalf("stage: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_COMMIT('-m', 'test: route log marker')"); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	remoteURL := "file://" + filepath.Join(tmpDir, "route-log-remote")
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_REMOTE('add', 'origin', ?)", remoteURL); err != nil {
+		t.Fatalf("add remote: %v", err)
+	}
+	store.remote = "origin"
+	store.branch = "main"
+
+	var logBuf bytes.Buffer
+	prevOutput := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(prevOutput)
+
+	if err := store.Push(ctx); err != nil {
+		t.Fatalf("Push over a file:// remote should succeed via the SQL route: %v", err)
+	}
+	if err := store.Pull(ctx); err != nil {
+		t.Fatalf("Pull over a file:// remote should succeed via the SQL route: %v", err)
+	}
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "dolt push route: SQL") {
+		t.Fatalf("Push over a file:// (non-git-protocol) remote did not log taking the SQL route; got log:\n%s", logged)
+	}
+	if !strings.Contains(logged, "dolt pull route: SQL") {
+		t.Fatalf("Pull over a file:// (non-git-protocol) remote did not log taking the SQL route; got log:\n%s", logged)
+	}
+	if strings.Contains(logged, "route: CLI") {
+		t.Fatalf("a file:// remote should never take the CLI route, but the log claims it did:\n%s", logged)
+	}
+}
+
+// TestPushPullLogCLIRouteForGitProtocolRemote is the RED companion for the
+// other side of item 2: a git-protocol-scheme remote must make Push/Pull log
+// the CLI route, distinguishable from the file:// SQL route proven above.
+//
+// The remote points at a local path that does not exist. git+file:// keeps
+// the whole exchange on the local filesystem, so the dolt subprocess fails
+// fast instead of risking a DNS/network hang -- appropriate here because this
+// test is about the route DECISION, which is logged before the subprocess
+// ever runs, not about a successful transfer. Push/Pull are expected to
+// return an error; only the log line is under test.
+func TestPushPullLogCLIRouteForGitProtocolRemote(t *testing.T) {
+	skipIfNoDolt(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	tmpDir := t.TempDir()
+	dbName := uniqueTestDBName(t)
+
+	store, err := New(ctx, &Config{
+		Path:            tmpDir,
+		CommitterName:   "test",
+		CommitterEmail:  "test@example.com",
+		Database:        dbName,
+		CreateIfMissing: true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer store.Close()
+
+	if store.CLIDir() == "" || !store.hasCLIDatabase() {
+		t.Skip("this store has no local CLI database to route through (external-server client?); CLI routing cannot be constructed")
+	}
+
+	remoteURL := "git+file://" + filepath.Join(tmpDir, "nonexistent-git-remote")
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_REMOTE('add', 'origin', ?)", remoteURL); err != nil {
+		t.Fatalf("add remote: %v", err)
+	}
+	store.remote = "origin"
+	store.branch = "main"
+
+	var logBuf bytes.Buffer
+	prevOutput := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(prevOutput)
+
+	if err := store.Push(ctx); err == nil {
+		t.Fatalf("Push against a nonexistent git+file:// target should fail (route logging is under test, not transfer success)")
+	}
+	if err := store.Pull(ctx); err == nil {
+		t.Fatalf("Pull against a nonexistent git+file:// target should fail (route logging is under test, not transfer success)")
+	}
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "dolt push route: CLI") {
+		t.Fatalf("Push over a git+file:// (git-protocol) remote did not log taking the CLI route; got log:\n%s", logged)
+	}
+	if !strings.Contains(logged, "dolt pull route: CLI") {
+		t.Fatalf("Pull over a git+file:// (git-protocol) remote did not log taking the CLI route; got log:\n%s", logged)
+	}
+	if strings.Contains(logged, "route: SQL") {
+		t.Fatalf("a git-protocol remote should never take the SQL route, but the log claims it did:\n%s", logged)
+	}
+}

--- a/internal/storage/dolt/route_logging_test.go
+++ b/internal/storage/dolt/route_logging_test.go
@@ -3,12 +3,49 @@ package dolt
 import (
 	"bytes"
 	"context"
-	"log"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/beads/internal/debug"
 )
+
+// captureRouteLog runs fn with the debug sink enabled and returns what it
+// wrote to stderr. logRouteDecision reports through debug.Logf, which is gated
+// on BD_DEBUG/-v and writes straight to os.Stderr, so both halves are needed.
+//
+// MUST NOT be used from a parallel test, and no test that calls it may add
+// t.Parallel: it swaps os.Stderr and flips debug's verbose flag, both of which
+// are process-global. Seven files in this package already call t.Parallel, so
+// this is a live hazard rather than a theoretical one.
+func captureRouteLog(t *testing.T, fn func()) string {
+	t.Helper()
+
+	debug.SetVerbose(true)
+	t.Cleanup(func() { debug.SetVerbose(false) })
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+
+	fn()
+
+	_ = w.Close()
+	os.Stderr = origStderr
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("reading captured stderr: %v", err)
+	}
+	_ = r.Close()
+	return buf.String()
+}
 
 // TestPushPullLogSQLRouteForFileRemote is part of the RED coverage for
 // be-9i0yq.2 item 2: prepareCLIRouteForGitProtocol and its siblings
@@ -56,19 +93,21 @@ func TestPushPullLogSQLRouteForFileRemote(t *testing.T) {
 	store.remote = "origin"
 	store.branch = "main"
 
-	var logBuf bytes.Buffer
-	prevOutput := log.Writer()
-	log.SetOutput(&logBuf)
-	defer log.SetOutput(prevOutput)
-
-	if err := store.Push(ctx); err != nil {
-		t.Fatalf("Push over a file:// remote should succeed via the SQL route: %v", err)
+	var pushErr, pullErr error
+	logged := captureRouteLog(t, func() {
+		pushErr = store.Push(ctx)
+		if pushErr != nil {
+			return
+		}
+		pullErr = store.Pull(ctx)
+	})
+	if pushErr != nil {
+		t.Fatalf("Push over a file:// remote should succeed via the SQL route: %v", pushErr)
 	}
-	if err := store.Pull(ctx); err != nil {
-		t.Fatalf("Pull over a file:// remote should succeed via the SQL route: %v", err)
+	if pullErr != nil {
+		t.Fatalf("Pull over a file:// remote should succeed via the SQL route: %v", pullErr)
 	}
 
-	logged := logBuf.String()
 	if !strings.Contains(logged, "dolt push route: SQL") {
 		t.Fatalf("Push over a file:// (non-git-protocol) remote did not log taking the SQL route; got log:\n%s", logged)
 	}

--- a/internal/storage/dolt/route_logging_test.go
+++ b/internal/storage/dolt/route_logging_test.go
@@ -80,68 +80,10 @@ func TestPushPullLogSQLRouteForFileRemote(t *testing.T) {
 	}
 }
 
-// TestPushPullLogCLIRouteForGitProtocolRemote is the RED companion for the
-// other side of item 2: a git-protocol-scheme remote must make Push/Pull log
-// the CLI route, distinguishable from the file:// SQL route proven above.
-//
-// The remote points at a local path that does not exist. git+file:// keeps
-// the whole exchange on the local filesystem, so the dolt subprocess fails
-// fast instead of risking a DNS/network hang -- appropriate here because this
-// test is about the route DECISION, which is logged before the subprocess
-// ever runs, not about a successful transfer. Push/Pull are expected to
-// return an error; only the log line is under test.
-func TestPushPullLogCLIRouteForGitProtocolRemote(t *testing.T) {
-	skipIfNoDolt(t)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	tmpDir := t.TempDir()
-	dbName := uniqueTestDBName(t)
-
-	store, err := New(ctx, &Config{
-		Path:            tmpDir,
-		CommitterName:   "test",
-		CommitterEmail:  "test@example.com",
-		Database:        dbName,
-		CreateIfMissing: true,
-	})
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	defer store.Close()
-
-	if store.CLIDir() == "" || !store.hasCLIDatabase() {
-		t.Skip("this store has no local CLI database to route through (external-server client?); CLI routing cannot be constructed")
-	}
-
-	remoteURL := "git+file://" + filepath.Join(tmpDir, "nonexistent-git-remote")
-	if _, err := store.db.ExecContext(ctx, "CALL DOLT_REMOTE('add', 'origin', ?)", remoteURL); err != nil {
-		t.Fatalf("add remote: %v", err)
-	}
-	store.remote = "origin"
-	store.branch = "main"
-
-	var logBuf bytes.Buffer
-	prevOutput := log.Writer()
-	log.SetOutput(&logBuf)
-	defer log.SetOutput(prevOutput)
-
-	if err := store.Push(ctx); err == nil {
-		t.Fatalf("Push against a nonexistent git+file:// target should fail (route logging is under test, not transfer success)")
-	}
-	if err := store.Pull(ctx); err == nil {
-		t.Fatalf("Pull against a nonexistent git+file:// target should fail (route logging is under test, not transfer success)")
-	}
-
-	logged := logBuf.String()
-	if !strings.Contains(logged, "dolt push route: CLI") {
-		t.Fatalf("Push over a git+file:// (git-protocol) remote did not log taking the CLI route; got log:\n%s", logged)
-	}
-	if !strings.Contains(logged, "dolt pull route: CLI") {
-		t.Fatalf("Pull over a git+file:// (git-protocol) remote did not log taking the CLI route; got log:\n%s", logged)
-	}
-	if strings.Contains(logged, "route: SQL") {
-		t.Fatalf("a git-protocol remote should never take the SQL route, but the log claims it did:\n%s", logged)
-	}
-}
+// TestPushPullLogCLIRouteForGitProtocolRemote, the RED companion for the
+// other side of item 2, lives in route_logging_integration_test.go (build
+// tag "integration"): a git-protocol remote needs a store with its own local
+// CLI-accessible .dolt directory, which the plain New() this file uses
+// cannot construct (it resolves to a client of the suite's shared,
+// containerized test server instead). See that file for the full test and
+// why it needs startLocalDoltServer.

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -3859,6 +3859,18 @@ func (s *DoltStore) PushRemote(ctx context.Context, remote string, force bool) e
 	return s.pushToRemote(ctx, remote, force)
 }
 
+// logRouteDecision records which transport a push/pull operation used --
+// CLI subprocess or in-process SQL -- so the route taken is discoverable
+// from the log without reading source (be-9i0yq.2 item 2). op is "push" or
+// "pull".
+func logRouteDecision(op, remote string, cli bool) {
+	route := "SQL"
+	if cli {
+		route = "CLI"
+	}
+	log.Printf("dolt %s route: %s (remote=%q)", op, route, remote)
+}
+
 // pushToRemote is the internal implementation for all push operations.
 // It routes through CLI or SQL based on the remote's protocol and credentials.
 func (s *DoltStore) pushToRemote(ctx context.Context, remote string, force bool) (retErr error) {
@@ -3883,6 +3895,7 @@ func (s *DoltStore) pushToRemote(ctx context.Context, remote string, force bool)
 	if useCLI, err := s.prepareCLIRouteForGitProtocol(ctx, remote); err != nil {
 		return err
 	} else if useCLI {
+		logRouteDecision("push", remote, true)
 		return s.doltCLIPush(ctx, remote, force, creds)
 	}
 	// Credential CLI routing: when credentials are set and server is external,
@@ -3892,6 +3905,7 @@ func (s *DoltStore) pushToRemote(ctx context.Context, remote string, force bool)
 	if useCLI, err := s.prepareCLIRouteForCredentials(ctx, remote, creds); err != nil {
 		return err
 	} else if useCLI {
+		logRouteDecision("push", remote, true)
 		return s.doltCLIPush(ctx, remote, force, creds)
 	}
 	// Cloud auth CLI routing: when cloud storage env vars (AZURE_*, AWS_*,
@@ -3901,13 +3915,16 @@ func (s *DoltStore) pushToRemote(ctx context.Context, remote string, force bool)
 	if useCLI, err := s.prepareCLIRouteForCloudAuth(ctx, remote); err != nil {
 		return err
 	} else if useCLI {
+		logRouteDecision("push", remote, true)
 		return s.doltCLIPush(ctx, remote, force, creds)
 	}
 	if useCLI, err := s.shouldUseCLIForLocalRemoteWithError(ctx, remote); err != nil {
 		return err
 	} else if useCLI {
+		logRouteDecision("push", remote, true)
 		return s.doltCLIPush(ctx, remote, force, creds)
 	}
+	logRouteDecision("push", remote, false)
 	if s.remoteUser != "" && remote == s.remote {
 		return withRemoteOperationEnv(creds, s.isS3Remote(ctx, remote), func() error {
 			if force {
@@ -4163,6 +4180,7 @@ func (s *DoltStore) pullTransportReporting(ctx context.Context, remote string) (
 	if useCLI, err := s.prepareCLIRouteForGitProtocol(ctx, remote); err != nil {
 		return pullReport{}, err
 	} else if useCLI {
+		logRouteDecision("pull", remote, true)
 		// CLI pull leaves any conflicts in the working set; run the auto-resolver so
 		// git-protocol remotes get the same audit-only dependency / metadata repair
 		// as the SQL DOLT_PULL path (#4259).
@@ -4173,17 +4191,20 @@ func (s *DoltStore) pullTransportReporting(ctx context.Context, remote string) (
 	if useCLI, err := s.prepareCLIRouteForCredentials(ctx, remote, creds); err != nil {
 		return pullReport{}, err
 	} else if useCLI {
+		logRouteDecision("pull", remote, true)
 		return pullReport{}, s.finishCLIPull(ctx, s.doltCLIPull(ctx, remote, creds))
 	}
 	// Cloud auth CLI routing (GH#6), including post-pull auto-resolution.
 	if useCLI, err := s.prepareCLIRouteForCloudAuth(ctx, remote); err != nil {
 		return pullReport{}, err
 	} else if useCLI {
+		logRouteDecision("pull", remote, true)
 		return pullReport{}, s.finishCLIPull(ctx, s.doltCLIPull(ctx, remote, creds))
 	}
 	// Local file:// pulls intentionally stay on the SQL path. The matching CLI
 	// guard is a push-only optimization; SQL pull keeps pullWithAutoResolve in
 	// charge of metadata-only conflict repair.
+	logRouteDecision("pull", remote, false)
 	var report pullReport
 	if s.remoteUser != "" && remote == s.remote {
 		err := withRemoteOperationEnv(creds, s.isS3Remote(ctx, remote), func() error {

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -3861,14 +3861,20 @@ func (s *DoltStore) PushRemote(ctx context.Context, remote string, force bool) e
 
 // logRouteDecision records which transport a push/pull operation used --
 // CLI subprocess or in-process SQL -- so the route taken is discoverable
-// from the log without reading source (be-9i0yq.2 item 2). op is "push" or
-// "pull".
+// without reading source (be-9i0yq.2 item 2). op is "push" or "pull".
+//
+// This fires on every push and every pull, so it goes to the gated debug sink
+// rather than log.Printf: the latter is unconditional stderr with a timestamp
+// prefix and would put a line in front of every user on every operation,
+// including under --quiet. The three remaining log.Printf calls in this file
+// are warnings on exceptional paths, which is a different contract. Under
+// BD_DEBUG or -v the line is exactly as discoverable as before.
 func logRouteDecision(op, remote string, cli bool) {
 	route := "SQL"
 	if cli {
 		route = "CLI"
 	}
-	log.Printf("dolt %s route: %s (remote=%q)", op, route, remote)
+	debug.Logf("dolt %s route: %s (remote=%q)\n", op, route, remote)
 }
 
 // pushToRemote is the internal implementation for all push operations.

--- a/release-gates/be-j4oer-gate.md
+++ b/release-gates/be-j4oer-gate.md
@@ -1,0 +1,119 @@
+# Release gate — Make git-protocol CLI/SQL routing and Pull's silent-staleness failure mode observable (be-9i0yq.2)
+
+- **Builder bead (CLOSED):** be-9i0yq.2 — add `logRouteDecision` logging at
+  every CLI/SQL routing decision point in `pushToRemote` and
+  `pullTransportReporting`, and cover it with tests, including a regression
+  test proving Pull's silent-stale-success detection (`verifyPullLanded`)
+  already exists and works.
+- **Deploy bead:** be-j4oer
+- **Review bead:** be-5u36o (CLOSED), verdict **PASS**, recorded on commit
+  `efca1a21ca9d77723bf6c19c0859cfc200a98f28`. Round 1 (be-j7eon,
+  request-changes) flagged one test-construction defect only — zero
+  style/security findings in either round.
+- **Commits:** `2fdfce0ff049a3cc0e4236f172edda48af13950c` (tdd_red) →
+  `bcad1edbb938a39058c226f60006b65352501ff9` (tdd_green, round 1) →
+  `efca1a21ca9d77723bf6c19c0859cfc200a98f28` (round-2 fix, tdd_green), 3
+  files over `origin/main`.
+- **Branch:** `builder/be-9i0yq.2` (provenance only; possibly shared, not a
+  push target). Isolated deploy branch `deploy/be-j4oer-gate` cut fresh
+  from `efca1a21c` and pushed to `headfork`
+  (`quad341/beads-sec003-contrib`) — `fork`/`headfork`/`prhead` all
+  independently confirmed push-capable via `git push --dry-run` exit-status
+  this round (fork's older `quad341/beads.git` URL GitHub-redirects to the
+  same renamed repo); `headfork` used to avoid the rename-redirect
+  ambiguity. `origin`'s push URL is the literal disabled sentinel
+  (`DISABLED-upstream-is-fetch-only-push-to-fork-and-PR`, confirmed exit 128
+  on dry-run) — fetch-only by design.
+- **Evaluated:** 2026-08-22 by beads/deployer
+
+## Scope
+
+Diff scope, confirmed via `git diff origin/main...HEAD --stat` (three-dot,
+merge-base — `origin/main` has advanced by one unrelated commit since this
+branch's fork point, so two-dot would misreport that commit's own changes as
+deletions):
+
+```
+ internal/storage/dolt/route_logging_integration_test.go | 100 ++++++++++++
+ internal/storage/dolt/route_logging_test.go              |  89 ++++++++++
+ internal/storage/dolt/store.go                            |  21 +++
+ 3 files changed, 210 insertions(+)
+```
+
+All three files are inside `internal/storage/dolt/`. `store.go` adds
+`logRouteDecision` calls at 8 call sites (push: 3898/3908/3918/3924/3927;
+pull: 4183/4194/4201/4207), each fed a `remote string` parameter traced
+end-to-end to the `remote string // Default remote for push/pull` struct
+field (store.go:351) — a configured name, never a URL or credential.
+`route_logging_integration_test.go` is new (round-2 fix): moves
+`TestPushPullLogCLIRouteForGitProtocolRemote` into its own
+`//go:build integration` file with a real local `dolt sql-server` via
+`startLocalDoltServer`, fixing a self-skip defect where the test's original
+`New()`-based store never had a local `.dolt` dir to route CLI through.
+`route_logging_test.go`'s diff is the other side of that move: the old
+defective test body removed, replaced with a short pointer comment;
+`TestPushPullLogSQLRouteForFileRemote` in the same file is untouched.
+
+## Gate criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | **PASS** | be-5u36o records verdict PASS on commit `efca1a21c`, zero style/security findings in round 2 (independently re-run, not carried over from round 1). Round 1 (be-j7eon) was request-changes solely on a spec/test-construction defect (self-skip) — its own style_findings and security_findings were already `none` too. |
+| 2 | Acceptance criteria met | **PASS** | All 4 round-1 exit_contract items independently re-confirmed by the reviewer in round 2, not re-accepted on the builder's word: (1) pull silent-stale-success detection (`verifyPullLanded`, store.go:4113, called from `pullFromRemoteUnchecked` store.go:4026) predates this branch's fork point per `git merge-base --is-ancestor 2240ee784 5cbe3a29a`; (2) no new false positives; (3) route-taken logging unregressed; (4) `TestPushPullLogCLIRouteForGitProtocolRemote` self-skip fixed. I independently re-ran all four named tests myself this round — see criterion 3. |
+| 3 | Tests pass | **PASS** | Independently re-run against `efca1a21c` (not trusting reviewer's counts): `go build` clean (untagged + `-tags=integration,gms_pure_go`); `go vet` clean (both); `gofmt -l` clean on all 3 touched files. Targeted diff-owned + exit-contract run: **5 PASS / 0 FAIL / 0 SKIP** (`TestGitRemoteSyncRoundTrip`, `TestGitRemoteExternalServerRouting`, `TestPullReportsSuccessOnlyWhenTheMergeLanded`, `TestPushPullLogCLIRouteForGitProtocolRemote` [the sole diff-owned test — `git diff --name-only efca1a21c^!` touches only the two route_logging files], `TestPushPullLogSQLRouteForFileRemote`) — matches reviewer's reported counts exactly. Broad untagged sweep: **129 PASS / 0 explicit FAIL / 0 SKIP**, package run terminated by a pre-existing suite-wide 10-minute panic-timeout (see 3a). |
+| 3a | Pre-existing-failure attribution independently re-confirmed | **PASS** | `TestCrossProject_ReadIsolation_DifferentPrefixes` is the test in flight when this run's own 10m timeout panic fired (`running tests: TestCrossProject_ReadIsolation_DifferentPrefixes (7s)`) — independently reproducing the identical failure signature the reviewer documented, in a separate process/run. Port 28231 reconfirmed live-held by the same foreign `dolt` process, same PID (`2479577`), as the reviewer's own live check. `cross_project_test.go` confirmed outside this diff's scope (`git diff --name-only origin/main...efca1a21c` — zero hits). Not diff-owned, not a regression, proven pre-existing by independent reproduction rather than trusted attribution. |
+| 3b | Policy/lint lane | **PASS** | `make ci-pr-policy`: build-tag policy clean (99 files), go-install guidance clean, 7/8 version-consistency checks clean. One known non-diff-owned, non-repo-owned false positive — see below. |
+| 4 | No unresolved HIGH findings | **PASS** | Zero style or security findings in both review rounds. Round 1's only gap (self-skip test construction) was a spec finding, not security/style, and is fixed + independently re-verified this round. |
+| 5 | Clean working tree | **PASS** | `git status --porcelain` on the evaluated commit is empty before cutting the deploy branch. |
+| 6 | Clean divergence from `origin/main` | **PASS** | `origin/main` advanced by exactly one commit (`3641fcf8f`, "key the deferred-parent table gate on which table is missing") since this branch's merge-base (`5cbe3a29a`) — touches only `internal/storage/domain/db/ready_work*.go`, `internal/storage/issueops/ready_work*.go`, and `internal/storage/embeddeddolt/ready_work_missing_table_test.go`: zero path overlap with this diff's 3 files. `git merge-tree --write-tree origin/main efca1a21c` exits 0, printing only the resulting tree OID — no conflict messages. No self-rebase needed. |
+| 7 | Single feature theme | **PASS** | All 3 changed files live under `internal/storage/dolt/`, all serving one theme: CLI/SQL route-decision observability plus test coverage for it and for pull silent-staleness detection. No unrelated changes riding along. |
+
+## Tests run on release branch (independent re-verification)
+
+| Check | Result |
+|---|---|
+| `go build ./internal/storage/dolt/...` (untagged + `-tags=integration,gms_pure_go`) | both clean |
+| `go vet ./internal/storage/dolt/...` (untagged + `-tags=integration,gms_pure_go`) | both clean |
+| `gofmt -l` on all 3 touched files | clean (no output) |
+| `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true CGO_ENABLED=1 GOFLAGS=-tags=integration,gms_pure_go go test ./internal/storage/dolt/ -run 'TestPushPullLog\|TestPullReportsSuccessOnlyWhenTheMergeLanded\|TestGitRemoteSyncRoundTrip\|TestGitRemoteExternalServerRouting' -v` | 5 PASS / 0 FAIL / 0 SKIP, 52.2s, real podman-backed `dolt-sql-server:2.2.0` container |
+| `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true CGO_ENABLED=1 go test ./internal/storage/dolt/... -v` (untagged broad sweep) | 129 PASS / 0 explicit FAIL / 0 SKIP; package terminated by pre-existing 10m panic-timeout on `TestCrossProject_ReadIsolation_DifferentPrefixes` (624.5s total), see criterion 3a |
+| `make ci-pr-policy` | 1 non-diff-owned false positive, see below; otherwise clean |
+
+### `make ci-pr-policy` non-blocking finding (not diff-owned, not repo-owned)
+
+`.githooks/commit-msg` fails the `BEGIN/END BEADS INTEGRATION` marker check.
+Independently confirmed this is a local artifact, not a repo file:
+`git ls-files .githooks/commit-msg` returns nothing (untracked), and
+`git check-ignore -v .githooks/commit-msg` resolves it to
+`.git/info/exclude` (a local, per-clone exclude list, not a committed
+`.gitignore`). Also confirmed outside this diff's scope
+(`git diff --name-only efca1a21c^! | grep commit-msg` — no match). Fires on
+every gate round in this worktree regardless of diff; does not gate this
+deploy.
+
+## Findings from review (no action required)
+
+From be-5u36o (round 2): zero style findings, zero security findings.
+`route_logging_integration_test.go` read in full by the reviewer: correct
+build tag, concurrency-slot guard matching suite convention, hard
+`t.Fatalf` precondition (not a silent skip) — the direct fix for round 1's
+defect. `route_logging_test.go`'s diff is a clean move (removal + pointer
+comment), nothing orphaned. Security: pure test-construction-fix commit,
+zero production-code changes this round; `remote` param re-confirmed
+end-to-end as a configured name, never a URL, across all 8 call sites and
+their callers.
+
+## Verdict
+
+**PASS** — all 7 criteria (plus 3a/3b) clear, including an independent
+re-verification of every criterion 2/3 claim (build, vet, gofmt, the full
+named test set, and the pre-existing-failure fingerprint) rather than
+trusting the reviewer's evidence alone. Proceeding to open the PR from
+`deploy/be-j4oer-gate` (`efca1a21ca9d77723bf6c19c0859cfc200a98f28`).
+
+This repo (`gastownhall/beads`) is a contributor-only upstream for this
+rig — merge authority belongs to upstream maintainers, not our
+mayor/mpr. Per the repo-scoped carve-out, this deploy's job ends at the
+open PR: no `gh pr merge`, no `release-gate/deploy-clearance` commit
+status, no formal merge-request routing. Gate result is reported to mayor
+as an FYI only.


### PR DESCRIPTION
## What this changes

Push and Pull each pick between a `dolt` CLI subprocess and an in-process SQL call across several routing gates (git-protocol, credentials, cloud-auth, local-remote for push), but which route a given call actually took was only recoverable by reading source. This adds a log line at every CLI return point and the shared SQL fallback in both `pushToRemote` and `pullTransportReporting`, so `dolt push route: CLI|SQL (remote=...)` (and the pull equivalent) is always visible under `BD_DEBUG` or `-v`.

It also fixes a self-skip defect in the CLI-route logging test that meant it was never actually exercising the CLI path it claimed to check.

## Review notes

- `remote` is a configured remote *name* (e.g. `"origin"`), never a URL or credential — traced end-to-end from the `remote string` struct field through every call site and logged with `%q` to prevent log-forging via embedded control characters.
- Zero production-code changes beyond the log calls themselves; no new dependencies.
- The new integration test gives its own store a real local `.dolt` directory via `startLocalDoltServer` (matching an existing pattern already used in the same file), instead of the shared-server client the original version used — that's what makes it actually exercise CLI routing instead of self-skipping.

## Review round 2 — what changed

- **The route line is no longer unconditional output.** `logRouteDecision` used `log.Printf`, which is unconditional stderr with the stdlib timestamp prefix — and unlike the three other `log.Printf` calls in `store.go`, all warnings on exceptional paths, this one fires on *every* push and pull. It would have printed for every user on every operation, including under `--quiet`. It now uses `debug.Logf`, the gated sink, which was already imported. (`debug.Logf` does not append a newline, so the format string carries one.)
- **Both tests stopped mutating the process-global `log` writer.** They now share a `captureRouteLog` helper that enables the debug sink and captures `os.Stderr`. That removes the `log.SetOutput` hazard next to this package's seven `t.Parallel` files rather than just documenting it; the helper and both call sites still carry an explicit must-not-become-parallel note, because it touches two process globals (`os.Stderr` and debug's verbose flag). The `t.Fatalf` calls moved out of the captured closure — `t.Fatalf` runs `Goexit`, which would have skipped the `os.Stderr` restore and left the pipe installed.
- **Corrected a claim in this body.** It previously said this PR "adds direct test coverage proving Pull already refuses to report success when a merge doesn't actually land". It does not: `TestPullReportsSuccessOnlyWhenTheMergeLanded` is already on `origin/main` (`internal/storage/dolt/git_remote_test.go:1699`) and is not in this diff, which is 4 files — the two route-logging test files, `store.go`, and the gate doc. It was *run* as regression evidence, not added here.

Red/green on the sink change, against a live `dolt-sql-server`: with `log.Printf` restored, `TestPushPullLogSQLRouteForFileRemote` **FAILs** with an empty capture — the `log` package holds the `os.Stderr` it captured at init and never sees the swap — and with `debug.Logf` it **PASSes** in 5.13s. The test gates the sink rather than passing either way.

## Test plan

- [x] `TestPushPullLogCLIRouteForGitProtocolRemote`, `TestPushPullLogSQLRouteForFileRemote` (the two diff-owned tests) — pass against a live dolt-sql-server.
- [x] `TestPullReportsSuccessOnlyWhenTheMergeLanded`, `TestGitRemoteSyncRoundTrip`, `TestGitRemoteExternalServerRouting` — pre-existing tests on `main`, re-run as regression evidence for the routing change, not added by this PR.
- [x] Full `go test ./internal/storage/dolt/...` — 129/129 pass beyond the above; one pre-existing, already-tracked port-contention timeout unrelated to this change (reproduced independently; see gate file for full attribution).
- [x] `gofmt`, `go vet`, `go build` (untagged + integration tags) — clean.
- [x] Release gate: [`release-gates/be-j4oer-gate.md`](release-gates/be-j4oer-gate.md)
