### PR TITLE
test(dolt): document contention-vs-bug verdict for 2 federation tests

### DIFF
--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -348,7 +348,13 @@ func TestFederationHistoryQueries(t *testing.T) {
 	}
 }
 
-// TestFederationListRemotes tests the ListRemotes API
+// TestFederationListRemotes tests the ListRemotes API.
+//
+// Can report "context deadline exceeded" under the full concurrent test
+// suite even though its own operations complete in well under a second:
+// this package serializes access to one shared Dolt server through a
+// size-2 slot semaphore (acquireTestSlot in dolt_test.go), so heavy
+// parallel load queues test start rather than failing any assertion here.
 func TestFederationListRemotes(t *testing.T) {
 	skipIfNoDolt(t)
 
@@ -412,6 +418,10 @@ func TestFederationSyncStatus(t *testing.T) {
 	}
 }
 
+// Like TestFederationListRemotes above, this test can show "context
+// deadline exceeded" under full-suite concurrency due to the shared Dolt
+// server's bounded test-slot queue, not a defect in the sync/commit
+// ordering below.
 func TestFederationSyncCommitsPendingPeerMetadataBeforeFetch(t *testing.T) {
 	skipIfNoDolt(t)
 

--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -350,11 +350,15 @@ func TestFederationHistoryQueries(t *testing.T) {
 
 // TestFederationListRemotes tests the ListRemotes API.
 //
-// Can report "context deadline exceeded" under the full concurrent test
-// suite even though its own operations complete in well under a second:
-// this package serializes access to one shared Dolt server through a
-// size-2 slot semaphore (acquireTestSlot in dolt_test.go), so heavy
-// parallel load queues test start rather than failing any assertion here.
+// A "context deadline exceeded" reported against this test is not the context
+// built below. That one is created AFTER setupTestStore returns, so the
+// test-slot queue wait is already over and it starts with a fresh minute --
+// setupTestStore's doc comment in dolt_test.go prescribes that ordering for
+// exactly this reason. The deadline that can genuinely expire here is
+// setupTestStore's own testContext, the package-wide testTimeout, around
+// New() and initSchemaOnDB; it surfaces as "failed to create Dolt store" or
+// "failed to initialize branch-local ignored schema" attributed to this test
+// rather than as a failure of any assertion below.
 func TestFederationListRemotes(t *testing.T) {
 	skipIfNoDolt(t)
 
@@ -418,10 +422,11 @@ func TestFederationSyncStatus(t *testing.T) {
 	}
 }
 
-// Like TestFederationListRemotes above, this test can show "context
-// deadline exceeded" under full-suite concurrency due to the shared Dolt
-// server's bounded test-slot queue, not a defect in the sync/commit
-// ordering below.
+// TestFederationSyncCommitsPendingPeerMetadataBeforeFetch has the same
+// exposure as TestFederationListRemotes above: a "context deadline exceeded"
+// attributed to it comes from setupTestStore's testTimeout around the store
+// open, not from the minute-long context below and not from a defect in the
+// sync/commit ordering.
 func TestFederationSyncCommitsPendingPeerMetadataBeforeFetch(t *testing.T) {
 	skipIfNoDolt(t)
 


### PR DESCRIPTION
## Summary

Comment-only diff to `internal/storage/dolt/federation_test.go` documenting
the triage verdict for 3 singleton real-server test failures originally
surfaced by CI (PR #5836's run):

- `TestFederationListRemotes` — resource-contention/timeout under the
  package's 2-slot test semaphore (`acquireTestSlot`/`testSem`,
  `internal/storage/dolt/dolt_test.go:36-45`), not a product bug. Documented
  in place, not worked around.
- `TestFederationSyncCommitsPendingPeerMetadataBeforeFetch` — same
  contention cause, same disposition.
- `TestClaimerReclaimsAcrossSpellingWithoutWriting` — already fixed
  upstream; confirmed passing on current `main`, included as corroboration
  (not part of this diff).

No executable code changed, no new imports, no new logic paths.

## Test plan

- [x] `go test -tags=integration,gms_pure_go -v -count=1 -timeout 15m -run
      '^(TestFederationListRemotes|TestFederationSyncCommitsPendingPeerMetadataBeforeFetch|TestClaimerReclaimsAcrossSpellingWithoutWriting)$'
      ./internal/storage/dolt/` — 3 PASS, 0 FAIL, 0 SKIP (real container run,
      independently reproduced twice on two different commits)
- [x] `gofmt -l` on the diff file — clean
- [x] `go vet -tags=integration,gms_pure_go ./internal/storage/dolt/...` —
      clean