### PR TITLE
fix(dolt): harden authenticated remote sync

### DIFF
--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -100,6 +100,43 @@ func TestPrepareDoltCLITransferCommandAppliesCredentialsAndS3Env(t *testing.T) {
 	}
 }
 
+func TestDoltCLITransferArgsIncludeRemoteUser(t *testing.T) {
+	tests := []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{
+			name: "pull with credentials",
+			got:  doltCLIPullArgs("origin", "main", &remoteCredentials{username: "root", password: "secret"}),
+			want: []string{"pull", "--user", "root", "origin", "main"},
+		},
+		{
+			name: "push with credentials",
+			got:  doltCLIPushArgs("origin", "main", false, &remoteCredentials{username: "root", password: "secret"}),
+			want: []string{"push", "--user", "root", "origin", "main"},
+		},
+		{
+			name: "force push with credentials",
+			got:  doltCLIPushArgs("origin", "main", true, &remoteCredentials{username: "root", password: "secret"}),
+			want: []string{"push", "--force", "--user", "root", "origin", "main"},
+		},
+		{
+			name: "pull without credentials",
+			got:  doltCLIPullArgs("origin", "main", nil),
+			want: []string{"pull", "origin", "main"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if strings.Join(tt.got, "\x00") != strings.Join(tt.want, "\x00") {
+				t.Fatalf("args = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
 func TestApplyNoGitHooksToCmd(t *testing.T) {
 	cmd := exec.Command("dolt", "push") // #nosec G204 -- test command is not executed
 	applyNoGitHooksToCmd(cmd)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -3797,11 +3797,7 @@ func (s *DoltStore) doltCLIPush(ctx context.Context, remote string, force bool, 
 	if err := s.prePushFSCK(ctx); err != nil {
 		return err
 	}
-	args := []string{"push"}
-	if force {
-		args = append(args, "--force")
-	}
-	args = append(args, remote, s.branch)
+	args := doltCLIPushArgs(remote, s.branch, force, creds)
 	cmd, transferCtx, cancel := s.prepareDoltCLITransfer(ctx, remote, creds, args...)
 	defer cancel()
 	applyNoGitHooksToCmd(cmd) // GH#3724
@@ -3810,6 +3806,15 @@ func (s *DoltStore) doltCLIPush(ctx context.Context, remote string, force bool, 
 		return cliTransferError("dolt push", remote, transferCtx, out, err)
 	}
 	return nil
+}
+
+func doltCLIPushArgs(remote, branch string, force bool, creds *remoteCredentials) []string {
+	args := []string{"push"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = appendDoltRemoteUser(args, creds)
+	return append(args, remote, branch)
 }
 
 // cliTransferError wraps a failed CLI transfer, distinguishing a transfer that
@@ -3827,13 +3832,29 @@ func cliTransferError(op, remote string, transferCtx context.Context, out []byte
 // Used for git-protocol remotes where CALL DOLT_PULL times out through the SQL connection.
 // If creds is non-nil, credentials are set on the subprocess environment only.
 func (s *DoltStore) doltCLIPull(ctx context.Context, remote string, creds *remoteCredentials) error {
-	cmd, transferCtx, cancel := s.prepareDoltCLITransfer(ctx, remote, creds, "pull", remote, s.branch)
+	args := doltCLIPullArgs(remote, s.branch, creds)
+	cmd, transferCtx, cancel := s.prepareDoltCLITransfer(ctx, remote, creds, args...)
 	defer cancel()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return cliTransferError("dolt pull", remote, transferCtx, out, err)
 	}
 	return nil
+}
+
+func doltCLIPullArgs(remote, branch string, creds *remoteCredentials) []string {
+	args := appendDoltRemoteUser([]string{"pull"}, creds)
+	return append(args, remote, branch)
+}
+
+// appendDoltRemoteUser adds the username required by authenticated remotes API
+// transfers. DOLT_REMOTE_PASSWORD supplies only the password; the Dolt CLI
+// does not infer --user from DOLT_REMOTE_USER.
+func appendDoltRemoteUser(args []string, creds *remoteCredentials) []string {
+	if creds != nil && creds.username != "" {
+		return append(args, "--user", creds.username)
+	}
+	return args
 }
 
 // Push pushes commits to the remote.


### PR DESCRIPTION
## What

Make authenticated Dolt remotes work in both supported ownership models:

- Native CLI transfers now pass the configured remote username with `--user`.
- `BEADS_DOLT_SERVER_OWNS_REMOTE_CREDENTIALS=1` routes HTTP remotes through the SQL server, so the client process does not need the remote password.
- SQL pulls temporarily snapshot dirty local-only tables, reset them for the merge, and restore their schema and rows before commit.

## Why

The CLI consumes the password from its environment but does not infer `--user` from `DOLT_REMOTE_USER`, so authenticated pulls and pushes could fail despite valid credentials.

In shared-server deployments, putting the password in every interactive client session defeats server-side credential ownership. Routing through `CALL DOLT_PULL` / `CALL DOLT_PUSH` keeps that password in the server process while retaining an explicit non-secret username.

That SQL route exposed a second failure: dirty ignored tables such as `local_metadata`, migrations, and wisps can make Dolt reject a merge. These tables are deliberately local-only, so the pull transaction now preserves them across the merge instead of requiring users to discard local state.

This is separate from the federation credential work in #5214 and #5215; those changes do not add the missing CLI username, server-owned routing, or local-table preservation.

## Verification

- `go test ./internal/storage/dolt -run 'Test(DoltCLITransferArgsIncludeRemoteUser|ServerOwnedRemoteCredentialsDisableCLIRouting|IgnoredTableSnapshotRoundTrip)$' -count=1`
- Full `./scripts/test.sh ./internal/storage/dolt/...` on the v1.2.2 backport branch
- `make ci-pr-lint` with golangci-lint v2.10.1, including the Windows lint pass
- Live authenticated pull and push through a shared Dolt SQL server with no remote password in the client environment

The broader package run on this checkout is currently obstructed by an unrelated local Dolt listener already occupying the test suite's fixed port 3308; the focused tests and exact lint gates pass.
