### PR TITLE
fix(dep): state each dep list row's direction, in text and --json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or mixed runs, `__` and `---` included, are unaffected and still collapse.
 
 ### Fixed
+- **`bd dep list` now states each row's direction**
+  ([#5959](https://github.com/gastownhall/beads/pull/5959)). Rows rendered as
+  `<id>: <title> [P1] (open) via blocks` — a line that was identical for
+  `--direction=down` and `--direction=up`, and whose natural reading is the
+  reverse of the default's meaning: under `bd dep list a`, the row
+  `b: … via blocks` scans as "a blocks b" when it says that b blocks a. Text
+  rows now carry `BLOCKED BY` / `DEPENDS ON` (down) or `BLOCKS` /
+  `DEPENDED ON BY` (up), using the same blocking-type split `bd dep tree` uses
+  for its `[BLOCKED]` badge. `--json` rows gain two additive keys, `anchor_id`
+  and `dependency_direction` (`depends-on` / `depended-on-by`), so a row reads
+  in subject-verb-object order; every key the payload carried before is
+  unchanged. A listing naming several anchors also gains a per-anchor heading —
+  a single-anchor listing keeps the shape it has always had.
 
 - **Incremental auto-export now actually takes the incremental path**
   ([#5806](https://github.com/gastownhall/beads/pull/5806)). Change detection

--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -776,7 +776,151 @@ func printDepListEdges(anchors []issueops.AnchorEdges) error {
 		}
 		fmt.Printf("\n%s Dependencies of %s:\n\n", ui.RenderAccent("📋"), anchor.ID)
 		for _, dep := range anchor.Edges {
-			fmt.Printf("  %s via %s\n", dep.DependsOnID, dep.Type)
+			// This route is reached for "down" only, so the label is the
+			// down one; it is printed anyway so that every row `bd dep list`
+			// can emit says which end of its edge it is, in every mode.
+			fmt.Printf("  %s %s via %s\n", depEdgeDirectionLabel("down", dep.Type), dep.DependsOnID, dep.Type)
+		}
+	}
+	fmt.Println()
+	return nil
+}
+
+// depEdgeDirectionLabel names which END of an edge a `bd dep list` row sits on,
+// relative to the anchor the caller asked about.
+//
+// Direction is the whole meaning of a dependency edge, and without a label the
+// row renders as "<id>: <title> [P1] (open) via blocks" — a line that is
+// IDENTICAL for --direction=down and --direction=up. The two opposite readings
+// of an edge are therefore indistinguishable in the output, and the natural
+// reading of the default (down) form is the REVERSE of what it means: under
+// `bd dep list a`, the row "b: ... via blocks" scans as "a blocks b" when what
+// it says is that b blocks a. `bd dep tree` is the only surface that
+// disambiguates today, by badging its root [BLOCKED] and its children [blocks];
+// a caller who reaches for `dep list` first reads the graph backwards with
+// nothing in the output to catch it.
+//
+// The blocking-type split is the same one `dep tree` uses for that badge
+// (IsBlockingEdge), so the sharper wording appears exactly where "blocked" is
+// the true relation, and the structural wording covers every other type —
+// including the open vocabulary a workspace defines for itself, where no
+// blocking claim would be warranted.
+func depEdgeDirectionLabel(direction string, depType types.DependencyType) string {
+	if direction == "up" {
+		if depType.IsBlockingEdge() {
+			return "BLOCKS"
+		}
+		return "DEPENDED ON BY"
+	}
+	if depType.IsBlockingEdge() {
+		return "BLOCKED BY"
+	}
+	return "DEPENDS ON"
+}
+
+// depEdgeDirectionValue is the --json counterpart of depEdgeDirectionLabel: the
+// VERB of the triple <anchor_id> <dependency_direction> <id>, so a machine
+// consumer reads an edge in subject-verb-object order without having to know
+// which flag produced the answer. The payload used to be the far-end issue's
+// own row and nothing else, which carries no direction at all — the same
+// ambiguity as the text form, in a shape that is harder to eyeball.
+func depEdgeDirectionValue(direction string) string {
+	if direction == "up" {
+		return "depended-on-by"
+	}
+	return "depends-on"
+}
+
+// depListRow is one `bd dep list --json` row: the far-end issue's own fields,
+// plus the two that say which edge it came from. Both additions are ADDITIVE —
+// every key the payload carried before is still present, unmoved and unrenamed.
+type depListRow struct {
+	*types.IssueWithDependencyMetadata
+	// AnchorID is the issue the caller asked about: the edge's SUBJECT. It is
+	// per-row rather than per-answer because one listing may name several
+	// anchors, and a flat array cannot otherwise say which anchor a row
+	// belongs to.
+	AnchorID string `json:"anchor_id"`
+	// DependencyDirection is "depends-on" (anchor_id depends on this issue) or
+	// "depended-on-by" (anchor_id is depended on by this issue).
+	DependencyDirection string `json:"dependency_direction"`
+}
+
+// depListNeighbors pairs one anchor with the neighbors a Relations query
+// answered for it, so the renderer can name BOTH ends of every edge.
+type depListNeighbors struct {
+	anchorID  string
+	neighbors []*issueops.RelatedIssue
+}
+
+// printDepListNeighbors renders the Relations answer for `bd dep list`, and is
+// shared by the embedded and proxied-server routes so the two cannot drift
+// apart in what they print.
+func printDepListNeighbors(groups []depListNeighbors, direction string) error {
+	total := 0
+	for _, g := range groups {
+		total += len(g.neighbors)
+	}
+
+	if jsonOutput {
+		rows := []depListRow{}
+		for _, g := range groups {
+			for _, iss := range g.neighbors {
+				rows = append(rows, depListRow{
+					IssueWithDependencyMetadata: iss,
+					AnchorID:                    g.anchorID,
+					DependencyDirection:         depEdgeDirectionValue(direction),
+				})
+			}
+		}
+		return outputJSON(rows)
+	}
+
+	if total == 0 {
+		if len(groups) == 1 {
+			if direction == "up" {
+				fmt.Printf("\nNo issues depend on %s\n", groups[0].anchorID)
+			} else {
+				fmt.Printf("\n%s has no dependencies\n", groups[0].anchorID)
+			}
+		} else {
+			fmt.Println("\nNo dependencies found")
+		}
+		return nil
+	}
+
+	for _, g := range groups {
+		if len(g.neighbors) == 0 {
+			continue
+		}
+		// The anchor is named once per group only when the listing carries
+		// more than one — the single-id call, which is the overwhelmingly
+		// common one, keeps the shape it has always had, and every row in
+		// either shape still says which end of the edge it is.
+		if len(groups) > 1 {
+			heading := "Dependencies of " + g.anchorID
+			if direction == "up" {
+				heading = "Dependents of " + g.anchorID
+			}
+			fmt.Printf("\n%s %s:\n\n", ui.RenderAccent("📋"), heading)
+		}
+		for _, iss := range g.neighbors {
+			var idStr string
+			switch iss.Status {
+			case types.StatusOpen:
+				idStr = ui.StatusOpenStyle.Render(iss.ID)
+			case types.StatusInProgress:
+				idStr = ui.StatusInProgressStyle.Render(iss.ID)
+			case types.StatusBlocked:
+				idStr = ui.StatusBlockedStyle.Render(iss.ID)
+			case types.StatusClosed:
+				idStr = ui.StatusClosedStyle.Render(iss.ID)
+			default:
+				idStr = iss.ID
+			}
+			fmt.Printf("  %s %s: %s [P%d] (%s) via %s\n",
+				depEdgeDirectionLabel(direction, iss.DependencyType),
+				idStr, iss.Title, iss.Priority, iss.Status, iss.DependencyType)
 		}
 	}
 	fmt.Println()
@@ -832,6 +976,16 @@ var depListCmd = &cobra.Command{
 By default shows dependencies (what issues depend on). Use --direction to control:
   - down: Show dependencies (what this issue depends on) - default
   - up:   Show dependents (what depends on this issue)
+
+Every row states its own direction, because "sc-b: ... via blocks" alone reads
+as the reverse of what it means:
+
+  BLOCKED BY / DEPENDS ON     the listed issue is one the queried issue needs
+  BLOCKS / DEPENDED ON BY     the listed issue is one that needs the queried issue
+
+With --json each row carries "anchor_id" (the issue you asked about) and
+"dependency_direction" ("depends-on" or "depended-on-by"), so a row reads in
+subject-verb-object order: <anchor_id> <dependency_direction> <id>.
 
 Multiple IDs can be provided for batch dep listing. With --json, the output
 is a flat array of dependency records across all requested issues.
@@ -943,7 +1097,7 @@ Examples:
 			request.Types = []types.DependencyType{types.DependencyType(typeFilter)}
 		}
 
-		var allIssues []*issueops.RelatedIssue
+		groups := make([]depListNeighbors, 0, len(resolved))
 		for _, r := range resolved {
 			rel, err := r.store.IssueRelations()
 			if err != nil {
@@ -954,7 +1108,7 @@ Examples:
 			if err != nil {
 				return HandleErrorRespectJSON("%v", err)
 			}
-			allIssues = append(allIssues, issues...)
+			groups = append(groups, depListNeighbors{anchorID: r.fullID, neighbors: issues})
 		}
 
 		// Relations silently drops "down" edges whose target has no row in
@@ -969,49 +1123,11 @@ Examples:
 		// role exists to detect it from here — tracked separately.
 		if direction == "down" && len(resolved) == 1 {
 			if reader, err := resolved[0].store.EdgeReader(); err == nil {
-				warnDroppedDepEdges(ctx, reader, resolved[0].fullID, typeFilter, allIssues)
+				warnDroppedDepEdges(ctx, reader, resolved[0].fullID, typeFilter, groups[0].neighbors)
 			}
 		}
 
-		if jsonOutput {
-			if allIssues == nil {
-				allIssues = []*issueops.RelatedIssue{}
-			}
-			return outputJSON(allIssues)
-		}
-
-		if len(allIssues) == 0 {
-			if len(resolved) == 1 {
-				if direction == "up" {
-					fmt.Printf("\nNo issues depend on %s\n", resolved[0].fullID)
-				} else {
-					fmt.Printf("\n%s has no dependencies\n", resolved[0].fullID)
-				}
-			} else {
-				fmt.Println("\nNo dependencies found")
-			}
-			return nil
-		}
-
-		for _, iss := range allIssues {
-			var idStr string
-			switch iss.Status {
-			case types.StatusOpen:
-				idStr = ui.StatusOpenStyle.Render(iss.ID)
-			case types.StatusInProgress:
-				idStr = ui.StatusInProgressStyle.Render(iss.ID)
-			case types.StatusBlocked:
-				idStr = ui.StatusBlockedStyle.Render(iss.ID)
-			case types.StatusClosed:
-				idStr = ui.StatusClosedStyle.Render(iss.ID)
-			default:
-				idStr = iss.ID
-			}
-			fmt.Printf("  %s: %s [P%d] (%s) via %s\n",
-				idStr, iss.Title, iss.Priority, iss.Status, iss.DependencyType)
-		}
-		fmt.Println()
-		return nil
+		return printDepListNeighbors(groups, direction)
 	},
 }
 

--- a/cmd/bd/dep_list_direction_test.go
+++ b/cmd/bd/dep_list_direction_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// The defect these tests pin: `bd dep list <id>` rendered every row as
+// "<id>: <title> [P1] (open) via blocks" — a line that is BYTE-IDENTICAL for
+// --direction=down and --direction=up. Direction is the whole meaning of a
+// dependency edge, so a reader who takes the natural reading of the default
+// (down) form reads the graph backwards, with nothing in the output to catch
+// it. The KNOWN-BAD CONTROL is explicit in each test: assert that the two
+// directions no longer render the same bytes, which is exactly what the
+// pre-fix renderer did.
+
+func depListTestNeighbor(id, title string, depType types.DependencyType) *issueops.RelatedIssue {
+	iss := &types.IssueWithDependencyMetadata{DependencyType: depType}
+	iss.ID = id
+	iss.Title = title
+	iss.Priority = 1
+	iss.Status = types.StatusOpen
+	return iss
+}
+
+func TestDepEdgeDirectionLabelDistinguishesDirections(t *testing.T) {
+	cases := []struct {
+		depType  types.DependencyType
+		down, up string
+	}{
+		// Blocking edges get the sharper wording, the same split dep tree
+		// uses for its [BLOCKED] badge.
+		{types.DepBlocks, "BLOCKED BY", "BLOCKS"},
+		{types.DepConditionalBlocks, "BLOCKED BY", "BLOCKS"},
+		{types.DepWaitsFor, "BLOCKED BY", "BLOCKS"},
+		// Everything else — including parent-child, which is structural and
+		// not a blocker, and a workspace's own custom type — gets the
+		// structural wording, which claims nothing about blocking.
+		{types.DepParentChild, "DEPENDS ON", "DEPENDED ON BY"},
+		{types.DepTracks, "DEPENDS ON", "DEPENDED ON BY"},
+		{types.DepRelated, "DEPENDS ON", "DEPENDED ON BY"},
+		{types.DependencyType("workspace-custom"), "DEPENDS ON", "DEPENDED ON BY"},
+	}
+	for _, tc := range cases {
+		gotDown := depEdgeDirectionLabel("down", tc.depType)
+		gotUp := depEdgeDirectionLabel("up", tc.depType)
+		if gotDown != tc.down {
+			t.Errorf("%s down label = %q, want %q", tc.depType, gotDown, tc.down)
+		}
+		if gotUp != tc.up {
+			t.Errorf("%s up label = %q, want %q", tc.depType, gotUp, tc.up)
+		}
+		// Known-bad control: pre-fix these were the same (absent) string.
+		if gotDown == gotUp {
+			t.Errorf("%s renders identically in both directions (%q) — the ambiguity is back", tc.depType, gotDown)
+		}
+	}
+	// An empty direction is the flag's own default, and must read as "down"
+	// rather than as an unlabeled row.
+	if got := depEdgeDirectionLabel("", types.DepBlocks); got != "BLOCKED BY" {
+		t.Errorf("empty direction label = %q, want BLOCKED BY", got)
+	}
+}
+
+func TestDepListTextRowStatesDirection(t *testing.T) {
+	groups := []depListNeighbors{{
+		anchorID:  "bd-anchor",
+		neighbors: []*issueops.RelatedIssue{depListTestNeighbor("bd-other", "Other issue", types.DepBlocks)},
+	}}
+
+	down := captureStdout(t, func() error { return printDepListNeighbors(groups, "down") })
+	up := captureStdout(t, func() error { return printDepListNeighbors(groups, "up") })
+
+	if !strings.Contains(down, "BLOCKED BY") || !strings.Contains(down, "bd-other") {
+		t.Errorf("down output does not say bd-other BLOCKS the anchor:\n%s", down)
+	}
+	if !strings.Contains(up, "BLOCKS") || strings.Contains(up, "BLOCKED BY") {
+		t.Errorf("up output does not say the anchor blocks bd-other:\n%s", up)
+	}
+	// Known-bad control: the pre-fix renderer produced the same bytes here.
+	if down == up {
+		t.Errorf("both directions render identically:\n%s", down)
+	}
+	// The parts that carried the row before are still there.
+	for _, want := range []string{"Other issue", "[P1]", "(open)", "via blocks"} {
+		if !strings.Contains(down, want) {
+			t.Errorf("down output lost %q:\n%s", want, down)
+		}
+	}
+}
+
+func TestDepListMultiAnchorTextNamesEachAnchor(t *testing.T) {
+	groups := []depListNeighbors{
+		{anchorID: "bd-a", neighbors: []*issueops.RelatedIssue{depListTestNeighbor("bd-x", "X", types.DepBlocks)}},
+		{anchorID: "bd-b", neighbors: []*issueops.RelatedIssue{depListTestNeighbor("bd-y", "Y", types.DepBlocks)}},
+	}
+	out := captureStdout(t, func() error { return printDepListNeighbors(groups, "up") })
+	// With several anchors in one listing, "BLOCKS bd-x" alone cannot say
+	// WHICH anchor it blocks — the flat pre-fix list dropped that entirely.
+	for _, want := range []string{"Dependents of bd-a", "Dependents of bd-b", "bd-x", "bd-y"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("multi-anchor output missing %q:\n%s", want, out)
+		}
+	}
+
+	// A single anchor keeps its historical shape: no heading, just rows.
+	single := captureStdout(t, func() error { return printDepListNeighbors(groups[:1], "up") })
+	if strings.Contains(single, "Dependents of") {
+		t.Errorf("single-anchor output grew a heading it never had:\n%s", single)
+	}
+}
+
+func TestDepListJSONCarriesDirection(t *testing.T) {
+	groups := []depListNeighbors{{
+		anchorID:  "bd-anchor",
+		neighbors: []*issueops.RelatedIssue{depListTestNeighbor("bd-other", "Other issue", types.DepBlocks)},
+	}}
+
+	prev := jsonOutput
+	jsonOutput = true
+	defer func() { jsonOutput = prev }()
+
+	decode := func(direction string) []map[string]interface{} {
+		t.Helper()
+		out := captureStdout(t, func() error { return printDepListNeighbors(groups, direction) })
+		var rows []map[string]interface{}
+		if err := json.Unmarshal([]byte(out), &rows); err != nil {
+			t.Fatalf("dep list --json (%s) is not a flat array: %v\n%s", direction, err, out)
+		}
+		if len(rows) != 1 {
+			t.Fatalf("dep list --json (%s) returned %d rows, want 1", direction, len(rows))
+		}
+		return rows
+	}
+
+	down := decode("down")[0]
+	up := decode("up")[0]
+
+	if down["dependency_direction"] != "depends-on" {
+		t.Errorf("down dependency_direction = %v, want depends-on", down["dependency_direction"])
+	}
+	if up["dependency_direction"] != "depended-on-by" {
+		t.Errorf("up dependency_direction = %v, want depended-on-by", up["dependency_direction"])
+	}
+	// Known-bad control: pre-fix the payload was the far-end issue's own row
+	// and nothing else, so these two were indistinguishable.
+	if down["dependency_direction"] == up["dependency_direction"] {
+		t.Error("both directions carry the same dependency_direction — the ambiguity is back")
+	}
+	for _, row := range []map[string]interface{}{down, up} {
+		if row["anchor_id"] != "bd-anchor" {
+			t.Errorf("anchor_id = %v, want bd-anchor", row["anchor_id"])
+		}
+		// The addition is additive: the keys the payload always carried are
+		// still present, unmoved and unrenamed.
+		for _, key := range []string{"id", "title", "status", "priority", "dependency_type"} {
+			if _, ok := row[key]; !ok {
+				t.Errorf("row lost pre-existing key %q: %v", key, row)
+			}
+		}
+	}
+}

--- a/cmd/bd/dep_proxied_server.go
+++ b/cmd/bd/dep_proxied_server.go
@@ -390,14 +390,14 @@ func runDepListProxiedServer(cmd *cobra.Command, ctx context.Context, args []str
 		request.Types = []types.DependencyType{types.DependencyType(typeFilter)}
 	}
 
-	var allIssues []*issueops.RelatedIssue
+	groups := make([]depListNeighbors, 0, len(args))
 	for _, id := range args {
 		request.ID = id
 		issues, err := rel.Related(ctx, request)
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
 		}
-		allIssues = append(allIssues, issues...)
+		groups = append(groups, depListNeighbors{anchorID: id, neighbors: issues})
 	}
 
 	// Same gap as the embedded RunE for this command (cmd/bd/dep.go): Relations
