### PR TITLE
fix: keep bd preview commands read-only on v1.1 hotfix

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -906,6 +906,16 @@ func formatTimeForRPC(t *time.Time) string {
 	return t.Format(time.RFC3339)
 }
 
+// openDryRunTargetStore opens the store a `create --dry-run --repo <other>`
+// resolves --parent against. It is read-only on BOTH paths and must stay that
+// way: newDoltStoreFromConfig runs schema initialization on whatever it opens
+// and can rename a legacy hyphenated database and rewrite the target's
+// metadata.json on the way (GH#3231), so using it here would have a dry-run
+// mutate a repository the user only named as a lookup target — the same
+// migrate-at-open trap this preview policy exists to close, one repo over.
+// newPreviewStoreFromConfig is the non-mutating factory for a foreign
+// project (bd-6dnrw.32), relaxed for previews exactly as the root pre-run
+// relaxes the command's own store.
 func openDryRunTargetStore(ctx context.Context, repoPath string) (storage.DoltStorage, error) {
 	if remotecache.IsRemoteURL(repoPath) {
 		cache, err := remotecache.DefaultCache()
@@ -914,7 +924,7 @@ func openDryRunTargetStore(ctx context.Context, repoPath string) (storage.DoltSt
 		}
 		// The dry-run parent lookup only reads from this cached remote store.
 		// Do not add writes here; dry-runs must not mutate cached remotes.
-		store, err := cache.OpenStore(ctx, repoPath, newDoltStoreFromConfig)
+		store, err := cache.OpenStore(ctx, repoPath, newPreviewStoreFromConfig)
 		if err != nil {
 			return nil, fmt.Errorf("dry-run parent lookup requires an existing cached remote store for %s: %w", repoPath, err)
 		}
@@ -931,7 +941,7 @@ func openDryRunTargetStore(ctx context.Context, repoPath string) (storage.DoltSt
 		return nil, fmt.Errorf("failed to inspect target repo %s: %w", targetPath, err)
 	}
 
-	store, err := newDoltStoreFromConfig(ctx, beadsDir)
+	store, err := newPreviewStoreFromConfig(ctx, beadsDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open target store for dry-run: %w", err)
 	}

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -1102,50 +1102,6 @@ func TestEmbeddedPreviewDoesNotConsumeVersionMarker(t *testing.T) {
 	}
 }
 
-func TestEmbeddedChangeDirOverridesInheritedBeadsDir(t *testing.T) {
-	bd := buildEmbeddedBD(t)
-	callerDir, callerBeadsDir, _ := bdInit(t, bd, "--prefix", "caller")
-	targetDir, targetBeadsDir, _ := bdInit(t, bd, "--prefix", "target")
-
-	cmd := exec.Command(bd, "-C", targetDir, "create", "Explicit target", "--json")
-	cmd.Dir = callerDir
-	cmd.Env = append(bdEnv(callerDir), "BEADS_DIR="+callerBeadsDir)
-	stdout, stderr, err := runCommandBuffers(t, cmd)
-	if err != nil {
-		t.Fatalf("bd -C target create failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
-	}
-
-	countIssues := func(beadsDir, database string) int {
-		t.Helper()
-		db, cleanup, err := embeddeddolt.OpenSQL(
-			t.Context(),
-			filepath.Join(beadsDir, "embeddeddolt"),
-			database,
-			"main",
-		)
-		if err != nil {
-			t.Fatalf("OpenSQL %s: %v", database, err)
-		}
-		defer func() {
-			if err := cleanup(); err != nil {
-				t.Errorf("cleanup OpenSQL %s: %v", database, err)
-			}
-		}()
-		var count int
-		if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM issues").Scan(&count); err != nil {
-			t.Fatalf("count issues in %s: %v", database, err)
-		}
-		return count
-	}
-
-	if got := countIssues(callerBeadsDir, "caller"); got != 0 {
-		t.Fatalf("inherited BEADS_DIR received %d issues, want 0", got)
-	}
-	if got := countIssues(targetBeadsDir, "target"); got != 1 {
-		t.Fatalf("-C target received %d issues, want 1", got)
-	}
-}
-
 // TestEmbeddedCreateCommitPending verifies that CommitPending works on EmbeddedDoltStore:
 // no-op when clean, commits when there are pending changes.
 func TestEmbeddedCreateCommitPending(t *testing.T) {

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -871,6 +872,278 @@ A new feature
 			t.Errorf("expected title-related error, got: %s", out)
 		}
 	})
