### PR TITLE
bench: in-tree A/B harness for SearchCountsSQL query shapes

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -101,6 +101,30 @@ and committing synthetic fixture rows into that workspace.
 pass `--keep-indexes` only when intentionally leaving the final index set
 installed.
 
+## SQL Shape A/B Harness (SearchCountsSQL)
+
+`internal/storage/sqlbuild/bench` is an in-tree harness for A/B-ing candidate
+SQL shapes for `sqlbuild.SearchCountsSQL` against a seeded corpus (~5k rows,
+~20k labels per plane, a ~50-row narrow filter) before proposing a change to
+that query. It exists because PR #5339 changed `SearchCountsSQL`'s predicate
+form, was approved on result-equivalence reasoning alone, and then measured
+~3x slower after merge (EXPLAIN showed the driver filter inlined at 8
+references vs. main's 1). The harness asserts row-set identity between shapes
+before reporting any timing, and reports per-round timings, spread, and
+EXPLAIN driver-filter reference counts, not just a mean.
+
+**Run this before proposing any `SearchCountsSQL` shape change, and paste the
+printed per-round timings, spread, and EXPLAIN reference counts into the PR
+description:**
+
+```bash
+go test -run TestSearchCountsHarness -v ./internal/storage/sqlbuild/bench/...
+```
+
+Requires the pinned Dolt image (`dolthub/dolt-sql-server:2.2.0`) reachable via
+Docker/testcontainers; skips cleanly (not a failure) when it isn't, and never
+runs under a plain `go test ./...`.
+
 ## Performance Targets
 
 ### Typical Results (M2 Pro)

--- a/internal/storage/sqlbuild/bench/alternate.go
+++ b/internal/storage/sqlbuild/bench/alternate.go
@@ -1,0 +1,42 @@
+package bench
+
+import (
+	"fmt"
+	"time"
+)
+
+// RoundResult is one shape's timing for one round of an alternating run.
+type RoundResult struct {
+	Shape    string
+	Round    int
+	Duration time.Duration
+}
+
+// RunAlternating runs exec for every shape, strictly interleaved round by
+// round (round 1: shape[0], shape[1], ...; round 2: shape[0], shape[1], ...;
+// and so on) rather than all rounds of one shape followed by all rounds of
+// the next. Strict alternation spreads any environmental drift (cache
+// warmth, background load) evenly across shapes instead of letting it favor
+// whichever shape happens to run first — the same discipline the PR #5339
+// review used (8 alternating rounds) to trust its measurement.
+//
+// On the first error from exec, RunAlternating stops immediately and returns
+// the results gathered so far alongside a wrapped error identifying the
+// failing shape and round.
+func RunAlternating(rounds int, shapes []Shape, exec func(shape Shape, round int) (time.Duration, error)) ([]RoundResult, error) {
+	if len(shapes) == 0 {
+		return nil, fmt.Errorf("bench: RunAlternating requires at least one shape")
+	}
+
+	var results []RoundResult
+	for round := 1; round <= rounds; round++ {
+		for _, shape := range shapes {
+			d, err := exec(shape, round)
+			if err != nil {
+				return results, fmt.Errorf("bench: shape %s round %d: %w", shape.Name, round, err)
+			}
+			results = append(results, RoundResult{Shape: shape.Name, Round: round, Duration: d})
+		}
+	}
+	return results, nil
+}

--- a/internal/storage/sqlbuild/bench/alternate_test.go
+++ b/internal/storage/sqlbuild/bench/alternate_test.go
@@ -1,0 +1,93 @@
+package bench_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/sqlbuild/bench"
+)
+
+// TestRunAlternating_StrictRoundRobinOrder pins the defining property of
+// alternating A/B measurement: shapes must interleave every round (a, b, a,
+// b, ...), never run as two back-to-back blocks. Block execution would let
+// unrelated system warm-up/cooldown effects masquerade as a shape difference.
+func TestRunAlternating_StrictRoundRobinOrder(t *testing.T) {
+	var calls []string
+	shapes := []bench.Shape{{Name: "a"}, {Name: "b"}}
+	exec := func(shape bench.Shape, round int) (time.Duration, error) {
+		calls = append(calls, shape.Name)
+		return time.Millisecond, nil
+	}
+	results, err := bench.RunAlternating(3, shapes, exec)
+	if err != nil {
+		t.Fatalf("RunAlternating: %v", err)
+	}
+	wantOrder := []string{"a", "b", "a", "b", "a", "b"}
+	if len(calls) != len(wantOrder) {
+		t.Fatalf("got %d calls, want %d", len(calls), len(wantOrder))
+	}
+	for i, name := range wantOrder {
+		if calls[i] != name {
+			t.Errorf("call %d: got shape %q, want %q (order must alternate every round)", i, calls[i], name)
+		}
+	}
+	if len(results) != 6 {
+		t.Fatalf("got %d results, want 6", len(results))
+	}
+}
+
+func TestRunAlternating_RecordsShapeRoundDuration(t *testing.T) {
+	shapes := []bench.Shape{{Name: "only"}}
+	exec := func(shape bench.Shape, round int) (time.Duration, error) {
+		return time.Duration(round) * time.Millisecond, nil
+	}
+	results, err := bench.RunAlternating(2, shapes, exec)
+	if err != nil {
+		t.Fatalf("RunAlternating: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	for i, r := range results {
+		wantRound := i + 1
+		if r.Round != wantRound {
+			t.Errorf("result %d: Round = %d, want %d", i, r.Round, wantRound)
+		}
+		if r.Shape != "only" {
+			t.Errorf("result %d: Shape = %q, want %q", i, r.Shape, "only")
+		}
+		if r.Duration != time.Duration(wantRound)*time.Millisecond {
+			t.Errorf("result %d: Duration = %v, want %v", i, r.Duration, time.Duration(wantRound)*time.Millisecond)
+		}
+	}
+}
+
+func TestRunAlternating_PropagatesExecError(t *testing.T) {
+	shapes := []bench.Shape{{Name: "a"}, {Name: "b"}}
+	boom := errors.New("boom")
+	calls := 0
+	exec := func(shape bench.Shape, round int) (time.Duration, error) {
+		calls++
+		if shape.Name == "b" && round == 1 {
+			return 0, boom
+		}
+		return time.Millisecond, nil
+	}
+	_, err := bench.RunAlternating(3, shapes, exec)
+	if !errors.Is(err, boom) {
+		t.Fatalf("RunAlternating error = %v, want wrapping %v", err, boom)
+	}
+	if calls != 2 {
+		t.Errorf("exec called %d times, want 2 (must abort on first error rather than continuing)", calls)
+	}
+}
+
+func TestRunAlternating_RejectsEmptyShapes(t *testing.T) {
+	_, err := bench.RunAlternating(3, nil, func(bench.Shape, int) (time.Duration, error) {
+		return 0, nil
+	})
+	if err == nil {
+		t.Fatal("expected error for empty shapes slice")
+	}
+}

--- a/internal/storage/sqlbuild/bench/explain.go
+++ b/internal/storage/sqlbuild/bench/explain.go
@@ -1,0 +1,17 @@
+package bench
+
+import "strings"
+
+// PlanReferenceCount counts occurrences of marker in explainOutput — the
+// harness's stand-in for "how many times does the driver filter appear in
+// the plan," the signal that surfaced PR #5339's regression (main referenced
+// the driver filter once; the CTE form inlined it at 8 references). Counts
+// every occurrence, including more than one on the same line; matching is
+// case-sensitive since EXPLAIN table/alias names are. An empty marker counts
+// as never present rather than matching every position.
+func PlanReferenceCount(explainOutput, marker string) int {
+	if marker == "" {
+		return 0
+	}
+	return strings.Count(explainOutput, marker)
+}

--- a/internal/storage/sqlbuild/bench/explain_test.go
+++ b/internal/storage/sqlbuild/bench/explain_test.go
@@ -1,0 +1,35 @@
+package bench_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/sqlbuild/bench"
+)
+
+// TestPlanReferenceCount pins occurrence-based counting (not line-based): the
+// PR #5339 story this harness models ("driver filter inlined at 8 references
+// vs main's 1") counts how many times a marker appears in the plan text,
+// including multiple occurrences on the same line.
+func TestPlanReferenceCount(t *testing.T) {
+	cases := []struct {
+		name          string
+		explainOutput string
+		marker        string
+		want          int
+	}{
+		{"empty output", "", "dependencies", 0},
+		{"marker absent", "Filter\n  TableScan: issues\n", "dependencies", 0},
+		{"single occurrence", "Filter\n  TableScan: dependencies\n", "dependencies", 1},
+		{"multiple lines", "TableScan: dependencies\nTableScan: dependencies\nTableScan: dependencies\n", "dependencies", 3},
+		{"multiple occurrences same line", "Join(dependencies, dependencies)\n", "dependencies", 2},
+		{"case sensitive", "TableScan: DEPENDENCIES\n", "dependencies", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bench.PlanReferenceCount(tc.explainOutput, tc.marker)
+			if got != tc.want {
+				t.Errorf("PlanReferenceCount(%q, %q) = %d, want %d", tc.explainOutput, tc.marker, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/storage/sqlbuild/bench/fixture_test.go
+++ b/internal/storage/sqlbuild/bench/fixture_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/steveyegge/beads/internal/storage/depid"
 	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 )
 
@@ -108,10 +109,14 @@ func insertMainRows(ctx context.Context, t *testing.T, db *sql.DB, plane planeCo
 			if i >= narrowStart {
 				assignee = seedNarrowAssignee
 			}
-			placeholders = append(placeholders, "(?, ?, ?, ?, ?, ?, ?, ?)")
+			placeholders = append(placeholders, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 			args = append(args,
 				ids[i],          // id
 				"bench "+ids[i], // title
+				"",              // description
+				"",              // design
+				"",              // acceptance_criteria
+				"",              // notes
 				"open",          // status
 				2,               // priority
 				"task",          // issue_type
@@ -121,7 +126,7 @@ func insertMainRows(ctx context.Context, t *testing.T, db *sql.DB, plane planeCo
 			)
 		}
 		query := fmt.Sprintf(
-			"INSERT INTO %s (id, title, status, priority, issue_type, assignee, created_at, updated_at) VALUES %s "+
+			"INSERT INTO %s (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type, assignee, created_at, updated_at) VALUES %s "+
 				"ON DUPLICATE KEY UPDATE title = VALUES(title)",
 			plane.tables.Main, strings.Join(placeholders, ","),
 		)
@@ -172,14 +177,14 @@ func insertDependencyRows(ctx context.Context, t *testing.T, db *sql.DB, plane p
 	narrow := narrowIDs(ids)
 
 	placeholders := make([]string, 0, len(narrow))
-	args := make([]any, 0, len(narrow)*6)
+	args := make([]any, 0, len(narrow)*7)
 	for i, id := range narrow {
 		target := background[i%len(background)]
-		placeholders = append(placeholders, "(?, ?, ?, ?, ?, ?)")
-		args = append(args, id, target, "blocks", "bench", seedBaseline, "{}")
+		placeholders = append(placeholders, "(?, ?, ?, ?, ?, ?, ?)")
+		args = append(args, depid.New(id, target), id, target, "blocks", "bench", seedBaseline, "{}")
 	}
 	query := fmt.Sprintf(
-		"INSERT INTO %s (issue_id, %s, type, created_by, created_at, metadata) VALUES %s",
+		"INSERT INTO %s (id, issue_id, %s, type, created_by, created_at, metadata) VALUES %s",
 		plane.tables.Dependencies, plane.depTargetColumn, strings.Join(placeholders, ","),
 	)
 	_, err := db.ExecContext(ctx, query, args...)

--- a/internal/storage/sqlbuild/bench/fixture_test.go
+++ b/internal/storage/sqlbuild/bench/fixture_test.go
@@ -1,0 +1,187 @@
+package bench_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
+)
+
+// planeConfig bundles what fixture and test code need to drive one plane
+// (issues or wisps) through the shared sqlbuild table-name parameterization,
+// so seeding and assertions can iterate over both planes generically instead
+// of duplicating logic per plane.
+type planeConfig struct {
+	name            string
+	tables          sqlbuild.FilterTables
+	depTargetColumn string // "depends_on_issue_id" or "depends_on_wisp_id"
+}
+
+var issuesPlane = planeConfig{
+	name:            "issues",
+	tables:          sqlbuild.IssuesFilterTables,
+	depTargetColumn: "depends_on_issue_id",
+}
+
+var wispsPlane = planeConfig{
+	name:            "wisps",
+	tables:          sqlbuild.WispsFilterTables,
+	depTargetColumn: "depends_on_wisp_id",
+}
+
+const (
+	// seedBackgroundCount is the size of the large background corpus each
+	// plane is seeded with — big enough that a narrow WHERE clause scanning
+	// it is representative of the production hot path this harness targets
+	// (see counts.go's driver-filter doc comment).
+	seedBackgroundCount = 5000
+	// seedLabelsPerRow gives seedBackgroundCount*seedLabelsPerRow = 20000
+	// label rows across the corpus.
+	seedLabelsPerRow = 4
+	// seedNarrowCount is the size of the tagged subset a realistic
+	// assignee-scoped WHERE clause isolates out of seedBackgroundCount rows —
+	// the "narrow ephemeral-work search" shape SearchCountsSQL's predicate
+	// form exists for.
+	seedNarrowCount    = 50
+	seedNarrowAssignee = "bench-narrow-target"
+
+	seedInsertBatch = sqlbuild.QueryBatchSize
+)
+
+// seedBaseline is a fixed instant (not time.Now()) so every seeded row has a
+// byte-identical timestamp across runs, keeping the corpus fully
+// deterministic.
+var seedBaseline = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// seedRowIDs returns the deterministic ID list for plane's background
+// corpus. The last seedNarrowCount IDs are the ones seedPlaneCorpus tags
+// with seedNarrowAssignee.
+func seedRowIDs(plane planeConfig) []string {
+	ids := make([]string, seedBackgroundCount)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("bench-%s-%05d", plane.name, i)
+	}
+	return ids
+}
+
+// narrowIDs returns the subset of ids tagged with seedNarrowAssignee.
+func narrowIDs(ids []string) []string {
+	return ids[len(ids)-seedNarrowCount:]
+}
+
+// seedPlaneCorpus deterministically seeds plane's main/labels/dependencies
+// tables: seedBackgroundCount rows with seedLabelsPerRow labels each, plus
+// the trailing seedNarrowCount rows tagged with seedNarrowAssignee and given
+// a dependency on an earlier background row. No randomness — every field is
+// a function of the row index, so repeated runs produce an identical corpus.
+// Comment counts are intentionally left at zero (comments are not seeded);
+// the shapes under test do not depend on comment content, only its count
+// column being present and comparable.
+func seedPlaneCorpus(ctx context.Context, t *testing.T, db *sql.DB, plane planeConfig) []string {
+	t.Helper()
+	ids := seedRowIDs(plane)
+	insertMainRows(ctx, t, db, plane, ids)
+	insertLabelRows(ctx, t, db, plane, ids)
+	insertDependencyRows(ctx, t, db, plane, ids)
+	return ids
+}
+
+func insertMainRows(ctx context.Context, t *testing.T, db *sql.DB, plane planeConfig, ids []string) {
+	t.Helper()
+	narrowStart := len(ids) - seedNarrowCount
+
+	for start := 0; start < len(ids); start += seedInsertBatch {
+		end := start + seedInsertBatch
+		if end > len(ids) {
+			end = len(ids)
+		}
+		placeholders := make([]string, 0, end-start)
+		args := make([]any, 0, (end-start)*8)
+		for i := start; i < end; i++ {
+			assignee := ""
+			if i >= narrowStart {
+				assignee = seedNarrowAssignee
+			}
+			placeholders = append(placeholders, "(?, ?, ?, ?, ?, ?, ?, ?)")
+			args = append(args,
+				ids[i],          // id
+				"bench "+ids[i], // title
+				"open",          // status
+				2,               // priority
+				"task",          // issue_type
+				assignee,        // assignee
+				seedBaseline,    // created_at
+				seedBaseline,    // updated_at
+			)
+		}
+		query := fmt.Sprintf(
+			"INSERT INTO %s (id, title, status, priority, issue_type, assignee, created_at, updated_at) VALUES %s "+
+				"ON DUPLICATE KEY UPDATE title = VALUES(title)",
+			plane.tables.Main, strings.Join(placeholders, ","),
+		)
+		_, err := db.ExecContext(ctx, query, args...)
+		require.NoError(t, err, "seed %s rows [%d:%d)", plane.tables.Main, start, end)
+	}
+}
+
+func insertLabelRows(ctx context.Context, t *testing.T, db *sql.DB, plane planeConfig, ids []string) {
+	t.Helper()
+	type labelRow struct {
+		issueID, label string
+	}
+	var rows []labelRow
+	for i, id := range ids {
+		for k := 0; k < seedLabelsPerRow; k++ {
+			rows = append(rows, labelRow{issueID: id, label: fmt.Sprintf("bench-label-%03d", (i*7+k)%50)})
+		}
+	}
+
+	for start := 0; start < len(rows); start += seedInsertBatch {
+		end := start + seedInsertBatch
+		if end > len(rows) {
+			end = len(rows)
+		}
+		placeholders := make([]string, 0, end-start)
+		args := make([]any, 0, (end-start)*2)
+		for _, r := range rows[start:end] {
+			placeholders = append(placeholders, "(?, ?)")
+			args = append(args, r.issueID, r.label)
+		}
+		query := fmt.Sprintf(
+			"INSERT INTO %s (issue_id, label) VALUES %s ON DUPLICATE KEY UPDATE label = label",
+			plane.tables.Labels, strings.Join(placeholders, ","),
+		)
+		_, err := db.ExecContext(ctx, query, args...)
+		require.NoError(t, err, "seed %s rows [%d:%d)", plane.tables.Labels, start, end)
+	}
+}
+
+// insertDependencyRows gives each narrow-tagged row a single dependency on
+// an earlier background row, so dep_count/rdep_count/deps_json are
+// meaningfully non-zero for the rows the narrow WHERE clause isolates
+// (and rdep_count is non-zero for whichever background rows they land on).
+func insertDependencyRows(ctx context.Context, t *testing.T, db *sql.DB, plane planeConfig, ids []string) {
+	t.Helper()
+	background := ids[:len(ids)-seedNarrowCount]
+	narrow := narrowIDs(ids)
+
+	placeholders := make([]string, 0, len(narrow))
+	args := make([]any, 0, len(narrow)*6)
+	for i, id := range narrow {
+		target := background[i%len(background)]
+		placeholders = append(placeholders, "(?, ?, ?, ?, ?, ?)")
+		args = append(args, id, target, "blocks", "bench", seedBaseline, "{}")
+	}
+	query := fmt.Sprintf(
+		"INSERT INTO %s (issue_id, %s, type, created_by, created_at, metadata) VALUES %s",
+		plane.tables.Dependencies, plane.depTargetColumn, strings.Join(placeholders, ","),
+	)
+	_, err := db.ExecContext(ctx, query, args...)
+	require.NoError(t, err, "seed %s rows", plane.tables.Dependencies)
+}

--- a/internal/storage/sqlbuild/bench/harness_test.go
+++ b/internal/storage/sqlbuild/bench/harness_test.go
@@ -1,0 +1,297 @@
+package bench_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/storage/schema"
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
+	"github.com/steveyegge/beads/internal/storage/sqlbuild/bench"
+	"github.com/steveyegge/beads/internal/testutil"
+)
+
+// harnessSuite seeds a real Dolt database once per suite and resets to a
+// baseline commit between tests, mirroring internal/storage/domain/db's
+// suite_test.go pattern rather than reinventing DB lifecycle management.
+//
+// KNOWN ENVIRONMENT GAP: this suite is gated by testutil.RequireDoltContainer
+// and skips cleanly wherever Docker/testcontainers cannot pull the pinned
+// Dolt image (as in this sandbox). It has not been run end-to-end against a
+// live server; see be-qm6fb's handoff notes.
+type harnessSuite struct {
+	suite.Suite
+	db             *sql.DB
+	dbName         string
+	baselineCommit string
+	eventsDDL      string
+}
+
+func (s *harnessSuite) SetupSuite() {
+	testutil.RequireDoltContainer(s.T())
+
+	port := testutil.DoltContainerPortInt()
+	s.Require().NotZero(port, "test container port must be set")
+
+	ctx := context.Background()
+
+	rootDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: port, User: "root"}.String()
+	root, err := sql.Open("mysql", rootDSN)
+	s.Require().NoError(err)
+	defer root.Close()
+
+	s.dbName = "beads_sqlbuild_bench_" + randomSuffix(8)
+	_, err = root.ExecContext(ctx, "CREATE DATABASE `"+s.dbName+"`")
+	s.Require().NoError(err)
+
+	dsn := doltutil.ServerDSN{Host: "127.0.0.1", Port: port, User: "root", Database: s.dbName}.String()
+	db, err := sql.Open("mysql", dsn)
+	s.Require().NoError(err)
+	s.Require().NoError(db.PingContext(ctx))
+	s.db = db
+
+	var version string
+	s.Require().NoError(db.QueryRowContext(ctx, "SELECT VERSION()").Scan(&version), "capture served Dolt version")
+	s.T().Logf("served Dolt version: %s (pinned image: %s)", version, testutil.DoltDockerImage)
+
+	_, err = schema.MigrateUp(ctx, db)
+	s.Require().NoError(err, "applying beads schema")
+
+	_, err = db.ExecContext(ctx, "CALL DOLT_ADD('-A')")
+	s.Require().NoError(err, "dolt add baseline")
+	_, err = db.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--allow-empty')", "sqlbuild bench harness baseline")
+	s.Require().NoError(err, "dolt commit baseline")
+	s.Require().NoError(
+		db.QueryRowContext(ctx, "SELECT HASHOF('HEAD')").Scan(&s.baselineCommit),
+		"capture baseline commit hash",
+	)
+
+	var tblName string
+	s.Require().NoError(
+		db.QueryRowContext(ctx, "SHOW CREATE TABLE events").Scan(&tblName, &s.eventsDDL),
+		"capture events DDL (events is dolt_ignored, must be recreated after DOLT_RESET)",
+	)
+
+	seedPlaneCorpus(ctx, s.T(), db, issuesPlane)
+	seedPlaneCorpus(ctx, s.T(), db, wispsPlane)
+
+	_, err = db.ExecContext(ctx, "CALL DOLT_ADD('-A')")
+	s.Require().NoError(err, "dolt add seeded corpus")
+	_, err = db.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--allow-empty')", "sqlbuild bench harness seeded corpus")
+	s.Require().NoError(err, "dolt commit seeded corpus")
+	s.Require().NoError(
+		db.QueryRowContext(ctx, "SELECT HASHOF('HEAD')").Scan(&s.baselineCommit),
+		"capture seeded baseline commit hash",
+	)
+}
+
+func (s *harnessSuite) TearDownSuite() {
+	if s.db != nil {
+		_ = s.db.Close()
+		s.db = nil
+	}
+	if s.dbName == "" {
+		return
+	}
+	port := testutil.DoltContainerPortInt()
+	if port == 0 {
+		return
+	}
+	rootDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: port, User: "root"}.String()
+	root, err := sql.Open("mysql", rootDSN)
+	if err != nil {
+		return
+	}
+	defer root.Close()
+	_, _ = root.ExecContext(context.Background(), "DROP DATABASE IF EXISTS `"+s.dbName+"`")
+}
+
+func (s *harnessSuite) SetupTest() {
+	ctx := context.Background()
+	_, err := s.db.ExecContext(ctx, "CALL DOLT_RESET('--hard', ?)", s.baselineCommit)
+	s.Require().NoError(err, "reset to baseline %s", s.baselineCommit)
+	_, err = s.db.ExecContext(ctx, "DROP TABLE IF EXISTS events")
+	s.Require().NoError(err, "drop events after reset")
+	_, err = s.db.ExecContext(ctx, s.eventsDDL)
+	s.Require().NoError(err, "recreate events after reset")
+}
+
+func TestSearchCountsHarness(t *testing.T) {
+	suite.Run(t, &harnessSuite{})
+}
+
+// TestNullSelfCheck_IssuesPlane and TestNullSelfCheck_WispsPlane register
+// MainShape() under two different names and assert CompareRowSets reports no
+// diffs between them — proof the harness's comparison machinery is sound
+// (two runs of the *same* shape must always agree) without requiring a
+// second real candidate SQL shape, which is out of scope for this bead (see
+// be-qm6fb's no-CTE-revival note).
+func (s *harnessSuite) TestNullSelfCheck_IssuesPlane() {
+	s.runNullSelfCheck(issuesPlane)
+}
+
+func (s *harnessSuite) TestNullSelfCheck_WispsPlane() {
+	s.runNullSelfCheck(wispsPlane)
+}
+
+func (s *harnessSuite) runNullSelfCheck(plane planeConfig) {
+	ctx := context.Background()
+	t := s.T()
+
+	shapeA := bench.Shape{Name: "main", Render: bench.MainShape().Render}
+	shapeB := bench.Shape{Name: "main-again", Render: bench.MainShape().Render}
+
+	whereSQL := fmt.Sprintf("WHERE i.assignee = %s", quoteLiteral(seedNarrowAssignee))
+	hyd := sqlbuild.CountsHydration{Lite: true}
+
+	rowsA := s.runShape(ctx, plane, shapeA, whereSQL, hyd)
+	rowsB := s.runShape(ctx, plane, shapeB, whereSQL, hyd)
+
+	s.Require().Len(rowsA, seedNarrowCount, "narrow WHERE clause should isolate exactly the tagged subset")
+
+	diffs := bench.CompareRowSets(rowsA, rowsB)
+	if len(diffs) != 0 {
+		t.Fatalf("null self-check found diffs between two runs of the same shape (%s plane): %v", plane.name, diffs)
+	}
+
+	results, err := bench.RunAlternating(3, []bench.Shape{shapeA, shapeB}, func(shape bench.Shape, round int) (time.Duration, error) {
+		start := time.Now()
+		s.runShape(ctx, plane, shape, whereSQL, hyd)
+		return time.Since(start), nil
+	})
+	s.Require().NoError(err)
+	stats := bench.Summarize(results)
+	for _, st := range stats {
+		t.Logf("%s plane, shape %s: n=%d min=%v max=%v mean=%v spread=%v", plane.name, st.Shape, st.N, st.Min, st.Max, st.Mean, st.Spread)
+	}
+}
+
+// TestExplainReferenceCount_Reported exercises PlanReferenceCount against a
+// real EXPLAIN plan from the live server, confirming the plumbing from
+// rendered SQL through to a reference count actually works end-to-end.
+func (s *harnessSuite) TestExplainReferenceCount_Reported() {
+	ctx := context.Background()
+	t := s.T()
+
+	whereSQL := fmt.Sprintf("WHERE i.assignee = %s", quoteLiteral(seedNarrowAssignee))
+	sqlText, args := bench.MainShape().Render(issuesPlane.tables, nil, whereSQL, "", "", true, sqlbuild.CountsHydration{Lite: true})
+
+	rows, err := s.db.QueryContext(ctx, "EXPLAIN "+sqlText, args...)
+	s.Require().NoError(err, "EXPLAIN main shape")
+	defer rows.Close()
+
+	var plan string
+	for rows.Next() {
+		var line string
+		s.Require().NoError(rows.Scan(&line))
+		plan += line + "\n"
+	}
+	s.Require().NoError(rows.Err())
+
+	count := bench.PlanReferenceCount(plan, issuesPlane.tables.Dependencies)
+	t.Logf("EXPLAIN references to %q: %d", issuesPlane.tables.Dependencies, count)
+	if count < 1 {
+		t.Errorf("expected at least one EXPLAIN reference to %q, got %d\nplan:\n%s", issuesPlane.tables.Dependencies, count, plan)
+	}
+}
+
+// runShape renders and executes shape against plane, scanning results into
+// bench.Row. It intentionally reads only the id plus the six "extra"
+// mega-query columns (labels/dep/rdep/comment/parent/deps) — the rest of the
+// hydration payload is shape-invariant and irrelevant to an A/B comparison.
+func (s *harnessSuite) runShape(ctx context.Context, plane planeConfig, shape bench.Shape, whereSQL string, hyd sqlbuild.CountsHydration) []bench.Row {
+	t := s.T()
+	t.Helper()
+
+	sqlText, args := shape.Render(plane.tables, nil, whereSQL, "ORDER BY i.id", "", plane.name == "issues", hyd)
+
+	fullSQL, fullArgs := sqlbuild.SearchCountsSQL(plane.tables, nil, whereSQL, "ORDER BY i.id", "", plane.name == "issues", hyd)
+	s.Require().Equal(fullSQL, sqlText, "shape %s must render the full mega-query so extra columns are present", shape.Name)
+
+	rows, err := s.db.QueryContext(ctx, sqlText, args...)
+	s.Require().NoError(err, "query shape %s", shape.Name)
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	s.Require().NoError(err)
+
+	var out []bench.Row
+	for rows.Next() {
+		vals := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range vals {
+			ptrs[i] = &vals[i]
+		}
+		s.Require().NoError(rows.Scan(ptrs...))
+
+		byName := make(map[string]any, len(cols))
+		for i, c := range cols {
+			byName[c] = vals[i]
+		}
+		out = append(out, rowFromColumns(byName))
+	}
+	s.Require().NoError(rows.Err())
+	_ = fullArgs
+	return out
+}
+
+func rowFromColumns(byName map[string]any) bench.Row {
+	return bench.Row{
+		IssueID:      asString(byName["id"]),
+		LabelsJSON:   asString(byName["labels_json"]),
+		DepCount:     asInt64(byName["dep_count"]),
+		RDepCount:    asInt64(byName["rdep_count"]),
+		CommentCount: asInt64(byName["comment_count"]),
+		ParentID:     asString(byName["parent_id"]),
+		DepsJSON:     asString(byName["deps_json"]),
+	}
+}
+
+func asString(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case []byte:
+		return string(t)
+	case string:
+		return t
+	default:
+		return fmt.Sprintf("%v", t)
+	}
+}
+
+func asInt64(v any) int64 {
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case int64:
+		return t
+	case []byte:
+		var n int64
+		_, _ = fmt.Sscanf(string(t), "%d", &n)
+		return n
+	default:
+		return 0
+	}
+}
+
+func quoteLiteral(s string) string {
+	return "'" + s + "'"
+}
+
+var suffixLetters = []rune("abcdefghijklmnopqrstuvwxyz")
+
+func randomSuffix(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = suffixLetters[rand.Intn(len(suffixLetters))]
+	}
+	return string(b)
+}

