### PR TITLE
fix(mcp): preserve comment completeness in reads

### DIFF
--- a/integrations/beads-mcp/README.md
+++ b/integrations/beads-mcp/README.md
@@ -214,12 +214,12 @@ await beads_ready_work(workspace_root="/Users/you/project-a")
 - `create` - Create new issue (bug, feature, task, epic, chore, decision)
 - `list` - List issues with filters (status, priority, type, assignee)
 - `ready` - Find tasks with no blockers ready to work on
-- `show` - Show detailed issue info including dependencies
+- `show` - Show detailed issue info including dependencies, `comment_count`, and comment bodies
 - `update` - Update issue (status, priority, design, notes, etc). Note: `status="closed"` or `status="open"` automatically route to `close` or `reopen` tools to respect approval workflows
 - `close` - Close completed issue
 - `dep` - Add dependency (blocks, related, parent-child, discovered-from)
 - `comment` - Add a durable, timestamped comment to an issue (a record of work/decisions)
-- `comments` - List all comments on an issue (`show` reports comment_count but not the bodies)
+- `comments` - List only the comment chronology for an issue
 - `note` - Append a note to an issue's notes field
 - `blocked` - Get blocked issues
 - `stats` - Get project statistics

--- a/integrations/beads-mcp/src/beads_mcp/bd_client.py
+++ b/integrations/beads-mcp/src/beads_mcp/bd_client.py
@@ -513,7 +513,10 @@ class BdCliClient(BdClientBase):
         if not isinstance(data, dict):
             raise BdCommandError(f"Invalid response for show {params.issue_id}")
 
