### PR TITLE
fix(list,query): emit truncation signals for piped and JSON consumers (#5102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   converged falls through to the locked path unchanged, as does any caller
   carrying fresh-bootstrap heal authority.
 
+- **`bd list` and `bd query` now signal a `--limit`-capped page to every
+  consumer** ([#5974](https://github.com/gastownhall/beads/pull/5974), closes the
+  actionable half of [#5102](https://github.com/gastownhall/beads/issues/5102)).
+  The stderr truncation hint was gated on stderr being a terminal, so pipes and
+  `--json` callers - exactly the consumers that cannot tell a partial page is
+  partial - got a silently capped list. The hint now always fires when a
+  caller-set limit cut the page (since #4094 piped stdout never applies the
+  default limit), and under `BD_JSON_ENVELOPE=1` both commands carry the same
+  `pagination {returned, truncated}` key `bd ready` gained in #4892. Stdout is
+  untouched on every route.
+
 - **Incremental auto-export now actually takes the incremental path**
   ([#5806](https://github.com/gastownhall/beads/pull/5806)). Change detection
   compared `GetStateHash()` values — a hash of the entire database plus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,9 +229,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   actionable half of [#5102](https://github.com/gastownhall/beads/issues/5102)).
   The stderr truncation hint was gated on stderr being a terminal, so pipes and
   `--json` callers - exactly the consumers that cannot tell a partial page is
-  partial - got a silently capped list. The hint now always fires when a
-  caller-set limit cut the page (since #4094 piped stdout never applies the
-  default limit), and under `BD_JSON_ENVELOPE=1` both commands carry the same
+  partial - got a silently capped list. The hint now always fires when the
+  effective limit cut the page. Piped `bd list` does not apply its default
+  limit (since #4094), while `bd query` still has an effective default of 50
+  even when piped. Under `BD_JSON_ENVELOPE=1` both commands carry the same
   `pagination {returned, truncated}` key `bd ready` gained in #4892. Stdout is
   untouched on every route.
 

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -55,13 +55,24 @@ func buildEmbeddedBD(t *testing.T) string {
 		cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", embeddedBD, ".")
 		// A compiled test binary can be launched from any directory. Build from
 		// this source file's package directory rather than inheriting that
-		// arbitrary process working directory.
-		_, sourceFile, _, ok := runtime.Caller(0)
-		if !ok {
-			embeddedBDErr = fmt.Errorf("locate embedded bd test source directory")
-			return
+		// arbitrary process working directory. Under -trimpath runtime.Caller
+		// records the import path, not a filesystem path, so fall back to
+		// resolving the package through whatever module context the cwd has.
+		if _, sourceFile, _, ok := runtime.Caller(0); ok && filepath.IsAbs(sourceFile) {
+			if dir := filepath.Dir(sourceFile); dir != "" {
+				if fi, statErr := os.Stat(dir); statErr == nil && fi.IsDir() {
+					cmd.Dir = dir
+				}
+			}
 		}
-		cmd.Dir = filepath.Dir(sourceFile)
+		if cmd.Dir == "" {
+			out, err := exec.Command("go", "list", "-f", "{{.Dir}}", "github.com/steveyegge/beads/cmd/bd").Output()
+			if err != nil || strings.TrimSpace(string(out)) == "" {
+				embeddedBDErr = fmt.Errorf("cannot locate the cmd/bd source directory (test binary built with -trimpath and no module context in the working directory); set BEADS_TEST_BD_BINARY to a prebuilt bd binary")
+				return
+			}
+			cmd.Dir = strings.TrimSpace(string(out))
+		}
 		if out, err := cmd.CombinedOutput(); err != nil {
 			embeddedBDErr = fmt.Errorf("go build failed: %v\n%s", err, out)
 		}

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -31,6 +32,12 @@ var (
 // buildEmbeddedBD returns the path to an embedded bd binary for subprocess tests.
 // If BEADS_TEST_BD_BINARY is set, uses that pre-built binary (skipping the ~45s build).
 // CI can pre-build once and pass the path to all test invocations.
+// errEmbeddedBDSourceUnavailable: the test binary was built with -trimpath
+// (runtime.Caller records the import path, not a filesystem path) and the
+// process working directory has no module context to resolve the package
+// through, so there is no source tree to build bd from.
+var errEmbeddedBDSourceUnavailable = errors.New("cannot locate the cmd/bd source directory (test binary built with -trimpath and no module context in the working directory); set BEADS_TEST_BD_BINARY to a prebuilt bd binary")
+
 func buildEmbeddedBD(t *testing.T) string {
 	t.Helper()
 	embeddedBDOnce.Do(func() {
@@ -68,7 +75,7 @@ func buildEmbeddedBD(t *testing.T) string {
 		if cmd.Dir == "" {
 			out, err := exec.Command("go", "list", "-f", "{{.Dir}}", "github.com/steveyegge/beads/cmd/bd").Output()
 			if err != nil || strings.TrimSpace(string(out)) == "" {
-				embeddedBDErr = fmt.Errorf("cannot locate the cmd/bd source directory (test binary built with -trimpath and no module context in the working directory); set BEADS_TEST_BD_BINARY to a prebuilt bd binary")
+				embeddedBDErr = errEmbeddedBDSourceUnavailable
 				return
 			}
 			cmd.Dir = strings.TrimSpace(string(out))
@@ -77,6 +84,12 @@ func buildEmbeddedBD(t *testing.T) string {
 			embeddedBDErr = fmt.Errorf("go build failed: %v\n%s", err, out)
 		}
 	})
+	if errors.Is(embeddedBDErr, errEmbeddedBDSourceUnavailable) {
+		// Same posture as testenv.MustHaveGoBuild: a test that needs to build
+		// bd from source cannot run where the source is unreachable, and
+		// that is a skip with a pointer, not a failure of the code under test.
+		t.Skipf("skipping: %v", embeddedBDErr)
+	}
 	if embeddedBDErr != nil {
 		t.Fatalf("Failed to build embedded bd binary: %v", embeddedBDErr)
 	}

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -53,6 +53,15 @@ func buildEmbeddedBD(t *testing.T) string {
 		}
 		embeddedBD = filepath.Join(tmpDir, name)
 		cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", embeddedBD, ".")
+		// A compiled test binary can be launched from any directory. Build from
+		// this source file's package directory rather than inheriting that
+		// arbitrary process working directory.
+		_, sourceFile, _, ok := runtime.Caller(0)
+		if !ok {
+			embeddedBDErr = fmt.Errorf("locate embedded bd test source directory")
+			return
+		}
+		cmd.Dir = filepath.Dir(sourceFile)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			embeddedBDErr = fmt.Errorf("go build failed: %v\n%s", err, out)
 		}
@@ -67,6 +76,13 @@ func bdEnv(dir string) []string {
 	var env []string
 	for _, e := range os.Environ() {
 		if strings.HasPrefix(e, "BEADS_") {
+			continue
+		}
+		// An ambient envelope opt-in would wrap every fixture command's JSON
+		// in {schema_version, data} and break the bare-array parsing all the
+		// bdList*JSON helpers do. Tests that want the envelope opt in per
+		// child command (exec.Cmd keeps the last duplicate env entry).
+		if strings.HasPrefix(e, "BD_JSON_ENVELOPE=") {
 			continue
 		}
 		env = append(env, e)

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -270,14 +270,15 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 			}
 			return HandleError("%v", err)
 		}
+		pag := listPaginationMeta(len(page.Items), page.HasMore, in.effectiveLimit)
 		if in.SkipLabels {
-			if err := outputJSON(newSkipLabelsListJSONResponse(page.Items)); err != nil {
+			if err := outputJSONWithPagination(newSkipLabelsListJSONResponse(page.Items), pag); err != nil {
 				return err
 			}
 			printTruncationHint(page.HasMore, in.effectiveLimit)
 			return nil
 		}
-		if err := outputJSON(page.Items); err != nil {
+		if err := outputJSONWithPagination(page.Items, pag); err != nil {
 			return err
 		}
 		printTruncationHint(page.HasMore, in.effectiveLimit)

--- a/cmd/bd/list_embedded_test.go
+++ b/cmd/bd/list_embedded_test.go
@@ -254,11 +254,12 @@ func TestEmbeddedList(t *testing.T) {
 	})
 
 	t.Run("limit_truncation_hint", func(t *testing.T) {
-		// GH#4094: hint is suppressed when stderr is not a terminal (piped).
-		// bdListCapture always runs in piped mode, so no hint expected even when truncated.
+		// GH#5102: the hint fires on stderr even when piped, matching bd
+		// ready — a piped consumer is exactly who can't tell a partial page
+		// is partial. bdListCapture always runs in piped mode.
 		stdout, stderr := bdListCapture(t, bd, dir, "--limit", "2")
-		if strings.Contains(stderr, "more results matched") {
-			t.Errorf("truncation hint must not appear on piped stderr (GH#4094):\nstderr: %q\nstdout: %q", stderr, stdout)
+		if !strings.Contains(stderr, "more results matched") {
+			t.Errorf("expected truncation hint on piped stderr (GH#5102):\nstderr: %q\nstdout: %q", stderr, stdout)
 		}
 		// Hint must never appear in stdout.
 		if strings.Contains(stdout, "more results matched") {
@@ -276,6 +277,50 @@ func TestEmbeddedList(t *testing.T) {
 		_, stderrHigh := bdListCapture(t, bd, dir, "--limit", "1000")
 		if strings.Contains(stderrHigh, "more results matched") {
 			t.Errorf("false-positive truncation hint when under limit:\n%s", stderrHigh)
+		}
+	})
+
+	t.Run("limit_pagination_envelope", func(t *testing.T) {
+		// GH#5102: under BD_JSON_ENVELOPE=1 a truncated page carries a
+		// "pagination" key (returned/truncated), parity with bd ready
+		// (GH#4892). Total is absent: this route has a has-more verdict,
+		// not a count.
+		runEnvelope := func(args ...string) map[string]json.RawMessage {
+			t.Helper()
+			fullArgs := append([]string{"list", "--json"}, args...)
+			cmd := exec.Command(bd, fullArgs...)
+			cmd.Dir = dir
+			cmd.Env = append(bdEnv(dir), "BD_JSON_ENVELOPE=1")
+			stdout, stderr, err := runCommandBuffers(t, cmd)
+			if err != nil {
+				t.Fatalf("bd list --json %s failed: %v\nstderr:\n%s", strings.Join(args, " "), err, stderr.String())
+			}
+			var env map[string]json.RawMessage
+			if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &env); err != nil {
+				t.Fatalf("parse envelope: %v\n%s", err, stdout.String())
+			}
+			return env
+		}
+
+		env := runEnvelope("--limit", "2")
+		raw, ok := env["pagination"]
+		if !ok {
+			t.Fatalf("truncated page must carry a pagination key, got: %v", env)
+		}
+		var pag struct {
+			Returned  int  `json:"returned"`
+			Truncated bool `json:"truncated"`
+		}
+		if err := json.Unmarshal(raw, &pag); err != nil {
+			t.Fatalf("parse pagination: %v", err)
+		}
+		if !pag.Truncated || pag.Returned != 2 {
+			t.Errorf("pagination = %+v, want truncated=true returned=2", pag)
+		}
+
+		// Not truncated: the key must be absent so callers can test presence.
+		if envAll := runEnvelope("--limit", "0"); envAll["pagination"] != nil {
+			t.Errorf("unexpected pagination key on untruncated page: %s", envAll["pagination"])
 		}
 	})
 

--- a/cmd/bd/list_output.go
+++ b/cmd/bd/list_output.go
@@ -15,8 +15,15 @@ import (
 // printTruncationHint emits a one-line notice to stderr when the list output
 // was truncated by --limit, so users and agents can't mistake a partial view
 // for a complete one (GH#3212, GH#788).
+//
+// The notice is deliberately NOT gated on stderr being a terminal, matching
+// bd ready's unconditional hint (GH#4892): piped consumers are exactly the
+// ones that cannot see a partial page is partial (GH#5102). Since GH#4094
+// piped stdout never applies the default limit, so this fires for a piped
+// caller only when a --limit they set themselves (flag, config, or
+// BD_LIST_LIMIT) cut the page — stdout stays clean either way.
 func printTruncationHint(truncated bool, effectiveLimit int) {
-	if !truncated || effectiveLimit <= 0 || !ui.IsStderrTerminal() {
+	if !truncated || effectiveLimit <= 0 {
 		return
 	}
 	fmt.Fprint(os.Stderr, formatTruncationHint(effectiveLimit))
@@ -36,6 +43,19 @@ func formatTruncationHint(effectiveLimit int) string {
 func composeTruncationHint(render func(string) string, text string) string {
 	rendered := strings.TrimRight(render(text), " \t\r\n")
 	return "\n" + rendered + "\n"
+}
+
+// listPaginationMeta builds the pagination entry for a truncated listing
+// page, mirroring bd ready's envelope (GH#4892). Nil when nothing was cut,
+// so the "pagination" key is absent and callers can test for its presence.
+// Total is left unset: this route's page carries a has-more verdict, not a
+// count, and inventing one would cost a second query (same trade the proxied
+// ready route made).
+func listPaginationMeta(returned int, truncated bool, effectiveLimit int) *PaginationMeta {
+	if !truncated || effectiveLimit <= 0 {
+		return nil
+	}
+	return &PaginationMeta{Returned: returned, Truncated: true}
 }
 
 func outputDotFormat(out io.Writer, issues []*types.Issue, depsByIssueID map[string][]*types.Dependency) error {

--- a/cmd/bd/list_output.go
+++ b/cmd/bd/list_output.go
@@ -19,9 +19,9 @@ import (
 // The notice is deliberately NOT gated on stderr being a terminal, matching
 // bd ready's unconditional hint (GH#4892): piped consumers are exactly the
 // ones that cannot see a partial page is partial (GH#5102). Since GH#4094
-// piped stdout never applies the default limit, so this fires for a piped
-// caller only when a --limit they set themselves (flag, config, or
-// BD_LIST_LIMIT) cut the page — stdout stays clean either way.
+// piped `bd list` stdout never applies its default limit. This fires whenever
+// the effective limit cut the page; `bd query` has an effective default of 50
+// even when piped. Stdout stays clean either way.
 func printTruncationHint(truncated bool, effectiveLimit int) {
 	if !truncated || effectiveLimit <= 0 {
 		return

--- a/cmd/bd/list_proxied_integration_test.go
+++ b/cmd/bd/list_proxied_integration_test.go
@@ -616,9 +616,13 @@ func TestProxiedServerList(t *testing.T) {
 		if len(page) != 2 {
 			t.Errorf("--limit 2 should cap at 2 rows, got %d", len(page))
 		}
-		stdout, _ := bdProxiedListCapture(t, bd, p, "--all", "--limit", "2")
+		stdout, stderr := bdProxiedListCapture(t, bd, p, "--all", "--limit", "2")
 		if strings.Contains(stdout, "more results matched") {
 			t.Errorf("truncation hint must not leak into stdout:\n%s", stdout)
+		}
+		// GH#5102: the hint reaches piped stderr on the proxied route too.
+		if !strings.Contains(stderr, "more results matched") {
+			t.Errorf("expected truncation hint on piped stderr (GH#5102), got:\n%s", stderr)
 		}
 	})
 

--- a/cmd/bd/list_proxied_server.go
+++ b/cmd/bd/list_proxied_server.go
@@ -196,11 +196,12 @@ func runListProxiedWatch(_ *cobra.Command, ctx context.Context, in listInput) er
 // workapi.FinishPage's, inside issueops.Reader.List, where the direct route's
 // are too.
 func emitProxiedListJSONResult(iwc []*types.IssueWithCounts, in listInput, hasMore bool) error {
+	pag := listPaginationMeta(len(iwc), hasMore, in.effectiveLimit)
 	var err error
 	if in.SkipLabels {
-		err = outputJSON(newSkipLabelsListJSONResponse(iwc))
+		err = outputJSONWithPagination(newSkipLabelsListJSONResponse(iwc), pag)
 	} else {
-		err = outputJSON(iwc)
+		err = outputJSONWithPagination(iwc, pag)
 	}
 	if err != nil {
 		return err

--- a/cmd/bd/max_rows_test.go
+++ b/cmd/bd/max_rows_test.go
@@ -573,11 +573,10 @@ func TestEmbeddedMaxRowsList(t *testing.T) {
 	// comment in list.go for why this can't false-negative a real
 	// violation. Covered directly (bump values, not exit behavior) by
 	// TestWithFetchOneExtra_LimitEqualsCap_BumpsBothForTruncationProbe
-	// below, since printTruncationHint's text is gated on
-	// ui.IsStderrTerminal() and unconditionally suppressed for this
-	// subprocess harness's piped stderr (see list_embedded_test.go's
-	// limit_truncation_hint subtest) — these end-to-end subtests can only
-	// assert the absence of the false cap error and the delivered count.
+	// below. Since GH#5102 the notice also reaches this harness's piped
+	// stderr (see list_embedded_test.go's limit_truncation_hint subtest);
+	// these end-to-end subtests still only assert the absence of the false
+	// cap error and the delivered count.
 	t.Run("LimitEqualsCap_TruncatesNotErrors", func(t *testing.T) {
 		out, code := bdRunRaw(t, bd, dir, nil, "list",
 			"--limit", "5", "--max-rows", "5")
@@ -705,12 +704,8 @@ func TestEmbeddedMaxRowsList(t *testing.T) {
 // user's --limit (be-x42v.4 round-3 follow-up).
 //
 // The end-to-end LimitEqualsCap_TruncatesNotErrors subprocess test in
-// TestEmbeddedMaxRowsList can only assert the *absence* of the false cap
-// error and the trimmed row count — it can't observe the truncation
-// *notice* text, which printTruncationHint gates on ui.IsStderrTerminal()
-// and is unconditionally suppressed for a subprocess's piped stderr (see
-// list_embedded_test.go's limit_truncation_hint subtest, which documents
-// the same TTY constraint). This unit test instead asserts the underlying
+// TestEmbeddedMaxRowsList asserts the absence of the false cap error and
+// the trimmed row count. This unit test instead asserts the underlying
 // signal directly: with Limit==MaxRows, both must bump by one so the query
 // still over-fetches by one row (restoring len(results) > effectiveLimit
 // detection) while EnforceMaxRowsCap doesn't trip on that extra row.

--- a/cmd/bd/proxied_integration_helpers_test.go
+++ b/cmd/bd/proxied_integration_helpers_test.go
@@ -40,6 +40,13 @@ func bdProxiedEnv(dir string) []string {
 		if strings.HasPrefix(e, "BEADS_") {
 			continue
 		}
+		// Same scrub as bdEnv: an ambient envelope opt-in would wrap every
+		// fixture command's JSON in {schema_version, data} and break the
+		// bare-array parsing the proxied helpers do. Tests that want the
+		// envelope opt in per child command.
+		if strings.HasPrefix(e, "BD_JSON_ENVELOPE=") {
+			continue
+		}
 		env = append(env, e)
 	}
 	return append(env,

--- a/cmd/bd/query.go
+++ b/cmd/bd/query.go
@@ -195,7 +195,7 @@ func runQuery(ctx context.Context, querier issueops.Querier, in queryInput) erro
 		return HandleErrorRespectJSON("%v", err)
 	}
 	if jsonOutput {
-		if err := outputJSON(page.Items); err != nil {
+		if err := outputJSONWithPagination(page.Items, listPaginationMeta(len(page.Items), page.HasMore, in.limit)); err != nil {
 			return err
 		}
 	} else {

--- a/cmd/bd/query_proxied_integration_test.go
+++ b/cmd/bd/query_proxied_integration_test.go
@@ -173,9 +173,13 @@ func TestProxiedServerQuery(t *testing.T) {
 		if len(page) != 2 {
 			t.Errorf("--limit 2 should cap at 2 rows, got %d", len(page))
 		}
-		stdout, _ := bdProxiedQueryCapture(t, bd, p, "priority>=0", "--all", "--limit", "2")
+		stdout, stderr := bdProxiedQueryCapture(t, bd, p, "priority>=0", "--all", "--limit", "2")
 		if strings.Contains(stdout, "more results matched") {
 			t.Errorf("truncation hint must not leak into stdout:\n%s", stdout)
+		}
+		// GH#5102: the hint reaches piped stderr on the proxied route too.
+		if !strings.Contains(stderr, "more results matched") {
+			t.Errorf("expected truncation hint on piped stderr (GH#5102), got:\n%s", stderr)
 		}
 	})
 

--- a/docs/reference/json-schema.md
+++ b/docs/reference/json-schema.md
@@ -31,15 +31,18 @@ Every `--json` command wraps output as:
 The original payload is untouched inside `.data` — no type corruption,
 no field injection. Works identically for objects, arrays, and maps.
 
-When a `--limit`-truncated listing runs in envelope mode (currently wired
-for `bd ready`), the envelope also carries a `pagination` key:
+When a `--limit`-truncated listing runs in envelope mode (`bd ready`,
+`bd list`, `bd query`), the envelope also carries a `pagination` key:
 
 ```json
 {"schema_version": 1, "data": [...], "pagination": {"returned": 10, "total": 42, "truncated": true}}
 ```
 
-`total` is omitted when unknown; the whole `pagination` key is absent when
-the result was not truncated. Legacy mode keeps the stderr text hint instead.
+`total` is omitted when unknown (`bd list` and `bd query` report only
+`returned` and `truncated`: their page carries a has-more verdict, not a
+count); the whole `pagination` key is absent when the result was not
+truncated. The stderr text hint is emitted in both legacy and envelope
+mode, tty or not, so piped callers can detect a capped page either way.
 
 ### Updating consumers
 


### PR DESCRIPTION
## Why

`bd list` and `bd query` can silently hand a piped or `--json` caller a capped page. `printTruncationHint` (`cmd/bd/list_output.go`) bails when stderr is not a terminal, so exactly the consumers that cannot tell a partial page is partial - pipes, scripts, agents - never see the hint. `bd ready` was fixed for this in #4892 (unconditional stderr hint plus a `pagination` key under `BD_JSON_ENVELOPE=1`); `list` and `query` never got the same treatment. This is the surviving core of #5102.

Un-gating makes the hint fire whenever the effective limit cuts the page. Piped `bd list` does not apply its default limit after #4094/#4158, while `bd query` still has an effective default limit of 50 even when piped. Stdout is untouched on every route.

## What

- `printTruncationHint`: drop the `ui.IsStderrTerminal()` gate. Covers `bd list` direct and proxied, `bd query`, and the filter modes that share the helper.
- New `listPaginationMeta` mirrors the #4892 envelope on `bd list`/`bd query --json` (direct and proxied): `pagination: {returned, truncated: true}` when a page was cut, key absent otherwise. `total` stays unset because these routes carry a has-more verdict, not a count; inventing one would cost a second query (same trade the proxied ready route made).
- Tests: `limit_truncation_hint` now asserts the hint is present on piped stderr; new `limit_pagination_envelope` subtest; proxied list/query subtests assert the stderr hint; stale tty-gate comments updated.
- Test-hermeticity fixes surfaced by adversarial review, kept as separate commits: `bdEnv` and `bdProxiedEnv` now strip ambient `BD_JSON_ENVELOPE` (tests that want it opt in per child command), and `buildEmbeddedBD` resolves the package dir correctly under `-trimpath` instead of treating `runtime.Caller`'s import path as a filesystem path; when no source tree is reachable at all it skips with a pointer to `BEADS_TEST_BD_BINARY` (the `testenv.MustHaveGoBuild` posture) rather than failing on a bogus chdir.

## Out of scope

The literal `100/423` shown/total footer from #5102 needs a `COUNT(*)` beside every page and intersects the #4776 default-cap discussion; left for that thread. This PR closes the "machine consumer can detect truncation without a second query" property, which was the actionable half.

## Validation

The 2026-09-09 refresh merges current `main` and corrects limit wording without changing execution behavior.

- Go 1.26.5: `go test -tags=gms_pure_go -run '^TestFormatTruncationHintExactBytes$|^TestComposeTruncationHintRejectsLipglossBlankLinePadding$' ./cmd/bd` passed.
- `git diff --check` passed.
- The embedded regression selector is `^TestEmbeddedList$/^(limit_truncation_hint|limit_pagination_envelope)$|^TestEmbeddedMaxRows|^TestWithFetchOneExtra`; the previously documented `^TestMaxRows` matched no tests. This refresh does not claim a completed run of that broader selector.
- Earlier implementation commits underwent adversarial and cross-vendor review, including the test-isolation and pagination-documentation fixes. Those results predate this refresh; current CI must validate the refreshed head.

Related: #5102 (core), #3212 / #3409 (closed predecessors), #4094 / #4776 (adjacent).

Original implementation and prior validation: Claude Fable 5.

_codex-gpt-6-astra-medium on behalf of matt wilkie_