@@ -409,50 +409,11 @@ func runDepListProxiedServer(cmd *cobra.Command, ctx context.Context, args []str
 	// touches stdout/--json.
 	if direction == "down" && len(args) == 1 {
 		if reader, err := proxiedEdgeReader(); err == nil {
-			warnDroppedDepEdges(ctx, reader, args[0], typeFilter, allIssues)
+			warnDroppedDepEdges(ctx, reader, args[0], typeFilter, groups[0].neighbors)
 		}
 	}
 
-	if jsonOutput {
-		if allIssues == nil {
-			allIssues = []*issueops.RelatedIssue{}
-		}
-		_ = outputJSON(allIssues)
-		return nil
-	}
-
-	if len(allIssues) == 0 {
-		if len(args) == 1 {
-			if direction == "up" {
-				fmt.Printf("\nNo issues depend on %s\n", args[0])
-			} else {
-				fmt.Printf("\n%s has no dependencies\n", args[0])
-			}
-		} else {
-			fmt.Println("\nNo dependencies found")
-		}
-		return nil
-	}
-
-	for _, iss := range allIssues {
-		var idStr string
-		switch iss.Status {
-		case types.StatusOpen:
-			idStr = ui.StatusOpenStyle.Render(iss.ID)
-		case types.StatusInProgress:
-			idStr = ui.StatusInProgressStyle.Render(iss.ID)
-		case types.StatusBlocked:
-			idStr = ui.StatusBlockedStyle.Render(iss.ID)
-		case types.StatusClosed:
-			idStr = ui.StatusClosedStyle.Render(iss.ID)
-		default:
-			idStr = iss.ID
-		}
-		fmt.Printf("  %s: %s [P%d] (%s) via %s\n",
-			idStr, iss.Title, iss.Priority, iss.Status, iss.DependencyType)
-	}
-	fmt.Println()
-	return nil
+	return printDepListNeighbors(groups, direction)
 }
 
 // runDepListRecordsProxiedServer answers `bd dep list a b c` with raw edge