-        return Issue.model_validate(data)
+        issue = Issue.model_validate(data)
+        if issue.comments and issue.comment_count != len(issue.comments):
+            return issue.model_copy(update={"comment_count": len(issue.comments)})
+        return issue
 
     async def create(self, params: CreateIssueParams) -> Issue:
         """Create a new issue.

--- a/integrations/beads-mcp/src/beads_mcp/models.py
+++ b/integrations/beads-mcp/src/beads_mcp/models.py
@@ -55,6 +55,8 @@ class IssueMinimal(BaseModel):
     labels: list[str] = Field(default_factory=list)
     dependency_count: int = 0
     dependent_count: int = 0
+    comment_count: int = 0
+    comments_omitted: bool = False
 
     @field_validator("priority")
     @classmethod
@@ -79,7 +81,7 @@ class CompactedResult(BaseModel):
 
 
 class BriefIssue(BaseModel):
-    """Ultra-minimal issue for scanning (4 fields).
+    """Ultra-minimal issue for scanning.
 
     Use for quick scans where only identification + priority needed.
     ~95% smaller than full Issue.
@@ -89,6 +91,8 @@ class BriefIssue(BaseModel):
     title: str
     status: IssueStatus
     priority: int = Field(ge=0, le=4)
+    comment_count: int = 0
+    comments_omitted: bool = False
 
 
 class BriefDep(BaseModel):
@@ -122,6 +126,16 @@ class OperationResult(BaseModel):
 # =============================================================================
 
 
+class Comment(BaseModel):
+    """A comment on an issue (matches `bd comments <id> --json`)."""
+
+    id: str
+    issue_id: str
+    author: str | None = None
+    text: str
+    created_at: datetime
+
+
 class IssueBase(BaseModel):
     """Base issue model with shared fields."""
 
@@ -142,6 +156,8 @@ class IssueBase(BaseModel):
     labels: list[str] = Field(default_factory=list)
     dependency_count: int = 0
     dependent_count: int = 0
+    comment_count: int = 0
+    comments_omitted: bool = False
 
     @field_validator("priority")
     @classmethod
@@ -163,6 +179,7 @@ class Issue(IssueBase):
 
     dependencies: list[LinkedIssue] = Field(default_factory=list)
     dependents: list[LinkedIssue] = Field(default_factory=list)
+    comments: list[Comment] = Field(default_factory=list)
 
 
 class Dependency(BaseModel):
@@ -331,16 +348,6 @@ class InitResult(BaseModel):
 # =============================================================================
 # COMMENTS & NOTES
 # =============================================================================
-
-
-class Comment(BaseModel):
-    """A comment on an issue (matches `bd comments <id> --json`)."""
-
-    id: str
-    issue_id: str
-    author: str | None = None
-    text: str
-    created_at: datetime
 
 
 class AddCommentParams(BaseModel):

--- a/integrations/beads-mcp/src/beads_mcp/server.py
+++ b/integrations/beads-mcp/src/beads_mcp/server.py
@@ -74,6 +74,7 @@ logging.basicConfig(
 )
 
 T = TypeVar("T")
+IssueT = TypeVar("IssueT", bound=Issue)
 
 # Global state for cleanup
 _cleanup_done = False
@@ -411,7 +412,7 @@ async def get_tool_info(tool_name: str) -> dict[str, Any]:
                 "labels_any": "list[str] (optional) - OR filter: must have at least one",
                 "unassigned": "bool (default false) - Only unassigned issues",
                 "sort_policy": "str (optional) - hybrid|priority|oldest",
-                "brief": "bool (default false) - Return only {id, title, status, priority}",
+                "brief": ("bool (default false) - Return only identification plus comment completeness metadata"),
                 "fields": "list[str] (optional) - Custom field projection",
                 "max_description_length": "int (optional) - Truncate descriptions",
                 "workspace_root": "str (optional) - Workspace path",
@@ -432,7 +433,7 @@ async def get_tool_info(tool_name: str) -> dict[str, Any]:
                 "query": "str (optional) - Search in title (case-insensitive)",
                 "unassigned": "bool (default false) - Only unassigned issues",
                 "limit": "int (1-100, default 20)",
-                "brief": "bool (default false) - Return only {id, title, status, priority}",
+                "brief": ("bool (default false) - Return only identification plus comment completeness metadata"),
                 "fields": "list[str] (optional) - Custom field projection",
                 "max_description_length": "int (optional) - Truncate descriptions",
                 "workspace_root": "str (optional)",
@@ -442,10 +443,10 @@ async def get_tool_info(tool_name: str) -> dict[str, Any]:
         },
         "show": {
             "name": "show",
-            "description": "Show full details for a specific issue including dependencies",
+            "description": "Show full details including dependencies and comments",
             "parameters": {
                 "issue_id": "str (required) - e.g., 'bd-a1b2'",
-                "brief": "bool (default false) - Return only {id, title, status, priority}",
+                "brief": ("bool (default false) - Return only identification plus comment completeness metadata"),
                 "brief_deps": "bool (default false) - Full issue with compact dependencies",
                 "fields": "list[str] (optional) - Custom field projection",
                 "max_description_length": "int (optional) - Truncate description",
@@ -547,7 +548,7 @@ async def get_tool_info(tool_name: str) -> dict[str, Any]:
         },
         "comments": {
             "name": "comments",
-            "description": "List all comments on an issue (show reports comment_count but not the bodies)",
+            "description": "List only the comment chronology for an issue",
             "parameters": {
                 "issue_id": "str (required)",
                 "workspace_root": "str (optional)",
@@ -577,7 +578,7 @@ async def get_tool_info(tool_name: str) -> dict[str, Any]:
             "name": "blocked",
             "description": "Show blocked issues and what blocks them",
             "parameters": {
-                "brief": "bool (default false) - Return only {id, title, status, priority}",
+                "brief": ("bool (default false) - Return only identification plus comment completeness metadata"),
                 "brief_deps": "bool (default false) - Full issues with compact dependencies",
                 "workspace_root": "str (optional)",
             },
@@ -781,16 +782,20 @@ def _to_minimal(issue: Issue) -> IssueMinimal:
         labels=issue.labels,
         dependency_count=issue.dependency_count,
         dependent_count=issue.dependent_count,
+        comment_count=issue.comment_count,
+        comments_omitted=issue.comment_count > 0,
     )
 
 
 def _to_brief(issue: Issue) -> BriefIssue:
-    """Convert full Issue to brief format (id, title, status, priority)."""
+    """Convert full Issue to brief format with comment completeness metadata."""
     return BriefIssue(
         id=issue.id,
         title=issue.title,
         status=issue.status,
         priority=issue.priority,
+        comment_count=issue.comment_count,
+        comments_omitted=issue.comment_count > 0,
     )
 
 
@@ -824,9 +829,31 @@ VALID_ISSUE_FIELDS: set[str] = {
     "labels",
     "dependency_count",
     "dependent_count",
+    "comment_count",
+    "comments_omitted",
     "dependencies",
     "dependents",
+    "comments",
 }
+
+
+def _mark_omitted_comments(issue: IssueT) -> IssueT:
+    """Mark count-only issue records so an absent chronology is never ambiguous."""
+    if issue.comment_count > len(issue.comments) and not issue.comments_omitted:
+        return issue.model_copy(update={"comments_omitted": True})
+    return issue
+
+
+async def _hydrate_comments(issue: IssueT) -> IssueT:
+    """Fetch a chronology that a bulk caller explicitly requested."""
+    comments = await beads_list_comments(issue_id=issue.id)
+    return issue.model_copy(
+        update={
+            "comments": comments,
+            "comment_count": len(comments),
+            "comments_omitted": False,
+        }
+    )
 
 
 def _filter_fields(obj: Issue, fields: list[str]) -> dict[str, Any]:
@@ -897,7 +924,7 @@ async def ready_work(
         unassigned: Filter to only unassigned issues
         sort_policy: Sort policy: hybrid (default), priority, oldest
         workspace_root: Workspace path override
-        brief: If True, return only {id, title, status} (~97% smaller)
+        brief: If True, return identification plus comment completeness metadata
         fields: Return only specified fields (custom projections)
         max_description_length: Truncate descriptions to this length
 
@@ -914,6 +941,9 @@ async def ready_work(
         unassigned=unassigned,
         sort_policy=sort_policy,
     )
+    issues = [_mark_omitted_comments(issue) for issue in issues]
+    if fields and "comments" in fields:
+        issues = [await _hydrate_comments(issue) for issue in issues]
 
     # Apply description truncation first
     if max_description_length:
@@ -981,7 +1011,7 @@ async def list_issues(
         unassigned: Filter to only unassigned issues
         limit: Maximum issues to return (1-100, default 20)
         workspace_root: Workspace path override
-        brief: If True, return only {id, title, status} (~97% smaller)
+        brief: If True, return identification plus comment completeness metadata
         fields: Return only specified fields (custom projections)
         max_description_length: Truncate descriptions to this length
 
@@ -999,6 +1029,9 @@ async def list_issues(
         unassigned=unassigned,
         limit=limit,
     )
+    issues = [_mark_omitted_comments(issue) for issue in issues]
+    if fields and "comments" in fields:
+        issues = [await _hydrate_comments(issue) for issue in issues]
 
     # Apply description truncation first
     if max_description_length:
@@ -1049,12 +1082,13 @@ async def show_issue(
     Args:
         issue_id: The issue ID to show (e.g., 'bd-a1b2')
         workspace_root: Workspace path override
-        brief: If True, return only {id, title, status, priority}
+        brief: If True, return identification plus comment completeness metadata
         brief_deps: If True, return full issue but with compact dependencies
         fields: Return only specified fields (custom projections)
         max_description_length: Truncate description to this length
     """
