### PR TITLE
fix(dolt): skip redundant preflight for remote TCP servers

### DIFF
--- a/internal/storage/dolt/external_server_preflight_test.go
+++ b/internal/storage/dolt/external_server_preflight_test.go
@@ -1,0 +1,156 @@
+package dolt
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestServerConnectionNeedsPreflight(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{
+			name: "remote IPv4 writable",
+			cfg:  Config{ServerHost: "100.122.24.50", ServerPort: 3309, ReadOnly: false},
+			want: false,
+		},
+		{
+			name: "remote hostname read-only",
+			cfg:  Config{ServerHost: "dolt.tailnet.example", ServerPort: 3309, ReadOnly: true},
+			want: false,
+		},
+		{
+			name: "loopback IPv4",
+			cfg:  Config{ServerHost: "127.0.0.1", ServerPort: 3307},
+			want: true,
+		},
+		{
+			name: "localhost hostname",
+			cfg:  Config{ServerHost: "LOCALHOST", ServerPort: 3307},
+			want: true,
+		},
+		{
+			name: "loopback IPv6",
+			cfg:  Config{ServerHost: "::1", ServerPort: 3307},
+			want: true,
+		},
+		{
+			name: "all interfaces",
+			cfg:  Config{ServerHost: "0.0.0.0", ServerPort: 3307},
+			want: true,
+		},
+		{
+			name: "unix socket on remote-configured host",
+			cfg: Config{
+				ServerHost:   "100.122.24.50",
+				ServerPort:   3309,
+				ServerSocket: "/tmp/dolt.sock",
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := serverConnectionNeedsPreflight(&tt.cfg); got != tt.want {
+				t.Fatalf("serverConnectionNeedsPreflight(%+v) = %t, want %t", tt.cfg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDialServerPreflightSkipsRemoteTCP(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{ServerHost: "100.122.24.50", ServerPort: 3309}
+	conn, addr, err, ran := dialServerPreflight(cfg)
+	if err != nil {
+		t.Fatalf("dialServerPreflight returned error for skipped remote TCP preflight: %v", err)
+	}
+	if ran {
+		t.Fatal("dialServerPreflight ran for a remote TCP server")
+	}
+	if conn != nil {
+		_ = conn.Close()
+		t.Fatal("dialServerPreflight returned a connection for a skipped preflight")
+	}
+	if want := net.JoinHostPort(cfg.ServerHost, "3309"); addr != want {
+		t.Fatalf("dialServerPreflight addr = %q, want %q", addr, want)
+	}
+}
+
+func TestRecordSkippedPreflightResultConnectionFailure(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	for range circuitFailureThreshold - 1 {
+		breaker.RecordFailure()
+	}
+
+	cfg := &Config{ServerHost: "100.122.24.50", ServerPort: 3309}
+	err := recordSkippedPreflightResult(cfg, breaker, errors.New("dial tcp: i/o timeout"))
+	if err == nil {
+		t.Fatal("recordSkippedPreflightResult returned nil for a connection failure")
+	}
+	for _, want := range []string{"Dolt server unreachable", "100.122.24.50:3309", "nc -zv"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("connection error missing %q: %v", want, err)
+		}
+	}
+	if got := breaker.State(); got != circuitOpen {
+		t.Fatalf("circuit state = %q, want %q", got, circuitOpen)
+	}
+}
+
+func TestRecordSkippedPreflightResultSemanticFailureDoesNotTrip(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	for range circuitFailureThreshold - 1 {
+		breaker.RecordFailure()
+	}
+
+	wantErr := errors.New("Error 1045: access denied")
+	gotErr := recordSkippedPreflightResult(
+		&Config{ServerHost: "100.122.24.50", ServerPort: 3309},
+		breaker,
+		wantErr,
+	)
+	if !errors.Is(gotErr, wantErr) {
+		t.Fatalf("semantic error = %v, want original %v", gotErr, wantErr)
+	}
+	if strings.Contains(gotErr.Error(), "Dolt server unreachable") {
+		t.Fatalf("semantic error was rewritten as a reachability failure: %v", gotErr)
+	}
+	if got := breaker.State(); got != circuitClosed {
+		t.Fatalf("circuit state = %q, want %q", got, circuitClosed)
+	}
+}
+
+func TestRecordSkippedPreflightResultSuccessResetsBreaker(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	for range circuitFailureThreshold - 1 {
+		breaker.RecordFailure()
+	}
+
+	if err := recordSkippedPreflightResult(
+		&Config{ServerHost: "100.122.24.50", ServerPort: 3309},
+		breaker,
+		nil,
+	); err != nil {
+		t.Fatalf("success result returned error: %v", err)
+	}
+
+	for range circuitFailureThreshold - 1 {
+		breaker.RecordFailure()
+	}
+	if got := breaker.State(); got != circuitClosed {
+		t.Fatalf("circuit state after reset and sub-threshold failures = %q, want %q", got, circuitClosed)
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1714,6 +1714,60 @@ var ensureRunningDetailed = doltserver.EnsureRunningDetailed
 // dolt sql-server process.
 var stopRejectedAutoStartedServer = doltserver.Stop
 
+// serverConnectionNeedsPreflight reports whether server mode should make the
+// lightweight transport probe before opening the MySQL connection. Local TCP
+// servers use the probe to support auto-start, and unix sockets use it to
+// preserve socket-specific diagnostics. Remote TCP servers cannot be
+// auto-started by this process, so their MySQL driver's longer connection
+// timeout is the authoritative reachability check (GH#5273).
+func serverConnectionNeedsPreflight(cfg *Config) bool {
+	return cfg.ServerSocket != "" || !isExternalServerHost(cfg.ServerHost)
+}
+
+// dialServerPreflight performs the optional lightweight transport probe. The
+// final result reports whether a probe ran, allowing the caller to keep the
+// existing local circuit-breaker behavior while recording remote success only
+// after the MySQL connection has opened.
+func dialServerPreflight(cfg *Config) (conn net.Conn, addr string, err error, ran bool) {
+	if cfg.ServerSocket != "" {
+		conn, err = net.DialTimeout("unix", cfg.ServerSocket, 500*time.Millisecond)
+		return conn, cfg.ServerSocket, err, true
+	}
+
+	addr = net.JoinHostPort(cfg.ServerHost, fmt.Sprintf("%d", cfg.ServerPort))
+	if !serverConnectionNeedsPreflight(cfg) {
+		return nil, addr, nil, false
+	}
+
+	conn, err = net.DialTimeout("tcp", addr, 500*time.Millisecond)
+	return conn, addr, err, true
+}
+
+// recordSkippedPreflightResult updates connection-level circuit state for the
+// remote TCP path and preserves the external-server diagnostic that the old
+// transport probe supplied. Semantic MySQL failures pass through unchanged.
+func recordSkippedPreflightResult(cfg *Config, breaker *circuitBreaker, err error) error {
+	if err == nil {
+		if breaker != nil {
+			breaker.RecordSuccess()
+		}
+		return nil
+	}
+	if !isConnectionError(err) {
+		return err
+	}
+	if breaker != nil {
+		breaker.RecordFailure()
+	}
+
+	addr := net.JoinHostPort(cfg.ServerHost, fmt.Sprintf("%d", cfg.ServerPort))
+	return fmt.Errorf("Dolt server unreachable at %s: %w\n\n"+
+		"Configured Dolt server at %s is unreachable.\n"+
+		"Verify the external server is running and reachable from this host:\n"+
+		"  nc -zv %s %d  # or curl %s for an HTTP-style check",
+		addr, err, addr, cfg.ServerHost, cfg.ServerPort, addr)
+}
+
 // newServerMode creates a DoltStore connected to a running dolt sql-server.
 // This path is pure Go and does not require CGO.
 func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
@@ -1740,20 +1794,11 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	// the DSN built in openServerConnection agree on the transport.
 	cfg.ServerSocket = ResolveSocketTransport(cfg.ServerSocket, cfg.ServerHost, cfg.ServerPort, 500*time.Millisecond)
 
-	// Fail-fast connectivity check before MySQL protocol initialization.
-	// This gives an immediate, clear error if the Dolt server isn't running,
-	// rather than waiting for MySQL driver timeouts.
-	var addr string
-	var conn net.Conn
-	var dialErr error
-	if cfg.ServerSocket != "" {
-		addr = cfg.ServerSocket
-		conn, dialErr = net.DialTimeout("unix", cfg.ServerSocket, 500*time.Millisecond)
-	} else {
-		addr = net.JoinHostPort(cfg.ServerHost, fmt.Sprintf("%d", cfg.ServerPort))
-		conn, dialErr = net.DialTimeout("tcp", addr, 500*time.Millisecond)
-	}
-	if dialErr != nil {
+	// Fail-fast connectivity check before MySQL protocol initialization for
+	// local TCP and unix-socket servers. Remote TCP servers skip this redundant
+	// 500 ms probe and rely on the MySQL driver's 5-second connect timeout.
+	conn, addr, dialErr, preflightRan := dialServerPreflight(cfg)
+	if preflightRan && dialErr != nil {
 		// Auto-start: if enabled and connecting locally via TCP, start a server.
 		// Socket mode is excluded — auto-start creates a TCP listener, not a
 		// unix socket, so the DSN would still fail. Socket users are expected
@@ -1905,7 +1950,9 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	// (dolt sql-server crash risk otherwise, gastownhall/beads#4132, #4133).
 	// This single close site covers both the initial successful dial above
 	// and the post-auto-start retry dial in the branch just above.
-	doltserver.DrainAndCloseProbe(conn)
+	if conn != nil {
+		doltserver.DrainAndCloseProbe(conn)
+	}
 
 	// If this process already owns a test-started auto-start server, later
 	// stores sharing it must participate in the refcount so one Close() does
@@ -1914,13 +1961,16 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		autoStartedDir = serverDir
 	}
 
-	// TCP dial succeeded — record success to reset the breaker
-	if breaker != nil {
+	// A local transport probe succeeded — record success to reset the breaker.
+	if preflightRan && breaker != nil {
 		breaker.RecordSuccess()
 	}
 
 	// Server mode: connect via MySQL protocol to dolt sql-server
 	db, connStr, dbFacts, err := openServerConnection(ctx, cfg)
+	if !preflightRan && err != nil {
+		err = recordSkippedPreflightResult(cfg, breaker, err)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -1935,7 +1985,13 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 
 	// Test connection
 	if err := db.PingContext(ctx); err != nil {
+		if !preflightRan {
+			err = recordSkippedPreflightResult(cfg, breaker, err)
+		}
 		return nil, fmt.Errorf("failed to ping Dolt database: %w", err)
+	}
+	if !preflightRan {
+		_ = recordSkippedPreflightResult(cfg, breaker, nil)
 	}
 
 	beadsDir := cfg.BeadsDir

--- a/internal/storage/doltutil/dsn_test.go
+++ b/internal/storage/doltutil/dsn_test.go
@@ -3,7 +3,26 @@ package doltutil
 import (
 	"strings"
 	"testing"
+	"time"
+
+	mysql "github.com/go-sql-driver/mysql"
 )
+
+func TestServerDSN_DefaultConnectTimeout(t *testing.T) {
+	dsn := ServerDSN{
+		Host: "dolt.example.com",
+		Port: 3307,
+		User: "root",
+	}.String()
+
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		t.Fatalf("ParseDSN(%q): %v", dsn, err)
+	}
+	if cfg.Timeout != 5*time.Second {
+		t.Fatalf("default connect timeout = %s, want 5s", cfg.Timeout)
+	}
+}
 
 func TestServerDSN_TLSExplicitlyDisabledByDefault(t *testing.T) {
 	dsn := ServerDSN{


### PR DESCRIPTION
## What

Skip the redundant 500 ms raw transport preflight for non-local TCP Dolt servers and let the existing MySQL driver's bounded 5-second connect timeout decide reachability. Local TCP and Unix-socket preflights, local auto-start, circuit-breaker accounting, and external-server diagnostics remain intact.

## Why

At higher-latency or temporarily cold network paths, the single 500 ms raw dial can fail before the MySQL driver gets its existing 5-second window. This produces an immediate `Dolt server unreachable` result even though a retry succeeds. The exact direction is the confirmed-unlanded item 2 in #5273; #5911 is a matching v1.2.2 field report.

The topology split was first demonstrated by @Shockwave2k in the closed showcase PR #4167. This focused follow-up is necessary because that PR was explicitly non-mergeable and is not maintainer-editable.

This change does not retry a command or SQL transaction. Connection failures still feed the circuit breaker; authentication, schema, identity, and other semantic MySQL errors are not reclassified as outages.

Please consider backporting the focused fix to the v1.2.2-derived maintenance line (currently `bee/release-v1.2.3`). Current `main` expects newer schema such as `leases`, so a maintenance release is the safe upgrade path for existing v1.2.2 remote-server installations.

Refs #5273.

## Verification

- Red test first: the new external-preflight tests failed to compile before the production helper existed.
- `./scripts/test.sh -run 'Test(ServerConnectionNeedsPreflight|DialServerPreflightSkipsRemoteTCP|RecordSkippedPreflightResult.*)$' ./internal/storage/dolt`
- `./scripts/test.sh ./internal/storage/dolt/... ./internal/storage/doltutil/...`
- `make test`
- `git diff --check`
- `make ci-pr-lint` reaches `golangci-lint` and reports the same two pre-existing Darwin findings on clean `upstream/main`: G304 in `internal/config/permissions_open_nonlinux.go` and G103 in `internal/utils/path_case_darwin.go`.

_codex-gpt-5.6-sol-unknown-reasoning on behalf of Riley Developer_