--- a/internal/storage/sqlbuild/bench/harness_test.go
+++ b/internal/storage/sqlbuild/bench/harness_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -188,7 +189,13 @@ func (s *harnessSuite) TestExplainReferenceCount_Reported() {
 	whereSQL := fmt.Sprintf("WHERE i.assignee = %s", quoteLiteral(seedNarrowAssignee))
 	sqlText, args := bench.MainShape().Render(issuesPlane.tables, nil, whereSQL, "", "", true, sqlbuild.CountsHydration{Lite: true})
 
-	rows, err := s.db.QueryContext(ctx, "EXPLAIN "+sqlText, args...)
+	// FORMAT=TREE (not the classic tabular EXPLAIN): the tabular form's
+	// numeric "rows" estimate column comes back from this server as the
+	// literal text "NULL" for this query shape, rather than a real SQL NULL,
+	// which the driver's row decoder rejects (strconv.ParseUint) before
+	// Scan ever runs. TREE format returns a single text "plan" column, no
+	// numeric columns at all, sidestepping that decode failure entirely.
+	rows, err := s.db.QueryContext(ctx, "EXPLAIN FORMAT=TREE "+sqlText, args...)
 	s.Require().NoError(err, "EXPLAIN main shape")
 	defer rows.Close()
 
@@ -287,8 +294,14 @@ func asInt64(v any) int64 {
 	}
 }
 
