### PR TITLE
fix(dolt): harden authenticated remote sync

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1514,6 +1514,7 @@ var rootCmd = &cobra.Command{
 			doltCfg.Database = configfile.DefaultDoltDatabase
 		}
 		doltCfg.SyncRemote = resolveSyncRemote()
+		dolt.ApplyServerOwnedRemoteBase(doltCfg)
 
 		// --global flag: switch to the global shared-server database.
 		// Must be in shared-server mode; errors otherwise.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -111,6 +111,7 @@ Any key whose name contains `api_key`, `api-key`, `secret`, `token`, or `passwor
 | `dolt.auto-push-interval` | — | `BD_DOLT_AUTO_PUSH_INTERVAL` | `5m` | Minimum time between auto-pushes |
 | `dolt.auto-push-timeout` | — | `BD_DOLT_AUTO_PUSH_TIMEOUT` | `30s` | Timeout for a single auto-push attempt |
 | `dolt.shared-server` | `--shared-server` | `BEADS_DOLT_SHARED_SERVER` | `false` | Share one Dolt server at `~/.beads/shared-server/` |
+| `dolt.server-owned-remote-base` | — | — | (none) | Per-machine HTTPS origin (including username) whose authenticated transfers stay on the external SQL server, e.g. `https://root@dolt.example:32551` |
 | `dolt.max-conns` | — | `BEADS_DOLT_MAX_CONNS` | `10` | Connection pool size |
 | `git.author` | — | `BD_GIT_AUTHOR` | (none) | Override commit author for beads commits |
 | `git.no-gpg-sign` | — | `BD_GIT_NO_GPG_SIGN` | `false` | Disable GPG signing for beads commits |

--- a/go.mod
+++ b/go.mod
@@ -174,7 +174,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gocraft/dbr/v2 v2.7.6 // indirect
-	github.com/gofrs/flock v0.8.1 // indirect
+	github.com/gofrs/flock v0.8.1
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -2,14 +2,19 @@ package config
 
 import (
 	"bufio"
+	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/gofrs/flock"
+	"github.com/steveyegge/beads/internal/atomicfile"
 	"gopkg.in/yaml.v3"
 )
 
