### PR TITLE
fix(storage): widen schema-init timeout headroom for migrating-store-open tests

### DIFF
--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -34,6 +34,17 @@ import (
 // exceeded" at exactly the old bound under real host contention (15+
 // concurrent agent sessions) — see TestSchemaInitTimeoutHasLoadHeadroom for
 // the regression guard.
+//
+// This is not a two-test change. testTimeout backs testContext, which 125
+// files in this package call, and it is multiplied at 13 `5*testTimeout`
+// sites (the dropCtx database-drop cleanups in initschema_pool_poison_test.go,
+// schema_version_test.go, schema_skew_test.go, remote_migrate_gate_test.go and
+// smart_remote_migrate_gate_test.go). Raising 45s to 90s therefore takes those
+// bounds from 225s to 450s: a genuinely hung drop now needs 7.5 minutes to
+// report instead of 3.75. That is the cost being accepted here — a slower
+// failure signal across the package in exchange for not failing honest work
+// under host contention. If that trade stops being worth it, the fix is to
+// give the schema-init path its own bound rather than to lower this one back.
 const testTimeout = 90 * time.Second
 
 // testSem limits concurrent database-touching tests to avoid overwhelming the

--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -27,7 +27,14 @@ import (
 // ignored migration, each Dolt-committed), which grows as migrations
 // accumulate — with headroom for a loaded machine; some tests set up two
 // stores under one context.
-const testTimeout = 45 * time.Second
+//
+// Was 45s; raised to 90s for be-696w. At 45s, migrating-open tests
+// (cross_project_test.go's TestCrossProject_*, TestMigratingOpen_FirstReadSucceeds)
+// intermittently failed with "failed to initialize schema: context deadline
+// exceeded" at exactly the old bound under real host contention (15+
+// concurrent agent sessions) — see TestSchemaInitTimeoutHasLoadHeadroom for
+// the regression guard.
+const testTimeout = 90 * time.Second
 
 // testSem limits concurrent database-touching tests to avoid overwhelming the
 // shared Dolt testcontainer. Without this, 200+ parallel tests cause a

--- a/internal/storage/dolt/schema_init_timeout_test.go
+++ b/internal/storage/dolt/schema_init_timeout_test.go
@@ -1,0 +1,22 @@
+package dolt
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSchemaInitTimeoutHasLoadHeadroom guards be-696w: testTimeout (dolt_test.go)
+// bounds every migrating store-open in this package, directly or via
+// testContext. At 45s it was measured too tight under real host contention —
+// cross_project_test.go and TestMigratingOpen_FirstReadSucceeds both failed
+// with "failed to initialize schema: context deadline exceeded" at exactly
+// that bound (see be-696w). This is a floor, not an exact-value check, so a
+// future deliberate increase does not need to touch this test — only a
+// regression back toward the too-tight value trips it.
+func TestSchemaInitTimeoutHasLoadHeadroom(t *testing.T) {
+	const minTestTimeout = 90 * time.Second
+	if testTimeout < minTestTimeout {
+		t.Fatalf("testTimeout = %s, want >= %s (be-696w: 45s measured too tight under host contention)",
+			testTimeout, minTestTimeout)
+	}
+}


### PR DESCRIPTION
## Summary

`internal/storage/dolt/dolt_test.go`'s shared per-test context timeout
(`testTimeout`) was measured too tight under real host contention (15+
concurrent agent sessions), intermittently failing a different
`TestCrossProject_*` test each run plus `TestMigratingOpen_FirstReadSucceeds`
with `"failed to initialize schema: context deadline exceeded"` at exactly
the old 45s bound. Root cause: `store.go`'s `initSchema` sets no fixed
deadline of its own — the 45s bound came entirely from the caller's test
context, with no headroom for a loaded machine despite the constant's own
doc comment stating that intent.

- Raises `testTimeout` from 45s to 90s (`dolt_test.go`)
- Adds `TestSchemaInitTimeoutHasLoadHeadroom`, a floor-only regression guard
  (`testTimeout >= 90s`) that catches a future regression back toward the
  too-tight value without pinning an exact constant

Test-only change (both touched files are `_test.go`); no production code
touched, no new dependencies.

## Test plan

- [x] `TestSchemaInitTimeoutHasLoadHeadroom` — PASS (new regression guard)
- [x] 10× `TestCrossProject_*` — PASS under a real Dolt container with the
      new 90s bound
- [x] `TestMigratingOpen_FirstReadSucceeds` — PASS (integration-tagged)
- [x] 13 PASS / 0 FAIL / 0 SKIP total, independently re-verified on the
      exact commit in this PR via explicit `-v` output grep (not exit code
      or "ok" text alone), matching the reviewing agent's own independently
      reported count exactly
- [x] `gofmt`, `go vet`, `go build` — clean
- [x] No new HIGH/security findings (test-only diff, zero production attack
      surface)

---
Deploy-gate evaluated by an automated multi-agent release pipeline
(build → review → deploy gate) against 7 release criteria; full evidence
record kept in-repo on the deploy branch at
`release-gates/be-gwlps-schema-init-timeout-headroom-gate.md`.