+// quoteLiteral renders s as a single-quoted SQL string literal for embedding
+// directly into whereSQL text (see ShapeFunc — whereSQL must be real SQL, not
+// a placeholder, so EXPLAIN has something to plan against). It is for
+// trusted, in-test literals only: doubling embedded single quotes is
+// sufficient to keep the literal well-formed, but this is not a general
+// escaping routine and must never be used with untrusted input.
 func quoteLiteral(s string) string {
-	return "'" + s + "'"
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // TestQuoteLiteral guards quoteLiteral's SQL-literal escaping. quoteLiteral

--- a/internal/storage/sqlbuild/bench/harness_test.go
+++ b/internal/storage/sqlbuild/bench/harness_test.go
@@ -161,15 +161,20 @@ func (s *harnessSuite) runNullSelfCheck(plane planeConfig) {
 		t.Fatalf("null self-check found diffs between two runs of the same shape (%s plane): %v", plane.name, diffs)
 	}
 
-	results, err := bench.RunAlternating(3, []bench.Shape{shapeA, shapeB}, func(shape bench.Shape, round int) (time.Duration, error) {
+	// 8 alternating rounds matches the scale the PR #5339 review used to
+	// trust its own measurement (see be-qm6fb).
+	results, err := bench.RunAlternating(8, []bench.Shape{shapeA, shapeB}, func(shape bench.Shape, round int) (time.Duration, error) {
 		start := time.Now()
 		s.runShape(ctx, plane, shape, whereSQL, hyd)
 		return time.Since(start), nil
 	})
 	s.Require().NoError(err)
+	for _, rr := range results {
+		t.Logf("%s plane, shape %s, round %d: %v", plane.name, rr.Shape, rr.Round, rr.Duration)
+	}
 	stats := bench.Summarize(results)
 	for _, st := range stats {
-		t.Logf("%s plane, shape %s: n=%d min=%v max=%v mean=%v spread=%v", plane.name, st.Shape, st.N, st.Min, st.Max, st.Mean, st.Spread)
+		t.Logf("%s plane, shape %s summary: n=%d min=%v max=%v mean=%v spread=%v", plane.name, st.Shape, st.N, st.Min, st.Max, st.Mean, st.Spread)
 	}
 }
 

--- a/internal/storage/sqlbuild/bench/harness_test.go
+++ b/internal/storage/sqlbuild/bench/harness_test.go
@@ -291,6 +291,21 @@ func quoteLiteral(s string) string {
 	return "'" + s + "'"
 }
 
+// TestQuoteLiteral guards quoteLiteral's SQL-literal escaping. quoteLiteral
+// embeds its argument directly into whereSQL text passed to ShapeFunc.Render
+// (required so EXPLAIN gets real SQL, not a placeholder) rather than binding
+// it as a driver arg, so an unescaped embedded quote would corrupt the
+// rendered statement. Both call sites currently pass the fixed constant
+// seedNarrowAssignee, which contains no quote character, so this is not
+// exploitable today — this test guards against that changing silently.
+func TestQuoteLiteral(t *testing.T) {
+	got := quoteLiteral("bench's-target")
+	want := "'bench''s-target'"
+	if got != want {
+		t.Errorf("quoteLiteral(%q) = %q, want %q (embedded single quotes must be doubled per SQL literal-escaping convention)", "bench's-target", got, want)
+	}
+}
+
 var suffixLetters = []rune("abcdefghijklmnopqrstuvwxyz")
 
 func randomSuffix(n int) string {

--- a/internal/storage/sqlbuild/bench/rowset.go
+++ b/internal/storage/sqlbuild/bench/rowset.go
@@ -1,0 +1,166 @@
+package bench
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// Row is the subset of SearchCountsSQL's output columns a shape comparison
+// cares about: the id plus the six "extra" mega-query columns. The rest of
+// the hydration payload is shape-invariant.
+type Row struct {
+	IssueID      string
+	LabelsJSON   string
+	DepCount     int64
+	RDepCount    int64
+	CommentCount int64
+	ParentID     string
+	DepsJSON     string
+}
+
+// DiffKind classifies one CompareRowSets finding.
+type DiffKind string
+
+const (
+	DiffMissing  DiffKind = "missing"  // present in want, absent from got
+	DiffExtra    DiffKind = "extra"    // present in got, absent from want
+	DiffMismatch DiffKind = "mismatch" // present in both, fields disagree
+)
+
+// RowSetDiff is one disagreement between two row sets for the same IssueID.
+type RowSetDiff struct {
+	Kind    DiffKind
+	IssueID string
+	Detail  string
+}
+
+// CompareRowSets reports every disagreement between got and want, keyed by
+// IssueID rather than position — result-set row order is not part of
+// SearchCountsSQL's contract. labels_json and deps_json are compared as JSON
+// (element order and, for deps_json's objects, key order are both
+// insensitive), since SQL aggregation gives no ordering guarantee there. The
+// returned slice is sorted by IssueID then Kind for deterministic output;
+// an empty/nil result means the two row sets are equivalent.
+func CompareRowSets(got, want []Row) []RowSetDiff {
+	gotByID := make(map[string]Row, len(got))
+	for _, r := range got {
+		gotByID[r.IssueID] = r
+	}
+	wantByID := make(map[string]Row, len(want))
+	for _, r := range want {
+		wantByID[r.IssueID] = r
+	}
+
+	var diffs []RowSetDiff
+	for id := range wantByID {
+		if _, ok := gotByID[id]; !ok {
+			diffs = append(diffs, RowSetDiff{Kind: DiffMissing, IssueID: id, Detail: "present in want, absent from got"})
+		}
+	}
+	for id := range gotByID {
+		if _, ok := wantByID[id]; !ok {
+			diffs = append(diffs, RowSetDiff{Kind: DiffExtra, IssueID: id, Detail: "present in got, absent from want"})
+		}
+	}
+	for id, g := range gotByID {
+		w, ok := wantByID[id]
+		if !ok {
+			continue
+		}
+		if detail := rowMismatch(g, w); detail != "" {
+			diffs = append(diffs, RowSetDiff{Kind: DiffMismatch, IssueID: id, Detail: detail})
+		}
+	}
+
+	sort.Slice(diffs, func(i, j int) bool {
+		if diffs[i].IssueID != diffs[j].IssueID {
+			return diffs[i].IssueID < diffs[j].IssueID
+		}
+		return diffs[i].Kind < diffs[j].Kind
+	})
+	return diffs
+}
+
+// rowMismatch returns a combined human-readable description of every field
+// where g and w disagree, or "" if they agree on all fields.
+func rowMismatch(g, w Row) string {
+	var detail string
+	add := func(field string, gv, wv any) {
+		if detail != "" {
+			detail += "; "
+		}
+		detail += fmt.Sprintf("%s: got %v, want %v", field, gv, wv)
+	}
+
+	if g.DepCount != w.DepCount {
+		add("dep_count", g.DepCount, w.DepCount)
+	}
+	if g.RDepCount != w.RDepCount {
+		add("rdep_count", g.RDepCount, w.RDepCount)
+	}
+	if g.CommentCount != w.CommentCount {
+		add("comment_count", g.CommentCount, w.CommentCount)
+	}
+	if g.ParentID != w.ParentID {
+		add("parent_id", g.ParentID, w.ParentID)
+	}
+	if !jsonArrayEqual(g.LabelsJSON, w.LabelsJSON) {
+		add("labels_json", g.LabelsJSON, w.LabelsJSON)
+	}
+	if !jsonArrayEqual(g.DepsJSON, w.DepsJSON) {
+		add("deps_json", g.DepsJSON, w.DepsJSON)
+	}
+	return detail
+}
+
+// jsonArrayEqual reports whether two JSON-array strings contain the same
+// elements, ignoring element order and (for object elements) key order.
+// Two empty/blank strings are treated as equal.
+func jsonArrayEqual(a, b string) bool {
+	if a == b {
+		return true
+	}
+	na, aOK := normalizeJSONArray(a)
+	nb, bOK := normalizeJSONArray(b)
+	if !aOK || !bOK {
+		return false
+	}
+	if len(na) != len(nb) {
+		return false
+	}
+	for i := range na {
+		if na[i] != nb[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// normalizeJSONArray parses s as a JSON array, canonicalizes each element
+// (re-marshaling sorts object keys), and returns the element strings sorted
+// for order-insensitive comparison. Blank input normalizes to an empty,
+// successful result so "" and "[]" compare equal.
+func normalizeJSONArray(s string) ([]string, bool) {
+	if s == "" {
+		return nil, true
+	}
+	var raw []json.RawMessage
+	if err := json.Unmarshal([]byte(s), &raw); err != nil {
+		return nil, false
+	}
+	out := make([]string, 0, len(raw))
+	for _, elem := range raw {
+		var v any
+		if err := json.Unmarshal(elem, &v); err != nil {
+			return nil, false
+		}
+		canon, err := json.Marshal(v)
+		if err != nil {
+			return nil, false
+		}
+		out = append(out, string(canon))
+	}
+	sort.Strings(out)
+	return out, true
+}

--- a/internal/storage/sqlbuild/bench/rowset_test.go
+++ b/internal/storage/sqlbuild/bench/rowset_test.go
@@ -1,0 +1,102 @@
+package bench_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/sqlbuild/bench"
+)
+
+func TestCompareRowSets_IdenticalReorderedRows_NoDiffs(t *testing.T) {
+	got := []bench.Row{
+		{IssueID: "b", DepCount: 2, LabelsJSON: `["y","x"]`},
+		{IssueID: "a", DepCount: 1, LabelsJSON: `["x","y"]`},
+	}
+	want := []bench.Row{
+		{IssueID: "a", DepCount: 1, LabelsJSON: `["y","x"]`},
+		{IssueID: "b", DepCount: 2, LabelsJSON: `["x","y"]`},
+	}
+	diffs := bench.CompareRowSets(got, want)
+	if len(diffs) != 0 {
+		t.Fatalf("expected no diffs for row-order- and label-order-insensitive identical sets, got %v", diffs)
+	}
+}
+
+// TestCompareRowSets_ReorderedDepsJSON_NoDiff pins JSON-aware comparison for
+// deps_json: SQL aggregation (JSON_ARRAYAGG/JSON_OBJECT) gives no ordering
+// guarantee over element or key order, so a byte-for-byte string compare
+// would report false mismatches between two SQL shapes that are actually
+// equivalent.
+func TestCompareRowSets_ReorderedDepsJSON_NoDiff(t *testing.T) {
+	got := []bench.Row{
+		{IssueID: "a", DepsJSON: `[{"issue_id":"a","depends_on_id":"x","type":"blocks"},{"issue_id":"a","depends_on_id":"y","type":"blocks"}]`},
+	}
+	want := []bench.Row{
+		{IssueID: "a", DepsJSON: `[{"depends_on_id":"y","issue_id":"a","type":"blocks"},{"type":"blocks","depends_on_id":"x","issue_id":"a"}]`},
+	}
+	diffs := bench.CompareRowSets(got, want)
+	if len(diffs) != 0 {
+		t.Fatalf("expected deps_json element-order and key-order to be insensitive, got %v", diffs)
+	}
+}
+
+func TestCompareRowSets_MissingRow(t *testing.T) {
+	got := []bench.Row{{IssueID: "a"}}
+	want := []bench.Row{{IssueID: "a"}, {IssueID: "b"}}
+	diffs := bench.CompareRowSets(got, want)
+	if len(diffs) != 1 || diffs[0].Kind != bench.DiffMissing || diffs[0].IssueID != "b" {
+		t.Fatalf("got %v, want single missing diff for issue b", diffs)
+	}
+}
+
+func TestCompareRowSets_ExtraRow(t *testing.T) {
+	got := []bench.Row{{IssueID: "a"}, {IssueID: "c"}}
+	want := []bench.Row{{IssueID: "a"}}
+	diffs := bench.CompareRowSets(got, want)
+	if len(diffs) != 1 || diffs[0].Kind != bench.DiffExtra || diffs[0].IssueID != "c" {
+		t.Fatalf("got %v, want single extra diff for issue c", diffs)
+	}
+}
+
+func TestCompareRowSets_FieldMismatch(t *testing.T) {
+	cases := []struct {
+		name      string
+		got, want bench.Row
+	}{
+		{"dep_count", bench.Row{IssueID: "a", DepCount: 1}, bench.Row{IssueID: "a", DepCount: 2}},
+		{"rdep_count", bench.Row{IssueID: "a", RDepCount: 1}, bench.Row{IssueID: "a", RDepCount: 2}},
+		{"comment_count", bench.Row{IssueID: "a", CommentCount: 1}, bench.Row{IssueID: "a", CommentCount: 2}},
+		{"parent_id", bench.Row{IssueID: "a", ParentID: "p1"}, bench.Row{IssueID: "a", ParentID: "p2"}},
+		{"labels_json", bench.Row{IssueID: "a", LabelsJSON: `["x"]`}, bench.Row{IssueID: "a", LabelsJSON: `["y"]`}},
+		{"deps_json", bench.Row{IssueID: "a", DepsJSON: `[{"issue_id":"a","depends_on_id":"x"}]`}, bench.Row{IssueID: "a", DepsJSON: `[{"issue_id":"a","depends_on_id":"y"}]`}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diffs := bench.CompareRowSets([]bench.Row{tc.got}, []bench.Row{tc.want})
+			if len(diffs) != 1 || diffs[0].Kind != bench.DiffMismatch || diffs[0].IssueID != "a" {
+				t.Fatalf("got %v, want single mismatch diff for issue a (field %s)", diffs, tc.name)
+			}
+		})
+	}
+}
+
+func TestCompareRowSets_EmptyBothSides(t *testing.T) {
+	diffs := bench.CompareRowSets(nil, nil)
+	if len(diffs) != 0 {
+		t.Fatalf("expected no diffs for empty/empty, got %v", diffs)
+	}
+}
+
+// TestCompareRowSets_DeterministicOrder pins stable output ordering so
+// harness reports and test assertions don't flake on map iteration order.
+func TestCompareRowSets_DeterministicOrder(t *testing.T) {
+	got := []bench.Row{{IssueID: "z"}, {IssueID: "a"}, {IssueID: "m"}}
+	diffs := bench.CompareRowSets(got, nil)
+	var ids []string
+	for _, d := range diffs {
+		ids = append(ids, d.IssueID)
+	}
+	if !sort.StringsAreSorted(ids) {
+		t.Errorf("diffs not sorted by IssueID: %v", ids)
+	}
+}

--- a/internal/storage/sqlbuild/bench/shapes.go
+++ b/internal/storage/sqlbuild/bench/shapes.go
@@ -1,0 +1,39 @@
+// Package bench is an in-tree A/B harness for comparing candidate SQL
+// shapes for sqlbuild.SearchCountsSQL against a seeded corpus, without
+// requiring an external benchmarking rig or a second git checkout. See
+// be-qm6fb: PR 5339 changed SearchCountsSQL's predicate form and was
+// approved on result-equivalence reasoning alone, then measured ~3x slower
+// after merge. This package is the measuring instrument any future attempt
+// at that optimization (join-form bounds, temp-table materialization,
+// labels-only bound) must clear before review.
+//
+// Run it with (requires the pinned Dolt image, dolthub/dolt-sql-server:2.2.0,
+// cached locally — it skips cleanly otherwise):
+//
+//	go test -run TestSearchCountsHarness -v ./internal/storage/sqlbuild/bench/...
+//
+// Run before proposing any SearchCountsSQL shape change; paste the printed
+// per-round timings, spread, and EXPLAIN reference counts into the PR
+// description.
+package bench
+
+import "github.com/steveyegge/beads/internal/storage/sqlbuild"
+
+// ShapeFunc renders a candidate SQL shape for the counts mega-query. It
+// mirrors sqlbuild.SearchCountsSQL's signature exactly so any candidate can
+// be swapped in without touching call sites.
+type ShapeFunc func(tables sqlbuild.FilterTables, ids []string, whereSQL, orderBySQL, limitSQL string, includeWispReverseDeps bool, hyd sqlbuild.CountsHydration) (string, []any)
+
+// Shape names a renderer so harness output can report which shape a
+// measurement or row set came from.
+type Shape struct {
+	Name   string
+	Render ShapeFunc
+}
+
+// MainShape wraps the production sqlbuild.SearchCountsSQL renderer, giving
+// the harness a baseline shape to compare candidates against (or, via a
+// null self-check, to compare against itself).
+func MainShape() Shape {
+	return Shape{Name: "main", Render: sqlbuild.SearchCountsSQL}
+}

--- a/internal/storage/sqlbuild/bench/shapes_test.go
+++ b/internal/storage/sqlbuild/bench/shapes_test.go
@@ -1,0 +1,54 @@
+package bench_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
+	"github.com/steveyegge/beads/internal/storage/sqlbuild/bench"
+)
+
+func TestMainShape_Name(t *testing.T) {
+	shape := bench.MainShape()
+	if shape.Name != "main" {
+		t.Errorf("MainShape().Name = %q, want %q", shape.Name, "main")
+	}
+	if shape.Render == nil {
+		t.Fatal("MainShape().Render is nil")
+	}
+}
+
+// TestMainShape_MatchesProductionSearchCountsSQL pins MainShape as a pure
+// passthrough to sqlbuild.SearchCountsSQL: the harness must never drift from
+// what production actually runs, or an A/B comparison would be comparing a
+// stand-in against itself instead of against a real candidate shape.
+func TestMainShape_MatchesProductionSearchCountsSQL(t *testing.T) {
+	tables := sqlbuild.IssuesFilterTables
+	hyd := sqlbuild.CountsHydration{}
+
+	wantSQL, wantArgs := sqlbuild.SearchCountsSQL(tables, nil, "WHERE i.status = 'open'", "ORDER BY i.priority", "LIMIT 50", true, hyd)
+	gotSQL, gotArgs := bench.MainShape().Render(tables, nil, "WHERE i.status = 'open'", "ORDER BY i.priority", "LIMIT 50", true, hyd)
+
+	if gotSQL != wantSQL {
+		t.Errorf("MainShape SQL diverges from sqlbuild.SearchCountsSQL:\ngot:  %s\nwant: %s", gotSQL, wantSQL)
+	}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Errorf("MainShape args = %v, want %v", gotArgs, wantArgs)
+	}
+}
+
+func TestMainShape_ByIDsForm(t *testing.T) {
+	tables := sqlbuild.WispsFilterTables
+	ids := []string{"w-1", "w-2"}
+	hyd := sqlbuild.CountsHydration{Lite: true}
+
+	wantSQL, wantArgs := sqlbuild.SearchCountsSQL(tables, ids, "", "", "", false, hyd)
+	gotSQL, gotArgs := bench.MainShape().Render(tables, ids, "", "", "", false, hyd)
+
+	if gotSQL != wantSQL {
+		t.Error("MainShape by-IDs SQL diverges from sqlbuild.SearchCountsSQL")
+	}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Errorf("MainShape by-IDs args = %v, want %v", gotArgs, wantArgs)
+	}
+}

--- a/internal/storage/sqlbuild/bench/stats.go
+++ b/internal/storage/sqlbuild/bench/stats.go
@@ -1,0 +1,48 @@
+package bench
+
+import "time"
+
+// ShapeStats summarizes one shape's timings across an alternating run.
+type ShapeStats struct {
+	Shape  string
+	N      int
+	Min    time.Duration
+	Max    time.Duration
+	Mean   time.Duration
+	Spread time.Duration // Max - Min
+}
+
+// Summarize groups results by Shape, in first-appearance order, and computes
+// per-shape N/Min/Max/Mean/Spread. Spread (not just mean) is what the PR
+// #5339 review actually distrusted about a single-round comparison — a shape
+// with a wide spread needs more rounds before its mean means anything.
+func Summarize(results []RoundResult) []ShapeStats {
+	order := make([]string, 0)
+	byShape := make(map[string][]time.Duration)
+	for _, r := range results {
+		if _, seen := byShape[r.Shape]; !seen {
+			order = append(order, r.Shape)
+		}
+		byShape[r.Shape] = append(byShape[r.Shape], r.Duration)
+	}
+
+	stats := make([]ShapeStats, 0, len(order))
+	for _, shape := range order {
+		durations := byShape[shape]
+		st := ShapeStats{Shape: shape, N: len(durations)}
+		var sum time.Duration
+		for i, d := range durations {
+			sum += d
+			if i == 0 || d < st.Min {
+				st.Min = d
+			}
+			if i == 0 || d > st.Max {
+				st.Max = d
+			}
+		}
+		st.Mean = sum / time.Duration(len(durations))
+		st.Spread = st.Max - st.Min
+		stats = append(stats, st)
+	}
+	return stats
+}

--- a/internal/storage/sqlbuild/bench/stats_test.go
+++ b/internal/storage/sqlbuild/bench/stats_test.go
@@ -1,0 +1,74 @@
+package bench_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/sqlbuild/bench"
+)
+
+func TestSummarize_ComputesPerShapeStats(t *testing.T) {
+	results := []bench.RoundResult{
+		{Shape: "a", Round: 1, Duration: 10 * time.Millisecond},
+		{Shape: "b", Round: 1, Duration: 30 * time.Millisecond},
+		{Shape: "a", Round: 2, Duration: 20 * time.Millisecond},
+		{Shape: "b", Round: 2, Duration: 34 * time.Millisecond},
+		{Shape: "a", Round: 3, Duration: 30 * time.Millisecond},
+		{Shape: "b", Round: 3, Duration: 32 * time.Millisecond},
+	}
+	stats := bench.Summarize(results)
+	if len(stats) != 2 {
+		t.Fatalf("got %d shape stats, want 2", len(stats))
+	}
+	byName := make(map[string]bench.ShapeStats, len(stats))
+	for _, s := range stats {
+		byName[s.Shape] = s
+	}
+
+	a, ok := byName["a"]
+	if !ok {
+		t.Fatal("missing stats for shape a")
+	}
+	if a.N != 3 {
+		t.Errorf("a.N = %d, want 3", a.N)
+	}
+	if a.Min != 10*time.Millisecond {
+		t.Errorf("a.Min = %v, want 10ms", a.Min)
+	}
+	if a.Max != 30*time.Millisecond {
+		t.Errorf("a.Max = %v, want 30ms", a.Max)
+	}
+	if a.Mean != 20*time.Millisecond {
+		t.Errorf("a.Mean = %v, want 20ms", a.Mean)
+	}
+	if a.Spread != 20*time.Millisecond {
+		t.Errorf("a.Spread = %v, want 20ms (Max-Min)", a.Spread)
+	}
+
+	b, ok := byName["b"]
+	if !ok {
+		t.Fatal("missing stats for shape b")
+	}
+	if b.Min != 30*time.Millisecond || b.Max != 34*time.Millisecond {
+		t.Errorf("b.Min/Max = %v/%v, want 30ms/34ms", b.Min, b.Max)
+	}
+}
+
+func TestSummarize_EmptyInput(t *testing.T) {
+	stats := bench.Summarize(nil)
+	if len(stats) != 0 {
+		t.Fatalf("got %d stats for empty input, want 0", len(stats))
+	}
+}
+
+func TestSummarize_SingleSample_ZeroSpread(t *testing.T) {
+	stats := bench.Summarize([]bench.RoundResult{
+		{Shape: "solo", Round: 1, Duration: 5 * time.Millisecond},
+	})
+	if len(stats) != 1 {
+		t.Fatalf("got %d stats, want 1", len(stats))
+	}
+	if stats[0].Spread != 0 {
+		t.Errorf("single-sample Spread = %v, want 0", stats[0].Spread)
+	}
+}

