### PR TITLE
fix(filters): resolve bare date bounds in UTC so results do not follow the host

### DIFF
--- a/cmd/bd/count.go
+++ b/cmd/bd/count.go
@@ -251,12 +251,12 @@ func registerCountFlags(cmd *cobra.Command) {
 	cmd.Flags().String("notes-contains", "", "Filter by notes substring")
 
 	// Date ranges
-	cmd.Flags().String("created-after", "", "Filter issues created after date (YYYY-MM-DD or RFC3339)")
-	cmd.Flags().String("created-before", "", "Filter issues created before date (YYYY-MM-DD or RFC3339)")
-	cmd.Flags().String("updated-after", "", "Filter issues updated after date (YYYY-MM-DD or RFC3339)")
-	cmd.Flags().String("updated-before", "", "Filter issues updated before date (YYYY-MM-DD or RFC3339)")
-	cmd.Flags().String("closed-after", "", "Filter issues closed after date (YYYY-MM-DD or RFC3339)")
-	cmd.Flags().String("closed-before", "", "Filter issues closed before date (YYYY-MM-DD or RFC3339)")
+	cmd.Flags().String("created-after", "", "Filter issues created after date (YYYY-MM-DD is UTC, or RFC3339)")
+	cmd.Flags().String("created-before", "", "Filter issues created before date (YYYY-MM-DD is UTC, or RFC3339)")
+	cmd.Flags().String("updated-after", "", "Filter issues updated after date (YYYY-MM-DD is UTC, or RFC3339)")
+	cmd.Flags().String("updated-before", "", "Filter issues updated before date (YYYY-MM-DD is UTC, or RFC3339)")
+	cmd.Flags().String("closed-after", "", "Filter issues closed after date (YYYY-MM-DD is UTC, or RFC3339)")
+	cmd.Flags().String("closed-before", "", "Filter issues closed before date (YYYY-MM-DD is UTC, or RFC3339)")
 
 	// Empty/null checks
 	cmd.Flags().Bool("empty-description", false, "Filter issues with empty description")

--- a/cmd/bd/count_filter_test.go
+++ b/cmd/bd/count_filter_test.go
@@ -82,14 +82,15 @@ func TestParseCountRequestCarriesEveryFilterFlag(t *testing.T) {
 		t.Errorf("group = %q with no --by-* flag, want the scalar count", group)
 	}
 
-	// parseTimeFlag resolves a bare date in the LOCAL zone, which is what a
-	// user typing --created-after 2026-01-01 means, then normalizes the
-	// representation to UTC so the storage layer binds the same instant on
-	// every backend. The expectation constructs local midnight and converts,
-	// so a change to either half of that contract shows up here instead of
-	// shifting every bound by the test machine's offset.
+	// parseTimeFlag resolves a bare date in UTC, because these bounds are
+	// compared against created_at/updated_at/closed_at, which are stored in UTC
+	// and reported in UTC by --json. Resolving in the LOCAL zone — the old
+	// behavior — made the same command select a different 24 hours per host and
+	// silently drop rows near the day boundary (#5823). Constructing the
+	// expectation in UTC rather than from time.Local is the assertion: on a
+	// machine whose offset is nonzero, the two disagree.
 	day := func(d int) *time.Time {
-		stamp := time.Date(2026, 1, d, 0, 0, 0, 0, time.Local).UTC()
+		stamp := time.Date(2026, 1, d, 0, 0, 0, 0, time.UTC)
 		return &stamp
 	}
 	priority, min, max := 1, 0, 4

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -425,12 +425,12 @@ func init() {
 	listCmd.Flags().String("external-ref", "", "Filter by exact external_ref value")
 
 	// Date ranges
-	listCmd.Flags().String("created-after", "", "Filter issues created after date (YYYY-MM-DD or RFC3339)")
-	listCmd.Flags().String("created-before", "", "Filter issues created before date (YYYY-MM-DD or RFC3339)")
-	listCmd.Flags().String("updated-after", "", "Filter issues updated after date (YYYY-MM-DD or RFC3339)")
-	listCmd.Flags().String("updated-before", "", "Filter issues updated before date (YYYY-MM-DD or RFC3339)")
-	listCmd.Flags().String("closed-after", "", "Filter issues closed after date (YYYY-MM-DD or RFC3339)")
-	listCmd.Flags().String("closed-before", "", "Filter issues closed before date (YYYY-MM-DD or RFC3339)")
+	listCmd.Flags().String("created-after", "", "Filter issues created after date (YYYY-MM-DD is UTC, or RFC3339)")
+	listCmd.Flags().String("created-before", "", "Filter issues created before date (YYYY-MM-DD is UTC, or RFC3339)")
+	listCmd.Flags().String("updated-after", "", "Filter issues updated after date (YYYY-MM-DD is UTC, or RFC3339)")
+	listCmd.Flags().String("updated-before", "", "Filter issues updated before date (YYYY-MM-DD is UTC, or RFC3339)")
+	listCmd.Flags().String("closed-after", "", "Filter issues closed after date (YYYY-MM-DD is UTC, or RFC3339)")
+	listCmd.Flags().String("closed-before", "", "Filter issues closed before date (YYYY-MM-DD is UTC, or RFC3339)")
 
 	// Empty/null checks
 	listCmd.Flags().Bool("empty-description", false, "Filter issues with empty or missing description")
@@ -487,10 +487,10 @@ func init() {
 
 	// Time-based scheduling filters (GH#820)
 	listCmd.Flags().Bool("deferred", false, "Show only issues with defer_until set")
-	listCmd.Flags().String("defer-after", "", "Filter issues deferred after date (supports relative: +6h, tomorrow)")
-	listCmd.Flags().String("defer-before", "", "Filter issues deferred before date (supports relative: +6h, tomorrow)")
-	listCmd.Flags().String("due-after", "", "Filter issues due after date (supports relative: +6h, tomorrow)")
-	listCmd.Flags().String("due-before", "", "Filter issues due before date (supports relative: +6h, tomorrow)")
+	listCmd.Flags().String("defer-after", "", "Filter issues deferred after date (YYYY-MM-DD is UTC; supports relative: +6h, tomorrow)")
+	listCmd.Flags().String("defer-before", "", "Filter issues deferred before date (YYYY-MM-DD is UTC; supports relative: +6h, tomorrow)")
+	listCmd.Flags().String("due-after", "", "Filter issues due after date (YYYY-MM-DD is UTC; supports relative: +6h, tomorrow)")
+	listCmd.Flags().String("due-before", "", "Filter issues due before date (YYYY-MM-DD is UTC; supports relative: +6h, tomorrow)")
 	listCmd.Flags().Bool("overdue", false, "Show only issues with due_at in the past (not closed)")
 
 	// Pretty and watch flags (GH#654)

--- a/cmd/bd/list_format.go
+++ b/cmd/bd/list_format.go
@@ -13,11 +13,21 @@ import (
 	"github.com/steveyegge/beads/internal/ui"
 )
 
-// parseTimeFlag parses time strings using the layered time parsing architecture.
-// Supports compact durations (+6h, -1d), natural language (tomorrow, next monday),
-// and absolute formats (2006-01-02, RFC3339).
+// parseTimeFlag parses the date-bound filter flags (--created-after and its
+// siblings) using the layered time parsing architecture. Supports compact
+// durations (+6h, -1d), natural language (tomorrow, next monday), and absolute
+// formats (2006-01-02, RFC3339).
+//
+// Bare dates resolve in UTC because these bounds are compared against
+// created_at/updated_at/closed_at, which are stored in UTC and reported in UTC
+// by --json. Reading a date out of one command and passing it to another has to
+// select the same rows on every host; parsing in the host's zone silently
+// shifted the window by its offset and returned a short result set that looked
+// complete (#5823). Deadlines the user sets (--due, --defer) still parse
+// locally, since those name a day in the user's calendar rather than a point in
+// the stored timeline.
 func parseTimeFlag(s string) (time.Time, error) {
-	return timeparsing.ParseRelativeTime(s, time.Now())
+	return timeparsing.ParseRelativeTimeIn(s, time.Now(), time.UTC)
 }
 
 // pinIndicator returns a pushpin emoji prefix for pinned issues

--- a/cmd/bd/search.go
+++ b/cmd/bd/search.go
@@ -369,12 +369,12 @@ func init() {
 	searchCmd.Flags().BoolP("reverse", "r", false, "Reverse sort order")
 
 	// Date range flags
-	searchCmd.Flags().String("created-after", "", "Filter issues created after date (YYYY-MM-DD or RFC3339)")
-	searchCmd.Flags().String("created-before", "", "Filter issues created before date (YYYY-MM-DD or RFC3339)")
-	searchCmd.Flags().String("updated-after", "", "Filter issues updated after date (YYYY-MM-DD or RFC3339)")
-	searchCmd.Flags().String("updated-before", "", "Filter issues updated before date (YYYY-MM-DD or RFC3339)")
-	searchCmd.Flags().String("closed-after", "", "Filter issues closed after date (YYYY-MM-DD or RFC3339)")
-	searchCmd.Flags().String("closed-before", "", "Filter issues closed before date (YYYY-MM-DD or RFC3339)")
+	searchCmd.Flags().String("created-after", "", "Filter issues created after date (YYYY-MM-DD is UTC, or RFC3339)")
+	searchCmd.Flags().String("created-before", "", "Filter issues created before date (YYYY-MM-DD is UTC, or RFC3339)")
+	searchCmd.Flags().String("updated-after", "", "Filter issues updated after date (YYYY-MM-DD is UTC, or RFC3339)")
+	searchCmd.Flags().String("updated-before", "", "Filter issues updated before date (YYYY-MM-DD is UTC, or RFC3339)")
+	searchCmd.Flags().String("closed-after", "", "Filter issues closed after date (YYYY-MM-DD is UTC, or RFC3339)")
+	searchCmd.Flags().String("closed-before", "", "Filter issues closed before date (YYYY-MM-DD is UTC, or RFC3339)")
 
 	// Priority range flags
 	searchCmd.Flags().String("priority-min", "", "Filter by minimum priority (inclusive, 0-4 or P0-P4)")

--- a/internal/query/evaluator.go
+++ b/internal/query/evaluator.go
@@ -608,6 +608,11 @@ func (e *Evaluator) applyNot(not *NotNode, filter *types.IssueFilter) error {
 
 // parseTimeValue parses a time value from a comparison node.
 // Supports duration values (7d, 24h) which are interpreted as "now - duration".
+//
+// Every field routed here (created, updated, closed, started) is a recorded
+// instant stored in UTC, so a bare date resolves in UTC rather than the host's
+// zone — otherwise created>'2026-08-17' selects a different 24 hours depending
+// on where it runs (#5823).
 func (e *Evaluator) parseTimeValue(comp *ComparisonNode) (time.Time, error) {
 	if comp.ValueType == TokenDuration {
 		// Duration values like 7d mean "7 days ago" for < comparisons
@@ -616,7 +621,7 @@ func (e *Evaluator) parseTimeValue(comp *ComparisonNode) (time.Time, error) {
 		return e.parseDurationAgo(comp.Value)
 	}
 	// Otherwise use the standard time parser
-	return timeparsing.ParseRelativeTime(comp.Value, e.now)
+	return timeparsing.ParseRelativeTimeIn(comp.Value, e.now, time.UTC)
 }
 
 // parseDurationAgo parses a duration and returns now - duration.

--- a/internal/timeparsing/parser.go
+++ b/internal/timeparsing/parser.go
@@ -142,8 +142,25 @@ var dateOnlyRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
 // Timezone-less inputs are interpreted in now's location. Returns the parsed
 // time in UTC or an error if no layer could parse the input.
 func ParseRelativeTime(s string, now time.Time) (time.Time, error) {
-	location := now.Location()
+	return ParseRelativeTimeIn(s, now, now.Location())
+}
 
+// ParseRelativeTimeIn is ParseRelativeTime with the zone for timezone-less
+// absolute literals (a bare YYYY-MM-DD, or a datetime written without an
+// offset) supplied separately from now.
+//
+// The two are different questions, and conflating them is what made the same
+// filter command return different rows on different hosts (#5823). now is only
+// the instant relative expressions count from, and it names the same instant
+// whatever zone it carries. location decides which 24 hours "2026-08-17" means,
+// which has to agree with whatever the result gets compared against: UTC for a
+// bound tested against a stored timestamp, local for a deadline a human is
+// setting.
+//
+// Natural language deliberately keeps counting from now rather than from
+// location. "tomorrow" is a claim about the speaker's calendar, not the
+// database's.
+func ParseRelativeTimeIn(s string, now time.Time, location *time.Location) (time.Time, error) {
 	// Layer 1: Compact duration
 	if t, err := ParseCompactDuration(s, now); err == nil {
 		return t.UTC(), nil

--- a/internal/timeparsing/parser_test.go
+++ b/internal/timeparsing/parser_test.go
@@ -1,0 +1,94 @@
+package timeparsing
+
+import (
+	"testing"
+	"time"
+)
+
+// kiritimati is UTC+14 and newYork is UTC-5/-4: the two extremes #5823 used to
+// show that a bare bound's meaning followed the host around.
+var (
+	kiritimati = time.FixedZone("Pacific/Kiritimati", 14*60*60)
+	newYork    = time.FixedZone("America/New_York", -5*60*60)
+)
+
+// TestParseRelativeTimeInBareDateIgnoresHostZone is the #5823 regression: a
+// bare YYYY-MM-DD bound is compared against created_at/updated_at/closed_at,
+// which are stored in UTC, so it has to name the same instant no matter where
+// the command runs. It used to resolve at the host's local midnight, which put
+// a UTC+14 host 14 hours early and a UTC-5 host 5 hours late — enough to silently
+// drop rows near the day boundary from a result that still looked complete.
+func TestParseRelativeTimeInBareDateIgnoresHostZone(t *testing.T) {
+	want := time.Date(2026, 8, 17, 0, 0, 0, 0, time.UTC)
+
+	for name, zone := range map[string]*time.Location{
+		"UTC":        time.UTC,
+		"Kiritimati": kiritimati,
+		"New_York":   newYork,
+	} {
+		t.Run(name, func(t *testing.T) {
+			// now carries the host zone; only the literal's zone should matter.
+			now := time.Date(2026, 8, 16, 20, 13, 18, 0, zone)
+			got, err := ParseRelativeTimeIn("2026-08-17", now, time.UTC)
+			if err != nil {
+				t.Fatalf("ParseRelativeTimeIn: %v", err)
+			}
+			if !got.Equal(want) {
+				t.Errorf("bare date resolved to %s, want %s (bound moved with the host zone)",
+					got.Format(time.RFC3339), want.Format(time.RFC3339))
+			}
+		})
+	}
+}
+
+// TestParseRelativeTimeKeepsBareDateLocal guards the other half of the split.
+// --due and --defer still go through ParseRelativeTime, where a bare date names
+// a day on the user's calendar: "due 2026-09-01" must not become the evening of
+// August 31 for anyone west of UTC.
+func TestParseRelativeTimeKeepsBareDateLocal(t *testing.T) {
+	now := time.Date(2026, 8, 16, 20, 13, 18, 0, newYork)
+
+	got, err := ParseRelativeTime("2026-09-01", now)
+	if err != nil {
+		t.Fatalf("ParseRelativeTime: %v", err)
+	}
+	want := time.Date(2026, 9, 1, 0, 0, 0, 0, newYork)
+	if !got.Equal(want) {
+		t.Errorf("bare date resolved to %s, want local midnight %s",
+			got.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+}
+
+// TestParseRelativeTimeInLeavesRelativeFormsAlone pins that only the
+// timezone-less absolute literals moved. An offset-bearing literal is already
+// unambiguous and must be honored as written, and a duration names an instant
+// relative to now that the literal zone has no business shifting.
+func TestParseRelativeTimeInLeavesRelativeFormsAlone(t *testing.T) {
+	now := time.Date(2026, 8, 16, 20, 13, 18, 0, newYork)
+
+	t.Run("RFC3339 offset is honored", func(t *testing.T) {
+		got, err := ParseRelativeTimeIn("2026-08-17T00:00:00-04:00", now, time.UTC)
+		if err != nil {
+			t.Fatalf("ParseRelativeTimeIn: %v", err)
+		}
+		want := time.Date(2026, 8, 17, 4, 0, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Errorf("got %s, want %s", got.Format(time.RFC3339), want.Format(time.RFC3339))
+		}
+	})
+
+	t.Run("duration is unaffected by the literal zone", func(t *testing.T) {
+		utc, err := ParseRelativeTimeIn("-1d", now, time.UTC)
+		if err != nil {
+			t.Fatalf("ParseRelativeTimeIn: %v", err)
+		}
+		local, err := ParseRelativeTimeIn("-1d", now, newYork)
+		if err != nil {
+			t.Fatalf("ParseRelativeTimeIn: %v", err)
+		}
+		if !utc.Equal(local) {
+			t.Errorf("-1d resolved to %s under UTC but %s under New_York; a duration counts from now, not from the literal zone",
+				utc.Format(time.RFC3339), local.Format(time.RFC3339))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #5823. The date-bound filter flags accept `YYYY-MM-DD`, and resolved it at midnight in the **host's** zone while comparing it against `created_at`/`updated_at`/`closed_at`, which are stored in UTC and reported in UTC by `--json`. The same command against the same database therefore selected a different 24 hours depending on `TZ`, silently returning a short result set that looked complete.

The reporter's round trip is the sharp edge: read a timestamp out of `--json`, pass its date back into a filter, and the query can omit the very rows being audited. On a US Eastern host the blind window is the first four hours of each UTC day.

## Root cause

`ParseRelativeTime` used one value for two unrelated jobs — the instant relative expressions count from, and the zone a timezone-less literal resolves in:

```go
location := now.Location()
if dateOnlyRe.MatchString(s) {
    if t, err := time.ParseInLocation("2006-01-02", s, location); err == nil {
```

`ParseRelativeTimeIn` separates them.

## Why not change the shared parser outright

`ParseRelativeTime` also parses `--due`, `--defer`, and `bd defer --until`, where local is *correct*: a deadline names a day on the user's calendar, and moving those to UTC would expire Pacific due dates the previous evening. Those callers are untouched.

Natural language stays anchored to local `now` for the same reason — "tomorrow" is a claim about the speaker, not the database. Offset-bearing literals were already correct and are untouched, which the issue confirmed.

## Scope

Every CLI filter flag funnels through `parseTimeFlag`, so `bd list`, `bd count` and `bd search` are fixed at one site; `bd query` needs the same at its own parse. Flag help now reads `(YYYY-MM-DD is UTC, or RFC3339)`.

`docs/CLI_REFERENCE.md` is generated from the last release tag, so the new help text lands at the next release; `scripts/check-cli-docs-drift.sh` passes as-is.

## A test that encoded the bug

`count_filter_test.go` asserted local midnight as the intended contract, with a comment explaining it. Both the expectation and that rationale are rewritten rather than patched.

## Test plan

- [x] New `internal/timeparsing/parser_test.go`: a bare bound resolves to the same instant under UTC, Kiritimati (UTC+14) and New York (UTC-5); `--due`-style parsing still yields local midnight; durations and RFC3339 offsets are unaffected.
- [x] Verified RED before the fix and GREEN after, by stashing the source change and re-running.
- [x] `make ci-pr-lint` — 0 issues
- [x] `make test` — 96 packages, no failures

Note: main's CI was red when this branch was cut, so any check failures here may be pre-existing base breakage.