### PR TITLE
docs: add bead-rs under a new "Task queues for agent fleets" section

### DIFF
--- a/docs/related-projects.md
+++ b/docs/related-projects.md
@@ -21,3 +21,13 @@ versa.
   why*. They compose — independently arrived at the same hash-based-ID
   convention (`bd-a1b2`, `~hash`) for the same reason: preventing
   collisions across multi-agent and multi-branch work.
+
+## Task queues for agent fleets
+
+- **[bead-rs](https://github.com/jedarden/bead-rs)** — clean-room Rust
+  task-coordination store for agent fleets: a dependency graph of "beads" in
+  SQLite, exactly one unblocked bead handed out per request through a
+  single-transaction atomic claim, and a git-tracked checkpoint for recovery.
+  Same neighbourhood as Beads (it began as a response to read-then-write
+  claiming racing at twenty workers) but a separate lineage and schema; not a
+  Beads integration.


### PR DESCRIPTION
bead-rs is an independent, clean-room Rust task store for agent fleets in the same neighbourhood as Beads — separate lineage and schema, not an integration. Disclosure: I'm the author. Happy to reword or drop the section framing if you'd rather keep the file single-section.