+}
+
+// embeddedStoreSnapshot is the "did anything write to this database?"
+// tripwire the preview regression tests compare across a command run.
+type embeddedStoreSnapshot struct {
+	schemaVersion int
+	head          string
+	issueCount    int
+}
+
+func readEmbeddedStoreSnapshot(t *testing.T, beadsDir, database string) embeddedStoreSnapshot {
+	t.Helper()
+	db, cleanup, err := embeddeddolt.OpenSQL(
+		t.Context(),
+		filepath.Join(beadsDir, "embeddeddolt"),
+		database,
+		"main",
+	)
+	if err != nil {
+		t.Fatalf("OpenSQL: %v", err)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			t.Errorf("cleanup OpenSQL: %v", err)
+		}
+	}()
+
+	var got embeddedStoreSnapshot
+	if err := db.QueryRowContext(t.Context(),
+		"SELECT COALESCE(MAX(version), 0) FROM schema_migrations").Scan(&got.schemaVersion); err != nil {
+		t.Fatalf("read schema version: %v", err)
+	}
+	if err := db.QueryRowContext(t.Context(), "SELECT HASHOF('HEAD')").Scan(&got.head); err != nil {
+		t.Fatalf("read HEAD: %v", err)
+	}
+	if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM issues").Scan(&got.issueCount); err != nil {
+		t.Fatalf("read issue count: %v", err)
+	}
+	return got
+}
+
+// regressEmbeddedSchemaCursor rolls the recorded migration cursor back one
+// version WITHOUT touching the physical schema. The latest migration is
+// idempotent, so a writable open reapplies it, restores the cursor, and
+// commits a new HEAD — which is exactly what makes the cursor a usable
+// tripwire. Keeping the physical schema intact lets the preview's own reads
+// still work against the older recorded version.
+func regressEmbeddedSchemaCursor(t *testing.T, beadsDir, database string) {
+	t.Helper()
+	db, cleanup, err := embeddeddolt.OpenSQL(
+		t.Context(),
+		filepath.Join(beadsDir, "embeddeddolt"),
+		database,
+		"main",
+	)
+	if err != nil {
+		t.Fatalf("OpenSQL for regression fixture: %v", err)
+	}
+	if _, err := db.ExecContext(t.Context(),
+		"DELETE FROM schema_migrations WHERE version = ?", schema.LatestVersion()); err != nil {
+		_ = cleanup()
+		t.Fatalf("regress schema cursor: %v", err)
+	}
+	if _, err := db.ExecContext(t.Context(),
+		"CALL DOLT_COMMIT('-am', 'test: regress schema before dry-run')"); err != nil {
+		_ = cleanup()
+		t.Fatalf("commit regressed schema cursor: %v", err)
+	}
+	if err := cleanup(); err != nil {
+		t.Fatalf("cleanup regression fixture: %v", err)
+	}
+}
+
+func TestEmbeddedCreateDryRunDoesNotMigrate(t *testing.T) {
+	bd := buildEmbeddedBD(t)
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "dnm")
+	bdCreate(t, bd, dir, "Existing issue")
+
+	readSnapshot := func() embeddedStoreSnapshot {
+		return readEmbeddedStoreSnapshot(t, beadsDir, "dnm")
+	}
+
+	regressEmbeddedSchemaCursor(t, beadsDir, "dnm")
+
+	// Force the version-bump path that previously opened a second writable
+	// store and migrated before create.RunE reached --dry-run handling.
+	if err := os.WriteFile(filepath.Join(beadsDir, localVersionFile), []byte("0.9.0\n"), 0o600); err != nil {
+		t.Fatalf("write old local version: %v", err)
+	}
+
+	before := readSnapshot()
+	if before.schemaVersion != schema.LatestVersion()-1 {
+		t.Fatalf("fixture schema version = %d, want %d", before.schemaVersion, schema.LatestVersion()-1)
+	}
+
+	cmd := exec.Command(bd, "create", "--dry-run", "Preview only", "--json")
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd create --dry-run failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+
+	after := readSnapshot()
+	if after.schemaVersion != before.schemaVersion {
+		t.Errorf("schema version changed during dry-run: before=%d after=%d", before.schemaVersion, after.schemaVersion)
+	}
+	if after.head != before.head {
+		t.Errorf("Dolt HEAD changed during dry-run: before=%s after=%s", before.head, after.head)
+	}
+	if after.issueCount != before.issueCount {
+		t.Errorf("issue count changed during dry-run: before=%d after=%d", before.issueCount, after.issueCount)
+	}
+}
+
+// TestEmbeddedCreateDryRunCrossRepoDoesNotMigrateTarget covers the second
+// store a dry-run can reach: `create --dry-run --parent X --repo <other>`
+// resolves the parent against the OTHER repo, and openDryRunTargetStore used
+// to open it with the writable factory. The command's own store being opened
+// read-only says nothing about that one — the mutation lands in a repository
+// the user only named as a lookup target.
+func TestEmbeddedCreateDryRunCrossRepoDoesNotMigrateTarget(t *testing.T) {
+	bd := buildEmbeddedBD(t)
+	targetDir, targetBeadsDir, _ := bdInit(t, bd, "--prefix", "xtgt")
+	parent := bdCreate(t, bd, targetDir, "Parent in the target repo")
+	if parent.ID == "" {
+		t.Fatal("parent issue has no ID")
+	}
+
+	callerDir, callerBeadsDir, _ := bdInit(t, bd, "--prefix", "xsrc")
+
+	// The tripwire goes in the TARGET repo: only a writable open of that repo
+	// restores its cursor and commits.
+	regressEmbeddedSchemaCursor(t, targetBeadsDir, "xtgt")
+
+	// Force the version-bump path in the caller repo too, so this exercises
+	// the same post-upgrade window as the single-repo test.
+	if err := os.WriteFile(filepath.Join(callerBeadsDir, localVersionFile), []byte("0.9.0\n"), 0o600); err != nil {
+		t.Fatalf("write old local version: %v", err)
+	}
+
+	before := readEmbeddedStoreSnapshot(t, targetBeadsDir, "xtgt")
+	if before.schemaVersion != schema.LatestVersion()-1 {
+		t.Fatalf("fixture schema version = %d, want %d", before.schemaVersion, schema.LatestVersion()-1)
+	}
+
+	cmd := exec.Command(bd, "create", "--dry-run",
+		"--parent", parent.ID, "--repo", targetDir, "Preview only", "--json")
+	cmd.Dir = callerDir
+	cmd.Env = bdEnv(callerDir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd create --dry-run --parent --repo failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+
+	after := readEmbeddedStoreSnapshot(t, targetBeadsDir, "xtgt")
+	if after.schemaVersion != before.schemaVersion {
+		t.Errorf("target repo schema version changed during cross-repo dry-run: before=%d after=%d", before.schemaVersion, after.schemaVersion)
+	}
+	if after.head != before.head {
+		t.Errorf("target repo Dolt HEAD changed during cross-repo dry-run: before=%s after=%s", before.head, after.head)
+	}
+	if after.issueCount != before.issueCount {
+		t.Errorf("target repo issue count changed during cross-repo dry-run: before=%d after=%d", before.issueCount, after.issueCount)
+	}
+}
+
+// TestEmbeddedPreviewDoesNotConsumeVersionMarker is the two-invocation
+// regression for the one-shot upgrade signal: a preview run first after an
+// upgrade correctly skips the version-bump reconciliation, so it must also
+// leave .beads/.local_version alone. Burning the marker there would mean the
+// next ordinary command sees a matching version and never reconciles —
+// whichever command happened to run first would silently decide whether the
+// upgrade was finished.
+func TestEmbeddedPreviewDoesNotConsumeVersionMarker(t *testing.T) {
+	bd := buildEmbeddedBD(t)
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "pvm")
+	bdCreate(t, bd, dir, "Existing issue")
+
+	localVersionPath := filepath.Join(beadsDir, localVersionFile)
+	if err := os.WriteFile(localVersionPath, []byte("0.9.0\n"), 0o600); err != nil {
+		t.Fatalf("write old local version: %v", err)
+	}
+
+	// Invocation 1: preview.
+	preview := exec.Command(bd, "create", "--dry-run", "Preview only", "--json")
+	preview.Dir = dir
+	preview.Env = bdEnv(dir)
+	stdout, stderr, err := runCommandBuffers(t, preview)
+	if err != nil {
+		t.Fatalf("bd create --dry-run failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+
+	raw, err := os.ReadFile(localVersionPath)
+	if err != nil {
+		t.Fatalf("read local version after preview: %v", err)
+	}
+	if got := strings.TrimSpace(string(raw)); got != "0.9.0" {
+		t.Fatalf("preview consumed the version marker: .local_version = %q, want %q", got, "0.9.0")
+	}
+
+	// Invocation 2: an ordinary command, which must still see the upgrade.
+	status := exec.Command(bd, "upgrade", "status", "--json")
+	status.Dir = dir
+	status.Env = bdEnv(dir)
+	stdout, stderr, err = runCommandBuffers(t, status)
+	if err != nil {
+		t.Fatalf("bd upgrade status failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	var upgradeStatus struct {
+		Upgraded        bool   `json:"upgraded"`
+		PreviousVersion string `json:"previous_version"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &upgradeStatus); err != nil {
+		t.Fatalf("parse upgrade status: %v\nstdout:\n%s", err, stdout.String())
+	}
+	if !upgradeStatus.Upgraded || upgradeStatus.PreviousVersion != "0.9.0" {
+		t.Errorf("ordinary command after a preview no longer sees the upgrade: upgraded=%v previous=%q; stdout:\n%s",
+			upgradeStatus.Upgraded, upgradeStatus.PreviousVersion, stdout.String())
+	}
+
+	raw, err = os.ReadFile(localVersionPath)
+	if err != nil {
+		t.Fatalf("read local version after ordinary command: %v", err)
+	}
+	if got := strings.TrimSpace(string(raw)); got == "0.9.0" {
+		t.Errorf("ordinary command left .local_version at %q; the marker should have been updated", got)
+	}
+}
+
+func TestEmbeddedChangeDirOverridesInheritedBeadsDir(t *testing.T) {
+	bd := buildEmbeddedBD(t)
+	callerDir, callerBeadsDir, _ := bdInit(t, bd, "--prefix", "caller")
+	targetDir, targetBeadsDir, _ := bdInit(t, bd, "--prefix", "target")
+
+	cmd := exec.Command(bd, "-C", targetDir, "create", "Explicit target", "--json")
+	cmd.Dir = callerDir
+	cmd.Env = append(bdEnv(callerDir), "BEADS_DIR="+callerBeadsDir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd -C target create failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+
+	countIssues := func(beadsDir, database string) int {
+		t.Helper()
+		db, cleanup, err := embeddeddolt.OpenSQL(
+			t.Context(),
+			filepath.Join(beadsDir, "embeddeddolt"),
+			database,
+			"main",
+		)
+		if err != nil {
+			t.Fatalf("OpenSQL %s: %v", database, err)
+		}
+		defer func() {
+			if err := cleanup(); err != nil {
+				t.Errorf("cleanup OpenSQL %s: %v", database, err)
+			}
+		}()
+		var count int
+		if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM issues").Scan(&count); err != nil {
+			t.Fatalf("count issues in %s: %v", database, err)
+		}
+		return count
+	}
+
+	if got := countIssues(callerBeadsDir, "caller"); got != 0 {
+		t.Fatalf("inherited BEADS_DIR received %d issues, want 0", got)
+	}
+	if got := countIssues(targetBeadsDir, "target"); got != 1 {
+		t.Fatalf("-C target received %d issues, want 1", got)
+	}
 }
 
 // TestEmbeddedCreateCommitPending verifies that CommitPending works on EmbeddedDoltStore:

--- a/cmd/bd/directory_flag_test.go
+++ b/cmd/bd/directory_flag_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestResolveChangeDirBeadsDirDoesNotChangeCWD(t *testing.T) {
@@ -61,5 +63,34 @@ func TestResolveChangeDirBeadsDirRejectsFile(t *testing.T) {
 func TestResolveChangeDirBeadsDirRejectsDirectoryWithoutProject(t *testing.T) {
 	if _, err := resolveChangeDirBeadsDir(t.TempDir()); err == nil {
 		t.Fatal("expected -C target without a beads project to fail")
+	}
+}
+
+func TestIsPreviewCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		flag string
+		set  string
+		want bool
+	}{
+		{name: "dry run", flag: "dry-run", set: "true", want: true},
+		{name: "inspect", flag: "inspect", set: "true", want: true},
+		{name: "false preview flag", flag: "dry-run", set: "false", want: false},
+		{name: "no preview flag", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test"}
+			if tt.flag != "" {
+				cmd.Flags().Bool(tt.flag, false, "")
+				if err := cmd.Flags().Set(tt.flag, tt.set); err != nil {
+					t.Fatalf("set %s: %v", tt.flag, err)
+				}
+			}
+			if got := isPreviewCommand(cmd); got != tt.want {
+				t.Fatalf("isPreviewCommand() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -143,6 +143,22 @@ func isReadOnlyCommand(cmdName string) bool {
 	return readOnlyCommands[cmdName]
 }
 
+// isPreviewCommand reports whether cmd was explicitly invoked in a
+// non-mutating preview mode. Preview flags are command-local rather than
+// persistent, so checking them here after Cobra has parsed the selected
+// command is the earliest reliable point to keep the store open read-only.
+func isPreviewCommand(cmd *cobra.Command) bool {
+	for _, name := range []string{"dry-run", "inspect"} {
+		if flag := cmd.Flags().Lookup(name); flag != nil {
+			enabled, err := cmd.Flags().GetBool(name)
+			if err == nil && enabled {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // isWorkingSetReconcileCommand reports whether cmd's whole purpose is to
 // reconcile the Dolt working set: "bd dolt commit" or "bd vc commit". These
 // commands are the documented recovery from a pending-migration dirty-table
@@ -980,22 +996,38 @@ var rootCmd = &cobra.Command{
 			commandSpan.SetAttributes(attribute.String("bd.actor", actor))
 		}
 
-		// Track bd version changes
-		// Best-effort tracking - failures are silent
-		trackBdVersion()
+		// Check if this is a read-only command (GH#804) or an explicitly
+		// non-mutating preview. Both must open the store read-only: otherwise
+		// schema initialization runs before the command's RunE can honor
+		// --dry-run/--inspect or reject invalid arguments.
+		previewMode := isPreviewCommand(cmd)
+		useReadOnly := isReadOnlyCommand(cmd.Name()) || previewMode
 
-		// Check if this is a read-only command (GH#804)
-		// Read-only commands open the store in read-only mode to avoid modifying
-		// the database (which breaks file watchers).
-		useReadOnly := isReadOnlyCommand(cmd.Name())
+		// Track bd version changes.
+		// Best-effort tracking - failures are silent.
+		//
+		// A preview detects the change but must not consume it:
+		// .local_version is the one-shot signal autoMigrateOnVersionBump reads,
+		// and preview commands deliberately skip that reconciliation below.
+		if previewMode {
+			trackBdVersionPreview()
+		} else {
+			trackBdVersion()
+		}
 
 		// Auto-migrate database on version bump (bd-jgxi).
-		// Runs for ALL commands (including read-only ones) because the migration
+		// Runs for ALL non-preview commands (including read-only ones) because the migration
 		// opens its own store connection, writes the version metadata, commits it,
 		// and closes BEFORE the main store is opened. This ensures bd doctor and
 		// read-only commands see the correct version after a CLI upgrade.
-
-		autoMigrateOnVersionBump(beadsDir)
+		//
+		// Preview paths must never call this helper: it opens a separate
+		// writable store before the main read-only store and can therefore
+		// apply schema migrations before RunE validates arguments or renders a
+		// dry-run plan.
+		if !previewMode {
+			autoMigrateOnVersionBump(beadsDir)
+		}
 
 		// Initialize direct storage access
 		var err error

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -160,30 +160,6 @@ func isPreviewCommand(cmd *cobra.Command) bool {
 	return false
 }
 
-type rootStorePolicy struct {
-	readOnly         bool
-	disableAutoStart bool
-	runMaintenance   bool
-}
-
-// effectiveRootStorePolicy separates strict --readonly/config policy from
-// command classification. Classified reads retain their compatibility
-// maintenance and auto-start behavior; strict readonly is mutation-free.
-func effectiveRootStorePolicy(cmdName string, strictReadonly bool) rootStorePolicy {
-	return rootStorePolicy{
-		readOnly:         strictReadonly || isReadOnlyCommand(cmdName),
-		disableAutoStart: strictReadonly,
-		runMaintenance:   !strictReadonly,
-	}
-}
-
-func runsPostCommandMaintenance(cmdName string, strictReadonly bool) bool {
-	if cmdName == "serve" {
-		return false
-	}
-	return effectiveRootStorePolicy(cmdName, strictReadonly).runMaintenance
-}
-
 // isWorkingSetReconcileCommand reports whether cmd's whole purpose is to
 // reconcile the Dolt working set: "bd dolt commit" or "bd vc commit". These
 // commands are the documented recovery from a pending-migration dirty-table
@@ -1026,21 +1002,17 @@ var rootCmd = &cobra.Command{
 		// schema initialization runs before the command's RunE can honor
 		// --dry-run/--inspect or reject invalid arguments.
 		previewMode := isPreviewCommand(cmd)
-		policy := effectiveRootStorePolicy(cmd.Name(), readonlyMode)
-		useReadOnly := policy.readOnly || previewMode
+		useReadOnly := isReadOnlyCommand(cmd.Name()) || previewMode
 
-		// Track bd version changes unless strict readonly forbids repository mutation.
-		// Best-effort tracking - failures are silent.
+		// Track bd version changes. Best-effort tracking - failures are silent.
 		//
 		// A preview detects the change but must not consume it:
 		// .local_version is the one-shot signal autoMigrateOnVersionBump reads,
 		// and preview commands deliberately skip that reconciliation below.
-		if policy.runMaintenance {
-			if previewMode {
-				trackBdVersionPreview()
-			} else {
-				trackBdVersion()
-			}
+		if previewMode {
+			trackBdVersionPreview()
+		} else {
+			trackBdVersion()
 		}
 
 		// Auto-migrate database on version bump (bd-jgxi).
@@ -1053,7 +1025,7 @@ var rootCmd = &cobra.Command{
 		// writable store before the main read-only store and can therefore
 		// apply schema migrations before RunE validates arguments or renders a
 		// dry-run plan.
-		if policy.runMaintenance && !previewMode {
+		if !previewMode {
 			autoMigrateOnVersionBump(beadsDir)
 		}
 
@@ -1064,11 +1036,10 @@ var rootCmd = &cobra.Command{
 		// on a different filesystem (e.g., ext4 for performance on WSL).
 		doltPath := doltserver.ResolveDoltDir(beadsDir)
 		doltCfg := &dolt.Config{
-			ReadOnly:         useReadOnly,
-			Preview:          previewMode,
-			DisableAutoStart: policy.disableAutoStart,
-			BeadsDir:         beadsDir,
-			LenientOpen:      isWorkingSetReconcileCommand(cmd),
+			ReadOnly:    useReadOnly,
+			Preview:     previewMode,
+			BeadsDir:    beadsDir,
+			LenientOpen: isWorkingSetReconcileCommand(cmd),
 		}
 
 		// Load config to get database name and server connection settings
@@ -1302,71 +1273,69 @@ var rootCmd = &cobra.Command{
 				uowProvider = nil
 			}
 		} else {
-			if runsPostCommandMaintenance(cmd.Name(), readonlyMode) {
-				// Dolt auto-commit: after a successful write command (and after final flush),
-				// create a Dolt commit so changes don't remain only in the working set.
-				if commandDidWrite.Load() && !commandDidExplicitDoltCommit {
-					if err := maybeAutoCommit(rootCtx, doltAutoCommitParams{Command: cmd.Name()}); err != nil {
-						return HandleError("dolt auto-commit failed: %v", err)
-					}
+			// Dolt auto-commit: after a successful write command (and after final flush),
+			// create a Dolt commit so changes don't remain only in the working set.
+			if commandDidWrite.Load() && !commandDidExplicitDoltCommit {
+				if err := maybeAutoCommit(rootCtx, doltAutoCommitParams{Command: cmd.Name()}); err != nil {
+					return HandleError("dolt auto-commit failed: %v", err)
 				}
+			}
 
-				// Tip metadata auto-commit: if a tip was shown, create a separate Dolt commit for the
-				// tip_*_last_shown metadata updates. This may happen even for otherwise read-only commands.
-				if commandDidWriteTipMetadata && len(commandTipIDsShown) > 0 {
-					// Only applies when dolt auto-commit is enabled and backend is versioned (Dolt).
-					if mode, err := getDoltAutoCommitMode(); err != nil {
-						return HandleError("dolt tip auto-commit failed: %v", err)
-					} else if mode == doltAutoCommitOn {
-						// Apply tip metadata writes now (deferred in recordTipShown for Dolt).
-						// Preview/strict-readonly embedded opens refuse writes by construction;
-						// tip bookkeeping is incidental, so do not fail an otherwise successful
-						// preview after RunE has already honored --dry-run/--inspect.
-						tipWritesRefused := false
+			// Tip metadata auto-commit: if a tip was shown, create a separate Dolt commit for the
+			// tip_*_last_shown metadata updates. This may happen even for otherwise read-only commands.
+			if commandDidWriteTipMetadata && len(commandTipIDsShown) > 0 {
+				// Only applies when dolt auto-commit is enabled and backend is versioned (Dolt).
+				if mode, err := getDoltAutoCommitMode(); err != nil {
+					return HandleError("dolt tip auto-commit failed: %v", err)
+				} else if mode == doltAutoCommitOn {
+					// Apply tip metadata writes now (deferred in recordTipShown for Dolt).
+					// Preview embedded opens refuse writes by construction;
+					// tip bookkeeping is incidental, so do not fail an otherwise successful
+					// preview after RunE has already honored --dry-run/--inspect.
+					tipWritesRefused := false
+					for tipID := range commandTipIDsShown {
+						key := fmt.Sprintf("tip_%s_last_shown", tipID)
+						value := time.Now().Format(time.RFC3339)
+						if err := store.SetLocalMetadata(rootCtx, key, value); err != nil {
+							if errors.Is(err, embeddeddolt.ErrReadOnly) {
+								debug.Logf("tip auto-commit: store is read-only, skipping tip metadata: %v", err)
+								tipWritesRefused = true
+								break
+							}
+							return HandleError("dolt tip auto-commit failed: %v", err)
+						}
+					}
+
+					if !tipWritesRefused {
+						ids := make([]string, 0, len(commandTipIDsShown))
 						for tipID := range commandTipIDsShown {
-							key := fmt.Sprintf("tip_%s_last_shown", tipID)
-							value := time.Now().Format(time.RFC3339)
-							if err := store.SetLocalMetadata(rootCtx, key, value); err != nil {
-								if errors.Is(err, embeddeddolt.ErrReadOnly) {
-									debug.Logf("tip auto-commit: store is read-only, skipping tip metadata: %v", err)
-									tipWritesRefused = true
-									break
-								}
-								return HandleError("dolt tip auto-commit failed: %v", err)
-							}
+							ids = append(ids, tipID)
 						}
-
-						if !tipWritesRefused {
-							ids := make([]string, 0, len(commandTipIDsShown))
-							for tipID := range commandTipIDsShown {
-								ids = append(ids, tipID)
-							}
-							msg := formatDoltAutoCommitMessage("tip", getActor(), ids)
-							if err := maybeAutoCommit(rootCtx, doltAutoCommitParams{Command: "tip", MessageOverride: msg}); err != nil {
-								return HandleError("dolt tip auto-commit failed: %v", err)
-							}
+						msg := formatDoltAutoCommitMessage("tip", getActor(), ids)
+						if err := maybeAutoCommit(rootCtx, doltAutoCommitParams{Command: "tip", MessageOverride: msg}); err != nil {
+							return HandleError("dolt tip auto-commit failed: %v", err)
 						}
 					}
 				}
+			}
 
-				// Auto-backup: sync a Dolt-native backup if enabled and due
-				maybeAutoBackup(rootCtx)
+			// Auto-backup: sync a Dolt-native backup if enabled and due
+			maybeAutoBackup(rootCtx)
 
-				// Auto-export: write git-tracked JSONL for portability if enabled and due.
-				// Read-only commands must not perform post-run maintenance writes or emit
-				// sync guidance after machine-readable output.
-				if shouldRunPostCommandAutoExport(cmd) {
-					if err := maybeAutoExport(rootCtx, commandAllowsEmptyAutoExport(cmd)); err != nil {
-						return HandleError("%v", err)
-					}
+			// Auto-export: write git-tracked JSONL for portability if enabled and due.
+			// Read-only commands must not perform post-run maintenance writes or emit
+			// sync guidance after machine-readable output.
+			if shouldRunPostCommandAutoExport(cmd) {
+				if err := maybeAutoExport(rootCtx, commandAllowsEmptyAutoExport(cmd)); err != nil {
+					return HandleError("%v", err)
 				}
+			}
 
-				// Auto-push: push to Dolt remote if enabled and due.
-				// Skip for read-only commands to avoid unnecessary network operations
-				// and metadata writes on commands like bd list/show/ready (GH#2191).
-				if !isReadOnlyCommand(cmd.Name()) {
-					maybeAutoPush(rootCtx)
-				}
+			// Auto-push: push to Dolt remote if enabled and due.
+			// Skip for read-only commands to avoid unnecessary network operations
+			// and metadata writes on commands like bd list/show/ready (GH#2191).
+			if !isReadOnlyCommand(cmd.Name()) {
+				maybeAutoPush(rootCtx)
 			}
 
 			// Signal that store is closing (prevents background flush from accessing closed store)

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/steveyegge/beads/internal/molecules"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
 	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/telemetry"
@@ -157,6 +158,30 @@ func isPreviewCommand(cmd *cobra.Command) bool {
 		}
 	}
 	return false
+}
+
+type rootStorePolicy struct {
+	readOnly         bool
+	disableAutoStart bool
+	runMaintenance   bool
+}
+
+// effectiveRootStorePolicy separates strict --readonly/config policy from
+// command classification. Classified reads retain their compatibility
+// maintenance and auto-start behavior; strict readonly is mutation-free.
+func effectiveRootStorePolicy(cmdName string, strictReadonly bool) rootStorePolicy {
+	return rootStorePolicy{
+		readOnly:         strictReadonly || isReadOnlyCommand(cmdName),
+		disableAutoStart: strictReadonly,
+		runMaintenance:   !strictReadonly,
+	}
+}
+
+func runsPostCommandMaintenance(cmdName string, strictReadonly bool) bool {
+	if cmdName == "serve" {
+		return false
+	}
+	return effectiveRootStorePolicy(cmdName, strictReadonly).runMaintenance
 }
 
 // isWorkingSetReconcileCommand reports whether cmd's whole purpose is to
@@ -1001,18 +1026,21 @@ var rootCmd = &cobra.Command{
 		// schema initialization runs before the command's RunE can honor
 		// --dry-run/--inspect or reject invalid arguments.
 		previewMode := isPreviewCommand(cmd)
-		useReadOnly := isReadOnlyCommand(cmd.Name()) || previewMode
+		policy := effectiveRootStorePolicy(cmd.Name(), readonlyMode)
+		useReadOnly := policy.readOnly || previewMode
 
-		// Track bd version changes.
+		// Track bd version changes unless strict readonly forbids repository mutation.
 		// Best-effort tracking - failures are silent.
 		//
 		// A preview detects the change but must not consume it:
 		// .local_version is the one-shot signal autoMigrateOnVersionBump reads,
 		// and preview commands deliberately skip that reconciliation below.
-		if previewMode {
-			trackBdVersionPreview()
-		} else {
-			trackBdVersion()
+		if policy.runMaintenance {
+			if previewMode {
+				trackBdVersionPreview()
+			} else {
+				trackBdVersion()
+			}
 		}
 
 		// Auto-migrate database on version bump (bd-jgxi).
@@ -1025,7 +1053,7 @@ var rootCmd = &cobra.Command{
 		// writable store before the main read-only store and can therefore
 		// apply schema migrations before RunE validates arguments or renders a
 		// dry-run plan.
-		if !previewMode {
+		if policy.runMaintenance && !previewMode {
 			autoMigrateOnVersionBump(beadsDir)
 		}
 
@@ -1036,9 +1064,11 @@ var rootCmd = &cobra.Command{
 		// on a different filesystem (e.g., ext4 for performance on WSL).
 		doltPath := doltserver.ResolveDoltDir(beadsDir)
 		doltCfg := &dolt.Config{
-			ReadOnly:    useReadOnly,
-			BeadsDir:    beadsDir,
-			LenientOpen: isWorkingSetReconcileCommand(cmd),
+			ReadOnly:         useReadOnly,
+			Preview:          previewMode,
+			DisableAutoStart: policy.disableAutoStart,
+			BeadsDir:         beadsDir,
+			LenientOpen:      isWorkingSetReconcileCommand(cmd),
 		}
 
 		// Load config to get database name and server connection settings
@@ -1132,7 +1162,7 @@ var rootCmd = &cobra.Command{
 		dolt.ApplyCLIAutoStart(beadsDir, doltCfg)
 
 		if proxiedServerMode {
-			p, err := newProxiedServerUOWProvider(rootCtx, beadsDir)
+			p, err := newProxiedServerUOWProvider(rootCtx, beadsDir, previewProviderOptions(previewMode)...)
 			if err != nil {
 				return HandleError("failed to open uow provider: %v", err)
 			}
@@ -1272,58 +1302,71 @@ var rootCmd = &cobra.Command{
 				uowProvider = nil
 			}
 		} else {
-			// Dolt auto-commit: after a successful write command (and after final flush),
-			// create a Dolt commit so changes don't remain only in the working set.
-			if commandDidWrite.Load() && !commandDidExplicitDoltCommit {
-				if err := maybeAutoCommit(rootCtx, doltAutoCommitParams{Command: cmd.Name()}); err != nil {
-					return HandleError("dolt auto-commit failed: %v", err)
+			if runsPostCommandMaintenance(cmd.Name(), readonlyMode) {
+				// Dolt auto-commit: after a successful write command (and after final flush),
+				// create a Dolt commit so changes don't remain only in the working set.
+				if commandDidWrite.Load() && !commandDidExplicitDoltCommit {
+					if err := maybeAutoCommit(rootCtx, doltAutoCommitParams{Command: cmd.Name()}); err != nil {
+						return HandleError("dolt auto-commit failed: %v", err)
+					}
 				}
-			}
 
-			// Tip metadata auto-commit: if a tip was shown, create a separate Dolt commit for the
-			// tip_*_last_shown metadata updates. This may happen even for otherwise read-only commands.
-			if commandDidWriteTipMetadata && len(commandTipIDsShown) > 0 {
-				// Only applies when dolt auto-commit is enabled and backend is versioned (Dolt).
-				if mode, err := getDoltAutoCommitMode(); err != nil {
-					return HandleError("dolt tip auto-commit failed: %v", err)
-				} else if mode == doltAutoCommitOn {
-					// Apply tip metadata writes now (deferred in recordTipShown for Dolt).
-					for tipID := range commandTipIDsShown {
-						key := fmt.Sprintf("tip_%s_last_shown", tipID)
-						value := time.Now().Format(time.RFC3339)
-						if err := store.SetLocalMetadata(rootCtx, key, value); err != nil {
-							return HandleError("dolt tip auto-commit failed: %v", err)
+				// Tip metadata auto-commit: if a tip was shown, create a separate Dolt commit for the
+				// tip_*_last_shown metadata updates. This may happen even for otherwise read-only commands.
+				if commandDidWriteTipMetadata && len(commandTipIDsShown) > 0 {
+					// Only applies when dolt auto-commit is enabled and backend is versioned (Dolt).
+					if mode, err := getDoltAutoCommitMode(); err != nil {
+						return HandleError("dolt tip auto-commit failed: %v", err)
+					} else if mode == doltAutoCommitOn {
+						// Apply tip metadata writes now (deferred in recordTipShown for Dolt).
+						// Preview/strict-readonly embedded opens refuse writes by construction;
+						// tip bookkeeping is incidental, so do not fail an otherwise successful
+						// preview after RunE has already honored --dry-run/--inspect.
+						tipWritesRefused := false
+						for tipID := range commandTipIDsShown {
+							key := fmt.Sprintf("tip_%s_last_shown", tipID)
+							value := time.Now().Format(time.RFC3339)
+							if err := store.SetLocalMetadata(rootCtx, key, value); err != nil {
+								if errors.Is(err, embeddeddolt.ErrReadOnly) {
+									debug.Logf("tip auto-commit: store is read-only, skipping tip metadata: %v", err)
+									tipWritesRefused = true
+									break
+								}
+								return HandleError("dolt tip auto-commit failed: %v", err)
+							}
+						}
+
+						if !tipWritesRefused {
+							ids := make([]string, 0, len(commandTipIDsShown))
+							for tipID := range commandTipIDsShown {
+								ids = append(ids, tipID)
+							}
+							msg := formatDoltAutoCommitMessage("tip", getActor(), ids)
+							if err := maybeAutoCommit(rootCtx, doltAutoCommitParams{Command: "tip", MessageOverride: msg}); err != nil {
+								return HandleError("dolt tip auto-commit failed: %v", err)
+							}
 						}
 					}
+				}
 
-					ids := make([]string, 0, len(commandTipIDsShown))
-					for tipID := range commandTipIDsShown {
-						ids = append(ids, tipID)
-					}
-					msg := formatDoltAutoCommitMessage("tip", getActor(), ids)
-					if err := maybeAutoCommit(rootCtx, doltAutoCommitParams{Command: "tip", MessageOverride: msg}); err != nil {
-						return HandleError("dolt tip auto-commit failed: %v", err)
+				// Auto-backup: sync a Dolt-native backup if enabled and due
+				maybeAutoBackup(rootCtx)
+
+				// Auto-export: write git-tracked JSONL for portability if enabled and due.
+				// Read-only commands must not perform post-run maintenance writes or emit
+				// sync guidance after machine-readable output.
+				if shouldRunPostCommandAutoExport(cmd) {
+					if err := maybeAutoExport(rootCtx, commandAllowsEmptyAutoExport(cmd)); err != nil {
+						return HandleError("%v", err)
 					}
 				}
-			}
 
-			// Auto-backup: sync a Dolt-native backup if enabled and due
-			maybeAutoBackup(rootCtx)
-
-			// Auto-export: write git-tracked JSONL for portability if enabled and due.
-			// Read-only commands must not perform post-run maintenance writes or emit
-			// sync guidance after machine-readable output.
-			if shouldRunPostCommandAutoExport(cmd) {
-				if err := maybeAutoExport(rootCtx, commandAllowsEmptyAutoExport(cmd)); err != nil {
-					return HandleError("%v", err)
+				// Auto-push: push to Dolt remote if enabled and due.
+				// Skip for read-only commands to avoid unnecessary network operations
+				// and metadata writes on commands like bd list/show/ready (GH#2191).
+				if !isReadOnlyCommand(cmd.Name()) {
+					maybeAutoPush(rootCtx)
 				}
-			}
-
-			// Auto-push: push to Dolt remote if enabled and due.
-			// Skip for read-only commands to avoid unnecessary network operations
-			// and metadata writes on commands like bd list/show/ready (GH#2191).
-			if !isReadOnlyCommand(cmd.Name()) {
-				maybeAutoPush(rootCtx)
 			}
 
 			// Signal that store is closing (prevents background flush from accessing closed store)

--- a/cmd/bd/store_factory.go
+++ b/cmd/bd/store_factory.go
@@ -54,6 +54,12 @@ func newDoltStore(ctx context.Context, cfg *dolt.Config) (storage.DoltStorage, e
 	if cfg.ServerMode {
 		return dolt.New(ctx, cfg)
 	}
+	if cfg.Preview {
+		// Preview commands are stricter than ordinary read commands: they
+		// must not run schema initialization or permit incidental writes
+		// before their RunE honors --dry-run/--inspect.
+		return embeddeddolt.OpenForPreviewCommand(ctx, cfg.BeadsDir, cfg.Database, "main")
+	}
 	if cfg.ReadOnly {
 		// Read-only commands must not be bricked by the #4259
 		// remote-migrate gate (bd-578h9.5); server mode's ReadOnly opens
@@ -171,6 +177,22 @@ func migrateHyphenatedDB(beadsDir string, cfg *configfile.Config, oldName, newNa
 // only — no directory renames or metadata.json writes. This prevents cross-repo
 // hydration from mutating foreign projects (GH#3231).
 func newReadOnlyStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
+	return openNonMutatingStoreFromConfig(ctx, beadsDir, false)
+}
+
+// newPreviewStoreFromConfig is newReadOnlyStoreFromConfig for a preview
+// command (--dry-run, --inspect) reading a repository it was only pointed at:
+// the same non-mutating open, but a BEHIND schema cursor is tolerated rather
+// than refused, matching embeddeddolt.OpenForPreviewCommand and the preview
+// policy the root pre-run applies to the command's own store. A preview that
+// only reads a parent issue out of another repo should not be the thing that
+// refuses because that repo has not been migrated yet — and it must certainly
+// not migrate it.
+func newPreviewStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
+	return openNonMutatingStoreFromConfig(ctx, beadsDir, true)
+}
+
+func openNonMutatingStoreFromConfig(ctx context.Context, beadsDir string, preview bool) (storage.DoltStorage, error) {
 	cfg, err := configfile.Load(beadsDir)
 	if err == nil && cfg != nil && cfg.IsDoltProxiedServerMode() {
 		// TODO: this needs to be uow provider
@@ -191,6 +213,9 @@ func newReadOnlyStoreFromConfig(ctx context.Context, beadsDir string) (storage.D
 	}
 	if sanitized := sanitizeDBName(database); sanitized != database {
 		database = sanitized
+	}
+	if preview {
+		return embeddeddolt.OpenForPreviewCommand(ctx, beadsDir, database, "main")
 	}
 	// OpenReadOnly, not Open: a read-only open of a foreign project must not
 	// run the remote-migrate gate (a behind, remote-backed database would fail

--- a/cmd/bd/store_factory_nocgo.go
+++ b/cmd/bd/store_factory_nocgo.go
@@ -82,6 +82,13 @@ func newReadOnlyStoreFromConfig(ctx context.Context, beadsDir string) (storage.D
 	return nil, fmt.Errorf("%s", nocgoEmbeddedErrMsg)
 }
 
+// newPreviewStoreFromConfig is the non-CGO twin of the CGO build's preview
+// factory. The two differ only in how they open the EMBEDDED store, and this
+// build has no embedded store at all, so preview and read-only coincide here.
+func newPreviewStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
+	return newReadOnlyStoreFromConfig(ctx, beadsDir)
+}
+
 const nocgoEmbeddedErrMsg = `embedded Dolt requires a CGO build, but this bd binary was built with CGO_ENABLED=0.
 
 Three options:

--- a/cmd/bd/uow_factory.go
+++ b/cmd/bd/uow_factory.go
@@ -12,7 +12,17 @@ import (
 	"github.com/steveyegge/beads/internal/storage/uow"
 )
 
-func newProxiedServerUOWProvider(ctx context.Context, beadsDir string) (uow.UnitOfWorkProvider, error) {
+// previewProviderOptions is the CLI-side half of the preview policy: it turns
+// the root pre-run's previewMode bool into the uow.ProviderOption slice the
+// proxied-server provider is opened with.
+func previewProviderOptions(preview bool) []uow.ProviderOption {
+	if !preview {
+		return nil
+	}
+	return []uow.ProviderOption{uow.WithPreview()}
+}
+
+func newProxiedServerUOWProvider(ctx context.Context, beadsDir string, opts ...uow.ProviderOption) (uow.UnitOfWorkProvider, error) {
 	if beadsDir == "" {
 		return nil, fmt.Errorf("newProxiedServerUOWProvider: beadsDir must be set")
 	}
@@ -25,16 +35,17 @@ func newProxiedServerUOWProvider(ctx context.Context, beadsDir string) (uow.Unit
 
 	info, _ := configfile.LoadProxiedServerClientInfo(beadsDir)
 	if info != nil && info.External != nil {
-		return newExternalProxiedServerUOWProvider(ctx, beadsDir, database, info.External)
+		return newExternalProxiedServerUOWProvider(ctx, beadsDir, database, info.External, opts...)
 	}
 
-	return newManagedProxiedServerUOWProvider(ctx, beadsDir, database)
+	return newManagedProxiedServerUOWProvider(ctx, beadsDir, database, opts...)
 }
 
 func newExternalProxiedServerUOWProvider(
 	ctx context.Context,
 	beadsDir, database string,
 	external *configfile.ExternalDoltConfig,
+	opts ...uow.ProviderOption,
 ) (uow.UnitOfWorkProvider, error) {
 	rootPath, err := resolveProxiedServerRootPath(beadsDir)
 	if err != nil {
@@ -66,12 +77,14 @@ func newExternalProxiedServerUOWProvider(
 		*external,
 		external.ResolvedUser(),
 		os.Getenv(configfile.ExternalDoltPasswordEnvVar),
+		opts...,
 	)
 }
 
 func newManagedProxiedServerUOWProvider(
 	ctx context.Context,
 	beadsDir, database string,
+	opts ...uow.ProviderOption,
 ) (uow.UnitOfWorkProvider, error) {
 	doltBin, err := exec.LookPath("dolt")
 	if err != nil {
@@ -111,5 +124,6 @@ func newManagedProxiedServerUOWProvider(
 		"root",
 		"", // proxy is loopback-only, no auth
 		doltBin,
+		opts...,
 	)
 }

--- a/cmd/bd/uow_factory_test.go
+++ b/cmd/bd/uow_factory_test.go
@@ -10,6 +10,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestPreviewProviderOptions pins the CLI-side wiring the reviewer flagged as
+// untested: the root pre-run turns previewMode into providerOpts by calling
+// this function, and a refactor that dropped or inverted that could not fail
+// any existing test. uow.providerOptions is unexported, so this cannot poke
+// inside the returned uow.ProviderOption values (see
+// internal/storage/uow/preview_provider_test.go's TestApplyProviderOptions for
+// the same-package introspection); it instead pins the one thing an external
+// caller can observe — that preview=true yields exactly one option and
+// preview=false yields none — which is what the CLI wiring is responsible for.
+func TestPreviewProviderOptions(t *testing.T) {
+	if got := previewProviderOptions(false); got != nil {
+		t.Fatalf("previewProviderOptions(false) = %#v, want nil", got)
+	}
+
+	opts := previewProviderOptions(true)
+	if len(opts) != 1 {
+		t.Fatalf("previewProviderOptions(true) len = %d, want 1", len(opts))
+	}
+	if opts[0] == nil {
+		t.Fatal("previewProviderOptions(true)[0] is nil, want uow.WithPreview()")
+	}
+}
+
 func TestNewProxiedServerUOWProvider_RoutesExternalConfigToExternalProvider(t *testing.T) {
 	beadsDir := t.TempDir()
 	require.NoError(t, configfile.SaveProxiedServerClientInfo(beadsDir, &configfile.ProxiedServerClientInfo{

--- a/cmd/bd/version_tracking.go
+++ b/cmd/bd/version_tracking.go
@@ -52,6 +52,24 @@ func trackBdVersion() {
 
 }
 
+// trackBdVersionPreview detects an upgrade for preview/dry-run commands without
+// updating .local_version. Preview commands must not consume the one-shot
+// version marker because they also skip autoMigrateOnVersionBump; the next real
+// command still needs to perform that reconciliation.
+func trackBdVersionPreview() {
+	beadsDir := beads.FindBeadsDir()
+	if beadsDir == "" {
+		return
+	}
+
+	localVersionPath := filepath.Join(beadsDir, localVersionFile)
+	lastVersion := readLocalVersion(localVersionPath)
+	if lastVersion != "" && lastVersion != Version && doctor.CompareVersions(Version, lastVersion) > 0 {
+		versionUpgradeDetected = true
+		previousVersion = lastVersion
+	}
+}
+
 // readLocalVersion reads the last bd version from the local version file.
 // Returns empty string if file doesn't exist or can't be read.
 func readLocalVersion(path string) string {

--- a/cmd/bd/version_tracking.go
+++ b/cmd/bd/version_tracking.go
@@ -24,6 +24,28 @@ const localVersionFile = ".local_version"
 // This function is best-effort - failures are silent to avoid disrupting commands.
 // Sets global variables versionUpgradeDetected and previousVersion if upgrade detected.
 func trackBdVersion() {
+	trackBdVersionFile(true)
+}
+
+// trackBdVersionPreview does the same detection but leaves .local_version
+// alone.
+//
+// The file is a ONE-SHOT signal: the version-bump reconciliation
+// (autoMigrateOnVersionBump, including the pre-0.56 recovery path) fires only
+// while the recorded version differs from this binary's. A preview command
+// correctly skips that reconciliation — but if it had also rewritten the file,
+// it would have consumed the signal on the way past, and the next ordinary
+// command would see a matching version and never reconcile at all. Whichever
+// command happened to be first after an upgrade would silently decide whether
+// the upgrade was ever finished.
+//
+// Not writing is safe in the other direction too: the marker is advisory and
+// the very next non-preview command writes it.
+func trackBdVersionPreview() {
+	trackBdVersionFile(false)
+}
+
+func trackBdVersionFile(persist bool) {
 	// Find the beads directory
 	beadsDir := beads.FindBeadsDir()
 	if beadsDir == "" {
@@ -46,28 +68,10 @@ func trackBdVersion() {
 
 	// Update local version file (best effort)
 	// Only write if version actually changed to minimize I/O
-	if lastVersion != Version {
+	if persist && lastVersion != Version {
 		_ = writeLocalVersion(localVersionPath, Version) // Best effort: version tracking is advisory
 	}
 
-}
-
-// trackBdVersionPreview detects an upgrade for preview/dry-run commands without
-// updating .local_version. Preview commands must not consume the one-shot
-// version marker because they also skip autoMigrateOnVersionBump; the next real
-// command still needs to perform that reconciliation.
-func trackBdVersionPreview() {
-	beadsDir := beads.FindBeadsDir()
-	if beadsDir == "" {
-		return
-	}
-
-	localVersionPath := filepath.Join(beadsDir, localVersionFile)
-	lastVersion := readLocalVersion(localVersionPath)
-	if lastVersion != "" && lastVersion != Version && doctor.CompareVersions(Version, lastVersion) > 0 {
-		versionUpgradeDetected = true
-		previousVersion = lastVersion
-	}
 }
 
 // readLocalVersion reads the last bd version from the local version file.

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -206,6 +206,7 @@ type Config struct {
 	Remote         string // Default remote name (e.g., "origin")
 	Database       string // Database name within Dolt (default: "beads")
 	ReadOnly       bool   // Open in read-only mode (skip schema init)
+	Preview        bool   // Non-mutating preview: embedded opens skip schema init and refuse writes
 
 	// LenientOpen opens the store leniently: embedded mode only. A migration
 	// gate refusal (#4259) or a dirty-working-set refusal (#4566) skips the

--- a/internal/storage/embeddeddolt/preview_readonly_test.go
+++ b/internal/storage/embeddeddolt/preview_readonly_test.go
@@ -1,0 +1,57 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+)
+
+// TestPreviewStoreRefusesLocalMetadataWrite pins the classification the CLI's
+// PersistentPostRun tip auto-commit keys on. That block writes tip metadata
+// unconditionally — read-only commands have always tolerated it because
+// OpenForReadOnlyCommand is deliberately writable — so the write-refusing
+// preview store must return an error that errors.Is recognizes, or a
+// successful dry-run exits non-zero after the fact.
+func TestPreviewStoreRefusesLocalMetadataWrite(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt tests")
+	}
+
+	ctx := t.Context()
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+
+	store, err := embeddeddolt.Open(ctx, beadsDir, "previewdb", "main")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := store.SetLocalMetadata(ctx, "tip_example_last_shown", "2026-01-01T00:00:00Z"); err != nil {
+		t.Fatalf("SetLocalMetadata on writable store: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	preview, err := embeddeddolt.OpenForPreviewCommand(ctx, beadsDir, "previewdb", "main")
+	if err != nil {
+		t.Fatalf("OpenForPreviewCommand: %v", err)
+	}
+	defer func() { _ = preview.Close() }()
+
+	// Reads still work.
+	if _, err := preview.GetLocalMetadata(ctx, "tip_example_last_shown"); err != nil {
+		t.Fatalf("GetLocalMetadata on preview store: %v", err)
+	}
+
+	err = preview.SetLocalMetadata(ctx, "tip_example_last_shown", "2026-02-02T00:00:00Z")
+	if err == nil {
+		t.Fatal("SetLocalMetadata on preview store = nil error, want refusal")
+	}
+	if !errors.Is(err, embeddeddolt.ErrReadOnly) {
+		t.Fatalf("SetLocalMetadata on preview store = %v, want an error matching embeddeddolt.ErrReadOnly", err)
+	}
+}

--- a/internal/storage/embeddeddolt/readonly.go
+++ b/internal/storage/embeddeddolt/readonly.go
@@ -1,0 +1,17 @@
+package embeddeddolt
+
+import "errors"
+
+// ErrReadOnly is returned when a write is attempted on a store opened
+// read-only — OpenReadOnly, or OpenForPreviewCommand for a --dry-run/--inspect
+// command.
+//
+// It is exported (and declared here, without a cgo build tag) because callers
+// outside this package have to be able to tell "this store refuses writes by
+// construction" apart from a real failure. The CLI's post-command
+// tip-metadata write is the case that forced it: that write is incidental
+// bookkeeping which read-only opens have always tolerated because
+// OpenForReadOnlyCommand is deliberately writable, and a store that genuinely
+// refuses it must not turn an otherwise successful command into a non-zero
+// exit after the fact.
+var ErrReadOnly = errors.New("embeddeddolt: store is read-only")

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -45,9 +45,10 @@ type EmbeddedDoltStore struct {
 	branch        string
 	credentialKey []byte
 	closed        atomic.Bool
-	// readOnly marks a store opened via OpenReadOnly: open-time mutations
-	// (CREATE DATABASE, schema migrations) were skipped and write
-	// transactions are refused (bd-6dnrw.32).
+	// readOnly marks a store opened via OpenReadOnly or
+	// OpenForPreviewCommand: open-time mutations (CREATE DATABASE, schema
+	// migrations) were skipped and write transactions are refused
+	// (bd-6dnrw.32).
 	readOnly bool
 	// intent records why this store was opened, controlling how lenient
 	// initSchema is about pending-migration refusals it would otherwise treat
@@ -82,9 +83,6 @@ const (
 
 // errClosed is returned when a method is called after Close.
 var errClosed = errors.New("embeddeddolt: store is closed")
-
-// errReadOnly is returned when a write is attempted on a read-only store.
-var errReadOnly = errors.New("embeddeddolt: store is read-only")
 
 // IsClosed reports whether the store has been closed. Implements
 // storage.LifecycleManager so that callers (e.g., maybeAutoCommit) can
@@ -149,6 +147,20 @@ func newStore(ctx context.Context, beadsDir, database, branch string, intent ope
 // opens of the same directory keep their own lifecycle. Write transactions on
 // the returned store are refused.
 func OpenReadOnly(ctx context.Context, beadsDir, database, branch string) (*EmbeddedDoltStore, error) {
+	return openReadOnly(ctx, beadsDir, database, branch, true)
+}
+
+// OpenForPreviewCommand opens an existing embedded database without any
+// open-time mutation and refuses all write transactions. Unlike
+// OpenReadOnly, it permits a behind schema cursor so --dry-run/--inspect can
+// still validate state that is query-compatible with the current binary. A
+// missing column or other genuine incompatibility is reported by the preview
+// query itself; it is never repaired implicitly.
+func OpenForPreviewCommand(ctx context.Context, beadsDir, database, branch string) (*EmbeddedDoltStore, error) {
+	return openReadOnly(ctx, beadsDir, database, branch, false)
+}
+
+func openReadOnly(ctx context.Context, beadsDir, database, branch string, checkBehind bool) (*EmbeddedDoltStore, error) {
 	if database == "" {
 		return nil, fmt.Errorf("embeddeddolt: database name must not be empty (caller should default to %q)", "beads")
 	}
@@ -180,8 +192,10 @@ func OpenReadOnly(ctx context.Context, beadsDir, database, branch string) (*Embe
 	if err := schema.CheckForwardDrift(ctx, db); err != nil {
 		return nil, err
 	}
-	if err := schema.CheckBehindDrift(ctx, db); err != nil {
-		return nil, err
+	if checkBehind {
+		if err := schema.CheckBehindDrift(ctx, db); err != nil {
+			return nil, err
+		}
 	}
 
 	return s, nil
@@ -200,7 +214,7 @@ func (s *EmbeddedDoltStore) withConn(ctx context.Context, commit bool, fn func(t
 		return
 	}
 	if commit && s.readOnly {
-		err = errReadOnly
+		err = ErrReadOnly
 		return
 	}
 
@@ -244,7 +258,7 @@ func (s *EmbeddedDoltStore) ApplySchemaMigrations(ctx context.Context) (int, err
 		return 0, errClosed
 	}
 	if s.readOnly {
-		return 0, errReadOnly
+		return 0, ErrReadOnly
 	}
 	db, cleanup, err := OpenSQL(ctx, s.dataDir, s.database, s.branch)
 	if err != nil {

--- a/internal/storage/embeddeddolt/store_stub.go
+++ b/internal/storage/embeddeddolt/store_stub.go
@@ -26,6 +26,11 @@ func OpenReadOnly(_ context.Context, _, _, _ string) (*EmbeddedDoltStore, error)
 	return nil, errNoCGO
 }
 
+// OpenForPreviewCommand returns an error when CGO is not enabled.
+func OpenForPreviewCommand(_ context.Context, _, _, _ string) (*EmbeddedDoltStore, error) {
+	return nil, errNoCGO
+}
+
 // OpenForReadOnlyCommand returns an error when CGO is not enabled.
 func OpenForReadOnlyCommand(_ context.Context, _, _, _ string) (*EmbeddedDoltStore, error) {
 	return nil, errNoCGO

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -84,7 +84,7 @@ func (s *EmbeddedDoltStore) withPinnedDBConn(ctx context.Context, fn func(db ver
 // interface and must refuse them here instead (bd-578h9.12).
 func (s *EmbeddedDoltStore) withMutatingDBConn(ctx context.Context, fn func(db versioncontrolops.DBConn) error) error {
 	if s.readOnly {
-		return errReadOnly
+		return ErrReadOnly
 	}
 	return s.withDBConn(ctx, fn)
 }
@@ -93,7 +93,7 @@ func (s *EmbeddedDoltStore) withMutatingDBConn(ctx context.Context, fn func(db v
 // refusal as withMutatingDBConn (bd-578h9.12).
 func (s *EmbeddedDoltStore) withMutatingPinnedDBConn(ctx context.Context, fn func(db versioncontrolops.DBConn) error) error {
 	if s.readOnly {
-		return errReadOnly
+		return ErrReadOnly
 	}
 	return s.withPinnedDBConn(ctx, fn)
 }

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -24,6 +24,39 @@ const (
 type doltSQLProvider struct {
 	defaultBranch string
 	db            *sql.DB
+	// preview: the command that opened this provider is an explicitly
+	// non-mutating preview (--dry-run, --inspect). The open creates no
+	// database and applies no migration.
+	preview bool
+}
+
+// ProviderOption tunes how a SQL-server unit-of-work provider opens. Options
+// are variadic so existing constructor call sites — every one of which wants
+// the ordinary mutating open — stay unchanged.
+type ProviderOption func(*providerOptions)
+
+type providerOptions struct {
+	// preview opens for a command that promised not to mutate anything
+	// (--dry-run, --inspect). Such a command must reach its own RunE before
+	// anything writes, so the open may neither CREATE DATABASE nor run
+	// MigrateUpWithLock: both happen during root pre-run, before the flag the
+	// user passed has had any effect.
+	preview bool
+}
+
+// WithPreview opens the provider for a non-mutating preview command.
+func WithPreview() ProviderOption {
+	return func(o *providerOptions) { o.preview = true }
+}
+
+func applyProviderOptions(opts []ProviderOption) providerOptions {
+	var resolved providerOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&resolved)
+		}
+	}
+	return resolved
 }
 
 var (
@@ -88,6 +121,21 @@ func (p *doltSQLProvider) initSchema(ctx context.Context, database string) error
 		defer conn.Close()
 
 		ddl := db.NewDDLSQLRepository(conn)
+		if p.preview {
+			// Preview open: attach to the database that is already there and
+			// stop. No CreateDatabase, no MigrateUpWithLock — a --dry-run or
+			// --inspect that migrated the workspace before rendering its plan
+			// would be the exact side effect the flag exists to prevent.
+			if err := ddl.UseDatabase(ctx, database); err != nil {
+				if isSerializationError(err) {
+					return fmt.Errorf("uow: switching to database: %w", err)
+				}
+				return backoff.Permanent(fmt.Errorf(
+					"uow: database %q not found — preview commands (--dry-run, --inspect) never create or migrate a database; run the command without the preview flag first: %w",
+					database, err))
+			}
+			return nil
+		}
 		if err := ddl.CreateDatabaseIfNotExists(ctx, database); err != nil {
 			return backoff.Permanent(fmt.Errorf("uow: creating database: %w", err))
 		}
@@ -126,7 +174,7 @@ func openDB(ctx context.Context, dsn string) (*sql.DB, error) {
 	return conn, nil
 }
 
-func openAndInitSchema(ctx context.Context, ep proxy.Endpoint, database, rootUser, rootPassword string) (UnitOfWorkProvider, error) {
+func openAndInitSchema(ctx context.Context, ep proxy.Endpoint, database, rootUser, rootPassword string, opts providerOptions) (UnitOfWorkProvider, error) {
 	initDB, err := openDB(ctx, buildDSN(ep, "", rootUser, rootPassword))
 	if err != nil {
 		return nil, err
@@ -135,6 +183,7 @@ func openAndInitSchema(ctx context.Context, ep proxy.Endpoint, database, rootUse
 	initProvider := &doltSQLProvider{
 		defaultBranch: defaultBranch,
 		db:            initDB,
+		preview:       opts.preview,
 	}
 
 	if err := initProvider.initSchema(ctx, database); err != nil {
@@ -154,5 +203,6 @@ func openAndInitSchema(ctx context.Context, ep proxy.Endpoint, database, rootUse
 	return &doltSQLProvider{
 		defaultBranch: defaultBranch,
 		db:            dbConn,
+		preview:       opts.preview,
 	}, nil
 }

--- a/internal/storage/uow/doltserver_provider.go
+++ b/internal/storage/uow/doltserver_provider.go
@@ -22,6 +22,7 @@ func NewDoltServerUOWProvider(
 	rootUser string,
 	rootPassword string,
 	doltBinExec string,
+	opts ...ProviderOption,
 ) (UnitOfWorkProvider, error) {
 	if database == "" {
 		return nil, fmt.Errorf("uow: database name must not be empty (caller should default to %q)", "beads")
@@ -60,5 +61,5 @@ func NewDoltServerUOWProvider(
 		return nil, fmt.Errorf("uow: get proxy endpoint: %w", err)
 	}
 
-	return openAndInitSchema(ctx, ep, database, rootUser, rootPassword)
+	return openAndInitSchema(ctx, ep, database, rootUser, rootPassword, applyProviderOptions(opts))
 }

--- a/internal/storage/uow/external_doltserver_provider.go
+++ b/internal/storage/uow/external_doltserver_provider.go
@@ -21,6 +21,7 @@ func NewExternalDoltServerUOWProvider(
 	external configfile.ExternalDoltConfig,
 	rootUser string,
 	rootPassword string,
+	opts ...ProviderOption,
 ) (UnitOfWorkProvider, error) {
 	if database == "" {
 		return nil, fmt.Errorf("uow: database name must not be empty (caller should default to %q)", "beads")
@@ -51,5 +52,5 @@ func NewExternalDoltServerUOWProvider(
 		return nil, fmt.Errorf("uow: get proxy endpoint: %w", err)
 	}
 
-	return openAndInitSchema(ctx, ep, database, rootUser, rootPassword)
+	return openAndInitSchema(ctx, ep, database, rootUser, rootPassword, applyProviderOptions(opts))
 }

--- a/internal/storage/uow/preview_provider_test.go
+++ b/internal/storage/uow/preview_provider_test.go
@@ -1,0 +1,73 @@
+package uow
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// TestInitSchemaPreviewDoesNotMutate is the proxied-server half of the
+// preview policy: a --dry-run/--inspect command reaches this open during root
+// pre-run, before its own RunE has had any chance to honor the flag, so the
+// open must attach to the existing database and nothing more. sqlmock is in
+// ordered mode with only USE expected, so a CREATE DATABASE or a migration
+// statement fails the test rather than silently succeeding.
+func TestInitSchemaPreviewDoesNotMutate(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("USE `beads`").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	p := &doltSQLProvider{defaultBranch: defaultBranch, db: db, preview: true}
+	if err := p.initSchema(context.Background(), "beads"); err != nil {
+		t.Fatalf("initSchema(preview): %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet or extra statements during preview open: %v", err)
+	}
+}
+
+// TestInitSchemaPreviewMissingDatabaseFailsClosed pins the other half of the
+// contract: a database the preview cannot attach to is reported, never
+// created. The message has to say so, because "not found" on a path that
+// normally creates the database reads as a bug otherwise.
+func TestInitSchemaPreviewMissingDatabaseFailsClosed(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("USE `beads`").WillReturnError(errors.New("database not found: beads"))
+
+	p := &doltSQLProvider{defaultBranch: defaultBranch, db: db, preview: true}
+	err = p.initSchema(context.Background(), "beads")
+	if err == nil {
+		t.Fatal("initSchema(preview) on a missing database: got nil, want error")
+	}
+	if !strings.Contains(err.Error(), "--dry-run") {
+		t.Fatalf("preview open error does not explain the preview contract: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet or extra statements during preview open: %v", err)
+	}
+}
+
+// TestApplyProviderOptions keeps the option plumbing honest: the ordinary
+// callers pass nothing and must stay on the mutating open.
+func TestApplyProviderOptions(t *testing.T) {
+	if got := applyProviderOptions(nil); got.preview {
+		t.Fatal("applyProviderOptions(nil).preview = true, want false")
+	}
+	if got := applyProviderOptions([]ProviderOption{WithPreview()}); !got.preview {
+		t.Fatal("applyProviderOptions(WithPreview()).preview = false, want true")
+	}
+}


### PR DESCRIPTION
## Summary

Completes the v1.1 hotfix-line backport of upstream preview-command safety (`cb0b35a92`) so preview commands do not mutate stores during root pre-run/open.

Scope on this branch:

- Embedded preview opens (`--dry-run` / `--inspect`) use a dedicated preview open that skips schema init, tolerates behind schema cursors for query-compatible previews, and refuses writes.
- Root pre-run threads `Preview` into `dolt.Config`, skips `autoMigrateOnVersionBump()` for previews, and uses `trackBdVersionPreview()` so a preview does not consume `.local_version`.
- Proxied-server previews pass `uow.WithPreview()` through the UOW provider; preview `initSchema` attaches with `USE` only and does not run `CREATE DATABASE` or `schema.MigrateUpWithLock`.
- `create --dry-run --parent X --repo <other>` opens the other repo through `newPreviewStoreFromConfig` on both local and cached-remote paths.
- Tests pin the actual non-mutation properties, not just preview flag parsing.

Round-2 reviewer fix: commit `e7ba0ccda17220b599bb934d22e2a8bcb8c8223b` drops the accidental partial #4930 readonly-policy slice (`rootStorePolicy` / `effectiveRootStorePolicy` / `runsPostCommandMaintenance` / `DisableAutoStart: policy.disableAutoStart`) and removes the unrelated `TestEmbeddedChangeDirOverridesInheritedBeadsDir`. This keeps the hotfix scoped to #4985 preview safety; global `--readonly` behavior is left as the v1.1.1 branch had it.

Note: v1.1.1 does **not** have the later `reconcileVersionProxiedServer` helper, so there is no proxied version-metadata reconciliation call to skip on this release branch. The proxied side effect present here is the provider open's create/migrate path, and that is now gated by preview mode.

No live `/opt/homebrew/bin/bd-v53recovery` replacement is performed by this PR. The fleet freeze on `bd-v53recovery migrate/verify/--dry-run` should remain until this is merged and an operator-approved binary swap/readback completes.

## Root cause

The earlier partial backport keyed only on command name and the normal read-only path. On this branch, ordinary read-only embedded opens are intentionally still writable enough to run compatibility initialization, and proxied-server provider opens ran create/migrate before the command's own `RunE` could honor `--dry-run` / `--inspect`.

## Validation

On macOS with Homebrew ICU flags (`/opt/homebrew/opt/icu4c`):

```bash
CGO_CPPFLAGS='-I/opt/homebrew/opt/icu4c/include' \
CGO_CXXFLAGS='-I/opt/homebrew/opt/icu4c/include' \
CGO_LDFLAGS='-L/opt/homebrew/opt/icu4c/lib' \
PKG_CONFIG_PATH='/opt/homebrew/opt/icu4c/lib/pkgconfig' \
BEADS_TEST_EMBEDDED_DOLT=1 \
go test ./cmd/bd -run 'TestEmbeddedCreateDryRunDoesNotMigrate|TestEmbeddedCreateDryRunCrossRepoDoesNotMigrateTarget|TestEmbeddedPreviewDoesNotConsumeVersionMarker|TestEmbeddedCreateDryRunRepoDoesNotInitializeTarget|TestEmbeddedCreateCrossRepoDryRunWithParent|TestIsPreviewCommand|TestPreviewProviderOptions' -count=1 -v
```

Result after round-2 fix: PASS (`ok github.com/steveyegge/beads/cmd/bd 38.391s`).

```bash
CGO_CPPFLAGS='-I/opt/homebrew/opt/icu4c/include' \
CGO_CXXFLAGS='-I/opt/homebrew/opt/icu4c/include' \
CGO_LDFLAGS='-L/opt/homebrew/opt/icu4c/lib' \
PKG_CONFIG_PATH='/opt/homebrew/opt/icu4c/lib/pkgconfig' \
go test ./cmd/bd -run 'TestIsPreviewCommand|TestPreviewProviderOptions' -count=1 -v
```

Result: PASS (`ok github.com/steveyegge/beads/cmd/bd 1.286s`).

```bash
CGO_CPPFLAGS='-I/opt/homebrew/opt/icu4c/include' \
CGO_CXXFLAGS='-I/opt/homebrew/opt/icu4c/include' \
CGO_LDFLAGS='-L/opt/homebrew/opt/icu4c/lib' \
PKG_CONFIG_PATH='/opt/homebrew/opt/icu4c/lib/pkgconfig' \
go test ./internal/storage/uow -run 'TestInitSchemaPreview|TestApplyProviderOptions' -count=1 -v
```

Result: PASS (`ok github.com/steveyegge/beads/internal/storage/uow 0.480s`).

```bash
CGO_CPPFLAGS='-I/opt/homebrew/opt/icu4c/include' \
CGO_CXXFLAGS='-I/opt/homebrew/opt/icu4c/include' \
CGO_LDFLAGS='-L/opt/homebrew/opt/icu4c/lib' \
PKG_CONFIG_PATH='/opt/homebrew/opt/icu4c/lib/pkgconfig' \
BEADS_TEST_EMBEDDED_DOLT=1 \
go test ./internal/storage/embeddeddolt -run 'TestPreviewStoreRefusesLocalMetadataWrite' -count=1 -v
```

Result: PASS (`ok github.com/steveyegge/beads/internal/storage/embeddeddolt 2.750s`).

```bash
CGO_CPPFLAGS='-I/opt/homebrew/opt/icu4c/include' \
CGO_CXXFLAGS='-I/opt/homebrew/opt/icu4c/include' \
CGO_LDFLAGS='-L/opt/homebrew/opt/icu4c/lib' \
PKG_CONFIG_PATH='/opt/homebrew/opt/icu4c/lib/pkgconfig' \
go vet ./cmd/bd/... ./internal/storage/embeddeddolt/... ./internal/storage/uow/... ./internal/storage/dolt/...

go build ./...
```

Result: PASS.

Earlier validation on `a98a27609` before the round-2 scope narrowing also included touched storage package runs and a clean-worktree full `go test ./cmd/bd -count=1` pass from `/tmp/beads-current-pr5984` (`196.206s`). Full `go test ./cmd/bd -count=1` from inside `/Users/qeetbastudio/gt/...` remains contaminated by the parent GT `.beads` config and can fail `TestIsBackupAutoEnabled/default_+_git_remote_→_enabled`; the same test passed from the clean worktree.

## CI

```bash
gh api "repos/gastownhall/beads/actions/runs?head_sha=e7ba0ccda17220b599bb934d22e2a8bcb8c8223b" --jq '.total_count'
0
```

Zero workflow runs on this head. A change to the store-open path on a release branch should not merge on local tests alone; the fork/release-branch runs need maintainer/operator action before there is a CI signal.