--- a/release-gates/be-px3ke-searchcounts-bench-harness-gate.md
+++ b/release-gates/be-px3ke-searchcounts-bench-harness-gate.md
@@ -1,0 +1,233 @@
+# Release gate — In-tree A/B harness for SearchCountsSQL query shapes (be-qm6fb)
+
+- **Builder bead (CLOSED):** be-qm6fb — in-tree A/B benchmark harness that
+  times named `SearchCountsSQL` shape-renderers against a seeded corpus on
+  both the issues and wisp planes, asserts row-set identity before reporting
+  timings, and prints EXPLAIN driver-filter reference counts. Requested by
+  upstream maintainer `@bee-ghosttrack` on `gastownhall/beads#5339` as the
+  gate any future `SearchCountsSQL` shape attempt (join-form bounds,
+  temp-table materialization, labels-only bound) must clear before review.
+- **Deploy bead:** be-xbycd
+- **Review beads:**
+  - be-cbnts — round 1, verdict **REQUEST CHANGES**, commit `4ae35a1ea355`
+  - be-px3ke — round 2, verdict **PASS**, commit `4894e3c3ba297fc4c6cc38d42ab591efc92f54e2`
+- **Commit (pre-rebase, as reviewed):** `4894e3c3ba297fc4c6cc38d42ab591efc92f54e2`
+- **Commit (post-rebase, as deployed):** `94630463430967e9216315bcd9fec0468e8876bc`
+  — `origin/main` advanced mid-gate (PR #5806, "perf(export): incremental
+  auto-export via dolt_diff", merged), so this branch was rebased via the
+  deployer's bounded self-rebase exception. Zero path overlap between #5806
+  and this diff, confirmed before attempting; rebase was trivial
+  (fast-forward-eligible), `--force-with-lease` pushed to `headfork`. See
+  "Rebase" below.
+- **Branch:** `builder/be-qm6fb` (provenance only); deploy branch
+  `deploy/be-px3ke-gate` cut from `4894e3c3ba297fc4c6cc38d42ab591efc92f54e2`,
+  rebased onto current `origin/main`, and pushed to `headfork`
+  (`quad341/beads-sec003-contrib`) — `origin` (`gastownhall/beads`) has push
+  disabled by design on this contributor rig.
+- **Evaluated:** 2026-08-22 by beads/deployer
+
+## Scope
+
+New code only, exactly as be-qm6fb specified: the production function under
+test, `internal/storage/sqlbuild/counts.go`'s `SearchCountsSQL`, is untouched
+(read-only per the bead's own constraint). Diff scope, confirmed via
+`git diff --stat origin/main...HEAD` (13 files, 1216 insertions, 0 deletions):
+
+- `BENCHMARKS.md` — doc section: what the harness is, when to run it
+- `internal/storage/sqlbuild/bench/shapes.go` (+`shapes_test.go`) — named
+  shape-renderer registry; main's shape wrapping `SearchCountsSQL`
+- `internal/storage/sqlbuild/bench/rowset.go` (+`rowset_test.go`) — row-set
+  fetch + `CompareRowSets` identity check (order-insensitive)
+- `internal/storage/sqlbuild/bench/explain.go` (+`explain_test.go`) — EXPLAIN
+  PLAN driver-filter reference-count extraction
+- `internal/storage/sqlbuild/bench/alternate.go` (+`alternate_test.go`) —
+  strict round-robin alternating-round runner
+- `internal/storage/sqlbuild/bench/stats.go` (+`stats_test.go`) — per-shape
+  timing summary (min/max/mean/spread)
+- `internal/storage/sqlbuild/bench/fixture_test.go` — corpus seeding
+  (issues + wisps planes, ~5k/~20k rows, DDL via `schema.MigrateUp`)
+- `internal/storage/sqlbuild/bench/harness_test.go` — `TestSearchCountsHarness`
+  suite: `SetupSuite`, null self-check (both planes), EXPLAIN
+  reference-count check, `quoteLiteral` helper + `TestQuoteLiteral`
+
+All 13 files serve the one harness feature; no unrelated files touched —
+criterion 7 (single feature theme) holds.
+
+### Round 1 → round 2: what changed
+
+Round 1 (be-cbnts) FAILed on first live-container execution: `SetupSuite`
+aborted seeding the issues plane (`Error 1105: Field 'description' doesn't
+have a default value` — `issues.description` is `NOT NULL` with no default,
+unlike `wisps.description DEFAULT ''`, so the asymmetry wasn't visible from
+code-symmetry reasoning alone). Because `SetupSuite` failed on the first seed
+batch, 3 of 6 Done-when criteria were entirely unexercised. Round 1 also
+flagged a MAJOR security finding: `quoteLiteral()` naively wraps a string in
+single quotes with no escaping, spliced as literal SQL text (not a bound
+param) — not exploitable today (only ever called with a hardcoded const) but
+a SQL-injection-shaped footgun in a harness explicitly meant to be extended.
+
+Round 2 (`bae2d53b5` red / `946304634` green, pre-rebase `6f23b49cb`/
+`4894e3c3b`) fixed all of it: `insertMainRows` now supplies the 4 missing
+NOT-NULL-no-default columns; `insertDependencyRows` (discovered mid-fix)
+now derives `dependencies.id` via the existing `internal/storage/depid.New`;
+`TestExplainReferenceCount_Reported` (discovered mid-fix) switched to
+`EXPLAIN FORMAT=TREE` after tabular EXPLAIN's literal-text `"NULL"` in the
+numeric rows-estimate column made the driver reject the row before `Scan`;
+`quoteLiteral` now doubles embedded single quotes (`TestQuoteLiteral` guards
+it) with a doc comment warning it's for trusted, in-test literals only.
+
+## Gate criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | **PASS** | be-px3ke close reason: "Review PASS (round 2, commit 4894e3c3ba297fc4c6cc38d42ab591efc92f54e2). No blockers found across spec/style/security passes." `verdict: pass` recorded in notes. |
+| 2 | Acceptance criteria met | **PASS** | All 6 of be-qm6fb's Done-when items re-checked by reviewer against the round-2 run and recorded MET (harness completes end-to-end; null self-check shows no meaningful difference on either plane; row-set identity asserted inside the self-check itself, not just unit-covered; skip-clean behavior unchanged/re-confirmed by inspection; served Dolt version printed; BENCHMARKS.md doc line present). Independently spot-checked the diff-vs-spec mapping myself; no gaps found. |
+| 3 | Tests pass | **PASS** | Independently re-run on the rebased HEAD (`94630463430967e9216315bcd9fec0468e8876bc`), not trusted from the reviewer's report. See "Tests run" below. |
+| 3b | Policy/lint lane | **PASS** (documented exception) | `make ci-pr-policy` FAILs on one known, pre-existing, diff-unrelated check. `check-testing-short.sh` (directly relevant — this diff adds 6 new test files) independently re-run and PASS. See below. |
+| 4 | No unresolved HIGH findings | **PASS** | Round 1's one MAJOR (`quoteLiteral` SQL-injection-shaped footgun) is fixed in round 2 and independently call-site-traced by the reviewer: both call sites pass only a hardcoded const, no attacker-reachable input exists anywhere in the package. One informational, non-blocking residual noted (a trailing-backslash edge case under backslash-escaping SQL modes) — not exploitable at either existing call site, scoped by the new doc comment. |
+| 5 | Clean working tree | **PASS** | `git status --short` on `94630463430967e9216315bcd9fec0468e8876bc` clean before this gate file was added; clean again after committing it (see Verdict). |
+| 6 | Clean divergence from `origin/main` | **PASS** | `git merge-base --is-ancestor origin/main HEAD` succeeds post-rebase — 4 commits ahead, 0 behind. Required one bounded self-rebase mid-gate; see "Rebase" below. |
+| 7 | Single feature theme | **PASS** | All 13 files serve the one in-tree A/B benchmark-harness feature; production file `counts.go` untouched. See "Scope" above. |
+
+### Ancestry-scope check: widened to 3 sibling beads, re-verified post-rebase
+
+`assert_deploy_ancestry_scope origin/main HEAD be-px3ke be-qm6fb be-cbnts` →
+**rc=0 (PASS)**.
+
+Widening beyond `be-px3ke` alone was required: 2 of the 4 commits
+(round-2 red/green) cite `be-cbnts` in their trailers, not `be-qm6fb` or
+`be-px3ke` directly. Confirmed via `bd show be-cbnts` that this is genuinely
+the round-1 review bead for this exact same feature (request-changes verdict
+that produced the round-2 rework these commits contain) before widening —
+not a blanket override, per the function's own documented guidance to name
+only ids "you have actually confirmed belong to this deploy."
+
+This check was run twice: once pre-rebase (PASS, against the original
+4-commit range) and again just now against the post-rebase HEAD, since
+rebase rewrites every commit hash in the range and a stale PASS shouldn't be
+assumed to carry over silently. Both passed identically — the rebase was a
+clean replay that preserved all commit-message trailers verbatim.
+
+## Rebase (criterion 6 recovery)
+
+`origin/main` advanced from `3641fcf8f` to `893e42cda` (PR #5806 merged)
+between the initial fetch and the criterion-6 recheck, flipping criterion 6
+to FAIL. Handled via the deployer's sanctioned bounded-self-rebase exception:
+
+1. Confirmed zero path overlap between PR #5806's changed files and this
+   diff's 13 files before attempting anything (rebase-safety precondition,
+   not assumed).
+2. `PUSH_REMOTE=headfork` exported; `attempt_bounded_self_rebase
+   deploy/be-px3ke-gate main` → rc=0 (trivial, no conflicts).
+3. `BEFORE_SHA=4894e3c3ba297fc4c6cc38d42ab591efc92f54e2`,
+   `AFTER_SHA=94630463430967e9216315bcd9fec0468e8876bc`, `--force-with-lease`
+   pushed to `headfork`, local/remote SHAs confirmed matching post-push.
+4. Audit trail recorded on be-xbycd's notes at the time of the rebase.
+
+## Tests run on release branch (independent re-verification)
+
+Diff-owned tests, run against a real container (not mocked, not a self-skip):
+
+```
+cd .gc/worktrees/beads/deployer
+DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock \
+TESTCONTAINERS_RYUK_DISABLED=true BEADS_TEST_ENV_RUN_DOLT=1 TEST_VERBOSE=1 \
+./scripts/test.sh ./internal/storage/sqlbuild/bench/...
+```
+
+Container evidence (not taken on trust): testcontainers connected to the
+podman socket, created+started container `34129cb6ac14` for
+`dolthub/dolt-sql-server:2.2.0`, and logged `served Dolt version: 8.0.31
+(pinned image: dolthub/dolt-sql-server:2.2.0)`.
+
+| Result | Count |
+|---|---|
+| PASS | 20 |
+| FAIL | 0 |
+| SKIP | 0 |
+
+`ok  	github.com/steveyegge/beads/internal/storage/sqlbuild/bench	20.735s`
+
+All 20 top-level tests PASS, including `TestSearchCountsHarness` (the
+previously-blocked suite, all 3 subtests — `TestExplainReferenceCount_Reported`,
+`TestNullSelfCheck_IssuesPlane`, `TestNullSelfCheck_WispsPlane` — now
+genuinely run and PASS) and the new `TestQuoteLiteral`. This independently
+reproduces the reviewer's round-2 claim of 20/20 PASS, 0 FAIL, 0 SKIP, now
+on the post-rebase commit rather than the originally-reviewed one — same
+result, different HEAD, confirming the rebase introduced no regression.
+
+Additional independent checks on the rebased HEAD:
+
+| Check | Result |
+|---|---|
+| `go build ./...` | clean, rc=0 |
+| `go vet ./...` | clean, rc=0 |
+| `gofmt -l` on the 12 diff `.go` files | clean, 0 files listed |
+
+### Policy/lint lane (criterion 3b)
+
+`make ci-pr-policy` → FAIL, root cause: `.githooks/commit-msg` missing
+`BEGIN`/`END BEADS INTEGRATION` markers, tripping the version-consistency
+sub-step (`scripts/check-versions.sh`). This is a known, previously
+root-caused environmental gap (documented precedent: be-y1jo, be-g3iz8, and
+others) — `.githooks/commit-msg` is a git-ignored per-session shim, not a
+tracked repository file, regenerated every session start and excluded via
+`.git/info/exclude`. Independently re-verified rather than taken on
+precedent alone:
+
+```
+git diff --name-only origin/main...HEAD -- .githooks/commit-msg   # empty — untouched by this diff
+git diff origin/main -- .githooks/commit-msg                       # empty — byte-identical to origin/main
+grep -n "BEADS INTEGRATION" .githooks/commit-msg                   # no hits — gap is real
+```
+
+All other named checks in `check-versions.sh` passed (all 7 version-pinned
+files — MCP `pyproject.toml`/`__init__.py`, Claude/Codex `plugin.json`,
+Claude `marketplace.json`, npm `package.json`, MCP `uv.lock` — and 5 of 6
+`.githooks/*` marker files all show `1.2.2` clean). `check-build-tags.sh` and
+`check-go-install-guidance.sh` (the two checks preceding it) both PASS.
+
+`pr-policy.sh` runs under `set -euo pipefail`, so this one failure aborted
+the script before its remaining checks (doc-flags, doc-freshness,
+`testing.Short()` boundaries, workapi frontend boundary, `.beads/issues.jsonl`
+guard, OpenAPI spec gate) executed. Rather than assume those would have
+passed, each was independently dispositioned:
+
+- `check-testing-short.sh` — **directly relevant**, since this diff adds 6
+  new test files. Run standalone: `testing.Short() usage is limited to
+  approved runtime/stress/large-fixture skips.` — **PASS**, rc=0.
+- Doc-flags, doc-freshness, workapi-frontend-boundary, `.beads/issues.jsonl`
+  guard, OpenAPI spec gate — all scoped to paths this diff does not touch
+  (confirmed via `git diff --name-only origin/main...HEAD | grep -E
+  '^(docs/|internal/workapi/|\.beads/issues\.jsonl|internal/httpapi/spec/)'`
+  → empty). Not independently re-run; out of scope by file-path, same
+  evidentiary bar the be-y1jo precedent applied to its own out-of-scope
+  checks.
+
+## Findings from reviews (no action required)
+
+Zero HIGH findings across either round. Round 1's one MAJOR (`quoteLiteral`
+SQL-injection-shaped footgun) is resolved in round 2 — see "Round 1 → round
+2" above. Two minor, non-blocking informational items carried from round 1
+(fixed-constant table names in `fixture_test.go`, fixed-prefix DB names in
+`CREATE`/`DROP DATABASE` in `harness_test.go`) remain noted for
+injection-checklist completeness only; both have provably no exploit path
+(no attacker-reachable input). One new informational item from round 2
+(`quoteLiteral`'s fix doesn't neutralize a trailing-backslash edge case) is
+non-blocking for the same reason — no call site passes anything but a fixed
+constant, and the new doc comment scopes the helper to trusted input.
+
+## Verdict
+
+**PASS** — all 7 criteria pass (3b passes with a documented,
+independently-verified pre-existing-and-unrelated exception, plus a direct
+re-run of the one sub-check this diff's own content makes relevant). Cutting
+isolated deploy branch `deploy/be-px3ke-gate` from
+`94630463430967e9216315bcd9fec0468e8876bc` (post-rebase), pushing to
+`headfork`, and opening a PR against `gastownhall/beads:main`.
+
+**gastownhall/beads merge-authority carve-out:** this is a contributor-only
+repository (`origin` push disabled; upstream is fetch-only). Per deployer
+protocol, the job ends at the open PR — no merge-request routed to
+mayor/mpr, no deploy-clearance status posted. Merge belongs to upstream
+maintainers.


### PR DESCRIPTION
In-tree A/B benchmark harness for `SearchCountsSQL` query shapes: times named
shape-renderers against a seeded corpus on both the issues and wisp planes,
asserts row-set identity before reporting any timing, and prints EXPLAIN
driver-filter reference counts alongside wall-clock numbers.

## Why

PR #5339 changed `SearchCountsSQL`'s predicate form to bound each aggregate
subquery to the driver's filtered row set. It was approved on
result-equivalence reasoning with no measurement, then separately measured at
roughly 3x slower on the pinned `dolt-sql-server:2.2.0`, with EXPLAIN showing
the driver filter inlined at 8 references vs. main's 1 (GMS inlines the CTE).
That PR is closed unmerged; main keeps its current query shape.

There was no in-tree way to answer "is this query-shape change actually
faster?" before review. This harness closes that gap so any future attempt at
bounding these subqueries (join-form, temp-table materialization,
labels-only) has a reusable, reproducible way to produce numbers before
proposing the change.

## Summary

- `bench.Shape` registry of named, pluggable shape-renderers sharing
  `SearchCountsSQL`'s signature — main's shape is one entry; a future
  candidate shape is added alongside it, not swapped in.
- Deterministic corpus fixtures (~5k issues, ~20k wisp labels, real schema
  via `MigrateUp`) seeding both the issues and wisp planes.
- `CompareRowSets`: order-insensitive full result-set identity check, run
  before any timing is reported — a shape that returns the wrong rows aborts
  instead of benchmarking.
- EXPLAIN PLAN driver-filter reference-count extraction, since that's the
  more stable signal behind the original regression than wall time alone.
- Strict alternating-round runner (not all-A-then-all-B) with per-round
  timing plus min/max/mean/spread summaries.
- A null self-check (main's shape registered twice) to confirm the harness
  itself isn't measuring noise.
- Skips cleanly when the pinned Dolt image isn't cached locally; never runs
  under plain `go test ./...`.
- `BENCHMARKS.md` section documenting the command and when to run it.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `gofmt -l` clean on all changed files
- [x] Full package (20 tests) passes against a real Dolt container
      (`dolthub/dolt-sql-server:2.2.0`), including the end-to-end harness
      suite on both planes and the EXPLAIN reference-count check
- [x] Reviewed across 2 rounds (style/security/spec); a SQL-injection-shaped
      footgun in a test-only string-quoting helper (round 1) is fixed and
      independently call-site-verified with no attacker-reachable input;
      zero HIGH findings open

Full evidence trail: `release-gates/be-px3ke-searchcounts-bench-harness-gate.md`
in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