### PR DESCRIPTION
`bd dep list <id>` rendered every row as `<id>: <title> [P1] (open) via blocks` — a line that is byte-identical for `--direction=down` and `--direction=up`. The two opposite readings of an edge were therefore indistinguishable in the output, and the natural reading of the default (down) form is the reverse of what it means: under `bd dep list a`, the row `b: ... via blocks` scans as "a blocks b" when it says that b blocks a. `bd dep tree` was the only surface that disambiguated, by badging its root `[BLOCKED]` and its children `[blocks]`.

Direction is the whole meaning of a dependency edge, so a reader who takes the natural reading gets the graph backwards with nothing in the output to catch it.

**Text rows** now carry a direction label, using the same blocking-type split `dep tree` uses for its badge (`IsBlockingEdge`), so the sharper wording appears exactly where "blocked" is the true relation and the structural wording covers every other type — including the open vocabulary a workspace defines for itself:

```
BLOCKED BY / DEPENDS ON        the row is one the queried issue needs
BLOCKS / DEPENDED ON BY        the row is one that needs the queried issue
```

**`--json` rows** gain two additive keys, `anchor_id` (the issue you asked about) and `dependency_direction` (`depends-on` / `depended-on-by`), so a row reads in subject-verb-object order and a machine consumer no longer has to know which flag produced the answer. Every key the payload carried before is still present, unmoved and unrenamed.

