### PR TITLE
perf(dolt): skip the no-database admin connection when not creating

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2410,6 +2410,36 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, se
 		return db, connStr, serverConnFacts{}, nil
 	}
 
+	// A caller that will not create the database does not need the
+	// no-database admin connection: the only thing SHOW DATABASES can tell it
+	// is whether to give up, and connecting to the database-scoped DSN answers
+	// that too. This is the same reasoning the Gateway branch above already
+	// applies ("a successful connect IS the existence proof"), narrowed to the
+	// case where the create machinery is unreachable anyway.
+	//
+	// It matters because bd is a one-shot CLI: every invocation paid a second
+	// TCP connect, MySQL handshake and auth on a pool that ran one
+	// SHOW DATABASES and was thrown away. In server mode that was a third of
+	// all connections bd opened, on every command.
+	//
+	// Both facts are decided without the probe: CreateIfMissing is false, so
+	// this call cannot be the creator; and a database that answers a ping
+	// existed before the call. A ping that fails because the database is not
+	// there is reported as the same databaseNotFoundError the SHOW DATABASES
+	// path returned.
+	if !cfg.CreateIfMissing {
+		if err := db.PingContext(ctx); err != nil {
+			if isUnknownDatabaseError(err) {
+				return nil, "", serverConnFacts{}, databaseNotFoundError(cfg)
+			}
+			return nil, "", serverConnFacts{}, fmt.Errorf(
+				"failed to connect to Dolt server %s:%d (database %q): %w",
+				cfg.ServerHost, cfg.ServerPort, cfg.Database, err)
+		}
+		connReady = true
+		return db, connStr, serverConnFacts{alreadyExisted: true}, nil
+	}
+
 	// Ensure database exists (may need to create it)
 	// First connect without database to create it
 	initConnStr := buildServerDSN(cfg, "")
@@ -2551,6 +2581,33 @@ func serverEndpointIdentity(cfg *Config) string {
 		return "unix:" + cfg.ServerSocket
 	}
 	return "tcp:" + net.JoinHostPort(cfg.ServerHost, strconv.Itoa(cfg.ServerPort))
+}
+
+// erUnknownDatabase is MySQL's ER_BAD_DB_ERROR: the server refused the
+// connection because the database named in the DSN does not exist.
+const erUnknownDatabase = 1049
+
+// isUnknownDatabaseError reports whether err is that refusal. The error number
+// is the authoritative signal and is matched first: Dolt and MySQL word 1049
+// differently ("database not found: x" vs "Unknown database 'x'"), so text
+// matching alone silently misses one of them. The text check remains as a
+// fallback for wrapped errors that lost the typed value.
+//
+// isRetryableError treats the same condition as transient, but only in the
+// window right after a CREATE DATABASE, where the server's catalog has not
+// caught up yet (GH-1851). Here no CREATE was attempted, so 1049 is proof of
+// absence rather than a race.
+func isUnknownDatabaseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) {
+		return mysqlErr.Number == erUnknownDatabase
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "unknown database") ||
+		strings.Contains(lower, "database not found")
 }
 
 // databaseExistsOnServer checks if a database with the exact given name exists

