### PR TITLE
docs(testutil): document migration-0032 hang and Ryuk-disabled container-leak caveats

### DIFF
--- a/engdocs/TESTING.md
+++ b/engdocs/TESTING.md
@@ -110,6 +110,46 @@ external-dependency boundary. Keep new uses within the repository policy:
 make check-testing-short
 ```
 
+### Dolt Container Tests (podman-rootless)
+
+Anything that does not carry `BEADS_TEST_SKIP=dolt` — including
+`BEADS_TEST_ENV_RUN_DOLT=1` and a bare `go test` — reaches a real
+`dolt sql-server` through testcontainers-go. Two limitations of that harness
+are worth recognizing before reading a failure as a product bug. Neither is
+reachable in production or on GitHub Actions.
+
+**Migration 0032 hangs over the wire protocol.** Migration `0032`
+(`drop_schema_migrations_applied_at`) hangs indefinitely when applied through
+the containerized sql-server, surfacing after roughly 60s as:
+
+```
+failed to create embedded DoltStore: failed to initialize schema: context deadline exceeded
+```
+
+A `go test ./internal/storage/uow/... -count=1` with no `BEADS_TEST_SKIP` sits
+in `initSchema` until the package timeout rather than failing. The cause is the
+container port-forwarding path, not migration 0032's SQL: the identical
+statement completes normally through the embedded/CLI engine, and against a
+bare-host-process `dolt sql-server` matching the deployed shape. Evidence chain
+in `be-j3szz`. Use `BEADS_TEST_SKIP=dolt` unless the container path is what you
+are testing.
+
+**Disabling Ryuk removes the container safety net.** This repository sets no
+`TESTCONTAINERS_RYUK_DISABLED`, so CI runs with Ryuk — testcontainers-go's
+orphan-reaper sidecar — enabled. The podman-rootless flow generally requires
+turning it off by hand (`TESTCONTAINERS_RYUK_DISABLED=true`), because under
+rootless podman Ryuk frequently cannot start: it wants the runtime socket. See
+`be-w3n2m`. With Ryuk off, nothing reaps a container whose test process exited
+without running its cleanup — `os.Exit` reached before a deferred
+`TerminateDoltContainer`, for instance. `be-5kkk6` records the cost: 101 leaked
+containers, and an exhausted swap. When running with Ryuk disabled, keep
+teardown on the normal return path using the `testMainInner` pattern
+(`beads_test.go`), and check for strays afterwards:
+
+```bash
+docker ps -a --filter ancestor=dolthub/dolt-sql-server:2.2.0
+```
+
 ## Test Design
 
 ### Seams, Scenarios, and Doubles

--- a/internal/testutil/testdoltcommon.go
+++ b/internal/testutil/testdoltcommon.go
@@ -11,6 +11,28 @@ import (
 )
 
 // DoltDockerImage is the Docker image used for Dolt test containers.
+//
+// Known limitations of this containerized (podman-rootless + testcontainers-go)
+// real-server harness — both confirmed empirically, and neither reachable in
+// production or on real GitHub Actions CI:
+//
+//   - Schema migration 0032 (drop_schema_migrations_applied_at) hangs
+//     indefinitely over the sql-server wire protocol in this harness,
+//     surfacing as "failed to create embedded DoltStore: failed to
+//     initialize schema: context deadline exceeded" (~60s). Confirmed
+//     specific to this harness's container port-forwarding path, not to
+//     migration 0032's SQL itself: the identical statement completes
+//     normally via the embedded/CLI engine and against a bare-host-process
+//     dolt sql-server matching this fleet's real deployment shape. See
+//     be-j3szz for the full evidence chain.
+//   - Containers can leak because Ryuk (testcontainers-go's orphan-reaper
+//     sidecar) is disabled for this harness (TESTCONTAINERS_RYUK_DISABLED=true,
+//     a workaround for this host's broken dockerd/containerd — see be-hsa9t),
+//     so there is no safety net when a test process exits without running
+//     its cleanup (e.g. os.Exit called before a deferred
+//     TerminateDoltContainer). See be-5kkk6 for a historical incident (101
+//     leaked containers, swap exhaustion) and the testMainInner pattern this
+//     repo now uses elsewhere to guarantee deferred cleanup actually runs.
 const DoltDockerImage = "dolthub/dolt-sql-server:2.2.0"
 
 // RequireDoltBinary ensures the `dolt` CLI binary is available, and honors

--- a/internal/testutil/testdoltcommon.go
+++ b/internal/testutil/testdoltcommon.go
@@ -11,29 +11,6 @@ import (
 )
 
 // DoltDockerImage is the Docker image used for Dolt test containers.
-//
-// Known limitations of this containerized (podman-rootless + testcontainers-go)
-// real-server harness — both confirmed empirically, and neither reachable in
-// production or on real GitHub Actions CI:
-//
-//   - Schema migration 0032 (drop_schema_migrations_applied_at) hangs
-//     indefinitely over the sql-server wire protocol in this harness,
-//     surfacing as "failed to create embedded DoltStore: failed to
-//     initialize schema: context deadline exceeded" (~60s). Confirmed
-//     specific to this harness's container port-forwarding path, not to
-//     migration 0032's SQL itself: the identical statement completes
-//     normally via the embedded/CLI engine and against a bare-host-process
-//     dolt sql-server matching this fleet's real deployment shape. See
-//     be-j3szz for the full evidence chain.
-//   - Containers can leak because Ryuk (testcontainers-go's orphan-reaper
-//     sidecar) is disabled for this harness (TESTCONTAINERS_RYUK_DISABLED=true;
-//     under rootless podman Ryuk frequently cannot start because it wants
-//     the runtime socket — see be-w3n2m), so there is no safety net when a
-//     test process exits without running its cleanup (e.g. os.Exit called
-//     before a deferred TerminateDoltContainer). See be-5kkk6 for a
-//     historical incident (101 leaked containers, swap exhaustion) and the
-//     testMainInner pattern this repo now uses elsewhere to guarantee
-//     deferred cleanup actually runs.
 const DoltDockerImage = "dolthub/dolt-sql-server:2.2.0"
 
 // RequireDoltBinary ensures the `dolt` CLI binary is available, and honors

--- a/internal/testutil/testdoltcommon.go
+++ b/internal/testutil/testdoltcommon.go
@@ -26,13 +26,14 @@ import (
 //     dolt sql-server matching this fleet's real deployment shape. See
 //     be-j3szz for the full evidence chain.
 //   - Containers can leak because Ryuk (testcontainers-go's orphan-reaper
-//     sidecar) is disabled for this harness (TESTCONTAINERS_RYUK_DISABLED=true,
-//     a workaround for this host's broken dockerd/containerd — see be-hsa9t),
-//     so there is no safety net when a test process exits without running
-//     its cleanup (e.g. os.Exit called before a deferred
-//     TerminateDoltContainer). See be-5kkk6 for a historical incident (101
-//     leaked containers, swap exhaustion) and the testMainInner pattern this
-//     repo now uses elsewhere to guarantee deferred cleanup actually runs.
+//     sidecar) is disabled for this harness (TESTCONTAINERS_RYUK_DISABLED=true;
+//     under rootless podman Ryuk frequently cannot start because it wants
+//     the runtime socket — see be-w3n2m), so there is no safety net when a
+//     test process exits without running its cleanup (e.g. os.Exit called
+//     before a deferred TerminateDoltContainer). See be-5kkk6 for a
+//     historical incident (101 leaked containers, swap exhaustion) and the
+//     testMainInner pattern this repo now uses elsewhere to guarantee
+//     deferred cleanup actually runs.
 const DoltDockerImage = "dolthub/dolt-sql-server:2.2.0"
 
 // RequireDoltBinary ensures the `dolt` CLI binary is available, and honors


### PR DESCRIPTION
## Summary
- Documents two known limitations of this repo's podman-rootless + testcontainers-go real-server test harness as comments on `DoltDockerImage` in `internal/testutil/testdoltcommon.go`: the migration-0032 (`drop_schema_migrations_applied_at`) indefinite hang over the sql-server wire protocol, and the Ryuk-disabled container-leak risk under rootless podman.
- Round 2 fix (this commit): corrects a wrong citation and causal claim from round 1 — the Ryuk-disabled bullet now cites `be-w3n2m` (with its own verbatim finding: Ryuk frequently cannot start under rootless podman because it wants the runtime socket) instead of the unrelated `be-hsa9t` (a git-remote E2BIG fix that never mentions Ryuk/dockerd/containerd).
- No production code changes — comment-only, zero executable code touched. This diff adds zero new executable lines, so it has no patch coverage of its own to report (`pre-pr-check --coverage` flags the package's pre-existing 19.7% average, unrelated to this change).

## Test plan
- [x] `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true go test -v ./internal/testutil/...` — 7 PASS, 0 FAIL, 0 SKIP, independently re-verified on the deployed commit (matches the reviewer's own reported count exactly)
- [x] `make ci-pr-policy` — clean pass
- [x] `gc beads-contributor pre-pr-check` — 0 blockers, 2 informational warnings (pre-existing package coverage below the 20% advisory floor on a comment-only diff with no new executable lines; and title/body citing the deploy/review bead ids `be-ttfqp`/`be-wsu6b` for traceability, which the commits themselves don't cite — both expected for a deploy-gate PR, not scope drift)
- [x] No leaked test containers (`podman ps -a` empty post-run)
- [x] All three citations (`be-w3n2m`, `be-j3szz`, `be-5kkk6`) independently re-verified against actual bead content

Reviewed and passed in beads/reviewer bead `be-wsu6b` (round 2; round 1 was `be-ohrc0`, `request-changes`, fully addressed). Built in `be-r7j5x`. Deploy-gated in `be-ttfqp`.
