### PR TITLE
fix(show): render Created/Started/Updated in local timezone

### DIFF
--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -303,7 +303,7 @@ func init() {
 	showCmd.Flags().Bool("children", false, "Show only the children of this issue")
 	showCmd.Flags().String("as-of", "", "Show issue as it existed at a specific commit hash or branch (requires Dolt)")
 	showCmd.Flags().StringArray("id", nil, "Issue ID (use for IDs that look like flags, e.g., --id=gt--xyz)")
-	showCmd.Flags().Bool("local-time", false, "Show timestamps in local time instead of UTC")
+	showCmd.Flags().Bool("local-time", false, "Show timestamps in local time instead of UTC (date-only fields are always local)")
 	showCmd.Flags().BoolP("watch", "w", false, "Watch for changes and auto-refresh display")
 	showCmd.Flags().Bool("current", false, "Show the currently active issue (in-progress, hooked, or last touched)")
 	showCmd.Flags().Bool("include-dependents", false, "Stream full dependent issues in JSON output (--json only; may be slow on hub beads)")

--- a/cmd/bd/show_format.go
+++ b/cmd/bd/show_format.go
@@ -110,11 +110,11 @@ func formatIssueMetadata(issue *types.Issue) string {
 
 	// Line 2: Created · Updated · Due/Defer
 	timeParts := []string{}
-	timeParts = append(timeParts, fmt.Sprintf("Created: %s", issue.CreatedAt.Format("2006-01-02")))
+	timeParts = append(timeParts, fmt.Sprintf("Created: %s", issue.CreatedAt.Local().Format("2006-01-02")))
 	if issue.StartedAt != nil {
-		timeParts = append(timeParts, fmt.Sprintf("Started: %s", issue.StartedAt.Format("2006-01-02")))
+		timeParts = append(timeParts, fmt.Sprintf("Started: %s", issue.StartedAt.Local().Format("2006-01-02")))
 	}
-	timeParts = append(timeParts, fmt.Sprintf("Updated: %s", issue.UpdatedAt.Format("2006-01-02")))
+	timeParts = append(timeParts, fmt.Sprintf("Updated: %s", issue.UpdatedAt.Local().Format("2006-01-02")))
 
 	if issue.DueAt != nil {
 		timeParts = append(timeParts, fmt.Sprintf("Due: %s", issue.DueAt.Local().Format("2006-01-02")))

--- a/cmd/bd/show_format_metadata_test.go
+++ b/cmd/bd/show_format_metadata_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/steveyegge/beads/internal/types"
@@ -139,6 +140,40 @@ func TestFormatIssueMetadata_CreatedByLabel(t *testing.T) {
 	}
 	if strings.Contains(out, "Owner: ") {
 		t.Errorf("label %q must not appear — created_by must not render under the Owner label, got:\n%s", "Owner: ", out)
+	}
+}
+
+// TestFormatIssueMetadata_TimestampsRenderLocal guards the rule that the
+// metadata block reports timestamps on the reader's calendar, as the Due and
+// Deferred entries on the same line already did.
+//
+// Created/Started/Updated are stored in UTC. Printing those digits as a bare
+// date put the whole day wrong if it's already tomorrow in UTC.
+//
+// time.Local is swapped rather than TZ, because the zone is resolved once per
+// process and a t.Setenv would land too late to matter — and on a UTC CI box
+// the assertion would then pass without testing anything. That swap is a
+// process-global write, so this test must not be t.Parallel() and will trip
+// -race against any parallel test that reads time.Local.
+func TestFormatIssueMetadata_TimestampsRenderLocal(t *testing.T) {
+	pacific := time.FixedZone("PDT", -7*60*60)
+	orig := time.Local
+	time.Local = pacific
+	t.Cleanup(func() { time.Local = orig })
+
+	// 2026-08-24 01:30 UTC is 2026-08-23 18:30 Pacific — the same instant on
+	// two different calendar days, which is the whole bug.
+	stamp := time.Date(2026, 8, 24, 1, 30, 0, 0, time.UTC)
+	issue := &types.Issue{
+		ID: "test-tz", Title: "t", IssueType: types.TypeTask,
+		CreatedAt: stamp, UpdatedAt: stamp, StartedAt: &stamp,
+	}
+
+	out := ansi.Strip(formatIssueMetadata(issue))
+	for _, want := range []string{"Created: 2026-08-23", "Started: 2026-08-23", "Updated: 2026-08-23"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output (UTC digits rendered as-is put the date a day ahead), got:\n%s", want, out)
+		}
 	}
 }
 


### PR DESCRIPTION
`bd show` printed these stored-UTC timestamps as bare dates without converting, so if it’s already tomorrow in UTC, the whole calendar day was wrong.

Storage is unchanged and still UTC, as is `--json`.