A listing that names several anchors also gains a per-anchor heading: `BLOCKS bd-x` alone cannot say *which* anchor it blocks, and the flat pre-fix list dropped that entirely. A single-anchor listing — the overwhelmingly common call — keeps the shape it has always had.

The embedded and proxied-server routes now share one renderer, so the two cannot drift apart in what they print, following the pattern `printDepListEdges` already established.

### Before / after

```
$ bd dep list pr-a                      # pr-a is blocked by pr-b
before:   pr-b: The blocker [P2] (open) via blocks
after:    BLOCKED BY pr-b: The blocker [P2] (open) via blocks

$ bd dep list pr-b --direction=up       # pr-b blocks pr-a
before:   pr-a: The subject [P2] (open) via blocks     (byte-identical shape)
after:    BLOCKS pr-a: The subject [P2] (open) via blocks

$ bd dep list pr-a --json | jq '.[0] | {id, anchor_id, dependency_direction}'
{"id":"pr-b","anchor_id":"pr-a","dependency_direction":"depends-on"}
```

### Testing

- Four new tests in `cmd/bd/dep_list_direction_test.go` (text both directions, JSON both directions, multi-anchor headings, non-blocking types). Each was verified to fail against a neutered build that restores the pre-fix rendering, then pass restored.
- `go test -run 'TestDep|Embedded' ./cmd/bd/` green; full `./cmd/bd/` shows the same three pre-existing environment-sensitive config failures as pristine `main` (verified side by side), none related.
- `go build -tags gms_pure_go ./...`, `go vet ./cmd/bd/` clean; `scripts/generate-cli-docs.sh` produces no diff; `gofmt` clean.
- No behaviour change to which edges are selected or returned; the domain type is untouched — the two new JSON keys live on the CLI-local row type.


Fixes #5960.

### Compatibility notes

- `--json` is purely additive: no key renamed, removed, reordered, or retyped.
- No schema change — `anchor_id` and `dependency_direction` are derived at render time from the edge the query already walks; nothing new is stored.
- A CHANGELOG entry is included under `## [Unreleased]` → `### Fixed`.