-    issue = await beads_show_issue(issue_id=issue_id)
+    include_comments = not brief and (fields is None or "comments" in fields)
+    issue = await beads_show_issue(issue_id=issue_id, include_comments=include_comments)
 
     if max_description_length:
         issue = _truncate_description(issue, max_description_length)
@@ -1296,7 +1330,7 @@ async def comment(
 
 @mcp.tool(
     name="comments",
-    description="List all comments on an issue (show reports comment_count but not the comment bodies).",
+    description="List only the comment chronology for an issue.",
 )
 @with_workspace
 async def comments(
@@ -1348,10 +1382,11 @@ async def blocked(
     """Get blocked issues.
 
     Args:
-        brief: If True, return only {id, title, status, priority} per issue
+        brief: If True, return identification plus comment completeness metadata
         brief_deps: If True, return full issues but with compact dependencies
     """
     issues = await beads_blocked()
+    issues = [_mark_omitted_comments(issue) for issue in issues]
 
     # Brief mode - just identification (most compact)
     if brief:

--- a/integrations/beads-mcp/src/beads_mcp/tools.py
+++ b/integrations/beads-mcp/src/beads_mcp/tools.py
@@ -441,14 +441,30 @@ async def beads_list_issues(
 
 async def beads_show_issue(
     issue_id: Annotated[str, "Issue ID (e.g., bd-1)"],
+    include_comments: bool = True,
 ) -> Issue:
     """Show detailed information about a specific issue.
 
-    Includes full description, dependencies, and dependents.
+    Includes full description, dependencies, dependents, and comment chronology.
     """
     client = await _get_client()
     params = ShowIssueParams(issue_id=issue_id)
-    return await client.show(params)
+    issue = await client.show(params)
+
+    if include_comments and (issue.comments_omitted or issue.comment_count > len(issue.comments)):
+        comments = await client.list_comments(ListCommentsParams(issue_id=issue_id))
+        return issue.model_copy(
+            update={
+                "comments": comments,
+                "comment_count": len(comments),
+                "comments_omitted": False,
+            }
+        )
+
+    if issue.comments and issue.comment_count != len(issue.comments):
+        return issue.model_copy(update={"comment_count": len(issue.comments)})
+
+    return issue
 
 
 async def beads_create_issue(
@@ -627,7 +643,8 @@ async def beads_add_comment(
 
     Leave a durable, timestamped record of what you did, decided, or verified so
     humans don't have to read the agent transcript to know what happened. `show`
-    reports comment_count but not the bodies — use beads_list_comments to read them.
+    includes the complete comment chronology; beads_list_comments remains available
+    when only the chronology is needed.
 
     Prefer a comment over overwriting `notes`: comments accumulate as a per-turn
     trail, whereas the notes field is a single value that gets replaced.
@@ -640,10 +657,7 @@ async def beads_add_comment(
 async def beads_list_comments(
     issue_id: Annotated[str, "Issue ID (e.g., bd-1)"],
 ) -> list[Comment]:
-    """List all comments on an issue in chronological order.
-
-    `show` returns comment_count but not the comment bodies; use this to read them.
-    """
+    """List all comments on an issue in chronological order."""
     client = await _get_client()
     params = ListCommentsParams(issue_id=issue_id)
     return await client.list_comments(params)
@@ -693,7 +707,19 @@ async def beads_blocked(
     """
     client = await _get_client()
     params = BlockedParams(parent_id=parent)
-    return await client.blocked(params)
+    issues = await client.blocked(params)
+    result: list[BlockedIssue] = []
+    for issue in issues:
+        if "comment_count" not in issue.model_fields_set:
+            comments = await client.list_comments(ListCommentsParams(issue_id=issue.id))
+            issue = issue.model_copy(
+                update={
+                    "comment_count": len(comments),
+                    "comments_omitted": bool(comments),
+                }
+            )
+        result.append(issue)
+    return result
 
 
 async def beads_inspect_migration() -> dict[str, Any]:

--- a/integrations/beads-mcp/tests/test_bd_client.py
+++ b/integrations/beads-mcp/tests/test_bd_client.py
@@ -257,6 +257,16 @@ async def test_show(bd_client, mock_process):
         "issue_type": "bug",
         "created_at": "2024-01-01T00:00:00Z",
         "updated_at": "2024-01-01T00:00:00Z",
+        "comments_omitted": False,
+        "comments": [
+            {
+                "id": "c-1",
+                "issue_id": "bd-1",
+                "author": "agent",
+                "text": "Landed the fix",
+                "created_at": "2024-01-02T00:00:00Z",
+            }
+        ],
     }
     mock_process.communicate = AsyncMock(return_value=(json.dumps(issue_data).encode(), b""))
 
@@ -266,6 +276,9 @@ async def test_show(bd_client, mock_process):
 
     assert issue.id == "bd-1"
     assert issue.title == "Test issue"
+    assert issue.comment_count == 1
+    assert issue.comments_omitted is False
+    assert [comment.id for comment in issue.comments] == ["c-1"]
 
 
 @pytest.mark.asyncio
@@ -722,6 +735,7 @@ async def test_blocked(bd_client, mock_process):
             "issue_type": "bug",
             "created_at": "2025-01-25T00:00:00Z",
             "updated_at": "2025-01-25T00:00:00Z",
+            "comment_count": 3,
             "blocked_by_count": 2,
             "blocked_by": ["bd-2", "bd-3"],
         }
@@ -734,6 +748,7 @@ async def test_blocked(bd_client, mock_process):
     assert len(result) == 1
     assert result[0].id == "bd-1"
     assert result[0].blocked_by_count == 2
+    assert result[0].comment_count == 3
 
 
 @pytest.mark.asyncio

--- a/integrations/beads-mcp/tests/test_bd_client_integration.py
+++ b/integrations/beads-mcp/tests/test_bd_client_integration.py
@@ -126,6 +126,9 @@ async def test_create_and_show_issue(bd_client):
     assert created.issue_type == "bug"
     assert created.status == "open"
 
+    await bd_client.add_comment(AddCommentParams(issue_id=created.id, text="Verified chronology"))
+    comments = await bd_client.list_comments(ListCommentsParams(issue_id=created.id))
+
     # Show issue
     show_params = ShowIssueParams(issue_id=created.id)
     shown = await bd_client.show(show_params)
@@ -133,6 +136,11 @@ async def test_create_and_show_issue(bd_client):
     assert shown.id == created.id
     assert shown.title == created.title
     assert shown.description == created.description
+    assert shown.comment_count == len(comments) == 1
+    if shown.comments_omitted:
+        assert shown.comments == []
+    else:
+        assert [comment.id for comment in shown.comments] == [comment.id for comment in comments]
 
 
 @pytest.mark.asyncio

--- a/integrations/beads-mcp/tests/test_mcp_compaction.py
+++ b/integrations/beads-mcp/tests/test_mcp_compaction.py
@@ -54,6 +54,8 @@ def _to_minimal_test(issue: Issue) -> IssueMinimal:
         labels=issue.labels,
         dependency_count=issue.dependency_count,
         dependent_count=issue.dependent_count,
+        comment_count=issue.comment_count,
+        comments_omitted=issue.comment_count > 0,
     )
 
 
@@ -341,6 +343,7 @@ class TestConversionToMinimal:
             labels=["urgent", "backend"],
             dependency_count=2,
             dependent_count=1,
+            comment_count=3,
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),
         )
@@ -357,6 +360,8 @@ class TestConversionToMinimal:
         assert minimal.labels == ["urgent", "backend"]
         assert minimal.dependency_count == 2
         assert minimal.dependent_count == 1
+        assert minimal.comment_count == 3
+        assert minimal.comments_omitted is True
 
         # Check it doesn't have full Issue fields
         assert not hasattr(minimal, "description") or minimal.description is None

--- a/integrations/beads-mcp/tests/test_mcp_server_integration.py
+++ b/integrations/beads-mcp/tests/test_mcp_server_integration.py
@@ -145,30 +145,69 @@ async def test_show_issue_tool(mcp_client):
     created = json.loads(create_result.content[0].text)
     issue_id = created["id"]
 
+    await mcp_client.call_tool(
+        "comment",
+        {"issue_id": issue_id, "text": "Verified chronology"},
+    )
+    comments_result = await mcp_client.call_tool("comments", {"issue_id": issue_id})
+    expected_comments = json.loads(comments_result.content[0].text)
+
     # Show the issue
     show_result = await mcp_client.call_tool("show", {"issue_id": issue_id})
 
     issue = json.loads(show_result.content[0].text)
     assert issue["id"] == issue_id
     assert issue["title"] == "Issue to show"
+    assert issue["comment_count"] == len(expected_comments) == 1
+    assert issue["comments_omitted"] is False
+    assert [comment["id"] for comment in issue["comments"]] == [comment["id"] for comment in expected_comments]
+
+    fields_result = await mcp_client.call_tool(
+        "show",
+        {"issue_id": issue_id, "fields": ["comment_count", "comments_omitted", "comments"]},
+    )
+    projected = json.loads(fields_result.content[0].text)
+    assert projected["comment_count"] == 1
+    assert projected["comments_omitted"] is False
+    assert [comment["id"] for comment in projected["comments"]] == [expected_comments[0]["id"]]
 
 
 @pytest.mark.asyncio
 async def test_list_issues_tool(mcp_client):
     """Test list_issues tool."""
+    import json
+
     # Create some issues first
-    await mcp_client.call_tool("create", {"title": "Issue 1", "priority": 0, "issue_type": "bug", "brief": False})
+    first_result = await mcp_client.call_tool(
+        "create", {"title": "Issue 1", "priority": 0, "issue_type": "bug", "brief": False}
+    )
+    first_issue = json.loads(first_result.content[0].text)
     await mcp_client.call_tool(
         "create", {"title": "Issue 2", "priority": 1, "issue_type": "feature", "brief": False}
+    )
+    await mcp_client.call_tool(
+        "comment",
+        {"issue_id": first_issue["id"], "text": "List chronology"},
     )
 
     # List all issues
     result = await mcp_client.call_tool("list", {})
 
-    import json
-
     issues = json.loads(result.content[0].text)
     assert len(issues) >= 2
+    listed = next(issue for issue in issues if issue["id"] == first_issue["id"])
+    assert listed["comment_count"] == 1
+    assert listed["comments_omitted"] is True
+
+    comments_result = await mcp_client.call_tool(
+        "list",
+        {"fields": ["id", "comment_count", "comments_omitted", "comments"]},
+    )
+    projected_issues = json.loads(comments_result.content[0].text)
+    projected = next(issue for issue in projected_issues if issue["id"] == first_issue["id"])
+    assert projected["comment_count"] == 1
+    assert projected["comments_omitted"] is False
+    assert [comment["text"] for comment in projected["comments"]] == ["List chronology"]
 
     # List with status filter
     result = await mcp_client.call_tool("list", {"status": "open"})
@@ -367,6 +406,10 @@ async def test_ready_work_tool(mcp_client):
             "dep_type": "blocks",
         },
     )
+    await mcp_client.call_tool(
+        "comment",
+        {"issue_id": ready_issue["id"], "text": "Ready chronology"},
+    )
 
     # Get ready work
     result = await mcp_client.call_tool("ready", {"limit": 100})
@@ -375,6 +418,9 @@ async def test_ready_work_tool(mcp_client):
     ready_ids = [issue["id"] for issue in ready_issues]
     assert ready_issue["id"] in ready_ids
     assert blocked_issue["id"] not in ready_ids
+    our_ready = next(issue for issue in ready_issues if issue["id"] == ready_issue["id"])
+    assert our_ready["comment_count"] == 1
+    assert our_ready["comments_omitted"] is True
 
 
 @pytest.mark.asyncio
@@ -626,6 +672,10 @@ async def test_blocked_tool(mcp_client):
             "dep_type": "blocks",
         },
     )
+    await mcp_client.call_tool(
+        "comment",
+        {"issue_id": blocked_issue["id"], "text": "Blocked chronology"},
+    )
 
     # Get blocked issues
     result = await mcp_client.call_tool("blocked", {})
@@ -639,6 +689,8 @@ async def test_blocked_tool(mcp_client):
     our_blocked = next(issue for issue in blocked_issues if issue["id"] == blocked_issue["id"])
     assert our_blocked["blocked_by_count"] >= 1
     assert blocking_issue["id"] in our_blocked["blocked_by"]
+    assert our_blocked["comment_count"] == 1
+    assert our_blocked["comments_omitted"] is True
 
 
 @pytest.mark.asyncio
@@ -910,11 +962,13 @@ async def test_show_brief(mcp_client):
     show_result = await mcp_client.call_tool("show", {"issue_id": issue_id, "brief": True})
 
     data = json.loads(show_result.content[0].text)
-    # BriefIssue has only: id, title, status, priority
+    # BriefIssue keeps identification plus comment completeness metadata.
     assert data["id"] == issue_id
     assert data["title"] == "Show brief test"
     assert data["status"] == "open"
     assert "priority" in data
+    assert data["comment_count"] == 0
+    assert data["comments_omitted"] is False
     # Should NOT have full Issue fields
     assert "description" not in data
     assert "dependencies" not in data
@@ -1009,11 +1063,13 @@ async def test_list_brief(mcp_client):
 
     assert len(issues) >= 2
     for issue in issues:
-        # BriefIssue has only: id, title, status, priority
+        # BriefIssue keeps identification plus comment completeness metadata.
         assert "id" in issue
         assert "title" in issue
         assert "status" in issue
         assert "priority" in issue
+        assert "comment_count" in issue
+        assert "comments_omitted" in issue
         # Should NOT have full Issue fields
         assert "description" not in issue
         assert "issue_type" not in issue
@@ -1033,11 +1089,13 @@ async def test_ready_brief(mcp_client):
 
     assert len(issues) >= 1
     for issue in issues:
-        # BriefIssue has only: id, title, status, priority
+        # BriefIssue keeps identification plus comment completeness metadata.
         assert "id" in issue
         assert "title" in issue
         assert "status" in issue
         assert "priority" in issue
+        assert "comment_count" in issue
+        assert "comments_omitted" in issue
         # Should NOT have full Issue fields
         assert "description" not in issue
 

--- a/integrations/beads-mcp/tests/test_tools.py
+++ b/integrations/beads-mcp/tests/test_tools.py
@@ -124,6 +124,45 @@ async def test_beads_show_issue(sample_issue):
 
 
 @pytest.mark.asyncio
+async def test_beads_show_issue_hydrates_omitted_comments(sample_issue):
+    """A count-only CLI response is expanded before it reaches MCP callers."""
+    comment = Comment(
+        id="c-1",
+        issue_id=sample_issue.id,
+        author="agent",
+        text="Landed the fix",
+        created_at=datetime(2026, 8, 23, 2, 31, 0, tzinfo=timezone.utc),
+    )
+    count_only = sample_issue.model_copy(update={"comment_count": 1, "comments_omitted": True})
+    mock_client = AsyncMock()
+    mock_client.show = AsyncMock(return_value=count_only)
+    mock_client.list_comments = AsyncMock(return_value=[comment])
+
+    with patch("beads_mcp.tools._get_client", return_value=mock_client):
+        issue = await beads_show_issue(issue_id=sample_issue.id)
+
+    assert issue.comment_count == 1
+    assert issue.comments_omitted is False
+    assert [item.id for item in issue.comments] == ["c-1"]
+    mock_client.list_comments.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_beads_show_issue_reports_zero_without_comment_lookup(sample_issue):
+    """An empty chronology still carries an unconditional zero count."""
+    mock_client = AsyncMock()
+    mock_client.show = AsyncMock(return_value=sample_issue)
+
+    with patch("beads_mcp.tools._get_client", return_value=mock_client):
+        issue = await beads_show_issue(issue_id=sample_issue.id)
+
+    assert issue.comment_count == 0
+    assert issue.comments == []
+    assert issue.comments_omitted is False
+    mock_client.list_comments.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_beads_create_issue(sample_issue):
     """Test beads_create_issue tool."""
     mock_client = AsyncMock()
@@ -583,6 +622,17 @@ async def test_beads_blocked():
     )
     mock_client = AsyncMock()
     mock_client.blocked = AsyncMock(return_value=[blocked_issue])
+    mock_client.list_comments = AsyncMock(
+        return_value=[
+            Comment(
+                id="c-1",
+                issue_id=blocked_issue.id,
+                author="agent",
+                text="Blocked chronology",
+                created_at=now,
+            )
+        ]
+    )
 
     with patch("beads_mcp.tools._get_client", return_value=mock_client):
         result = await beads_blocked()
@@ -590,7 +640,10 @@ async def test_beads_blocked():
     assert len(result) == 1
     assert result[0].id == "bd-1"
     assert result[0].blocked_by_count == 2
+    assert result[0].comment_count == 1
+    assert result[0].comments_omitted is True
     mock_client.blocked.assert_called_once()
+    mock_client.list_comments.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- Preserve `comment_count`, `comments`, and `comments_omitted` when CLI issue JSON is parsed by the MCP models.
- Return comment completeness metadata from show, list, ready, blocked, brief, and compact projections.
- Hydrate the full comment chronology for full show responses and when callers explicitly request the `comments` field.
- Derive counts from comment bodies for compatibility with older `bd` binaries that omit `comment_count`.
- Add model, client, FastMCP, compaction, and real CLI/MCP regression coverage.

## Why

The MCP model layer discarded the CLI's comment metadata and bodies. A read could therefore present an issue without its later comments while giving callers no indication that the result was incomplete. This patch makes omission explicit and keeps full issue reads complete.

## Related upstream work

- #5078 documents the same machine-consumer failure at the `bd show --json` boundary: comment-borne state can be reported as absent when bodies are not returned.
- #4122 tracks the broader default-payload contract introduced by #4010. This PR does not change the CLI default; it preserves and consumes the completeness signals already available to the MCP integration.
- #5182 touches the same MCP files as part of a much broader events-journal branch and currently removes the `comment`, `comments`, and `note` MCP surfaces. This PR is scoped to current `main` and neither replaces nor incorporates #5182's events work.

## Verification

`BEADS_TEST_BD_BINARY=/Users/mark/.local/bin/bd make ci-package-mcp`

- Ruff: passed
- mypy: passed
- pytest: 230 passed, 5 environment-specific worktree tests skipped
- sdist and wheel build: passed

_codex-gpt-5-unknown-reasoning on behalf of Mark_