--- a/internal/storage/dolt/unknown_database_test.go
+++ b/internal/storage/dolt/unknown_database_test.go
@@ -1,0 +1,82 @@
+package dolt
+
+import (
+	"fmt"
+	"testing"
+
+	mysql "github.com/go-sql-driver/mysql"
+)
+
+// A server-mode open that was not asked to create the database skips the
+// no-database admin connection and lets the database-scoped ping decide
+// whether the database is there. That makes this classifier the whole
+// difference between "database not found" guidance and a raw driver error,
+// so it has to recognise the refusal in every form it actually arrives in.
+func TestIsUnknownDatabaseError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			// Dolt's wording. Text matching tuned to MySQL alone misses it.
+			name: "dolt 1049 typed error",
+			err:  &mysql.MySQLError{Number: erUnknownDatabase, Message: "database not found: beads"},
+			want: true,
+		},
+		{
+			// MySQL's wording for the same error number.
+			name: "mysql 1049 typed error",
+			err:  &mysql.MySQLError{Number: erUnknownDatabase, Message: "Unknown database 'beads'"},
+			want: true,
+		},
+		{
+			name: "typed 1049 wrapped by a caller",
+			err: fmt.Errorf("failed to connect: %w",
+				&mysql.MySQLError{Number: erUnknownDatabase, Message: "database not found: beads"}),
+			want: true,
+		},
+		{
+			// Fallback path: the typed value was lost, only text survives.
+			name: "untyped dolt text",
+			err:  fmt.Errorf("database not found: beads"),
+			want: true,
+		},
+		{
+			name: "untyped mysql text",
+			err:  fmt.Errorf("Error 1049 (HY000): Unknown database 'beads'"),
+			want: true,
+		},
+		{
+			// Access denied must not be read as absence: the database may
+			// well exist, and reporting it as missing sends the operator
+			// down the recovery path in databaseNotFoundError for nothing.
+			name: "access denied is not absence",
+			err:  &mysql.MySQLError{Number: 1045, Message: "Access denied for user 'bd'"},
+			want: false,
+		},
+		{
+			name: "server unreachable is not absence",
+			err:  fmt.Errorf("dial tcp 127.0.0.1:3307: connect: connection refused"),
+			want: false,
+		},
+		{
+			name: "unrelated table error is not absence",
+			err:  &mysql.MySQLError{Number: 1146, Message: "table not found: issues"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isUnknownDatabaseError(tt.err); got != tt.want {
+				t.Errorf("isUnknownDatabaseError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #5965 (connection B).

## What

In server mode, `openServerConnection` always opened a second, no-database
`*sql.DB` purely to run `SHOW DATABASES` before connecting to the real one.
When `CreateIfMissing` is false, that probe is now skipped and the
database-scoped ping decides existence instead.

The create path is untouched: `CreateIfMissing: true` still opens the admin
connection, still runs `SHOW DATABASES`, still runs the bare
`CREATE DATABASE` race arbitration. Only the branch that could never create
anything takes the shortcut.

## Why

`bd` is a one-shot CLI, so that admin pool cost a full extra TCP connect,
MySQL handshake and auth on every single invocation, for one query, on a pool
that was then discarded. Measured in #5965: 3 connections per invocation, of
which this is one.

A caller that will not create the database learns nothing from `SHOW DATABASES`
that connecting does not also tell it. This is the reasoning the `cfg.Gateway`
branch directly above already applies — *"a successful connect IS the existence
proof"* — narrowed to the case where the create machinery is unreachable
anyway.

Both facts the caller consumes are decided without the probe:

- `created` — `CreateIfMissing` is false, so this call cannot be the creator.
- `alreadyExisted` — a database that answers a ping existed before the call.

So the GH#4637 identity-verification gate and the GH#5012 fresh-bootstrap-heal
arbitration keep reading exactly the signals they read before.

One trap, recorded because it cost me a round: the refusal has to be classified
by error **number**, not text. Dolt says `database not found: x` where MySQL
says `Unknown database 'x'`, and my first cut matched text only — which
silently turned the missing-database case into a raw driver error instead of
the `databaseNotFoundError` recovery guidance. Matching 1049 keeps that output
byte-identical; the text check stays as a fallback for errors that lost the
typed value.

## Verification

Harness is the `repro-standalone.sh` in #5965: a dedicated `dolt sql-server` in
its own `data_dir` on its own port, its own `bd` project, no orchestrator, 200
issues seeded, 10 reps per row, connections counted from `SHOW GLOBAL STATUS`
deltas.

```
                                    conns/invocation
bd list --limit 5   before                3.0
bd list --limit 5   after                 2.0
```

`SHOW DATABASES` count over the 10 reps goes 10 -> 0 (total selects 140 -> 130).
Zero variance across reps in both directions.

Behaviour unchanged:

- `bd list --limit 20`, `bd ready --limit 20`, `bd show`, `bd stats` — output
  byte-identical before and after, and byte-identical to the released binary.
- Missing database (`dolt_database` pointed at a name the server does not have)
  — error output byte-identical before and after, including the full
  "Common causes" recovery block.
- `bd q` (write path) still creates issues.
- `CGO_ENABLED=0 go test -tags gms_pure_go ./internal/storage/dolt/...` passes.
  Note the Dolt-server integration tests in that package **skip** locally
  (`dolthub/dolt-sql-server:2.2.0` not cached); CI will be the first run of
  those against this change.
- `scripts/ci/pr-lint.sh`: gofmt clean, `go vet` clean. golangci-lint v2.10.1
  reports 2 pre-existing gosec findings in `internal/config/permissions_open_nonlinux.go`
  and `internal/utils/path_case_darwin.go` — darwin/non-linux files untouched by
  this change.

New test `TestIsUnknownDatabaseError` covers both vendors' wording, the typed
and wrapped forms, and the three negatives that must **not** be read as absence
(access denied, connection refused, unrelated table error).

## Not in this PR

#5965 also documents connection A — the fail-fast `net.DialTimeout` probe that
runs zero queries. That one is deliberately hardened against the dolt crash
class in #4132/#4133 and is entangled with the auto-start decision tree, so I
have left it alone rather than bundle a riskier change into this one.
