### PR TITLE
fix(doctor): ignore the generated dolt-server-config.yaml

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -65,6 +65,7 @@ dolt-server.log
 dolt-server.lock
 dolt-server.port
 dolt-server.activity
+dolt-server-config.yaml
 
 # Debug-mode pprof artifacts (written when dolt.debug: true in config.yaml)
 dolt-pprof/
@@ -129,6 +130,7 @@ var requiredPatterns = []string{
 	"dolt-server.lock",
 	"dolt-server.port",
 	"dolt-server.activity",
+	"dolt-server-config.yaml",
 	"daemon.*",
 	"*.lock",
 	"*.corrupt.backup/",

--- a/cmd/bd/doctor/gitignore_test.go
+++ b/cmd/bd/doctor/gitignore_test.go
@@ -1522,6 +1522,39 @@ func TestRequiredPatterns_ContainsSyncStatePatterns(t *testing.T) {
 	}
 }
 
+// TestGitignore_ContainsDoltServerConfig verifies that the generated Dolt
+// server config is ignored like the other dolt-server.* runtime state files
+// it sits beside. doltserver.Start() writes .beads/dolt-server-config.yaml
+// when the resolved dolt binary supports auto_gc_behavior.archive_level, and
+// it holds an absolute cfg_dir plus a per-machine port, so committing it
+// would break every other clone.
+//
+// The hyphenated name falls outside the "dolt-server." prefix shared by the
+// other five entries, so it was missed by both lists. It must be in
+// requiredPatterns too, otherwise bd doctor --fix cannot heal an existing
+// .beads/.gitignore.
+func TestGitignore_ContainsDoltServerConfig(t *testing.T) {
+	// Keep this in sync with doltserver.doltServerConfigFileName. It is not
+	// imported here because cmd/bd/doctor must not depend on the server
+	// package for a string constant.
+	const pattern = "dolt-server-config.yaml"
+
+	if !containsGitignorePattern(GitignoreTemplate, pattern) {
+		t.Errorf("GitignoreTemplate should contain %q", pattern)
+	}
+
+	found := false
+	for _, p := range requiredPatterns {
+		if p == pattern {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("requiredPatterns should include %q", pattern)
+	}
+}
+
 // TestCheckLastTouchedNotTracked_NoFile verifies that check passes when no last-touched file exists
 func TestCheckLastTouchedNotTracked_NoFile(t *testing.T) {
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## What

Adds `dolt-server-config.yaml` to both `GitignoreTemplate` and `requiredPatterns` in `cmd/bd/doctor/gitignore.go`, plus a regression test asserting it is in both.

## Why

Fixes #5977

`doltserver.Start()` writes `.beads/dolt-server-config.yaml` when the dolt binary supports `auto_gc_behavior.archive_level`. It holds an absolute `cfg_dir` and a per-machine port, so committing it breaks other clones — but it was in neither list, so it sits untracked in every affected repo.

It goes in `requiredPatterns` as well as the template because `missingGitignorePatterns()` iterates that list: without it, `bd doctor --fix` cannot add the rule to an existing `.beads/.gitignore`, so only newly-initialised repos would benefit.

## Verification

```bash
# regression test fails without the fix, passes with it
go test -tags gms_pure_go -run TestGitignore_ContainsDoltServerConfig ./cmd/bd/doctor/

go test -tags gms_pure_go ./cmd/bd/doctor/   # full package: ok
make ci-pr-lint                              # 0 issues (incl. Windows cross-lint)
make test                                    # 43 packages ok, 0 failures
```

Confirmed the new test fails on both assertions with the fix reverted, so it genuinely guards the regression.
