### PR TITLE
Align proxied-local-smoke Dolt CLI pin with measured 2.2.0 (refs be-egcj2.3)

### DIFF
--- a/.github/workflows/proxied-local-smoke.yml
+++ b/.github/workflows/proxied-local-smoke.yml
@@ -65,8 +65,10 @@ jobs:
     env:
       CGO_ENABLED: "1"
       # Pinned so the lane tests a known dolt CLI, not whatever the installer
-      # resolves on a given day. Bump deliberately.
-      DOLT_VERSION: 2.2.2
+      # resolves on a given day. Bump deliberately, and only in lockstep with
+      # the measured pin in scripts/ci/install-dolt.sh (see "Which Dolt
+      # version to install" in docs/architecture/dolt.md).
+      DOLT_VERSION: 2.2.0
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -1290,6 +1290,32 @@ func TestPinnedDoltCLIMatchesContainerImage(t *testing.T) {
 	}
 }
 
+// TestProxiedLocalSmokeMatchesPinnedDoltVersion keeps the proxied-local-smoke
+// lane's standalone Dolt CLI install on the same release as the rest of the
+// suite. That lane downloads its own dolt binary straight from GitHub
+// releases instead of going through scripts/ci/install-dolt.sh, so nothing
+// else catches it drifting off the measured pin (see "Which Dolt version to
+// install" in docs/architecture/dolt.md for why the pin is not just "latest").
+func TestProxiedLocalSmokeMatchesPinnedDoltVersion(t *testing.T) {
+	root := sourceRepoRoot(t)
+
+	installer, err := os.ReadFile(filepath.Join(root, "scripts", "ci", "install-dolt.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cliVersion := captureOne(t, `(?m)^readonly version="([0-9]+\.[0-9]+\.[0-9]+)"$`, string(installer), "scripts/ci/install-dolt.sh")
+
+	workflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "proxied-local-smoke.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	smokeVersion := captureOne(t, `(?m)^\s*DOLT_VERSION:\s*([0-9]+\.[0-9]+\.[0-9]+)\s*$`, string(workflow), "proxied-local-smoke.yml:DOLT_VERSION")
+
+	if cliVersion != smokeVersion {
+		t.Errorf("dolt pins disagree: CLI %s, proxied-local-smoke.yml DOLT_VERSION %s", cliVersion, smokeVersion)
+	}
+}
+
 func captureOne(t *testing.T, pattern, body, source string) string {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- Aligns the `proxied-local-smoke` CI lane's standalone Dolt CLI install with the repo's measured pin: `DOLT_VERSION` in `.github/workflows/proxied-local-smoke.yml` moves from `2.2.2` to `2.2.0`, matching `scripts/ci/install-dolt.sh` and the `DoltDockerImage` test-container pin (`internal/testutil/testdoltcommon.go`).
- Adds a regression test, `TestProxiedLocalSmokeMatchesPinnedDoltVersion` (`scripts/ci_workflow_test.go`), that reads both files and fails if the two pins ever drift apart again — this lane downloads its own `dolt` binary straight from GitHub releases instead of going through `install-dolt.sh`, so nothing else previously caught it drifting.
- Per `docs/architecture/dolt.md`'s "Which Dolt version to install" section: Dolt 2.3.0+ regressed `CALL DOLT_RESET('--hard')` (3/60 and 3/100 fresh databases affected in 2.3.0/2.3.1, vs. 0/40 and 0/60 on 2.1.8/2.2.0) — 2.2.0 is the current measured-clean pin, and this is a deliberate downgrade back to it, not an upgrade to an unvetted version.

## Test plan
- [x] `go test -v ./scripts/... ./test/docsync/...` — 86 PASS, 0 FAIL, 1 SKIP, independently re-verified on the deployed commit (matches the reviewer's own reported count exactly). The 1 SKIP is `TestTestScriptPrebuiltBinaryLaunchProbe` (pre-existing, environment-conditional, unrelated file).
- [x] All 4 exit-contract-named regression tests pass by name: `TestPinnedDoltCLIMatchesContainerImage`, `TestDoltVersionPinsAgree`, `TestPullDoltImageRetriesTransientFailures`, `TestWorkflowsInstallPinnedDolt`; new test `TestProxiedLocalSmokeMatchesPinnedDoltVersion` passes.
- [x] `gofmt -l scripts/ci_workflow_test.go` clean, `go vet ./...` clean, `go build ./...` clean.
- [x] `make ci-pr-policy` — clean pass.
- [x] `gc beads-contributor pre-pr-check` — 0 blockers.
- [x] Independently spot-checked all three version pins agree post-change (`proxied-local-smoke.yml` DOLT_VERSION, `install-dolt.sh` readonly version, `DoltDockerImage` literal) and that `docs/architecture/dolt.md`'s measured-pin table backs the downgrade rationale.

Reviewed and passed in beads/reviewer bead `be-58kaz`. Built in `be-egcj2.3`. Deploy-gated in `be-f30dn`.
