### PR TITLE
fix(dolt): harden Pull() merge-landed post-condition (maintainer follow-up to #5892)

### DIFF
--- a/cmd/bd/sync.go
+++ b/cmd/bd/sync.go
@@ -63,6 +63,7 @@ const (
 const (
 	syncTransientPushRace   = "push-race"
 	syncTransientDirtyGraph = "dirty-graph"
+	syncTransientPullBehind = "pull-behind"
 )
 
 // syncOutcome is one run of the sync loop.
@@ -298,6 +299,22 @@ func runSyncLoop(ctx context.Context, ops syncOps, maxAttempts int) (*syncOutcom
 			return out, nil
 		}
 		if pullErr != nil {
+			// A pull that merged nothing only because the branch is a strict
+			// ancestor of a remote tip that moved after our fetch is the pull-side
+			// twin of a push race: a peer advanced the remote, and the next pull
+			// fast-forwards it. Re-enter the loop instead of hard-failing the tick;
+			// if the budget runs out, the retries-exhausted exit tells the timer to
+			// try again next tick (same as a push race or a dirty working set). It
+			// is classified from the typed sentinel, never the message, so a
+			// genuine divergence — which verifyPullLanded leaves unwrapped — falls
+			// through to the hard error below.
+			if isPullBehindFastForwardableErr(pullErr) {
+				out.Transients = append(out.Transients, syncTransient{
+					Attempt: attempt, Kind: syncTransientPullBehind, Error: pullErr.Error(),
+				})
+				ops.report("pull behind a fast-forwardable remote tip (peer pushed after our fetch) — re-pulling and retrying")
+				continue
+			}
 			return out, fmt.Errorf("pull: %w", pullErr)
 		}
 		if conflictErr != nil {
@@ -497,6 +514,21 @@ func isPushRaceErr(err error) bool {
 // push rather than publishing a stale is_blocked.
 func isRecomputeDirtyGraphErr(err error) bool {
 	return err != nil && errors.Is(err, issueops.ErrBlockedRecomputeDirtyGraph)
+}
+
+// isPullBehindFastForwardableErr reports whether a pull's post-condition refused
+// to call the pull a success only because the branch this database reads is a
+// strict ancestor of a remote tip that moved after this pull's fetch — the
+// benign race a plain re-pull fast-forwards, and the one merged-nothing failure
+// retrying can fix.
+//
+// Classified from the typed sentinel, never the message
+// (versioncontrolops.ErrPullBehindFastForwardable), for the same reason
+// isRecomputeDirtyGraphErr is: a reworded diagnostic must not silently demote a
+// genuine divergence into this retryable class. Only verifyPullLanded's
+// merge-base test wraps the sentinel, and only for the ancestor case.
+func isPullBehindFastForwardableErr(err error) bool {
+	return err != nil && errors.Is(err, versioncontrolops.ErrPullBehindFastForwardable)
 }
 
 // graphConstraintViolations reports the constraint violations, if any,

--- a/cmd/bd/sync_test.go
+++ b/cmd/bd/sync_test.go
@@ -147,6 +147,15 @@ func (r *syncOpsRecorder) ops() syncOps {
 
 func raceErr() error { return errors.New("push rejected: remote is ahead (non-fast-forward)") }
 
+// behindErr mirrors what verifyPullLanded returns for the benign
+// fast-forwardable-behind race: the typed sentinel wrapped around the
+// merged-nothing diagnosis. The loop must classify it from the wrap, not the
+// message.
+func behindErr() error {
+	return fmt.Errorf("%w: pull from origin/main reported success but merged nothing",
+		versioncontrolops.ErrPullBehindFastForwardable)
+}
+
 func TestRunSyncLoopHappyPath(t *testing.T) {
 	r := &syncOpsRecorder{recomputeVals: []int{4}}
 	out, err := runSyncLoop(context.Background(), r.ops(), defaultSyncAttempts)
@@ -346,6 +355,78 @@ func TestRunSyncLoopPullErrorWithoutConflicts(t *testing.T) {
 	}
 	if r.pulls != 1 {
 		t.Errorf("pulls = %d, want 1 (no retry on a non-race failure)", r.pulls)
+	}
+}
+
+// A pull that merged nothing only because the branch is behind a fast-forwardable
+// remote tip (a peer pushed after our fetch) is the pull-side twin of a push
+// race: re-entering the loop re-pulls and merges the commits that beat us, and it
+// converges.
+func TestRunSyncLoopPullBehindFastForwardableRetriesAndSucceeds(t *testing.T) {
+	r := &syncOpsRecorder{
+		pullErrs:      []error{behindErr(), nil},
+		recomputeVals: []int{5},
+	}
+	out, err := runSyncLoop(context.Background(), r.ops(), defaultSyncAttempts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Status != syncStatusOK {
+		t.Fatalf("status = %q, want %q", out.Status, syncStatusOK)
+	}
+	if out.Attempts != 2 {
+		t.Errorf("Attempts = %d, want 2", out.Attempts)
+	}
+	if r.pulls != 2 {
+		t.Errorf("pulls = %d, want 2 (a fast-forwardable-behind pull must re-pull)", r.pulls)
+	}
+	if !out.Pushed {
+		t.Error("Pushed = false, want true after the retry converged")
+	}
+	if !out.sawTransient(syncTransientPullBehind) {
+		t.Errorf("Transients = %v, want a %q entry", out.Transients, syncTransientPullBehind)
+	}
+}
+
+// When the fast-forwardable-behind race never clears within the attempt budget,
+// the loop exits retries-exhausted (exit 3, "transient — retry next tick"), NOT a
+// hard error, and never pushes on a pull that landed nothing.
+func TestRunSyncLoopPullBehindFastForwardableRetriesExhausted(t *testing.T) {
+	r := &syncOpsRecorder{pullErrs: []error{behindErr()}}
+	out, err := runSyncLoop(context.Background(), r.ops(), 2)
+	if err != nil {
+		t.Fatalf("a self-healing fast-forwardable-behind pull must not hard-fail: %v", err)
+	}
+	if out.Status != syncStatusRetriesExhausted {
+		t.Fatalf("status = %q, want %q", out.Status, syncStatusRetriesExhausted)
+	}
+	if out.Attempts != 2 {
+		t.Errorf("Attempts = %d, want 2", out.Attempts)
+	}
+	if r.pulls != 2 {
+		t.Errorf("pulls = %d, want 2 (bounded by --attempts)", r.pulls)
+	}
+	if r.pushes != 0 {
+		t.Errorf("pushes = %d, want 0 (never push when no pull landed)", r.pushes)
+	}
+	if !out.sawTransient(syncTransientPullBehind) {
+		t.Errorf("Transients = %v, want a %q entry", out.Transients, syncTransientPullBehind)
+	}
+}
+
+// The classification is from the typed sentinel, never the message: a genuine
+// divergence carries the same "merged nothing" wording but must stay a hard
+// error, so a message match would demote it into the retry budget and burn every
+// tick on a divergence that can never fast-forward.
+func TestIsPullBehindFastForwardableErr(t *testing.T) {
+	if !isPullBehindFastForwardableErr(behindErr()) {
+		t.Error("the wrapped sentinel must classify as fast-forwardable-behind")
+	}
+	if isPullBehindFastForwardableErr(errors.New("pull reported success but merged nothing")) {
+		t.Error("a message-only lookalike must NOT classify as fast-forwardable-behind")
+	}
+	if isPullBehindFastForwardableErr(nil) {
+		t.Error("nil must not classify")
 	}
 }
 

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -5,6 +5,7 @@ package dolt
 import (
 	"context"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -22,6 +23,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/storage/schema"
+	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
 	"github.com/steveyegge/beads/internal/testutil"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -1800,4 +1802,129 @@ func TestPullReportsSuccessOnlyWhenTheMergeLanded(t *testing.T) {
 		t.Fatalf("Pull failed, but not with the merged-nothing post-condition: %v", pullErr)
 	}
 	t.Logf("Pull correctly refused to call this success: %v", pullErr)
+}
+
+// TestPullVerifyUsesBranchQualifiedPreHead pins ga-ivaps Finding 1 (attempt 2):
+// verifyPullLanded's cheap fast path skips the containment check when the branch
+// head MOVED across the pull — a head that moved is proof the transport landed.
+// That inference is only sound when the pre-pull head was read from the SAME
+// branch the post-pull comparison reads (s.branch). Pull now captures it via
+// branchHash(s.branch); a regression to GetCurrentCommit (session HEAD) would,
+// on a pooled connection sitting on the database's default branch, hand back a
+// different branch's head, so a merge that never reached s.branch would look
+// like it had — the fast path would fire and wave a lying pull through.
+//
+// It exercises that fast path directly and DETERMINISTICALLY by calling
+// verifyPullLanded with the two candidate pre-pull heads rather than trying to
+// force a pooled connection onto the wrong branch (which an effectively
+// single-connection server-mode store makes unreachable in-process — the very
+// reason TestPullReportsSuccessOnlyWhenTheMergeLanded has to t.Skip). The
+// wrong-branch head (main's tip, what the bug reads) must skip the check; the
+// branch-qualified head (feature's tip, what the fix reads) must run it and
+// catch the divergence. This is the non-environment-dependent coverage the
+// attempt-2 scorecard asked for.
+func TestPullVerifyUsesBranchQualifiedPreHead(t *testing.T) {
+	store, setup, cleanup := setupEmbeddedGitRemote(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	// A committed, pushed main so branchHash(main) is a real, distinct hash to
+	// stand in for "the branch a stray pooled connection is parked on".
+	seed := &types.Issue{
+		ID:        "bq-main-001",
+		Title:     "Main seed",
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Priority:  2,
+	}
+	if err := store.CreateIssue(ctx, seed, "tester"); err != nil {
+		t.Fatalf("CreateIssue(main seed) failed: %v", err)
+	}
+	if err := store.Commit(ctx, "Add bq-main-001"); err != nil {
+		t.Fatalf("Commit(main seed) failed: %v", err)
+	}
+	if err := store.Push(ctx); err != nil {
+		t.Fatalf("Push(main) failed: %v", err)
+	}
+
+	// The store operates on feature; publish it so a peer can clone and advance it.
+	if err := store.Branch(ctx, "feature"); err != nil {
+		t.Fatalf("Branch(feature) failed: %v", err)
+	}
+	if err := store.Checkout(ctx, "feature"); err != nil {
+		t.Fatalf("Checkout(feature) failed: %v", err)
+	}
+	if err := store.Push(ctx); err != nil {
+		t.Fatalf("pushing the feature branch failed: %v", err)
+	}
+
+	// feature gets a LOCAL-ONLY commit — the reviewer's exact scenario. It moves
+	// feature's tip off both main and the pushed feature tip, and makes the
+	// divergence a genuine one: the peer's branch below shares only the pushed
+	// feature tip as an ancestor, so neither head is the other's. An --allow-empty
+	// commit is the minimal way to advance the tip: what this test needs from the
+	// commit is the new hash on feature, nothing in its tree. Going through
+	// CreateIssue would drag in the write path's cross-table ID-collision probe —
+	// unrelated to verifyPullLanded — and couple the fixture to that schema. The
+	// store session is on feature (Checkout set s.branch above), so DOLT_COMMIT
+	// lands here.
+	if _, err := store.db.ExecContext(ctx,
+		"CALL DOLT_COMMIT('--allow-empty', '-m', 'feature local-only commit')"); err != nil {
+		t.Fatalf("local-only feature commit failed: %v", err)
+	}
+
+	// A peer advances origin/feature from its own process, diverging it from the
+	// local feature branch.
+	cloneDir := filepath.Join(setup.baseDir, "clone-bq")
+	doltClone(t, setup.remoteURL, cloneDir)
+	runCmd(t, cloneDir, "dolt", "fetch", "origin")
+	runCmd(t, cloneDir, "dolt", "checkout", "feature")
+	sourceInsertIssue(t, cloneDir, "bq-clone-001", "Clone issue on feature")
+	runDoltSQL(t, cloneDir, "CALL DOLT_ADD('.'); CALL DOLT_COMMIT('-Am', 'Add bq-clone-001 on feature')")
+	runCmd(t, cloneDir, "dolt", "push", "origin", "feature")
+
+	// The sql-server caches its last read of the remote, and the verify's own
+	// refresh fetch is served from that cache inside the TTL. Wait it out so the
+	// refresh actually sees the peer's commit and the divergence is real.
+	waitOutGitRemoteReadCache()
+
+	featureTip, err := store.branchHash(ctx, "feature")
+	if err != nil || featureTip == "" {
+		t.Fatalf("branchHash(feature) failed: hash=%q err=%v", featureTip, err)
+	}
+	mainTip, err := store.branchHash(ctx, "main")
+	if err != nil || mainTip == "" {
+		t.Fatalf("branchHash(main) failed: hash=%q err=%v", mainTip, err)
+	}
+	if featureTip == mainTip {
+		t.Fatalf("scenario broken: feature and main share tip %q, so a wrong-branch preHead would not differ from the branch-qualified one", featureTip)
+	}
+
+	// The bug's input: preHead read from the wrong branch (main). localHash is
+	// feature's tip, so localHash != preHead trips the fast path and the check is
+	// skipped — the lying pull is (wrongly) called a success. This is the fast
+	// path's load-bearing contract: it is only ever safe when preHead is s.branch.
+	if err := store.verifyPullLanded(ctx, "origin", mainTip); err != nil {
+		t.Fatalf("fast-path contract broken: a wrong-branch preHead must skip the check (return nil), got: %v", err)
+	}
+
+	// The fix's input: preHead read from s.branch (feature). localHash == preHead,
+	// so the fast path does not fire, the containment check runs, and it catches
+	// the divergence the merge left on the wrong branch.
+	got := store.verifyPullLanded(ctx, "origin", featureTip)
+	if got == nil {
+		t.Fatalf("branch-qualified preHead must run the containment check and catch the divergence, got nil")
+	}
+	if msg := got.Error(); !strings.Contains(msg, "merged nothing") || !strings.Contains(msg, "remotes/origin/feature") {
+		t.Fatalf("caught an error, but not the merged-nothing post-condition: %v", got)
+	}
+	// The divergence is genuine — sibling histories whose common ancestor is
+	// neither tip — so it must stay a HARD error, not the fast-forwardable
+	// retryable class bd sync would loop on.
+	if errors.Is(got, versioncontrolops.ErrPullBehindFastForwardable) {
+		t.Fatalf("a genuine divergence must not be classified fast-forwardable-retryable: %v", got)
+	}
+	t.Logf("branch-qualified preHead correctly caught the divergence: %v", got)
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -3987,14 +3987,31 @@ func (s *DoltStore) pullFromRemoteUnchecked(ctx context.Context, remote string) 
 		}
 	}
 
-	// bd-6dnrw.3: capture the pre-pull HEAD so a successful merge can recompute
-	// the denormalized is_blocked column for the rows it changed. Read before
-	// the transport; an unreadable HEAD degrades to a full recompute.
+	// bd-6dnrw.3: capture the pre-pull commit of the branch this store reads so a
+	// successful merge can recompute the denormalized is_blocked column for the
+	// rows it changed. Read before the transport; an unreadable head degrades to
+	// a full recompute.
+	//
+	// ga-ivaps Finding 3: read this unconditionally, including for read-only
+	// stores. verifyPullLanded's cheap fast path — a head that moved is proof the
+	// transport landed — needs it, and without it every pull that DID merge
+	// something pays a network DOLT_FETCH round trip it could have skipped. (A
+	// no-op pull moves no head and refreshes the tracking ref regardless, so the
+	// saved round trip is on the merged pulls, never the no-op ones.)
+	// recomputeBlockedAfterPull below still runs only for writable stores.
+	//
+	// ga-ivaps Finding 1 (attempt 2): read the tip of s.branch, not the session
+	// HEAD. verifyPullLanded compares this against branchHash(ctx, s.branch) after
+	// the pull, so reading the same branch here is what makes "the head moved"
+	// mean THIS branch moved. On a multi-connection pool a query can land on a
+	// connection still checked out to the database's default branch (the be-b0am
+	// hazard), so GetCurrentCommit could report a different branch's head; when
+	// that differs from the post-pull s.branch tip the fast path fires on a merge
+	// that never reached s.branch and skips the very containment check meant to
+	// catch it. branchHash reads dolt_branches, which is branch-global.
 	preHead := ""
-	if !s.readOnly {
-		if h, err := s.GetCurrentCommit(ctx); err == nil {
-			preHead = h
-		}
+	if h, err := s.branchHash(ctx, s.branch); err == nil {
+		preHead = h
 	}
 
 	if err := s.pullTransport(ctx, remote); err != nil {
@@ -4105,7 +4122,16 @@ func (s *DoltStore) verifyPullLanded(ctx context.Context, remote, preHead string
 	// reads a ref this connection wrote. Best-effort by design: a refresh that
 	// cannot run leaves the weaker stale-ref comparison, which is still worth
 	// making.
-	if err := schema.DrainCall(ctx, s.db, "CALL DOLT_FETCH(?, ?)", remote, s.branch); err != nil {
+	//
+	// ga-ivaps Finding (attempt 2): route the fetch over a long-timeout,
+	// credential-aware connection instead of s.db. s.db carries the default ~10s
+	// pool read timeout and none of the remote credentials the CLI-routed
+	// (git-protocol, credential, cloud-auth) remotes need, so on exactly those
+	// remotes the refresh would time out or auth-fail and the check would fall
+	// back to the stale-ref comparison — fail open — for the transports most
+	// likely to have dropped a merge. refreshTrackingRef mirrors the pull path's
+	// own network calls, so the refresh reaches the same remotes the pull can.
+	if err := s.refreshTrackingRef(ctx, remote); err != nil {
 		log.Printf("warning: could not refresh %s to verify the pull landed: %v", trackingRef, err)
 	}
 
@@ -4130,14 +4156,70 @@ func (s *DoltStore) verifyPullLanded(ctx context.Context, remote, preHead string
 		return nil
 	}
 
+	// ga-ivaps Finding 2 (attempt 2): the branch this database reads does not
+	// contain the refreshed tracking ref, and the merge base splits that into two
+	// states with very different recovery.
+	//
+	//   - mergeBase == localHash: local is a strict ANCESTOR of the tracking ref,
+	//     so the remote merely moved ahead and a plain re-pull fast-forwards it.
+	//     This is the ordinary "a peer pushed after our fetch" race — benign and
+	//     self-correcting — so it is wrapped in ErrPullBehindFastForwardable and
+	//     bd sync's loop retries it like a push race instead of hard-failing the
+	//     tick (cmd/bd/sync.go). The message still names both hashes and "merged
+	//     nothing", so a caller that surfaces it reads the same diagnosis.
+	//   - otherwise: local and the tracking ref have genuinely diverged (their
+	//     common ancestor is neither tip), which no re-pull can fast-forward away.
+	//     That is the stuck-transport / split-brain signal, and it stays a hard
+	//     error.
+	//
+	// The split fails safe: a true divergence can never be demoted to the
+	// retryable class, because its common ancestor is by definition neither tip.
+	// Distinguishing the benign race from a genuinely failed transport would
+	// still need the remote tip as of the transport's own fetch, which git-backed
+	// remotes never write into this database; the merge base is the best post-hoc
+	// split available. Classified before the display fallback below rewrites an
+	// empty localHash.
+	behindFastForwardable := localHash != "" && mergeBase.String == localHash
+
 	if localHash == "" {
 		localHash = "unknown"
 	}
-	return fmt.Errorf("pull from %s/%s reported success but merged nothing into %s: %s is at %s while %s is at %s "+
-		"(their common ancestor is %s), so the fetched commits are not on the branch this database reads; "+
-		"the transport did not land — re-run the pull, and if it repeats, check that the dolt CLI directory and "+
-		"the sql-server are serving the same database and branch",
+	mergedNothing := fmt.Errorf("pull from %s/%s reported success but merged nothing into %s: %s is at %s while %s is at %s "+
+		"(their common ancestor is %s), so the commits on the remote-tracking ref are not on the branch this "+
+		"database reads. Most often another client pushed after this pull fetched and a re-run will merge it; "+
+		"if the divergence survives repeated re-runs, the transport is not landing merges on this branch "+
+		"(for example the dolt CLI directory and the sql-server are serving different databases or branches)",
 		remote, s.branch, s.branch, s.branch, localHash, trackingRef, remoteHash, mergeBase.String)
+	if behindFastForwardable {
+		return fmt.Errorf("%w: %w", versioncontrolops.ErrPullBehindFastForwardable, mergedNothing)
+	}
+	return mergedNothing
+}
+
+// refreshTrackingRef fetches remote/s.branch into this database's
+// remote-tracking refs over a dedicated long-timeout, credential-aware
+// connection, so verifyPullLanded's comparison reads a tracking ref this
+// database just wrote. It mirrors pullTransport's own network calls: a
+// long-timeout connection (openLongTimeoutConn) wrapped in the remote's
+// credential/S3 environment (withRemoteOperationEnv), which is what lets the
+// refresh reach CLI-routed (git-protocol, credential, cloud-auth) remotes that
+// the default s.db pool — short read timeout, no CLI credentials — cannot.
+//
+// Only the FETCH runs here, and DOLT_FETCH is branch-global: it advances
+// remote-tracking refs and never touches the working branch, so the fresh
+// connection's default-branch checkout — the be-b0am hazard that makes a merge
+// on such a connection unsafe — does not apply. The containment reads in
+// verifyPullLanded stay on s.db, where the short pool timeout is right: they are
+// local, fast, and branch-parameterized.
+func (s *DoltStore) refreshTrackingRef(ctx context.Context, remote string) error {
+	db, err := s.openLongTimeoutConn()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	return withRemoteOperationEnv(s.credentialsForRemote(remote), s.isS3Remote(ctx, remote), func() error {
+		return schema.DrainCall(ctx, db, "CALL DOLT_FETCH(?, ?)", remote, s.branch)
+	})
 }
 
 // pullTransport routes one pull through CLI or SQL based on the remote's

--- a/internal/storage/versioncontrolops/mergesettle.go
+++ b/internal/storage/versioncontrolops/mergesettle.go
@@ -102,6 +102,17 @@ func (e *MergeConflictsError) Error() string {
 
 func (e *MergeConflictsError) Unwrap() error { return e.MergeErr }
 
+// ErrPullBehindFastForwardable marks the one "pull reported success but merged
+// nothing" state that a plain re-pull fixes on its own: the branch this database
+// reads is a strict ANCESTOR of the refreshed remote-tracking ref, so a peer
+// pushed after this pull's fetch and the next pull fast-forwards it. bd sync's
+// loop treats it as a transient — like a push race — instead of hard-failing the
+// tick. A genuine divergence (a common ancestor that is neither tip) is NOT
+// wrapped in this and stays a hard error, because retrying cannot converge it.
+// The concrete error this wraps still carries the full both-hashes diagnosis;
+// the sentinel only classifies it.
+var ErrPullBehindFastForwardable = errors.New("pull merged nothing but the local branch is behind a fast-forwardable remote tip")
+
 // SettleMerge finishes a merge that ran on db with the session flags
 // MergeAndSettle sets: it auto-resolves the safe conflict classes, repairs FK
 // cascade violations (bd-6dnrw.4), and leaves the settled working set in


### PR DESCRIPTION
## Maintainer follow-up to #5892

This is a maintainer follow-up PR carrying the review hardening that came out of
the `/adopt-pr` review of #5892. The original PR merged at its contributor head
before this maintainer fixup was applied, so the hardening below is not yet on
`main` and is carried forward here as a single maintainer commit.

**Original PR:** [#5892 — fix(dolt): stop Pull() reporting success when the merge never landed](https://github.com/gastownhall/beads/pull/5892)
- State: **MERGED** (squash-merged into `main`; the contributor fix `verifyPullLanded` is already on `main`).
- Original GitHub base: `main`.
- Workflow-configured base: `fix/be-server-lane-git-remote-tests` (that branch was where the adoption workflow was launched; the PR itself targeted and merged `main`, so this follow-up targets `main`, where the contributor change landed).

### What this adds
Only the maintainer hardening commit produced by the multi-model review — the
contributor's already-merged changes are **not** re-included:

- **Branch-qualify the fast-path pre-head.** `Pull()`'s merged-landed check now
  reads `s.branch` from the DB-global `dolt_branches` table instead of the
  pooled connection's ambient checkout, so the post-condition is correct on a
  shared sql-server where the connection's default branch may differ.
- **Split "merged nothing" into retryable vs hard.** A pull that landed nothing
  only because the local branch is a strict ancestor of a fast-forwardable
  remote tip (a peer pushed after our fetch) is now a typed, self-healing
  transient (`versioncontrolops.ErrPullBehindFastForwardable`); a genuine
  divergence stays a hard error. The `bd sync` loop re-pulls (never pushes) on
  that transient and converges, mirroring the existing push-race handling.
  Classification is `errors.Is` on the typed sentinel, never a message match.
- **Route the tracking-ref refresh off the short pool.** `refreshTrackingRef`
  uses a dedicated long-timeout connection with the vetted credential/S3 env
  wrapper and `DOLT_FETCH`, matching the existing pull-fallback network path.

### Tests
- `internal/storage/dolt`: `TestPullVerifyUsesBranchQualifiedPreHead` (new,
  deterministic — exercises the fast path directly) and the two added controls
  in `TestPullReportsSuccessOnlyWhenTheMergeLanded`.
- `cmd/bd`: `TestRunSyncLoopPullBehindFastForwardableRetriesAndSucceeds`,
  `TestRunSyncLoopPullBehindFastForwardableRetriesExhausted`, and
  `TestIsPullBehindFastForwardableErr` assert re-pull-not-push and
  classify-from-sentinel-not-message.

Original contributor commits preserved; this follow-up carries only the
maintainer-side hardening from the review.

---
_Adopted via `/adopt-pr` workflow (follow-up path for an already-merged original)._