@@ -88,11 +93,12 @@ var YamlOnlyKeys = map[string]bool{
 	"import.path": true,
 
 	// Dolt server settings
-	"dolt.shared-server":      true, // Shared Dolt server at ~/.beads/shared-server/ (GH#2377)
-	"dolt.max-conns":          true, // Connection pool size override (default 10, GH#3140)
-	"dolt.pool-read-timeout":  true, // Pool per-I/O read deadline override (default 10s, bd-vz0y9)
-	"dolt.pool-write-timeout": true, // Pool per-I/O write deadline override (default 10s, bd-vz0y9)
-	"dolt.debug":              true, // Debug-mode dolt sql-server: --loglevel=debug + --prof cpu
+	"dolt.shared-server":            true, // Shared Dolt server at ~/.beads/shared-server/ (GH#2377)
+	"dolt.server-owned-remote-base": true, // Per-machine trust boundary for server-owned remote secrets
+	"dolt.max-conns":                true, // Connection pool size override (default 10, GH#3140)
+	"dolt.pool-read-timeout":        true, // Pool per-I/O read deadline override (default 10s, bd-vz0y9)
+	"dolt.pool-write-timeout":       true, // Pool per-I/O write deadline override (default 10s, bd-vz0y9)
+	"dolt.debug":                    true, // Debug-mode dolt sql-server: --loglevel=debug + --prof cpu
 
 	// Secrets: tokens and API keys must NOT be stored in the Dolt database
 	// because that data is pushed to remotes, triggering secret-scanning
@@ -304,8 +310,9 @@ var userGlobalKeyPrefixes = []string{"metrics."}
 // userGlobalExactKeys are per-MACHINE settings that must never be written to
 // the project .beads/config.yaml, which is a git-TRACKED file (see
 // cmd/bd/doctor/gitignore.go: nothing in .beads/.gitignore excludes it). A
-// committed value propagates one machine's answer to every clone that pulls
-// it, which for these keys is worse than having no value at all.
+// committed value propagates one machine's identity or secret trust boundary
+// to every clone that pulls it, which for these keys is worse than having no
+// value at all.
 //
 // node_id is the exemplar: it names the beads STORE that grants leases here,
 // and the reclaim guard (issueops.ReclaimExpiredLeasesInTx) compares it
@@ -316,7 +323,10 @@ var userGlobalKeyPrefixes = []string{"metrics."}
 // happening while the operator believes they are protected. Routing the write
 // to ~/.config/bd/config.yaml keeps it per-machine; viper still merges that
 // file, so config.NodeID() reads it back.
-var userGlobalExactKeys = map[string]bool{"node_id": true}
+var userGlobalExactKeys = map[string]bool{
+	"node_id":                       true,
+	"dolt.server-owned-remote-base": true,
+}
 
 func IsUserGlobalKey(key string) bool {
 	if userGlobalExactKeys[key] {
@@ -461,26 +471,34 @@ func UnsetUserYamlConfig(key string) error {
 	if err != nil {
 		return err
 	}
-	normalizedKey := normalizeYamlKey(key)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return fmt.Errorf("failed to create user config directory: %w", err)
+	}
+	return withUserYamlConfigLock(configPath, func() error {
+		normalizedKey := normalizeYamlKey(key)
 
-	content, err := os.ReadFile(configPath) //nolint:gosec // configPath is a validated absolute user config path
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
+		content, err := os.ReadFile(configPath) //nolint:gosec // configPath is a validated absolute user config path
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to read user config.yaml: %w", err)
 		}
-		return fmt.Errorf("failed to read user config.yaml: %w", err)
-	}
 
-	newContent := commentOutYamlKey(string(content), normalizedKey)
+		newContent, err := unsetYamlKey(string(content), normalizedKey)
+		if err != nil {
+			return err
+		}
 
-	// Preserve the owner-private 0600 posture every other user-global writer
-	// uses (SetUserYamlConfig, setYamlConfigAtPath, the metrics bootstrap);
-	// rewriting at 0644 would relax this shared user config to world-readable.
-	if err := os.WriteFile(configPath, []byte(newContent), 0o600); err != nil { //nolint:gosec // configPath is from UserConfigYamlPath
-		return fmt.Errorf("failed to write user config.yaml: %w", err)
-	}
+		// Preserve the owner-private 0600 posture every other user-global writer
+		// uses (SetUserYamlConfig, setYamlConfigAtPath, the metrics bootstrap);
+		// rewriting at 0644 would relax this shared user config to world-readable.
+		if err := atomicfile.WriteFile(configPath, []byte(newContent), 0o600); err != nil {
+			return fmt.Errorf("failed to write user config.yaml: %w", err)
+		}
 
-	return nil
+		return nil
+	})
 }
 
 func SetUserYamlConfig(key, value string) error {
@@ -494,14 +512,50 @@ func SetUserYamlConfig(key, value string) error {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		return fmt.Errorf("failed to create user config directory: %w", err)
 	}
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		if err := os.WriteFile(configPath, []byte{}, 0o600); err != nil {
-			return fmt.Errorf("failed to create user config.yaml: %w", err)
+	return withUserYamlConfigLock(configPath, func() error {
+		if _, err := os.Stat(configPath); os.IsNotExist(err) {
+			if err := atomicfile.WriteFile(configPath, nil, 0o600); err != nil {
+				return fmt.Errorf("failed to create user config.yaml: %w", err)
+			}
+		} else if err != nil {
+			return fmt.Errorf("failed to stat user config.yaml: %w", err)
 		}
-	} else if err != nil {
-		return fmt.Errorf("failed to stat user config.yaml: %w", err)
+		return setUserYamlConfigAtPath(configPath, key, value)
+	})
+}
+
+// withUserYamlConfigLock serializes every user-global read-modify-write across
+// bd processes. The lock is a sibling rather than the config inode itself
+// because atomic replacement deliberately changes that inode.
+func withUserYamlConfigLock(configPath string, fn func() error) error {
+	configLock := flock.New(configPath + ".lock")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	locked, err := configLock.TryLockContext(ctx, 25*time.Millisecond)
+	if err != nil {
+		return fmt.Errorf("lock user config.yaml: %w", err)
 	}
-	return setYamlConfigAtPath(configPath, key, value)
+	if !locked {
+		return fmt.Errorf("timed out locking user config.yaml")
+	}
+	defer func() { _ = configLock.Unlock() }()
+	return fn()
+}
+
+func setUserYamlConfigAtPath(configPath, key, value string) error {
+	normalizedKey := normalizeYamlKey(key)
+	content, err := os.ReadFile(configPath) //nolint:gosec // configPath is from UserConfigYamlPath
+	if err != nil {
+		return fmt.Errorf("failed to read user config.yaml: %w", err)
+	}
+	newContent, err := updateYamlKey(string(content), normalizedKey, value)
+	if err != nil {
+		return err
+	}
+	if err := atomicfile.WriteFile(configPath, []byte(newContent), 0o600); err != nil {
+		return fmt.Errorf("failed to write user config.yaml: %w", err)
+	}
+	return nil
 }
 
 func setYamlConfigAtPath(configPath, key, value string) error {
@@ -522,7 +576,7 @@ func setYamlConfigAtPath(configPath, key, value string) error {
 	}
 
 	// Write back
-	if err := os.WriteFile(configPath, []byte(newContent), 0600); err != nil { //nolint:gosec // configPath is validated
+	if err := os.WriteFile(configPath, []byte(newContent), 0o600); err != nil { //nolint:gosec // configPath is validated
 		return fmt.Errorf("failed to write config.yaml: %w", err)
 	}
 
@@ -821,6 +875,65 @@ func commentOutYamlKey(content, key string) string {
 	return strings.Join(result, "\n")
 }
 
+func unsetYamlKey(content, key string) (string, error) {
+	if strings.Contains(key, ".") {
+		if updated, ok, err := removeNestedYamlKey(content, key); err != nil {
+			return "", err
+		} else if ok {
+			return updated, nil
+		}
+	}
+	return commentOutYamlKey(content, key), nil
+}
+
+func removeNestedYamlKey(content, key string) (string, bool, error) {
+	parts := strings.Split(key, ".")
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(content), &root); err != nil {
+		return "", false, err
+	}
+	if len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
+		return "", false, nil
+	}
+	mapping := root.Content[0]
+	// A literal dotted key is the legacy flat form; preserve its comment-out
+	// behavior instead of interpreting it as a nested path.
+	if findMappingChild(mapping, key) != -1 {
+		return "", false, nil
+	}
+
+	type parentStep struct {
+		mapping *yaml.Node
+		index   int
+	}
+	steps := make([]parentStep, 0, len(parts))
+	current := mapping
+	for _, part := range parts {
+		idx := findMappingChild(current, part)
+		if idx == -1 {
+			return "", false, nil
+		}
+		steps = append(steps, parentStep{mapping: current, index: idx})
+		current = current.Content[idx+1]
+	}
+
+	leaf := steps[len(steps)-1]
+	leaf.mapping.Content = append(leaf.mapping.Content[:leaf.index], leaf.mapping.Content[leaf.index+2:]...)
+	for i := len(steps) - 2; i >= 0; i-- {
+		child := steps[i].mapping.Content[steps[i].index+1]
+		if child.Kind != yaml.MappingNode || len(child.Content) != 0 {
+			break
+		}
+		parent := steps[i]
+		parent.mapping.Content = append(parent.mapping.Content[:parent.index], parent.mapping.Content[parent.index+2:]...)
+	}
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		return "", false, err
+	}
+	return string(out), true, nil
+}
+
 // formatYamlValue formats a value appropriately for YAML.
 func formatYamlValue(value string) string {
 	// Boolean values
@@ -888,7 +1001,18 @@ func validateYamlConfigValue(key, value string) error {
 	case "dolt.shared-server":
 		lower := strings.ToLower(value)
 		if lower != "true" && lower != "false" {
-			return fmt.Errorf("dolt.shared-server must be \"true\" or \"false\", got %q", value)
+			return fmt.Errorf("%s must be \"true\" or \"false\", got %q", key, value)
+		}
+	case "dolt.server-owned-remote-base":
+		parsed, err := url.Parse(value)
+		if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User == nil || parsed.User.Username() == "" {
+			return fmt.Errorf("dolt.server-owned-remote-base must be an HTTPS origin with a username, got %q", value)
+		}
+		if _, hasPassword := parsed.User.Password(); hasPassword {
+			return fmt.Errorf("dolt.server-owned-remote-base must not contain a password")
+		}
+		if (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+			return fmt.Errorf("dolt.server-owned-remote-base must not contain a path, query, or fragment, got %q", value)
 		}
 	case "dolt.debug":
 		lower := strings.ToLower(value)

--- a/internal/config/yaml_config_test.go
+++ b/internal/config/yaml_config_test.go
@@ -1,15 +1,89 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
+
+func TestConcurrentUserYamlConfigWritesPreserveEveryKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	const writers = 64
+	start := make(chan struct{})
+	errs := make(chan error, writers)
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			key := fmt.Sprintf("concurrent.key_%02d", i)
+			errs <- SetUserYamlConfig(key, fmt.Sprintf("value-%02d", i))
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent SetUserYamlConfig: %v", err)
+		}
+	}
+
+	for i := 0; i < writers; i++ {
+		key := fmt.Sprintf("concurrent.key_%02d", i)
+		want := fmt.Sprintf("value-%02d", i)
+		if got := GetUserYamlConfig(key); got != want {
+			t.Fatalf("GetUserYamlConfig(%q) = %q, want %q; a concurrent writer was lost", key, got, want)
+		}
+	}
+
+	configPath, err := UserConfigYamlPath()
+	if err != nil {
+		t.Fatalf("UserConfigYamlPath: %v", err)
+	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat user config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("user config mode = %04o, want 0600", got)
+	}
+}
+
+func TestUnsetUserYamlConfigRemovesNestedKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	if err := SetUserYamlConfig("dolt.server-owned-remote-base", "https://root@dolt.example:32551"); err != nil {
+		t.Fatalf("set nested trust boundary: %v", err)
+	}
+	if err := SetUserYamlConfig("metrics.disabled", "true"); err != nil {
+		t.Fatalf("set sibling nested key: %v", err)
+	}
+	if err := UnsetUserYamlConfig("dolt.server-owned-remote-base"); err != nil {
+		t.Fatalf("unset nested trust boundary: %v", err)
+	}
+	if got := GetUserYamlConfig("dolt.server-owned-remote-base"); got != "" {
+		t.Fatalf("nested trust boundary remains after unset: %q", got)
+	}
+	if got := GetUserYamlConfig("metrics.disabled"); got != "true" {
+		t.Fatalf("unset changed sibling nested key: metrics.disabled=%q", got)
+	}
+}
 
 func TestIsYamlOnlyKey(t *testing.T) {
 	tests := []struct {
@@ -649,6 +723,31 @@ func TestValidateYamlConfigValue_SharedServer(t *testing.T) {
 	}
 	if err := validateYamlConfigValue("dolt.shared-server", "1"); err == nil {
 		t.Error("expected '1' to be invalid (not a boolean string)")
+	}
+}
+
+func TestValidateYamlConfigValue_ServerOwnedRemoteBase(t *testing.T) {
+	for _, value := range []string{
+		"https://root@dolt.permanet.io:32551",
+		"https://automation@dolt.example",
+	} {
+		if err := validateYamlConfigValue("dolt.server-owned-remote-base", value); err != nil {
+			t.Errorf("expected %q to be valid: %v", value, err)
+		}
+	}
+	for _, value := range []string{
+		"http://root@dolt.example",
+		"https://dolt.example",
+		"https://root:secret@dolt.example",
+		"https://root@dolt.example/database",
+		"https://root@dolt.example?target=other",
+	} {
+		if err := validateYamlConfigValue("dolt.server-owned-remote-base", value); err == nil {
+			t.Errorf("expected %q to be invalid", value)
+		}
+	}
+	if !IsUserGlobalKey("dolt.server-owned-remote-base") {
+		t.Fatal("server-owned remote trust boundary must be stored per machine")
 	}
 }
 

--- a/internal/storage/dolt/credentials.go
+++ b/internal/storage/dolt/credentials.go
@@ -33,7 +33,7 @@ const awsResponseChecksumValidationEnv = "AWS_RESPONSE_CHECKSUM_VALIDATION"
 // authenticated remote operations itself. The client still supplies the
 // non-secret username so CALL DOLT_PULL/PUSH can pass --user, while the
 // password remains exclusively in the server process environment.
-const serverOwnsRemoteCredentialsEnv = "BEADS_DOLT_SERVER_OWNS_REMOTE_CREDENTIALS"
+const serverOwnsRemoteCredentialsEnv = "BEADS_DOLT_SERVER_OWNS_REMOTE_CREDENTIALS" //nolint:gosec // G101: environment variable name, not credential material
 
 func serverOwnsRemoteCredentials() bool {
 	return os.Getenv(serverOwnsRemoteCredentialsEnv) == "1"

--- a/internal/storage/dolt/credentials.go
+++ b/internal/storage/dolt/credentials.go
@@ -29,6 +29,16 @@ const credentialKeyFile = ".beads-credential-key" //nolint:gosec // G101: not a 
 
 const awsResponseChecksumValidationEnv = "AWS_RESPONSE_CHECKSUM_VALIDATION"
 
+// serverOwnsRemoteCredentialsEnv opts an external SQL server into executing
+// authenticated remote operations itself. The client still supplies the
+// non-secret username so CALL DOLT_PULL/PUSH can pass --user, while the
+// password remains exclusively in the server process environment.
+const serverOwnsRemoteCredentialsEnv = "BEADS_DOLT_SERVER_OWNS_REMOTE_CREDENTIALS"
+
+func serverOwnsRemoteCredentials() bool {
+	return os.Getenv(serverOwnsRemoteCredentialsEnv) == "1"
+}
+
 // federationEnvMutex protects process-wide env vars from concurrent access.
 // Environment variables are process-global, so we need to serialize federation operations.
 var federationEnvMutex sync.Mutex
@@ -679,6 +689,9 @@ func (s *DoltStore) shouldUseCLIForCredentials(ctx context.Context, remote strin
 }
 
 func (s *DoltStore) prepareCLIRouteForCredentials(ctx context.Context, remote string, creds *remoteCredentials) (bool, error) {
+	if serverOwnsRemoteCredentials() {
+		return false, nil
+	}
 	if creds.empty() {
 		return false, nil // no credentials to pass
 	}
@@ -708,6 +721,9 @@ func (s *DoltStore) shouldUseCLIForCredentialsWithError(ctx context.Context, rem
 }
 
 func (s *DoltStore) shouldUseCLIForLocalRemoteWithError(ctx context.Context, remote string) (bool, error) {
+	if serverOwnsRemoteCredentials() {
+		return false, nil
+	}
 	if !s.serverMode {
 		return false, nil
 	}
@@ -803,6 +819,9 @@ func (s *DoltStore) shouldUseCLIForCloudAuth(ctx context.Context, remote string)
 }
 
 func (s *DoltStore) prepareCLIRouteForCloudAuth(ctx context.Context, remote string) (bool, error) {
+	if serverOwnsRemoteCredentials() {
+		return false, nil
+	}
 	if !s.serverMode {
 		return false, nil // embedded mode: env vars are in-process
 	}

--- a/internal/storage/dolt/credentials.go
+++ b/internal/storage/dolt/credentials.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,16 +29,6 @@ import (
 const credentialKeyFile = ".beads-credential-key" //nolint:gosec // G101: not a credential, just a filename
 
 const awsResponseChecksumValidationEnv = "AWS_RESPONSE_CHECKSUM_VALIDATION"
-
-// serverOwnsRemoteCredentialsEnv opts an external SQL server into executing
-// authenticated remote operations itself. The client still supplies the
-// non-secret username so CALL DOLT_PULL/PUSH can pass --user, while the
-// password remains exclusively in the server process environment.
-const serverOwnsRemoteCredentialsEnv = "BEADS_DOLT_SERVER_OWNS_REMOTE_CREDENTIALS" //nolint:gosec // G101: environment variable name, not credential material
-
-func serverOwnsRemoteCredentials() bool {
-	return os.Getenv(serverOwnsRemoteCredentialsEnv) == "1"
-}
 
 // federationEnvMutex protects process-wide env vars from concurrent access.
 // Environment variables are process-global, so we need to serialize federation operations.
@@ -445,13 +436,49 @@ func (s *DoltStore) updatePeerLastSync(ctx context.Context, name string) error {
 // Used to pass credentials to CLI subprocesses via cmd.Env (isolated) or to
 // the SQL path via process env vars under mutex protection.
 type remoteCredentials struct {
-	username string
-	password string
+	username    string
+	password    string
+	serverOwned bool
 }
 
 // empty returns true if no credentials are set.
 func (c *remoteCredentials) empty() bool {
 	return c == nil || (c.username == "" && c.password == "")
+}
+
+func (c *remoteCredentials) ownedByServer() bool {
+	return c != nil && c.serverOwned
+}
+
+// serverOwnedRemoteUsername verifies that a SQL-visible remote stays inside
+// the per-machine HTTPS trust boundary before allowing the server process to
+// use its own password. Repository configuration cannot broaden this origin.
+func serverOwnedRemoteUsername(baseURL, remoteURL string) (string, error) {
+	base, err := url.Parse(baseURL)
+	if err != nil || base.Scheme != "https" || base.Host == "" || base.User == nil || base.User.Username() == "" {
+		return "", fmt.Errorf("invalid server-owned remote base %q", baseURL)
+	}
+	if _, hasPassword := base.User.Password(); hasPassword {
+		return "", fmt.Errorf("server-owned remote base must not contain a password")
+	}
+	if (base.Path != "" && base.Path != "/") || base.RawQuery != "" || base.Fragment != "" {
+		return "", fmt.Errorf("server-owned remote base must be an origin without a path, query, or fragment")
+	}
+
+	remote, err := url.Parse(remoteURL)
+	if err != nil || remote.Scheme != "https" || remote.Host == "" || remote.User == nil {
+		return "", fmt.Errorf("remote URL %q is not an authenticated HTTPS remotes API URL", remoteURL)
+	}
+	if _, hasPassword := remote.User.Password(); hasPassword {
+		return "", fmt.Errorf("remote URL must not contain a password")
+	}
+	if remote.RawQuery != "" || remote.Fragment != "" || remote.Path == "" || remote.Path == "/" {
+		return "", fmt.Errorf("remote URL %q must identify a database without a query or fragment", remoteURL)
+	}
+	if !strings.EqualFold(remote.Scheme, base.Scheme) || !strings.EqualFold(remote.Host, base.Host) || remote.User.Username() != base.User.Username() {
+		return "", fmt.Errorf("remote URL %q is outside server-owned remote base %q", remoteURL, baseURL)
+	}
+	return base.User.Username(), nil
 }
 
 // applyToCmd sets DOLT_REMOTE_USER/PASSWORD on the subprocess environment,
@@ -689,7 +716,7 @@ func (s *DoltStore) shouldUseCLIForCredentials(ctx context.Context, remote strin
 }
 
 func (s *DoltStore) prepareCLIRouteForCredentials(ctx context.Context, remote string, creds *remoteCredentials) (bool, error) {
-	if serverOwnsRemoteCredentials() {
+	if creds.ownedByServer() {
 		return false, nil
 	}
 	if creds.empty() {
@@ -720,8 +747,8 @@ func (s *DoltStore) shouldUseCLIForCredentialsWithError(ctx context.Context, rem
 	return s.prepareCLIRouteForCredentials(ctx, remote, creds)
 }
 
-func (s *DoltStore) shouldUseCLIForLocalRemoteWithError(ctx context.Context, remote string) (bool, error) {
-	if serverOwnsRemoteCredentials() {
+func (s *DoltStore) shouldUseCLIForLocalRemoteWithError(ctx context.Context, remote string, creds *remoteCredentials) (bool, error) {
+	if creds.ownedByServer() {
 		return false, nil
 	}
 	if !s.serverMode {
@@ -810,7 +837,7 @@ func envPrefixesForRemoteURL(url string) []string {
 // authenticate. Routing through a CLI subprocess (dolt push/pull) ensures
 // the child process inherits the current environment (GH#6).
 func (s *DoltStore) shouldUseCLIForCloudAuth(ctx context.Context, remote string) bool {
-	ok, err := s.prepareCLIRouteForCloudAuth(ctx, remote)
+	ok, err := s.prepareCLIRouteForCloudAuth(ctx, remote, nil)
 	if err != nil {
 		log.Printf("warning: %v", err)
 		return false
@@ -818,8 +845,8 @@ func (s *DoltStore) shouldUseCLIForCloudAuth(ctx context.Context, remote string)
 	return ok
 }
 
-func (s *DoltStore) prepareCLIRouteForCloudAuth(ctx context.Context, remote string) (bool, error) {
-	if serverOwnsRemoteCredentials() {
+func (s *DoltStore) prepareCLIRouteForCloudAuth(ctx context.Context, remote string, creds *remoteCredentials) (bool, error) {
+	if creds.ownedByServer() {
 		return false, nil
 	}
 	if !s.serverMode {
@@ -860,5 +887,5 @@ func (s *DoltStore) prepareCLIRouteForCloudAuth(ctx context.Context, remote stri
 }
 
 func (s *DoltStore) shouldUseCLIForCloudAuthWithError(ctx context.Context, remote string) (bool, error) {
-	return s.prepareCLIRouteForCloudAuth(ctx, remote)
+	return s.prepareCLIRouteForCloudAuth(ctx, remote, nil)
 }

--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -100,6 +100,43 @@ func TestPrepareDoltCLITransferCommandAppliesCredentialsAndS3Env(t *testing.T) {
 	}
 }
 
+func TestDoltCLITransferArgsIncludeRemoteUser(t *testing.T) {
+	tests := []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{
+			name: "pull with credentials",
+			got:  doltCLIPullArgs("origin", "main", &remoteCredentials{username: "root", password: "secret"}),
+			want: []string{"pull", "--user", "root", "origin", "main"},
+		},
+		{
+			name: "push with credentials",
+			got:  doltCLIPushArgs("origin", "main", false, &remoteCredentials{username: "root", password: "secret"}),
+			want: []string{"push", "--user", "root", "origin", "main"},
+		},
+		{
+			name: "force push with credentials",
+			got:  doltCLIPushArgs("origin", "main", true, &remoteCredentials{username: "root", password: "secret"}),
+			want: []string{"push", "--force", "--user", "root", "origin", "main"},
+		},
+		{
+			name: "pull without credentials",
+			got:  doltCLIPullArgs("origin", "main", nil),
+			want: []string{"pull", "origin", "main"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if strings.Join(tt.got, "\x00") != strings.Join(tt.want, "\x00") {
+				t.Fatalf("args = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
 func TestApplyNoGitHooksToCmd(t *testing.T) {
 	cmd := exec.Command("dolt", "push") // #nosec G204 -- test command is not executed
 	applyNoGitHooksToCmd(cmd)

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -1386,7 +1386,7 @@ func TestGitRemoteExternalServerRouting(t *testing.T) {
 		"git-protocol routing should create a matching client CLI remote",
 	)
 	require.True(t, store.shouldUseCLIForCredentials(ctx, store.remote, store.mainRemoteCredentials()), "credential route should reuse matching CLI remote")
-	useLocalCLI, err := store.shouldUseCLIForLocalRemoteWithError(ctx, store.remote)
+	useLocalCLI, err := store.shouldUseCLIForLocalRemoteWithError(ctx, store.remote, store.mainRemoteCredentials())
 	require.NoError(t, err)
 	require.True(t, useLocalCLI, "local remote guard should pass after materialization")
 }

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -48,6 +48,17 @@ func ApplyCLIAutoStart(beadsDir string, cfg *Config) {
 	cfg.AutoStart = resolveAutoStart(true, autoStartCfg, mode)
 }
 
+// ApplyServerOwnedRemoteBase resolves the durable per-machine trust boundary
+// that keeps authenticated remote operations inside an external SQL server.
+// It deliberately bypasses project configuration: a repository must not be
+// able to select an origin that receives a server-owned password.
+func ApplyServerOwnedRemoteBase(cfg *Config) {
+	if cfg.ServerOwnedRemoteBase != "" {
+		return
+	}
+	cfg.ServerOwnedRemoteBase = strings.TrimSpace(config.GetUserYamlConfig("dolt.server-owned-remote-base"))
+}
+
 // ApplyResolvedServerPort fills cfg's server port from doltserver's
 // precedence chain (env > port file > dolt config.yaml > beads config.yaml >
 // metadata.json), and — the part that is easy to drop — records WHICH of those
@@ -129,6 +140,7 @@ func NewFromConfigWithCLIOptions(ctx context.Context, beadsDir string, cfg *Conf
 	if err := applyResolvedConfig(ctx, beadsDir, fileCfg, cfg); err != nil {
 		return nil, err
 	}
+	ApplyServerOwnedRemoteBase(cfg)
 	ApplyCLIAutoStart(beadsDir, cfg)
 
 	return New(ctx, cfg)
@@ -159,6 +171,7 @@ func NewFromConfigWithOptions(ctx context.Context, beadsDir string, cfg *Config)
 	if err := applyResolvedConfig(ctx, beadsDir, fileCfg, cfg); err != nil {
 		return nil, err
 	}
+	ApplyServerOwnedRemoteBase(cfg)
 
 	// Enable auto-start for standalone users (similar to main.go's auto-start
 	// handling), with additional support for BEADS_TEST_MODE and a config.yaml

--- a/internal/storage/dolt/open_test.go
+++ b/internal/storage/dolt/open_test.go
@@ -10,9 +10,56 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
 )
+
+func TestApplyServerOwnedRemoteBase(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	if err := config.SetUserYamlConfig("dolt.server-owned-remote-base", "https://root@dolt.permanet.io:32551"); err != nil {
+		t.Fatalf("write user config.yaml: %v", err)
+	}
+	projectBeadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(projectBeadsDir, 0o755); err != nil {
+		t.Fatalf("create project beads directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectBeadsDir, "config.yaml"), []byte("dolt:\n  server-owned-remote-base: https://root@evil.example:32551\n"), 0o600); err != nil {
+		t.Fatalf("write hostile project config.yaml: %v", err)
+	}
+	t.Setenv("BEADS_DIR", projectBeadsDir)
+
+	cfg := &Config{}
+	ApplyServerOwnedRemoteBase(cfg)
+	if cfg.ServerOwnedRemoteBase != "https://root@dolt.permanet.io:32551" {
+		t.Fatalf("server-owned base = %q", cfg.ServerOwnedRemoteBase)
+	}
+
+	callerCfg := &Config{ServerOwnedRemoteBase: "https://root@caller.example:443"}
+	ApplyServerOwnedRemoteBase(callerCfg)
+	if callerCfg.ServerOwnedRemoteBase != "https://root@caller.example:443" {
+		t.Fatal("an explicit caller option must survive user-global configuration")
+	}
+}
+
+func TestApplyConfigDefaultsServerOwnedCredentialsIgnoreClientEnvironment(t *testing.T) {
+	t.Setenv("DOLT_REMOTE_USER", "permabot")
+	t.Setenv("DOLT_REMOTE_PASSWORD", "stale-client-password")
+
+	cfg := &Config{
+		ServerPort:            1,
+		RemoteUser:            "explicit-permabot",
+		RemotePassword:        "explicit-stale-password",
+		ServerOwnedRemoteBase: "https://root@dolt.permanet.io:32551",
+	}
+	applyConfigDefaults(cfg)
+	if cfg.RemoteUser != "" || cfg.RemotePassword != "" {
+		t.Fatalf("server-owned mode retained client credentials: user=%q password_set=%v", cfg.RemoteUser, cfg.RemotePassword != "")
+	}
+}
 
 // TestResolveAutoStart verifies all conditions that govern the AutoStart decision.
 //

--- a/internal/storage/dolt/pull_config_wedge_test.go
+++ b/internal/storage/dolt/pull_config_wedge_test.go
@@ -111,6 +111,77 @@ func TestIgnoredTableSnapshotRoundTrip(t *testing.T) {
 	}
 }
 
+// TestIgnoredTableSnapshotDiscoversSchemaPatterns guards against repeating the
+// 0062 regression: events became dolt_ignored after the pull code's static
+// table list was written, so pulls left it dirty and Dolt refused every merge.
+// Discovery must follow dolt_ignore itself, including tables added by future
+// migrations, rather than another list that can drift.
+func TestIgnoredTableSnapshotDiscoversSchemaPatterns(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const table = "future_pull_local_state"
+	if _, err := store.db.ExecContext(ctx,
+		"REPLACE INTO dolt_ignore (pattern, ignored) VALUES (?, true)", table); err != nil {
+		t.Fatalf("register future ignored table: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_ADD('dolt_ignore')"); err != nil {
+		t.Fatalf("stage ignore rule: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		"CALL DOLT_COMMIT('-m', 'test: register future ignored table')"); err != nil {
+		t.Fatalf("commit ignore rule: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		"CREATE TABLE "+quotePullIdentifier(table)+" (id INT PRIMARY KEY, value VARCHAR(32))"); err != nil {
+		t.Fatalf("create ignored table: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO "+quotePullIdentifier(table)+" VALUES (1, 'preserved')"); err != nil {
+		t.Fatalf("dirty ignored table: %v", err)
+	}
+
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	snapshots, err := snapshotDirtyIgnoredTables(ctx, tx)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("snapshot ignored tables: %v", err)
+	}
+	found := false
+	for _, snapshot := range snapshots {
+		if snapshot.table == table {
+			found = true
+			break
+		}
+	}
+	if !found {
+		_ = tx.Rollback()
+		t.Fatalf("snapshot did not discover %s from dolt_ignore: %+v", table, snapshots)
+	}
+	if err := restoreDirtyIgnoredTables(ctx, tx, snapshots); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("restore ignored tables: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit restore: %v", err)
+	}
+
+	var value string
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT value FROM "+quotePullIdentifier(table)+" WHERE id = 1").Scan(&value); err != nil {
+		t.Fatalf("query restored future table: %v", err)
+	}
+	if value != "preserved" {
+		t.Fatalf("restored value = %q, want preserved", value)
+	}
+}
+
 // TestFederationSyncCommitsConfigBeforeFetch is the `bd federation sync`
 // analogue of the pull config wedge: Sync auto-commits the working set before
 // its merge, and that pre-merge commit must include config. Plain Commit

--- a/internal/storage/dolt/pull_config_wedge_test.go
+++ b/internal/storage/dolt/pull_config_wedge_test.go
@@ -61,6 +61,56 @@ func TestCommitBeforePullIncludesConfig(t *testing.T) {
 	}
 }
 
+func TestIgnoredTableSnapshotRoundTrip(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const key = "pull-snapshot-round-trip"
+	if _, err := store.db.ExecContext(ctx,
+		"REPLACE INTO local_metadata (`key`, value) VALUES (?, ?)", key, "preserved"); err != nil {
+		t.Fatalf("dirty local_metadata: %v", err)
+	}
+
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	snapshots, err := snapshotDirtyIgnoredTables(ctx, tx)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("snapshot ignored tables: %v", err)
+	}
+	var resetCount int
+	if err := tx.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM local_metadata WHERE `key` = ?", key).Scan(&resetCount); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("query reset local_metadata: %v", err)
+	}
+	if resetCount != 0 {
+		_ = tx.Rollback()
+		t.Fatalf("local row count after snapshot = %d, want 0", resetCount)
+	}
+	if err := restoreDirtyIgnoredTables(ctx, tx, snapshots); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("restore ignored tables: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit restored working set: %v", err)
+	}
+
+	var value string
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT value FROM local_metadata WHERE `key` = ?", key).Scan(&value); err != nil {
+		t.Fatalf("query restored local_metadata: %v", err)
+	}
+	if value != "preserved" {
+		t.Fatalf("restored value = %q, want preserved", value)
+	}
+}
+
 // TestFederationSyncCommitsConfigBeforeFetch is the `bd federation sync`
 // analogue of the pull config wedge: Sync auto-commits the working set before
 // its merge, and that pre-merge commit must include config. Plain Commit

--- a/internal/storage/dolt/pull_report_sql_route_test.go
+++ b/internal/storage/dolt/pull_report_sql_route_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // TestPullTransportReportsWhetherAnythingMerged is the end-to-end proof for
@@ -63,9 +64,22 @@ func TestPullTransportReportsWhetherAnythingMerged(t *testing.T) {
 
 	// A table of our own, so the assertion "the peer's row arrived" does not
 	// depend on any beads-schema sweeping/ignore behaviour.
+	mustExec("configure issue prefix", "REPLACE INTO config (`key`, value) VALUES ('issue_prefix', 'pulltest')")
+	mustExec("stage issue prefix", "CALL DOLT_ADD('config')")
+	mustExec("commit issue prefix", "CALL DOLT_COMMIT('-m', 'test: configure issue prefix')")
 	mustExec("create marker", "CREATE TABLE pull_report_marker (id INT PRIMARY KEY, v VARCHAR(64))")
 	mustExec("stage", "CALL DOLT_ADD('-A')")
 	mustExec("commit", "CALL DOLT_COMMIT('-m', 'test: pull report marker')")
+	localIssue := &types.Issue{
+		ID:        "pull-preserves-local-event",
+		Title:     "pull preserves local event",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, localIssue, "tester"); err != nil {
+		t.Fatalf("create local issue/event: %v", err)
+	}
 
 	// file:// inside the server's filesystem; Dolt creates it on push.
 	remoteURL := "file://" + filepath.Join(tmpDir, "pull-report-remote")
@@ -74,6 +88,17 @@ func TestPullTransportReportsWhetherAnythingMerged(t *testing.T) {
 
 	store.remote = "origin"
 	store.branch = "main"
+
+	var eventsBefore, ignoredVersionBefore int
+	if err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events WHERE issue_id = ?", localIssue.ID).Scan(&eventsBefore); err != nil {
+		t.Fatalf("count local events before pull: %v", err)
+	}
+	if eventsBefore == 0 {
+		t.Fatal("local event precondition missing")
+	}
+	if err := store.db.QueryRowContext(ctx, "SELECT MAX(version) FROM ignored_schema_migrations").Scan(&ignoredVersionBefore); err != nil {
+		t.Fatalf("read ignored migration cursor before pull: %v", err)
+	}
 
 	// The peer: a real clone of the remote, on the same server.
 	mustExec("clone peer", "CALL DOLT_CLONE(?, ?)", remoteURL, peerDB)
@@ -92,7 +117,7 @@ func TestPullTransportReportsWhetherAnythingMerged(t *testing.T) {
 	mustPeerExec("push", "CALL DOLT_PUSH('origin', 'main')")
 
 	// SUBJECT: a pull with real work to do reports that it merged.
-	merged, err := store.pullTransportReporting(ctx, "origin")
+	merged, _, err := store.pullTransportReporting(ctx, "origin")
 	if err != nil {
 		t.Fatalf("pull with work to do failed: %v", err)
 	}
@@ -109,6 +134,7 @@ func TestPullTransportReportsWhetherAnythingMerged(t *testing.T) {
 	if got != "from peer" {
 		t.Fatalf("control broken: marker = %q, want %q", got, "from peer")
 	}
+	assertLocalPullStatePreserved(t, ctx, store, localIssue.ID, eventsBefore, ignoredVersionBefore)
 	if !merged.Reported {
 		t.Fatalf("the SQL pull route returned no engine report at all (%+v); the DOLT_PULL/DOLT_MERGE row is still being discarded", merged)
 	}
@@ -118,7 +144,7 @@ func TestPullTransportReportsWhetherAnythingMerged(t *testing.T) {
 
 	// CONTROL: the immediately repeated pull has genuinely nothing to merge.
 	// It must still SUCCEED — and now say so.
-	noop, err := store.pullTransportReporting(ctx, "origin")
+	noop, _, err := store.pullTransportReporting(ctx, "origin")
 	if err != nil {
 		t.Fatalf("control broken: a pull with nothing to merge must still succeed, got: %v", err)
 	}
@@ -129,11 +155,56 @@ func TestPullTransportReportsWhetherAnythingMerged(t *testing.T) {
 	if noop.Merged {
 		t.Errorf("a pull with nothing to merge reported Merged=true (message %q)", noop.Message)
 	}
+	assertLocalPullStatePreserved(t, ctx, store, localIssue.ID, eventsBefore, ignoredVersionBefore)
+
+	// The server-owned route fetches first and returns before merge preparation
+	// when this containment check says the refreshed tracking ref is already in
+	// main. Exercise that exact branch against the real no-op remote and prove
+	// it cannot clear either local-only table.
+	serverNoop, handled, err := store.serverOwnedPullNoop(ctx, "origin", "")
+	if err != nil {
+		t.Fatalf("server-owned no-op probe: %v", err)
+	}
+	if !handled || !serverNoop.Reported || serverNoop.Merged {
+		t.Fatalf("server-owned no-op = (%+v, handled=%v), want reported non-merge", serverNoop, handled)
+	}
+	assertLocalPullStatePreserved(t, ctx, store, localIssue.ID, eventsBefore, ignoredVersionBefore)
+
+	// Error-path regression for the production data-loss incident. Both clones
+	// edit the same ordinary table row, forcing an unresolved content conflict
+	// after pull has snapshotted and checked out the ignored working-set plane.
+	// The merge transaction rolls back; the snapshots must then be restored on
+	// the same pinned connection in a fresh transaction.
+	mustExec("insert local conflict", "INSERT INTO pull_report_marker VALUES (2, 'local')")
+	mustExec("stage local conflict", "CALL DOLT_ADD('-A')")
+	mustExec("commit local conflict", "CALL DOLT_COMMIT('-m', 'local: conflicting marker')")
+	mustPeerExec("insert peer conflict", "INSERT INTO pull_report_marker VALUES (2, 'peer')")
+	mustPeerExec("stage peer conflict", "CALL DOLT_ADD('-A')")
+	mustPeerExec("commit peer conflict", "CALL DOLT_COMMIT('-m', 'peer: conflicting marker')")
+	mustPeerExec("push peer conflict", "CALL DOLT_PUSH('origin', 'main')")
+	if _, _, err := store.pullTransportReporting(ctx, "origin"); err == nil {
+		t.Fatal("conflicting pull unexpectedly succeeded")
+	}
+	assertLocalPullStatePreserved(t, ctx, store, localIssue.ID, eventsBefore, ignoredVersionBefore)
 
 	// The whole point, stated as one assertion: the two outcomes are now
 	// distinguishable at the call site. Before this change both were nil.
 	if merged.Merged == noop.Merged {
 		t.Fatalf("a merged pull and a no-op pull are still indistinguishable: both reported Merged=%v", merged.Merged)
+	}
+}
+
+func assertLocalPullStatePreserved(t *testing.T, ctx context.Context, store *DoltStore, issueID string, wantEvents, wantIgnoredVersion int) {
+	t.Helper()
+	var events, ignoredVersion int
+	if err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events WHERE issue_id = ?", issueID).Scan(&events); err != nil {
+		t.Fatalf("count local events after pull: %v", err)
+	}
+	if err := store.db.QueryRowContext(ctx, "SELECT MAX(version) FROM ignored_schema_migrations").Scan(&ignoredVersion); err != nil {
+		t.Fatalf("read ignored migration cursor after pull: %v", err)
+	}
+	if events != wantEvents || ignoredVersion != wantIgnoredVersion {
+		t.Fatalf("pull changed local-only state: events=%d (want %d), ignored cursor=%d (want %d)", events, wantEvents, ignoredVersion, wantIgnoredVersion)
 	}
 }
 

--- a/internal/storage/dolt/remote_routing_test.go
+++ b/internal/storage/dolt/remote_routing_test.go
@@ -30,6 +30,40 @@ func TestEnsureMatchingCLIRemoteSurfacesValidationErrors(t *testing.T) {
 	}
 }
 
+func TestServerOwnedRemoteCredentialsDisableCLIRouting(t *testing.T) {
+	t.Setenv(serverOwnsRemoteCredentialsEnv, "1")
+	ctx := context.Background()
+	store := &DoltStore{serverMode: true}
+	creds := &remoteCredentials{username: "root"}
+
+	routes := []struct {
+		name string
+		run  func() (bool, error)
+	}{
+		{"credentials", func() (bool, error) {
+			return store.prepareCLIRouteForCredentials(ctx, "origin", creds)
+		}},
+		{"cloud auth", func() (bool, error) {
+			return store.prepareCLIRouteForCloudAuth(ctx, "origin")
+		}},
+		{"local remote", func() (bool, error) {
+			return store.shouldUseCLIForLocalRemoteWithError(ctx, "origin")
+		}},
+	}
+
+	for _, route := range routes {
+		t.Run(route.name, func(t *testing.T) {
+			useCLI, err := route.run()
+			if err != nil {
+				t.Fatalf("route returned error: %v", err)
+			}
+			if useCLI {
+				t.Fatal("expected SQL routing when the server owns remote credentials")
+			}
+		})
+	}
+}
+
 func TestSQLCapableCLIRoutingFallsBackWhenCLIDirIsNotDoltRepo(t *testing.T) {
 	ctx := context.Background()
 	creds := &remoteCredentials{username: "user", password: "pass"}

--- a/internal/storage/dolt/remote_routing_test.go
+++ b/internal/storage/dolt/remote_routing_test.go
@@ -3,6 +3,7 @@ package dolt
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -31,10 +32,9 @@ func TestEnsureMatchingCLIRemoteSurfacesValidationErrors(t *testing.T) {
 }
 
 func TestServerOwnedRemoteCredentialsDisableCLIRouting(t *testing.T) {
-	t.Setenv(serverOwnsRemoteCredentialsEnv, "1")
 	ctx := context.Background()
 	store := &DoltStore{serverMode: true}
-	creds := &remoteCredentials{username: "root"}
+	creds := &remoteCredentials{username: "root", serverOwned: true}
 
 	routes := []struct {
 		name string
@@ -44,10 +44,10 @@ func TestServerOwnedRemoteCredentialsDisableCLIRouting(t *testing.T) {
 			return store.prepareCLIRouteForCredentials(ctx, "origin", creds)
 		}},
 		{"cloud auth", func() (bool, error) {
-			return store.prepareCLIRouteForCloudAuth(ctx, "origin")
+			return store.prepareCLIRouteForCloudAuth(ctx, "origin", creds)
 		}},
 		{"local remote", func() (bool, error) {
-			return store.shouldUseCLIForLocalRemoteWithError(ctx, "origin")
+			return store.shouldUseCLIForLocalRemoteWithError(ctx, "origin", creds)
 		}},
 	}
 
@@ -61,6 +61,128 @@ func TestServerOwnedRemoteCredentialsDisableCLIRouting(t *testing.T) {
 				t.Fatal("expected SQL routing when the server owns remote credentials")
 			}
 		})
+	}
+}
+
+func TestServerOwnedRemoteCredentialsDerivedFromRemoteURL(t *testing.T) {
+	t.Setenv("DOLT_REMOTE_USER", "permabot")
+	t.Setenv("DOLT_REMOTE_PASSWORD", "stale-client-password")
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	mock.ExpectQuery("SELECT name, url FROM dolt_remotes").
+		WillReturnRows(sqlmock.NewRows([]string{"name", "url"}).
+			AddRow("origin", "https://root@dolt.permanet.io:32551/permanet_pod"))
+
+	store := &DoltStore{
+		db:                    db,
+		serverMode:            true,
+		dbPath:                t.TempDir(),
+		database:              "permanet_pod",
+		remote:                "origin",
+		serverOwnedRemoteBase: "https://root@dolt.permanet.io:32551",
+	}
+	if err := os.MkdirAll(store.CLIDir(), 0o755); err != nil {
+		t.Fatalf("create stale CLI database directory: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(store.CLIDir(), ".dolt"), 0o755); err != nil {
+		t.Fatalf("create stale CLI marker: %v", err)
+	}
+
+	creds, err := store.credentialsForRemote(context.Background(), "origin")
+	if err != nil {
+		t.Fatalf("credentialsForRemote: %v", err)
+	}
+	if creds == nil || creds.username != "root" {
+		t.Fatalf("derived credentials = %#v, want username root", creds)
+	}
+	if creds.password != "" {
+		t.Fatal("remote URL resolution must not synthesize a client-side password")
+	}
+	if !creds.ownedByServer() {
+		t.Fatal("username-only HTTP remote on an external server should be server-owned")
+	}
+
+	useCLI, err := store.prepareCLIRouteForCredentials(context.Background(), "origin", creds)
+	if err != nil {
+		t.Fatalf("prepareCLIRouteForCredentials: %v", err)
+	}
+	if useCLI {
+		t.Fatal("server-owned credentials must not route through the stale local Dolt CLI directory")
+	}
+	for name, route := range map[string]func() (bool, error){
+		"cloud auth": func() (bool, error) {
+			return store.prepareCLIRouteForCloudAuth(context.Background(), "origin", creds)
+		},
+		"local remote": func() (bool, error) {
+			return store.shouldUseCLIForLocalRemoteWithError(context.Background(), "origin", creds)
+		},
+	} {
+		useCLI, routeErr := route()
+		if routeErr != nil {
+			t.Fatalf("%s route: %v", name, routeErr)
+		}
+		if useCLI {
+			t.Fatalf("%s route must remain on SQL when the server owns credentials", name)
+		}
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
+func TestServerOwnedRemoteUsername(t *testing.T) {
+	tests := []struct {
+		name      string
+		baseURL   string
+		remoteURL string
+		wantUser  string
+		wantErr   bool
+	}{
+		{name: "trusted authenticated remotes API", baseURL: "https://root@dolt.example:32551", remoteURL: "https://root@dolt.example:32551/database", wantUser: "root"},
+		{name: "different host cannot receive server password", baseURL: "https://root@dolt.example:32551", remoteURL: "https://root@evil.example:32551/database", wantErr: true},
+		{name: "different user is rejected", baseURL: "https://root@dolt.example:32551", remoteURL: "https://permabot@dolt.example:32551/database", wantErr: true},
+		{name: "password in remote is rejected", baseURL: "https://root@dolt.example:32551", remoteURL: "https://root:secret@dolt.example:32551/database", wantErr: true},
+		{name: "password in base is rejected", baseURL: "https://root:secret@dolt.example:32551", remoteURL: "https://root@dolt.example:32551/database", wantErr: true},
+		{name: "plain HTTP is rejected", baseURL: "https://root@dolt.example:32551", remoteURL: "http://root@dolt.example:32551/database", wantErr: true},
+		{name: "git transport is rejected", baseURL: "https://root@dolt.example:32551", remoteURL: "git+https://root@dolt.example:32551/database", wantErr: true},
+		{name: "missing database is rejected", baseURL: "https://root@dolt.example:32551", remoteURL: "https://root@dolt.example:32551", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotUser, err := serverOwnedRemoteUsername(tt.baseURL, tt.remoteURL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("serverOwnedRemoteUsername(%q, %q) error = %v, wantErr %v", tt.baseURL, tt.remoteURL, err, tt.wantErr)
+			}
+			if gotUser != tt.wantUser {
+				t.Fatalf("serverOwnedRemoteUsername(%q, %q) user = %q, want %q", tt.baseURL, tt.remoteURL, gotUser, tt.wantUser)
+			}
+		})
+	}
+}
+
+func TestAuthenticatedFetchCall(t *testing.T) {
+	query, args := authenticatedFetchCall("root", "origin", "main")
+	if query != "CALL DOLT_FETCH('--user', ?, ?, ?)" {
+		t.Fatalf("authenticated query = %q", query)
+	}
+	wantArgs := []any{"root", "origin", "main"}
+	if len(args) != len(wantArgs) {
+		t.Fatalf("authenticated args = %#v, want %#v", args, wantArgs)
+	}
+	for i := range wantArgs {
+		if args[i] != wantArgs[i] {
+			t.Fatalf("authenticated args = %#v, want %#v", args, wantArgs)
+		}
+	}
+
+	query, args = authenticatedFetchCall("", "origin", "main")
+	if query != "CALL DOLT_FETCH(?, ?)" || len(args) != 2 {
+		t.Fatalf("anonymous fetch = %q %#v", query, args)
 	}
 }
 
@@ -94,7 +216,7 @@ func TestSQLCapableCLIRoutingFallsBackWhenCLIDirIsNotDoltRepo(t *testing.T) {
 		{
 			name: "local remote",
 			route: func(store *DoltStore) (bool, error) {
-				return store.shouldUseCLIForLocalRemoteWithError(ctx, "origin")
+				return store.shouldUseCLIForLocalRemoteWithError(ctx, "origin", nil)
 			},
 		},
 		{

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -352,7 +352,10 @@ type DoltStore struct {
 	branch         string // Current branch
 	remoteUser     string // Remote auth user for Hosted Dolt push/pull (optional)
 	remotePassword string // Remote auth password for Hosted Dolt push/pull (optional)
-	serverMode     bool   // true when connected to external dolt sql-server (not embedded)
+	// serverOwnedRemoteBase keeps authenticated transfers on the SQL server
+	// only for the configured per-machine HTTPS origin.
+	serverOwnedRemoteBase string
+	serverMode            bool // true when connected to external dolt sql-server (not embedded)
 
 	// autoStartedServerDir is set when this store triggered a dolt sql-server
 	// auto-start. Close() uses it to stop the server when the last store
@@ -411,6 +414,10 @@ type Config struct {
 	// When set, Push/Pull use the --user flag and set DOLT_REMOTE_PASSWORD env var.
 	RemoteUser     string // Hosted Dolt remote user (set via DOLT_REMOTE_USER env var)
 	RemotePassword string // Hosted Dolt remote password (set via DOLT_REMOTE_PASSWORD env var)
+	// ServerOwnedRemoteBase declares the per-machine HTTPS origin whose remote
+	// password is owned by an external SQL server. It includes the username but
+	// never a password, for example https://root@dolt.example:32551.
+	ServerOwnedRemoteBase string
 
 	// SyncRemote holds the effective sync remote URL (from sync.remote
 	// or deprecated sync.git-remote). Used for context-aware error hints.
@@ -1529,12 +1536,18 @@ func applyConfigDefaults(cfg *Config) {
 		cfg.ServerPassword = os.Getenv("BEADS_DOLT_PASSWORD")
 	}
 
-	// Remote credentials for Hosted Dolt push/pull (env vars take precedence)
-	if cfg.RemoteUser == "" {
-		cfg.RemoteUser = os.Getenv("DOLT_REMOTE_USER")
-	}
-	if cfg.RemotePassword == "" {
-		cfg.RemotePassword = os.Getenv("DOLT_REMOTE_PASSWORD")
+	// Remote credentials for Hosted Dolt push/pull. Server-owned mode is a
+	// durable routing policy: stale client credentials must not override it.
+	if cfg.ServerOwnedRemoteBase != "" {
+		cfg.RemoteUser = ""
+		cfg.RemotePassword = ""
+	} else {
+		if cfg.RemoteUser == "" {
+			cfg.RemoteUser = os.Getenv("DOLT_REMOTE_USER")
+		}
+		if cfg.RemotePassword == "" {
+			cfg.RemotePassword = os.Getenv("DOLT_REMOTE_PASSWORD")
+		}
 	}
 }
 
@@ -1959,6 +1972,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		branch:                 "main",
 		remoteUser:             cfg.RemoteUser,
 		remotePassword:         cfg.RemotePassword,
+		serverOwnedRemoteBase:  cfg.ServerOwnedRemoteBase,
 		serverMode:             true,
 		readOnly:               cfg.ReadOnly,
 		autoStartedServerDir:   autoStartedDir,
@@ -3621,13 +3635,45 @@ func (s *DoltStore) mainRemoteCredentials() *remoteCredentials {
 }
 
 // credentialsForRemote returns credentials only when the target remote is the
-// default remote (s.remote). Non-default remotes get nil creds to avoid sending
-// the wrong credentials to the wrong host.
-func (s *DoltStore) credentialsForRemote(remote string) *remoteCredentials {
-	if remote == s.remote {
-		return s.mainRemoteCredentials()
+// default remote (s.remote). In server-owned mode the non-secret username comes
+// exclusively from the SQL-visible HTTP remotes API URL; ambient client
+// credentials are ignored and the SQL server executes the transfer itself.
+func (s *DoltStore) credentialsForRemote(ctx context.Context, remote string) (*remoteCredentials, error) {
+	if remote != s.remote {
+		return nil, nil
 	}
-	return nil
+
+	creds := s.mainRemoteCredentials()
+	if creds == nil {
+		creds = &remoteCredentials{}
+	}
+	creds.serverOwned = s.serverOwnedRemoteBase != ""
+
+	if !creds.serverOwned {
+		if creds.empty() {
+			return nil, nil
+		}
+		return creds, nil
+	}
+	if !s.serverMode {
+		return nil, fmt.Errorf("remote %q is configured with server-owned credentials outside external-server mode", remote)
+	}
+
+	remotes, err := s.ListRemotes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list Dolt remotes before resolving authentication for remote %q: %w", remote, err)
+	}
+	for _, configured := range remotes {
+		if configured.Name != remote {
+			continue
+		}
+		urlUser, err := serverOwnedRemoteUsername(s.serverOwnedRemoteBase, configured.URL)
+		if err != nil {
+			return nil, fmt.Errorf("remote %q cannot use server-owned credentials: %w", remote, err)
+		}
+		return &remoteCredentials{username: urlUser, serverOwned: true}, nil
+	}
+	return nil, fmt.Errorf("remote %q has server-owned credentials but no SQL-visible remote URL", remote)
 }
 
 // prePushFSCK runs dolt fsck --quiet to verify local chunk integrity before
@@ -3895,7 +3941,10 @@ func (s *DoltStore) pushToRemote(ctx context.Context, remote string, force bool)
 		)...),
 	)
 	defer func() { endSpan(span, retErr) }()
-	creds := s.credentialsForRemote(remote)
+	creds, err := s.credentialsForRemote(ctx, remote)
+	if err != nil {
+		return err
+	}
 	// Git-protocol remotes: use CLI to avoid MySQL connection timeout during transfer.
 	// Must check before remoteUser — Hosted Dolt SSH remotes have remoteUser set
 	// but still need CLI to avoid SQL connection timeout.
@@ -3919,24 +3968,30 @@ func (s *DoltStore) pushToRemote(ctx context.Context, remote string, force bool)
 	// etc.) are set and we're in server mode, route through CLI so the dolt
 	// subprocess inherits the current env. The SQL server may not have these
 	// vars if it was started in a different context (GH#6).
-	if useCLI, err := s.prepareCLIRouteForCloudAuth(ctx, remote); err != nil {
-		return err
-	} else if useCLI {
-		return s.doltCLIPush(ctx, remote, force, creds)
+	if !creds.ownedByServer() {
+		if useCLI, err := s.prepareCLIRouteForCloudAuth(ctx, remote, creds); err != nil {
+			return err
+		} else if useCLI {
+			return s.doltCLIPush(ctx, remote, force, creds)
+		}
+		if useCLI, err := s.shouldUseCLIForLocalRemoteWithError(ctx, remote, creds); err != nil {
+			return err
+		} else if useCLI {
+			return s.doltCLIPush(ctx, remote, force, creds)
+		}
 	}
-	if useCLI, err := s.shouldUseCLIForLocalRemoteWithError(ctx, remote); err != nil {
-		return err
-	} else if useCLI {
-		return s.doltCLIPush(ctx, remote, force, creds)
-	}
-	if s.remoteUser != "" && remote == s.remote {
-		return withRemoteOperationEnv(creds, s.isS3Remote(ctx, remote), func() error {
+	if creds != nil && creds.username != "" && remote == s.remote {
+		operationCreds := creds
+		if creds.ownedByServer() {
+			operationCreds = nil
+		}
+		return withRemoteOperationEnv(operationCreds, s.isS3Remote(ctx, remote), func() error {
 			if force {
-				if err := s.execWithLongTimeoutNoTx(ctx, "CALL DOLT_PUSH('--force', '--user', ?, ?, ?)", s.remoteUser, remote, s.branch); err != nil {
+				if err := s.execWithLongTimeoutNoTx(ctx, "CALL DOLT_PUSH('--force', '--user', ?, ?, ?)", creds.username, remote, s.branch); err != nil {
 					return fmt.Errorf("failed to force push to %s/%s: %w", remote, s.branch, err)
 				}
 			} else {
-				if err := s.execWithLongTimeoutNoTx(ctx, "CALL DOLT_PUSH('--user', ?, ?, ?)", s.remoteUser, remote, s.branch); err != nil {
+				if err := s.execWithLongTimeoutNoTx(ctx, "CALL DOLT_PUSH('--user', ?, ?, ?)", creds.username, remote, s.branch); err != nil {
 					return fmt.Errorf("failed to push to %s/%s: %w", remote, s.branch, err)
 				}
 			}
@@ -4018,7 +4073,8 @@ func (s *DoltStore) pullFromRemoteUnchecked(ctx context.Context, remote string) 
 		}
 	}
 
-	if err := s.pullTransport(ctx, remote); err != nil {
+	_, remoteUser, err := s.pullTransportReporting(ctx, remote)
+	if err != nil {
 		return err
 	}
 
@@ -4027,7 +4083,7 @@ func (s *DoltStore) pullFromRemoteUnchecked(ctx context.Context, remote string) 
 	// merge landed. Checked before the recompute: recomputing derived state
 	// over a merge that never arrived would report a second success on top of
 	// the first.
-	if err := s.verifyPullLanded(ctx, remote, preHead); err != nil {
+	if err := s.verifyPullLanded(ctx, remote, preHead, remoteUser); err != nil {
 		return err
 	}
 
@@ -4114,7 +4170,7 @@ func (s *DoltStore) branchHash(ctx context.Context, branch string) (string, erro
 // database on this branch, so the refresh below — the only part that costs a
 // network round trip — is skipped for every pull that actually merged
 // something. An empty preHead means it could not be read, which verifies.
-func (s *DoltStore) verifyPullLanded(ctx context.Context, remote, preHead string) error {
+func (s *DoltStore) verifyPullLanded(ctx context.Context, remote, preHead, remoteUser string) error {
 	trackingRef := "remotes/" + remote + "/" + s.branch
 
 	localHash, headErr := s.branchHash(ctx, s.branch)
@@ -4126,7 +4182,8 @@ func (s *DoltStore) verifyPullLanded(ctx context.Context, remote, preHead string
 	// reads a ref this connection wrote. Best-effort by design: a refresh that
 	// cannot run leaves the weaker stale-ref comparison, which is still worth
 	// making.
-	if err := schema.DrainCall(ctx, s.db, "CALL DOLT_FETCH(?, ?)", remote, s.branch); err != nil {
+	fetchQuery, fetchArgs := authenticatedFetchCall(remoteUser, remote, s.branch)
+	if err := schema.DrainCall(ctx, s.db, fetchQuery, fetchArgs...); err != nil {
 		log.Printf("warning: could not refresh %s to verify the pull landed: %v", trackingRef, err)
 	}
 
@@ -4166,7 +4223,7 @@ func (s *DoltStore) verifyPullLanded(ctx context.Context, remote, preHead string
 // each route carries. Split from pullFromRemote so every successful route
 // funnels back through the is_blocked recompute.
 func (s *DoltStore) pullTransport(ctx context.Context, remote string) error {
-	_, err := s.pullTransportReporting(ctx, remote)
+	_, _, err := s.pullTransportReporting(ctx, remote)
 	return err
 }
 
@@ -4175,57 +4232,124 @@ func (s *DoltStore) pullTransport(ctx context.Context, remote string) error {
 // it merged or was already up to date, and its stdout is discarded — so they
 // report nothing; the SQL routes return what CALL DOLT_PULL (or the fallback's
 // CALL DOLT_MERGE) said. See pullReport for what that does and does not prove.
-func (s *DoltStore) pullTransportReporting(ctx context.Context, remote string) (pullReport, error) {
-	creds := s.credentialsForRemote(remote)
+//
+//nolint:unparam // pullReport is intentionally exposed to focused transport regression tests.
+func (s *DoltStore) pullTransportReporting(ctx context.Context, remote string) (pullReport, string, error) {
+	creds, err := s.credentialsForRemote(ctx, remote)
+	if err != nil {
+		return pullReport{}, "", err
+	}
+	remoteUser := ""
+	if creds != nil {
+		remoteUser = creds.username
+	}
 	// Git-protocol remotes: use CLI to avoid MySQL connection timeout during transfer.
 	// Must check before remoteUser — Hosted Dolt SSH remotes have remoteUser set
 	// but still need CLI to avoid SQL connection timeout.
 	// Credentials are passed directly to the subprocess via cmd.Env.
 	if useCLI, err := s.prepareCLIRouteForGitProtocol(ctx, remote); err != nil {
-		return pullReport{}, err
+		return pullReport{}, remoteUser, err
 	} else if useCLI {
 		// CLI pull leaves any conflicts in the working set; run the auto-resolver so
 		// git-protocol remotes get the same audit-only dependency / metadata repair
 		// as the SQL DOLT_PULL path (#4259).
-		return pullReport{}, s.finishCLIPull(ctx, s.doltCLIPull(ctx, remote, creds))
+		return pullReport{}, remoteUser, s.finishCLIPull(ctx, s.doltCLIPull(ctx, remote, creds))
 	}
 	// Credential CLI routing: mirrors git-protocol path, including post-pull
 	// auto-resolution.
 	if useCLI, err := s.prepareCLIRouteForCredentials(ctx, remote, creds); err != nil {
-		return pullReport{}, err
+		return pullReport{}, remoteUser, err
 	} else if useCLI {
-		return pullReport{}, s.finishCLIPull(ctx, s.doltCLIPull(ctx, remote, creds))
+		return pullReport{}, remoteUser, s.finishCLIPull(ctx, s.doltCLIPull(ctx, remote, creds))
 	}
 	// Cloud auth CLI routing (GH#6), including post-pull auto-resolution.
-	if useCLI, err := s.prepareCLIRouteForCloudAuth(ctx, remote); err != nil {
-		return pullReport{}, err
-	} else if useCLI {
-		return pullReport{}, s.finishCLIPull(ctx, s.doltCLIPull(ctx, remote, creds))
+	if !creds.ownedByServer() {
+		if useCLI, err := s.prepareCLIRouteForCloudAuth(ctx, remote, creds); err != nil {
+			return pullReport{}, remoteUser, err
+		} else if useCLI {
+			return pullReport{}, remoteUser, s.finishCLIPull(ctx, s.doltCLIPull(ctx, remote, creds))
+		}
 	}
 	// Local file:// pulls intentionally stay on the SQL path. The matching CLI
 	// guard is a push-only optimization; SQL pull keeps pullWithAutoResolve in
 	// charge of metadata-only conflict repair.
 	var report pullReport
-	if s.remoteUser != "" && remote == s.remote {
-		err := withRemoteOperationEnv(creds, s.isS3Remote(ctx, remote), func() error {
+	if creds != nil && creds.username != "" && remote == s.remote {
+		operationCreds := creds
+		if creds.ownedByServer() {
+			operationCreds = nil
+			// The shared external sql-server owns the remote password. Fetch on
+			// that server first and avoid DOLT_PULL entirely when the active
+			// branch already contains the refreshed tracking ref. This is more
+			// than an optimization: preparing a merge temporarily checks out
+			// dolt_ignored working-set tables, and an engine error can otherwise
+			// strand those local-only rows before their restoration commits.
+			noopReport, alreadyContains, fetchErr := s.serverOwnedPullNoop(ctx, remote, creds.username)
+			if fetchErr != nil {
+				return pullReport{}, remoteUser, fmt.Errorf("failed to fetch from %s/%s: %w", remote, s.branch, fetchErr)
+			}
+			if alreadyContains {
+				return noopReport, remoteUser, nil
+			}
+		}
+		err := withRemoteOperationEnv(operationCreds, s.isS3Remote(ctx, remote), func() error {
 			var err error
-			report, err = s.pullWithAutoResolveReporting(ctx, remote, "CALL DOLT_PULL('--user', ?, ?, ?)", s.remoteUser, remote, s.branch)
+			report, err = s.pullWithAutoResolveReporting(ctx, remote, creds.username, "CALL DOLT_PULL('--user', ?, ?, ?)", creds.username, remote, s.branch)
 			if err != nil {
 				return fmt.Errorf("failed to pull from %s/%s: %w", remote, s.branch, err)
 			}
 			return nil
 		})
-		return report, err
+		return report, remoteUser, err
 	}
-	err := withRemoteOperationEnv(nil, s.isS3Remote(ctx, remote), func() error {
+	err = withRemoteOperationEnv(nil, s.isS3Remote(ctx, remote), func() error {
 		var err error
-		report, err = s.pullWithAutoResolveReporting(ctx, remote, "CALL DOLT_PULL(?, ?)", remote, s.branch)
+		report, err = s.pullWithAutoResolveReporting(ctx, remote, "", "CALL DOLT_PULL(?, ?)", remote, s.branch)
 		if err != nil {
 			return fmt.Errorf("failed to pull from %s/%s: %w", remote, s.branch, err)
 		}
 		return nil
 	})
-	return report, err
+	return report, remoteUser, err
+}
+
+func (s *DoltStore) serverOwnedPullNoop(ctx context.Context, remote, remoteUser string) (pullReport, bool, error) {
+	alreadyContains, err := s.fetchShowsRemoteContained(ctx, remote, remoteUser)
+	if err != nil || !alreadyContains {
+		return pullReport{}, false, err
+	}
+	return pullReport{Reported: true, Message: "Everything up-to-date"}, true, nil
+}
+
+// fetchShowsRemoteContained refreshes remote/branch through this SQL server
+// and reports whether the store's active branch already contains that exact
+// tracking tip. Equal and locally-ahead are both honest no-op pulls. Diverged
+// or remotely-ahead histories return false so the normal merge path runs.
+func (s *DoltStore) fetchShowsRemoteContained(ctx context.Context, remote, remoteUser string) (bool, error) {
+	fetchQuery, fetchArgs := authenticatedFetchCall(remoteUser, remote, s.branch)
+	if err := schema.DrainCall(ctx, s.db, fetchQuery, fetchArgs...); err != nil {
+		return false, err
+	}
+
+	trackingRef := "remotes/" + remote + "/" + s.branch
+	var remoteHash string
+	if err := s.db.QueryRowContext(ctx,
+		"SELECT hash FROM dolt_remote_branches WHERE name = ?", trackingRef).Scan(&remoteHash); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	if remoteHash == "" {
+		return false, nil
+	}
+
+	var mergeBase sql.NullString
+	if err := s.db.QueryRowContext(ctx,
+		"SELECT DOLT_MERGE_BASE(?, ?)", s.branch, trackingRef).Scan(&mergeBase); err != nil {
+		return false, err
+	}
+	return mergeBase.Valid && mergeBase.String == remoteHash, nil
 }
 
 // pullWithAutoResolve executes a DOLT_PULL query with long timeout and auto-resolves
@@ -4260,51 +4384,66 @@ func (s *DoltStore) openLongTimeoutConn() (*sql.DB, error) {
 // fallback targets it directly, so pulls from non-default remotes (PullRemote,
 // federation peers) no longer fall back to s.remote.
 func (s *DoltStore) pullWithAutoResolve(ctx context.Context, remote string, query string, args ...any) error {
-	_, err := s.pullWithAutoResolveReporting(ctx, remote, query, args...)
+	_, err := s.pullWithAutoResolveReporting(ctx, remote, "", query, args...)
 	return err
 }
 
 // pullWithAutoResolveReporting is pullWithAutoResolve plus the row the pull (or
 // the fetch+merge fallback) returned — the engine's own account of whether
 // anything merged. See pullReport.
-func (s *DoltStore) pullWithAutoResolveReporting(ctx context.Context, remote string, query string, args ...any) (pullReport, error) {
+func (s *DoltStore) pullWithAutoResolveReporting(ctx context.Context, remote, remoteUser, query string, args ...any) (pullReport, error) {
 	var report pullReport
 	err := s.withCircuitWrite(ctx, func(ctx context.Context) error {
 		var err error
-		report, err = s.pullWithAutoResolveUnchecked(ctx, remote, query, args...)
+		report, err = s.pullWithAutoResolveUnchecked(ctx, remote, remoteUser, query, args...)
 		return err
 	})
 	return report, err
 }
 
-func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote string, query string, args ...any) (pullReport, error) {
-	// Audited for be-b0am's fresh-connection branch hazard: NOT safe, and all
-	// three callers share it. Passing a branch argument does not avoid it.
-	//
+func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote, remoteUser, query string, args ...any) (report pullReport, retErr error) {
 	// DOLT_PULL's second positional arg names the remote ref to merge FROM
-	// (dolt's doDoltPull binds it to remoteRefName); the merge TARGET is
-	// always the session's current working branch (CWBHeadRef), which on this
-	// fresh openLongTimeoutConn connection is the database's default branch,
-	// never s.branch. So store.go's two callers, which pass s.branch to
-	// CALL DOLT_PULL(...), pin only the source and still merge into the
-	// default branch; federation.go's peer-pull route (CALL DOLT_PULL(?),
-	// remote only) derives both source and target from that same default
-	// branch. The GH#3144 fallback below has the same shape — DOLT_FETCH
-	// names the remote ref, but CALL DOLT_MERGE(trackingRef) merges into the
-	// current branch too.
-	//
-	// Left unfixed here deliberately: this is be-b0am's root cause on a
-	// pull/merge path, and a merge landing on the wrong branch has a much
-	// larger blast radius than a stale is_blocked flag, so it needs its own
-	// regression test asserting the merge target rather than riding an
-	// unrelated TDD cycle. Tracked as be-5ybd, which covers all three call
-	// sites. The fix is s.pinStoreBranch(ctx, db) before BeginTx below.
+	// (dolt's doDoltPull binds it to remoteRefName); its merge target is the
+	// session's current working branch. This dedicated connection therefore
+	// must be pinned to the store branch before either snapshots or pull run.
 	db, err := s.openLongTimeoutConn()
 	if err != nil {
 		return pullReport{}, err
 	}
 	defer db.Close()
-	tx, err := db.BeginTx(ctx, nil)
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return pullReport{}, fmt.Errorf("failed to acquire pull connection: %w", err)
+	}
+	defer conn.Close()
+	if err := s.pinStoreBranch(ctx, conn); err != nil {
+		return pullReport{}, err
+	}
+
+	// Build connection-local snapshots before opening the merge transaction.
+	// Their contents survive an ordinary transaction rollback on this pinned
+	// connection, so conflict and engine-error paths can restore in a fresh tx.
+	ignoredSnapshots, err := prepareDirtyIgnoredTableSnapshots(ctx, conn)
+	if err != nil {
+		return pullReport{}, fmt.Errorf("snapshot ignored tables before pull: %w", err)
+	}
+	checkedOutIgnored := false
+	defer func() {
+		if retErr == nil || !checkedOutIgnored {
+			return
+		}
+		// Use a bounded detached context for ordinary engine/conflict failures.
+		// A driver-level cancellation closes the physical connection and its
+		// TEMPORARY snapshots; that storage-driver limitation is reported by the
+		// joined restore error rather than papered over with admin-side recovery.
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
+		defer cancel()
+		if restoreErr := restoreDirtyIgnoredTablesAfterRollback(cleanupCtx, conn, ignoredSnapshots); restoreErr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("restore ignored tables after failed pull: %w", restoreErr))
+		}
+	}()
+
+	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return pullReport{}, fmt.Errorf("failed to begin transaction: %w", err)
 	}
@@ -4325,10 +4464,12 @@ func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote str
 		return pullReport{}, fmt.Errorf("failed to set dolt_force_transaction_commit: %w", err)
 	}
 
-	ignoredSnapshots, err := snapshotDirtyIgnoredTables(ctx, tx)
-	if err != nil {
+	// Arm recovery before the first checkout: a later table can fail after an
+	// earlier DOLT_CHECKOUT has already mutated the working set.
+	checkedOutIgnored = len(ignoredSnapshots) > 0
+	if err := checkoutDirtyIgnoredTables(ctx, tx, ignoredSnapshots); err != nil {
 		_ = tx.Rollback()
-		return pullReport{}, fmt.Errorf("snapshot ignored tables before pull: %w", err)
+		return pullReport{}, fmt.Errorf("reset ignored tables before pull: %w", err)
 	}
 
 	// DOLT_PULL's row is the engine's only in-band account of what the pull
@@ -4337,14 +4478,15 @@ func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote str
 	// is identical — and it is the difference between a caller that knows
 	// nothing arrived and one that only knows no error occurred (ga-bq9zd).
 	pullRow, pullErr := schema.CallReturningRow(ctx, tx, query, args...)
-	report := parseMergeReport(pullRow)
+	report = parseMergeReport(pullRow)
 
 	// GH#3144: When DOLT_PULL fails because upstream branch tracking is not
 	// configured in repo_state.json (common when remote was added via
 	// bd dolt remote add rather than bd bootstrap/dolt clone), fall back to
 	// DOLT_FETCH + DOLT_MERGE which does not require tracking config.
 	if pullErr != nil && isBranchTrackingError(pullErr) {
-		if err := schema.DrainCall(ctx, tx, "CALL DOLT_FETCH(?, ?)", remote, s.branch); err != nil {
+		fetchQuery, fetchArgs := authenticatedFetchCall(remoteUser, remote, s.branch)
+		if err := schema.DrainCall(ctx, tx, fetchQuery, fetchArgs...); err != nil {
 			_ = tx.Rollback()
 			return pullReport{}, fmt.Errorf("fetch from %s/%s: %w", remote, s.branch, err)
 		}
@@ -4369,22 +4511,15 @@ func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote str
 		return pullReport{}, fmt.Errorf("restore ignored tables after pull: %w", err)
 	}
 
-	return report, s.settleMergeInTx(ctx, tx, pullErr)
+	retErr = s.settleMergeInTx(ctx, tx, pullErr)
+	return report, retErr
 }
 
-// ignoredPullTables are local-only tables that Beads intentionally excludes
-// from Dolt commits. A merge still refuses a dirty ignored table, so SQL pulls
-// temporarily move these rows into connection-local tables and restore them
-// after the remote operation.
-var ignoredPullTables = []string{
-	"ignored_schema_migrations",
-	"local_metadata",
-	"repo_mtimes",
-	"wisps",
-	"wisp_labels",
-	"wisp_dependencies",
-	"wisp_events",
-	"wisp_comments",
+func authenticatedFetchCall(remoteUser, remote, branch string) (string, []any) {
+	if remoteUser != "" {
+		return "CALL DOLT_FETCH('--user', ?, ?, ?)", []any{remoteUser, remote, branch}
+	}
+	return "CALL DOLT_FETCH(?, ?)", []any{remote, branch}
 }
 
 type ignoredTableSnapshot struct {
@@ -4394,19 +4529,37 @@ type ignoredTableSnapshot struct {
 	ddl     string
 }
 
-func snapshotDirtyIgnoredTables(ctx context.Context, tx *sql.Tx) ([]ignoredTableSnapshot, error) {
-	dirty := make(map[string]bool)
-	rows, err := tx.QueryContext(ctx, "SELECT table_name FROM dolt_status")
+type ignoredSnapshotConn interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func prepareDirtyIgnoredTableSnapshots(ctx context.Context, db ignoredSnapshotConn) ([]ignoredTableSnapshot, error) {
+	// Discover this set from dolt_ignore instead of duplicating the schema's
+	// ignore list here. The old hard-coded list predated the events plane flip
+	// (0062), so a dirty events table was left in place and DOLT_PULL refused to
+	// merge. Any future ignored table would have recreated the same wedge.
+	rows, err := db.QueryContext(ctx, `
+		SELECT DISTINCT ds.table_name
+		FROM dolt_status ds
+		WHERE EXISTS (
+			SELECT 1
+			FROM dolt_ignore di
+			WHERE di.ignored = true AND ds.table_name LIKE di.pattern
+		)
+		ORDER BY ds.table_name`)
 	if err != nil {
 		return nil, err
 	}
+	var dirtyIgnored []string
 	for rows.Next() {
 		var table string
 		if err := rows.Scan(&table); err != nil {
 			_ = rows.Close()
 			return nil, err
 		}
-		dirty[table] = true
+		dirtyIgnored = append(dirtyIgnored, table)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -4416,47 +4569,68 @@ func snapshotDirtyIgnoredTables(ctx context.Context, tx *sql.Tx) ([]ignoredTable
 	}
 
 	var snapshots []ignoredTableSnapshot
-	for _, table := range ignoredPullTables {
-		if !dirty[table] {
-			continue
-		}
-		temp := "__beads_pull_" + table
-		columns, err := pullSnapshotColumnList(ctx, tx, table)
+	for i, table := range dirtyIgnored {
+		quotedTable := quotePullIdentifier(table)
+		// The temporary name is generated locally rather than read from SQL,
+		// but quote it too so an unusual future table name cannot turn this
+		// maintenance path into malformed SQL.
+		temp := fmt.Sprintf("__beads_pull_%d", i)
+		quotedTemp := quotePullIdentifier(temp)
+		columns, err := pullSnapshotColumnList(ctx, db, table)
 		if err != nil {
 			return nil, err
 		}
 		var ddlTable, ddl string
-		if err := tx.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE `%s`", table)).Scan(&ddlTable, &ddl); err != nil {
+		if err := db.QueryRowContext(ctx, "SHOW CREATE TABLE "+quotedTable).Scan(&ddlTable, &ddl); err != nil {
 			return nil, err
 		}
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf("CREATE TEMPORARY TABLE `%s` LIKE `%s`", temp, table)); err != nil {
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("CREATE TEMPORARY TABLE %s LIKE %s", quotedTemp, quotedTable)); err != nil {
 			return nil, err
 		}
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf("INSERT INTO `%s` (%s) SELECT %s FROM `%s`", temp, columns, columns, table)); err != nil {
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("INSERT INTO %s (%s) SELECT %s FROM %s", quotedTemp, columns, columns, quotedTable)); err != nil {
 			return nil, err
 		}
 		snapshots = append(snapshots, ignoredTableSnapshot{table: table, temp: temp, columns: columns, ddl: ddl})
 	}
 
+	return snapshots, nil
+}
+
+func checkoutDirtyIgnoredTables(ctx context.Context, tx *sql.Tx, snapshots []ignoredTableSnapshot) error {
 	if len(snapshots) == 0 {
-		return nil, nil
+		return nil
 	}
 	if _, err := tx.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
-		return nil, err
+		return err
 	}
 	for i := len(snapshots) - 1; i >= 0; i-- {
 		if _, err := tx.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", snapshots[i].table); err != nil {
-			return nil, err
+			return err
 		}
 	}
 	if _, err := tx.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func snapshotDirtyIgnoredTables(ctx context.Context, tx *sql.Tx) ([]ignoredTableSnapshot, error) {
+	snapshots, err := prepareDirtyIgnoredTableSnapshots(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkoutDirtyIgnoredTables(ctx, tx, snapshots); err != nil {
 		return nil, err
 	}
 	return snapshots, nil
 }
 
-func pullSnapshotColumnList(ctx context.Context, tx *sql.Tx, table string) (string, error) {
-	rows, err := tx.QueryContext(ctx, `
+func quotePullIdentifier(identifier string) string {
+	return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
+}
+
+func pullSnapshotColumnList(ctx context.Context, db ignoredSnapshotConn, table string) (string, error) {
+	rows, err := db.QueryContext(ctx, `
 		SELECT column_name
 		FROM information_schema.columns
 		WHERE table_schema = DATABASE() AND table_name = ?
@@ -4483,6 +4657,18 @@ func pullSnapshotColumnList(ctx context.Context, tx *sql.Tx, table string) (stri
 	return strings.Join(columns, ", "), nil
 }
 
+func restoreDirtyIgnoredTablesAfterRollback(ctx context.Context, conn *sql.Conn, snapshots []ignoredTableSnapshot) error {
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if err := restoreDirtyIgnoredTables(ctx, tx, snapshots); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
 func restoreDirtyIgnoredTables(ctx context.Context, tx *sql.Tx, snapshots []ignoredTableSnapshot) error {
 	if len(snapshots) == 0 {
 		return nil
@@ -4491,7 +4677,7 @@ func restoreDirtyIgnoredTables(ctx context.Context, tx *sql.Tx, snapshots []igno
 		return err
 	}
 	for i := len(snapshots) - 1; i >= 0; i-- {
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DROP TABLE `%s`", snapshots[i].table)); err != nil {
+		if _, err := tx.ExecContext(ctx, "DROP TABLE "+quotePullIdentifier(snapshots[i].table)); err != nil {
 			return fmt.Errorf("drop reset %s: %w", snapshots[i].table, err)
 		}
 	}
@@ -4501,7 +4687,7 @@ func restoreDirtyIgnoredTables(ctx context.Context, tx *sql.Tx, snapshots []igno
 		}
 	}
 	for _, snapshot := range snapshots {
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf("INSERT INTO `%s` (%s) SELECT %s FROM `%s`", snapshot.table, snapshot.columns, snapshot.columns, snapshot.temp)); err != nil {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf("INSERT INTO %s (%s) SELECT %s FROM %s", quotePullIdentifier(snapshot.table), snapshot.columns, snapshot.columns, quotePullIdentifier(snapshot.temp))); err != nil {
 			return fmt.Errorf("restore %s: %w", snapshot.table, err)
 		}
 	}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -4325,6 +4325,12 @@ func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote str
 		return pullReport{}, fmt.Errorf("failed to set dolt_force_transaction_commit: %w", err)
 	}
 
+	ignoredSnapshots, err := snapshotDirtyIgnoredTables(ctx, tx)
+	if err != nil {
+		_ = tx.Rollback()
+		return pullReport{}, fmt.Errorf("snapshot ignored tables before pull: %w", err)
+	}
+
 	// DOLT_PULL's row is the engine's only in-band account of what the pull
 	// did: `dolt pull` on the CLI exits 0 whether it merged or was already up
 	// to date, and so does this CALL. Capturing it costs nothing — the drain
@@ -4358,7 +4364,149 @@ func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote str
 		pullErr = mergeErr
 	}
 
+	if err := restoreDirtyIgnoredTables(ctx, tx, ignoredSnapshots); err != nil {
+		_ = tx.Rollback()
+		return pullReport{}, fmt.Errorf("restore ignored tables after pull: %w", err)
+	}
+
 	return report, s.settleMergeInTx(ctx, tx, pullErr)
+}
+
+// ignoredPullTables are local-only tables that Beads intentionally excludes
+// from Dolt commits. A merge still refuses a dirty ignored table, so SQL pulls
+// temporarily move these rows into connection-local tables and restore them
+// after the remote operation.
+var ignoredPullTables = []string{
+	"ignored_schema_migrations",
+	"local_metadata",
+	"repo_mtimes",
+	"wisps",
+	"wisp_labels",
+	"wisp_dependencies",
+	"wisp_events",
+	"wisp_comments",
+}
+
+type ignoredTableSnapshot struct {
+	table   string
+	temp    string
+	columns string
+	ddl     string
+}
+
+func snapshotDirtyIgnoredTables(ctx context.Context, tx *sql.Tx) ([]ignoredTableSnapshot, error) {
+	dirty := make(map[string]bool)
+	rows, err := tx.QueryContext(ctx, "SELECT table_name FROM dolt_status")
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var table string
+		if err := rows.Scan(&table); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		dirty[table] = true
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	var snapshots []ignoredTableSnapshot
+	for _, table := range ignoredPullTables {
+		if !dirty[table] {
+			continue
+		}
+		temp := "__beads_pull_" + table
+		columns, err := pullSnapshotColumnList(ctx, tx, table)
+		if err != nil {
+			return nil, err
+		}
+		var ddlTable, ddl string
+		if err := tx.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE `%s`", table)).Scan(&ddlTable, &ddl); err != nil {
+			return nil, err
+		}
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf("CREATE TEMPORARY TABLE `%s` LIKE `%s`", temp, table)); err != nil {
+			return nil, err
+		}
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf("INSERT INTO `%s` (%s) SELECT %s FROM `%s`", temp, columns, columns, table)); err != nil {
+			return nil, err
+		}
+		snapshots = append(snapshots, ignoredTableSnapshot{table: table, temp: temp, columns: columns, ddl: ddl})
+	}
+
+	if len(snapshots) == 0 {
+		return nil, nil
+	}
+	if _, err := tx.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
+		return nil, err
+	}
+	for i := len(snapshots) - 1; i >= 0; i-- {
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", snapshots[i].table); err != nil {
+			return nil, err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
+		return nil, err
+	}
+	return snapshots, nil
+}
+
+func pullSnapshotColumnList(ctx context.Context, tx *sql.Tx, table string) (string, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT column_name
+		FROM information_schema.columns
+		WHERE table_schema = DATABASE() AND table_name = ?
+		ORDER BY ordinal_position`, table)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var columns []string
+	for rows.Next() {
+		var column string
+		if err := rows.Scan(&column); err != nil {
+			return "", err
+		}
+		columns = append(columns, "`"+strings.ReplaceAll(column, "`", "``")+"`")
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	if len(columns) == 0 {
+		return "", fmt.Errorf("ignored table %s has no columns", table)
+	}
+	return strings.Join(columns, ", "), nil
+}
+
+func restoreDirtyIgnoredTables(ctx context.Context, tx *sql.Tx, snapshots []ignoredTableSnapshot) error {
+	if len(snapshots) == 0 {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
+		return err
+	}
+	for i := len(snapshots) - 1; i >= 0; i-- {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DROP TABLE `%s`", snapshots[i].table)); err != nil {
+			return fmt.Errorf("drop reset %s: %w", snapshots[i].table, err)
+		}
+	}
+	for _, snapshot := range snapshots {
+		if _, err := tx.ExecContext(ctx, snapshot.ddl); err != nil {
+			return fmt.Errorf("recreate %s: %w", snapshot.table, err)
+		}
+	}
+	for _, snapshot := range snapshots {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf("INSERT INTO `%s` (%s) SELECT %s FROM `%s`", snapshot.table, snapshot.columns, snapshot.columns, snapshot.temp)); err != nil {
+			return fmt.Errorf("restore %s: %w", snapshot.table, err)
+		}
+	}
+	_, err := tx.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 1")
+	return err
 }
 
 // settleMergeInTx finishes a pull/merge that ran in tx: it auto-resolves the

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -3797,11 +3797,7 @@ func (s *DoltStore) doltCLIPush(ctx context.Context, remote string, force bool, 
 	if err := s.prePushFSCK(ctx); err != nil {
 		return err
 	}
-	args := []string{"push"}
-	if force {
-		args = append(args, "--force")
-	}
-	args = append(args, remote, s.branch)
+	args := doltCLIPushArgs(remote, s.branch, force, creds)
 	cmd, transferCtx, cancel := s.prepareDoltCLITransfer(ctx, remote, creds, args...)
 	defer cancel()
 	applyNoGitHooksToCmd(cmd) // GH#3724
@@ -3810,6 +3806,15 @@ func (s *DoltStore) doltCLIPush(ctx context.Context, remote string, force bool, 
 		return cliTransferError("dolt push", remote, transferCtx, out, err)
 	}
 	return nil
+}
+
+func doltCLIPushArgs(remote, branch string, force bool, creds *remoteCredentials) []string {
+	args := []string{"push"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = appendDoltRemoteUser(args, creds)
+	return append(args, remote, branch)
 }
 
 // cliTransferError wraps a failed CLI transfer, distinguishing a transfer that
@@ -3827,13 +3832,29 @@ func cliTransferError(op, remote string, transferCtx context.Context, out []byte
 // Used for git-protocol remotes where CALL DOLT_PULL times out through the SQL connection.
 // If creds is non-nil, credentials are set on the subprocess environment only.
 func (s *DoltStore) doltCLIPull(ctx context.Context, remote string, creds *remoteCredentials) error {
-	cmd, transferCtx, cancel := s.prepareDoltCLITransfer(ctx, remote, creds, "pull", remote, s.branch)
+	args := doltCLIPullArgs(remote, s.branch, creds)
+	cmd, transferCtx, cancel := s.prepareDoltCLITransfer(ctx, remote, creds, args...)
 	defer cancel()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return cliTransferError("dolt pull", remote, transferCtx, out, err)
 	}
 	return nil
+}
+
+func doltCLIPullArgs(remote, branch string, creds *remoteCredentials) []string {
+	args := appendDoltRemoteUser([]string{"pull"}, creds)
+	return append(args, remote, branch)
+}
+
+// appendDoltRemoteUser adds the username required by authenticated remotes API
+// transfers. DOLT_REMOTE_PASSWORD supplies only the password; the Dolt CLI
+// does not infer --user from DOLT_REMOTE_USER.
+func appendDoltRemoteUser(args []string, creds *remoteCredentials) []string {
+	if creds != nil && creds.username != "" {
+		return append(args, "--user", creds.username)
+	}
+	return args
 }
 
 // Push pushes commits to the remote.

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -38,6 +38,18 @@ func defaultStderr() io.Writer {
 
 const largeRigThreshold = 10000
 
+// AllowDirtyIgnoredMigrateEnv is an operator-only escape hatch for a clone
+// whose pending ignored migrations must transform pre-existing clone-local
+// rows. It is deliberately separate from BD_ALLOW_REMOTE_MIGRATE: selecting a
+// single remote migrator does not, by itself, authorize rewriting dirty local
+// state. Operators must stop every writer and take a cold backup before using
+// this override.
+const AllowDirtyIgnoredMigrateEnv = "BD_ALLOW_DIRTY_IGNORED_MIGRATE"
+
+func allowDirtyIgnoredMigrate() bool {
+	return os.Getenv(AllowDirtyIgnoredMigrateEnv) == "1"
+}
+
 // issueRowCounter returns the current issues-table row count, or an error if
 // the table is unreachable (fresh install → table doesn't exist yet). The
 // caller uses the error as the "no warning" signal. Variable so tests in this
@@ -600,7 +612,7 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	if err != nil {
 		return applied, fmt.Errorf("checking dirty tables against pending ignored migrations: %w", err)
 	}
-	if len(touchedIgnoredDirtyTables) > 0 {
+	if len(touchedIgnoredDirtyTables) > 0 && !allowDirtyIgnoredMigrate() {
 		// Deliberately a plain, untyped error (unlike the main-source guard
 		// above, which returns *DirtyTablesError): this check fires mid-pass,
 		// after the main-source migrations have already applied. A lenient
@@ -611,7 +623,10 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 		// tables like ignored_schema_migrations), not expected user data, so
 		// there is no dirty-commit recovery story to support here the way
 		// there is for the main-source guard (#4566 scope).
-		return applied, fmt.Errorf("pending ignored schema migrations alter pre-existing dirty tables: %s", strings.Join(touchedIgnoredDirtyTables, ", "))
+		return applied, fmt.Errorf("pending ignored schema migrations alter pre-existing dirty tables: %s; after stopping all writers and taking a cold backup, the designated migrator may set %s=1", strings.Join(touchedIgnoredDirtyTables, ", "), AllowDirtyIgnoredMigrateEnv)
+	}
+	if len(touchedIgnoredDirtyTables) > 0 {
+		fmt.Fprintf(stderr, "Warning: %s=1: migrating pre-existing clone-local ignored tables in place: %s\n", AllowDirtyIgnoredMigrateEnv, strings.Join(touchedIgnoredDirtyTables, ", "))
 	}
 
 	appliedIgnored, ignoredColumnAdded, err := ignoredSource.migrate(ctx, db, 0)

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -143,6 +143,27 @@ func TestIgnoredPendingMigrationDirtyTablesDetectsWispDependencies(t *testing.T)
 	}
 }
 
+func TestAllowDirtyIgnoredMigrateRequiresExactOperatorOptIn(t *testing.T) {
+	t.Setenv(AllowDirtyIgnoredMigrateEnv, "")
+	if allowDirtyIgnoredMigrate() {
+		t.Fatal("empty override enabled dirty ignored-table migration")
+	}
+
+	for _, value := range []string{"true", "TRUE", "yes", "0", " 1"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv(AllowDirtyIgnoredMigrateEnv, value)
+			if allowDirtyIgnoredMigrate() {
+				t.Fatalf("%s=%q enabled migration; want exact value 1 only", AllowDirtyIgnoredMigrateEnv, value)
+			}
+		})
+	}
+
+	t.Setenv(AllowDirtyIgnoredMigrateEnv, "1")
+	if !allowDirtyIgnoredMigrate() {
+		t.Fatalf("%s=1 did not enable designated maintenance migration", AllowDirtyIgnoredMigrateEnv)
+	}
+}
+
 func TestMigrationSQLTouchesTableStatementForms(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/storage/versioncontrolops/fastforward_test.go
+++ b/internal/storage/versioncontrolops/fastforward_test.go
@@ -85,6 +85,43 @@ func TestLocalIsStrictAncestorOfInvalidRef(t *testing.T) {
 	}
 }
 
+func TestHeadEqualsRef(t *testing.T) {
+	tests := []struct {
+		name string
+		head string
+		ref  string
+		want bool
+	}{
+		{name: "equal", head: "abc123", ref: "abc123", want: true},
+		{name: "different", head: "abc123", ref: "def456", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock.New: %v", err)
+			}
+			defer db.Close()
+
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT HASHOF('HEAD'), HASHOF(?)")).
+				WithArgs("origin/main").
+				WillReturnRows(sqlmock.NewRows([]string{"head_hash", "ref_hash"}).AddRow(tt.head, tt.ref))
+
+			got, err := HeadEqualsRef(context.Background(), db, "origin/main")
+			if err != nil {
+				t.Fatalf("HeadEqualsRef: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("HeadEqualsRef = %v, want %v", got, tt.want)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestWorkingSetClean(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/storage/versioncontrolops/remotes.go
+++ b/internal/storage/versioncontrolops/remotes.go
@@ -127,8 +127,43 @@ func PullWithStrategy(ctx context.Context, db DBConn, remote, branch, user, stra
 		return fmt.Errorf("fetch from %s/%s: %w", remote, branch, err)
 	}
 	trackingRef := remote + "/" + branch
+	// Since events moved to the ignored plane in schema 0062, a healthy clone
+	// intentionally carries durable working-set-only rows. Dolt 2.3.1 refuses
+	// DOLT_MERGE with "cannot merge with uncommitted changes" even when the
+	// fetched tracking ref is already byte-for-byte HEAD. Avoid asking Dolt to
+	// perform a no-op merge in that case. This is also cheaper than invoking the
+	// full settlement path after every successful sync.
+	equal, err := HeadEqualsRef(ctx, db, trackingRef)
+	if err != nil {
+		return fmt.Errorf("compare HEAD with %s after fetch: %w", trackingRef, err)
+	}
+	if equal {
+		return nil
+	}
 	if err := MergeAndSettleWithStrategy(ctx, db, trackingRef, strategy); err != nil {
 		return fmt.Errorf("merge %s: %w", trackingRef, err)
 	}
 	return nil
+}
+
+// HeadEqualsRef reports whether the current branch head is exactly ref. It
+// compares commit hashes rather than working roots so ignored working-set
+// tables cannot make an already-synchronized branch look dirty or divergent.
+func HeadEqualsRef(ctx context.Context, db DBConn, ref string) (bool, error) {
+	rows, err := db.QueryContext(ctx, "SELECT HASHOF('HEAD'), HASHOF(?)", ref)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return false, err
+		}
+		return false, fmt.Errorf("hash comparison returned no row")
+	}
+	var headHash, refHash string
+	if err := rows.Scan(&headHash, &refHash); err != nil {
+		return false, err
+	}
+	return headHash == refHash, nil
 }


### PR DESCRIPTION
## What

Make authenticated Dolt remotes work in both supported ownership models:

- Native CLI transfers now pass the configured remote username with `--user`.
- `BEADS_DOLT_SERVER_OWNS_REMOTE_CREDENTIALS=1` routes HTTP remotes through the SQL server, so the client process does not need the remote password.
- SQL pulls temporarily snapshot dirty local-only tables, reset them for the merge, and restore their schema and rows before commit.

## Why

The CLI consumes the password from its environment but does not infer `--user` from `DOLT_REMOTE_USER`, so authenticated pulls and pushes could fail despite valid credentials.

In shared-server deployments, putting the password in every interactive client session defeats server-side credential ownership. Routing through `CALL DOLT_PULL` / `CALL DOLT_PUSH` keeps that password in the server process while retaining an explicit non-secret username.

That SQL route exposed a second failure: dirty ignored tables such as `local_metadata`, migrations, and wisps can make Dolt reject a merge. These tables are deliberately local-only, so the pull transaction now preserves them across the merge instead of requiring users to discard local state.

This is separate from the federation credential work in #5214 and #5215; those changes do not add the missing CLI username, server-owned routing, or local-table preservation.

## Verification

- `go test ./internal/storage/dolt -run 'Test(DoltCLITransferArgsIncludeRemoteUser|ServerOwnedRemoteCredentialsDisableCLIRouting|IgnoredTableSnapshotRoundTrip)$' -count=1`
- Full `./scripts/test.sh ./internal/storage/dolt/...` on the v1.2.2 backport branch
- `make ci-pr-lint` with golangci-lint v2.10.1, including the Windows lint pass
- Live authenticated pull and push through a shared Dolt SQL server with no remote password in the client environment

The broader package run on this checkout is currently obstructed by an unrelated local Dolt listener already occupying the test suite's fixed port 3308; the focused tests and exact lint gates pass.
