### PR TITLE
fix(notion): make the query page bound configurable and honour Retry-After

### DIFF
--- a/internal/notion/client.go
+++ b/internal/notion/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -19,6 +20,12 @@ const (
 	maxResponseBytes     = 20 * 1024 * 1024
 	maxQueryPages        = 50
 	maxPageSize          = 100
+	// maxRequestAttempts bounds retries of a rate-limited or transiently failing
+	// request, including the first try.
+	maxRequestAttempts = 5
+	// maxRetryDelay clamps a server-supplied Retry-After so an interactive CLI
+	// cannot be parked for minutes by one header.
+	maxRetryDelay = 30 * time.Second
 )
 
 type Client struct {
@@ -26,6 +33,15 @@ type Client struct {
 	BaseURL       string
 	NotionVersion string
 	HTTPClient    *http.Client
+
+	// MaxQueryPages bounds pagination in QueryDataSource. Zero means
+	// maxQueryPages. Raise it for a data source larger than
+	// maxQueryPages*maxPageSize rows, which otherwise cannot be synced at all.
+	MaxQueryPages int
+
+	// sleep is the retry delay hook, swapped out in tests so backoff coverage
+	// does not spend real seconds.
+	sleep func(time.Duration)
 }
 
 func NewClient(token string) *Client {
@@ -35,6 +51,29 @@ func NewClient(token string) *Client {
 		NotionVersion: DefaultNotionVersion,
 		HTTPClient:    &http.Client{Timeout: DefaultTimeout},
 	}
+}
+
+// WithMaxQueryPages overrides the pagination bound for QueryDataSource.
+// Non-positive values fall back to the default.
+func (c *Client) WithMaxQueryPages(pages int) *Client {
+	clone := *c
+	clone.MaxQueryPages = pages
+	return &clone
+}
+
+func (c *Client) maxQueryPages() int {
+	if c.MaxQueryPages > 0 {
+		return c.MaxQueryPages
+	}
+	return maxQueryPages
+}
+
+func (c *Client) sleepFor(d time.Duration) {
+	if c.sleep != nil {
+		c.sleep(d)
+		return
+	}
+	time.Sleep(d)
 }
 
 func (c *Client) WithHTTPClient(httpClient *http.Client) *Client {
@@ -120,7 +159,8 @@ func (c *Client) CreateDatabase(ctx context.Context, parentPageID, title string)
 func (c *Client) QueryDataSource(ctx context.Context, dataSourceID string) ([]Page, error) {
 	var pages []Page
 	var cursor string
-	for pageNum := 0; pageNum < maxQueryPages; pageNum++ {
+	limit := c.maxQueryPages()
+	for pageNum := 0; pageNum < limit; pageNum++ {
 		request := map[string]interface{}{
 			"page_size":   maxPageSize,
 			"result_type": "page",
@@ -143,7 +183,14 @@ func (c *Client) QueryDataSource(ctx context.Context, dataSourceID string) ([]Pa
 		}
 		cursor = resp.NextCursor
 	}
-	return nil, fmt.Errorf("query pagination exceeded %d pages", maxQueryPages)
+	// Naming the ceiling in rows, not pages, is the difference between a caller
+	// knowing what to do and filing a bug: the number they can compare against
+	// their data source is limit*maxPageSize.
+	return nil, fmt.Errorf(
+		"query pagination exceeded %d pages (~%d rows): this data source is larger than the "+
+			"configured bound, so no sync can complete. Raise it via Client.WithMaxQueryPages, "+
+			"or reduce the number of rows in the data source",
+		limit, limit*maxPageSize)
 }
 
 func (c *Client) CreatePage(ctx context.Context, dataSourceID string, properties map[string]interface{}) (*Page, error) {
@@ -253,50 +300,125 @@ func (c *Client) doRequest(ctx context.Context, method, path string, requestBody
 		httpClient = &http.Client{Timeout: DefaultTimeout}
 	}
 
-	var bodyReader io.Reader
+	// Marshal once and rebuild the reader per attempt: a retry cannot reuse a
+	// drained body.
+	var payload []byte
 	if requestBody != nil {
-		payload, err := json.Marshal(requestBody)
+		var err error
+		payload, err = json.Marshal(requestBody)
 		if err != nil {
 			return nil, fmt.Errorf("marshal request body: %w", err)
 		}
-		bodyReader = bytes.NewReader(payload)
 	}
 
 	requestURL := path
 	if !strings.HasPrefix(requestURL, "http://") && !strings.HasPrefix(requestURL, "https://") {
 		requestURL = strings.TrimSuffix(c.BaseURL, "/") + path
 	}
-	req, err := http.NewRequestWithContext(ctx, method, requestURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.Token)
-	req.Header.Set("Notion-Version", c.NotionVersion)
-	req.Header.Set("Accept", "application/json")
-	if requestBody != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
 
+	// Notion enforces ~3 requests/second per connection and answers 429 with a
+	// Retry-After header. Without honouring it, any caller that paginates a
+	// large data source trips the limit and the whole sync dies on a transient
+	// condition the API explicitly tells us how to wait out.
+	var lastErr error
+	for attempt := 0; attempt < maxRequestAttempts; attempt++ {
+		var bodyReader io.Reader
+		if payload != nil {
+			bodyReader = bytes.NewReader(payload)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, requestURL, bodyReader)
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+		req.Header.Set("Notion-Version", c.NotionVersion)
+		req.Header.Set("Accept", "application/json")
+		if payload != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+
+		body, status, retryAfter, err := c.doAttempt(httpClient, req)
+		if err != nil {
+			return nil, err
+		}
+		if status >= 200 && status < 300 {
+			return body, nil
+		}
+
+		if !retryableStatus(status, method) || attempt == maxRequestAttempts-1 {
+			return nil, notionAPIError(status, body)
+		}
+		lastErr = notionAPIError(status, body)
+
+		// Retry-After is authoritative when present; otherwise exponential,
+		// clamped so a long server-side hint cannot stall a CLI indefinitely.
+		delay := time.Duration(1<<attempt) * time.Second
+		if retryAfter > 0 {
+			delay = retryAfter
+		}
+		if delay > maxRetryDelay {
+			delay = maxRetryDelay
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		c.sleepFor(delay)
+	}
+	return nil, lastErr
+}
+
+// doAttempt performs one request and fully reads the response, so the caller can
+// decide about retrying without holding an open body.
+func (c *Client) doAttempt(httpClient *http.Client, req *http.Request) ([]byte, int, time.Duration, error) {
 	resp, err := httpClient.Do(req) //nolint:gosec // G704: URL is constructed from configured Notion API base, not user input
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, 0, 0, fmt.Errorf("request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
+		return nil, 0, 0, fmt.Errorf("read response: %w", err)
 	}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		return body, nil
-	}
+	return body, resp.StatusCode, parseRetryAfter(resp.Header.Get("Retry-After")), nil
+}
 
+// retryableStatus reports whether a status is worth another attempt. 429 and 529
+// always are. Other 5xx only for methods without side effects — replaying a
+// failed POST that may have been applied server-side is how duplicates are made.
+func retryableStatus(status int, method string) bool {
+	if status == http.StatusTooManyRequests || status == 529 {
+		return true
+	}
+	if method != http.MethodGet && method != http.MethodDelete {
+		return false
+	}
+	return status == http.StatusInternalServerError ||
+		status == http.StatusBadGateway ||
+		status == http.StatusServiceUnavailable ||
+		status == http.StatusGatewayTimeout
+}
+
+// parseRetryAfter reads the delay-seconds form. The HTTP-date form is not
+// accepted rather than guessed at: a misparsed date yielding zero would silently
+// retry immediately, which is the opposite of what the header asked for.
+func parseRetryAfter(value string) time.Duration {
+	seconds, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || seconds < 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func notionAPIError(status int, body []byte) error {
 	var apiErr struct {
 		Code    string `json:"code"`
 		Message string `json:"message"`
 	}
 	if err := json.Unmarshal(body, &apiErr); err == nil && apiErr.Message != "" {
-		return nil, fmt.Errorf("Notion API error %s (%d): %s", apiErr.Code, resp.StatusCode, apiErr.Message)
+		return fmt.Errorf("Notion API error %s (%d): %s", apiErr.Code, status, apiErr.Message)
 	}
-	return nil, fmt.Errorf("Notion API error (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	return fmt.Errorf("Notion API error (%d): %s", status, strings.TrimSpace(string(body)))
 }

--- a/internal/notion/client.go
+++ b/internal/notion/client.go
@@ -317,7 +317,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, requestBody
 	}
 
 	// Notion enforces ~3 requests/second per connection and answers 429 with a
-	// Retry-After header. Without honouring it, any caller that paginates a
+	// Retry-After header. Without honoring it, any caller that paginates a
 	// large data source trips the limit and the whole sync dies on a transient
 	// condition the API explicitly tells us how to wait out.
 	var lastErr error

--- a/internal/notion/client.go
+++ b/internal/notion/client.go
@@ -26,6 +26,10 @@ const (
 	// maxRetryDelay clamps a server-supplied Retry-After so an interactive CLI
 	// cannot be parked for minutes by one header.
 	maxRetryDelay = 30 * time.Second
+	// statusNotionOverloaded is Notion's overload status. It has no net/http
+	// constant because it is not a standard HTTP status; Notion returns it from
+	// its edge, which may already have handed the request to the origin.
+	statusNotionOverloaded = 529
 )
 
 type Client struct {
@@ -39,9 +43,10 @@ type Client struct {
 	// maxQueryPages*maxPageSize rows, which otherwise cannot be synced at all.
 	MaxQueryPages int
 
-	// sleep is the retry delay hook, swapped out in tests so backoff coverage
-	// does not spend real seconds.
-	sleep func(time.Duration)
+	// after is the retry delay hook, swapped out in tests so backoff coverage
+	// does not spend real seconds. It hands back a channel rather than blocking,
+	// so the wait can be selected against ctx.Done().
+	after func(time.Duration) <-chan time.Time
 }
 
 func NewClient(token string) *Client {
@@ -68,12 +73,22 @@ func (c *Client) maxQueryPages() int {
 	return maxQueryPages
 }
 
-func (c *Client) sleepFor(d time.Duration) {
-	if c.sleep != nil {
-		c.sleep(d)
-		return
+// wait blocks for d, or gives up early with ctx's error if the context is
+// canceled first. A plain time.Sleep would ignore cancellation for up to
+// maxRetryDelay per attempt, and QueryDataSource pays that per page — so the
+// worst case scales with MaxQueryPages, the bound this client lets callers
+// raise.
+func (c *Client) wait(ctx context.Context, d time.Duration) error {
+	after := c.after
+	if after == nil {
+		after = time.After
 	}
-	time.Sleep(d)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-after(d):
+		return nil
+	}
 }
 
 func (c *Client) WithHTTPClient(httpClient *http.Client) *Client {
@@ -185,11 +200,14 @@ func (c *Client) QueryDataSource(ctx context.Context, dataSourceID string) ([]Pa
 	}
 	// Naming the ceiling in rows, not pages, is the difference between a caller
 	// knowing what to do and filing a bug: the number they can compare against
-	// their data source is limit*maxPageSize.
+	// their data source is limit*maxPageSize. The lever named has to be one the
+	// reader can actually pull — this message reaches CLI operators, who cannot
+	// call a Go method.
 	return nil, fmt.Errorf(
 		"query pagination exceeded %d pages (~%d rows): this data source is larger than the "+
-			"configured bound, so no sync can complete. Raise it via Client.WithMaxQueryPages, "+
-			"or reduce the number of rows in the data source",
+			"configured bound, so no sync can complete. Raise it with "+
+			"'bd config set notion.max_query_pages <n>' or the NOTION_MAX_QUERY_PAGES "+
+			"environment variable, or reduce the number of rows in the data source",
 		limit, limit*maxPageSize)
 }
 
@@ -345,13 +363,17 @@ func (c *Client) doRequest(ctx context.Context, method, path string, requestBody
 			return body, nil
 		}
 
-		if !retryableStatus(status, method) || attempt == maxRequestAttempts-1 {
+		if !retryableStatus(status, method) {
 			return nil, notionAPIError(status, body)
 		}
 		lastErr = notionAPIError(status, body)
+		if attempt == maxRequestAttempts-1 {
+			break
+		}
 
-		// Retry-After is authoritative when present; otherwise exponential,
-		// clamped so a long server-side hint cannot stall a CLI indefinitely.
+		// Retry-After is authoritative when present; otherwise exponential.
+		// Either way the wait is clamped to maxRetryDelay — including a header
+		// that asks for longer, which the clamp shortens.
 		delay := time.Duration(1<<attempt) * time.Second
 		if retryAfter > 0 {
 			delay = retryAfter
@@ -359,12 +381,9 @@ func (c *Client) doRequest(ctx context.Context, method, path string, requestBody
 		if delay > maxRetryDelay {
 			delay = maxRetryDelay
 		}
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
+		if err := c.wait(ctx, delay); err != nil {
+			return nil, err
 		}
-		c.sleepFor(delay)
 	}
 	return nil, lastErr
 }
@@ -385,17 +404,27 @@ func (c *Client) doAttempt(httpClient *http.Client, req *http.Request) ([]byte, 
 	return body, resp.StatusCode, parseRetryAfter(resp.Header.Get("Retry-After")), nil
 }
 
-// retryableStatus reports whether a status is worth another attempt. 429 and 529
-// always are. Other 5xx only for methods without side effects — replaying a
-// failed POST that may have been applied server-side is how duplicates are made.
+// retryableStatus reports whether a status is worth another attempt.
+//
+// 429 is safe for every verb: Notion rejects a rate-limited request before
+// processing it, so nothing was applied server-side and a replay cannot
+// duplicate anything.
+//
+// Every other retryable status — 529 included — can be reported after the write
+// already landed, so only verbs without side effects are replayed. Retrying a
+// creating POST on 529 is how one bd issue becomes two Notion rows: the
+// create-vs-update index is keyed on the bd ID and keeps only the last match,
+// so the duplicate is invisible and every later sync updates just one of the
+// pair.
 func retryableStatus(status int, method string) bool {
-	if status == http.StatusTooManyRequests || status == 529 {
+	if status == http.StatusTooManyRequests {
 		return true
 	}
 	if method != http.MethodGet && method != http.MethodDelete {
 		return false
 	}
-	return status == http.StatusInternalServerError ||
+	return status == statusNotionOverloaded ||
+		status == http.StatusInternalServerError ||
 		status == http.StatusBadGateway ||
 		status == http.StatusServiceUnavailable ||
 		status == http.StatusGatewayTimeout

--- a/internal/notion/client.go
+++ b/internal/notion/client.go
@@ -23,8 +23,9 @@ const (
 	// maxRequestAttempts bounds retries of a rate-limited or transiently failing
 	// request, including the first try.
 	maxRequestAttempts = 5
-	// maxRetryDelay clamps a server-supplied Retry-After so an interactive CLI
-	// cannot be parked for minutes by one header.
+	// maxRetryDelay bounds how long one attempt will wait before the next. A
+	// Retry-After longer than this is refused rather than clamped down to it —
+	// see doRequest.
 	maxRetryDelay = 30 * time.Second
 	// statusNotionOverloaded is Notion's overload status. It has no net/http
 	// constant because it is not a standard HTTP status; Notion returns it from
@@ -371,9 +372,19 @@ func (c *Client) doRequest(ctx context.Context, method, path string, requestBody
 			break
 		}
 
+		// A Retry-After longer than we are willing to wait is refused outright
+		// rather than clamped down to the ceiling. Waiting 30s when the server
+		// asked for an hour just spends the remaining attempts inside the window
+		// it told us to stay out of, which is how that window gets extended.
+		if retryAfter > maxRetryDelay {
+			return nil, fmt.Errorf(
+				"Notion asked for a %s wait before retrying, longer than the %s this client will wait: %w",
+				retryAfter, maxRetryDelay, lastErr)
+		}
+
 		// Retry-After is authoritative when present; otherwise exponential.
-		// Either way the wait is clamped to maxRetryDelay — including a header
-		// that asks for longer, which the clamp shortens.
+		// Either way the wait is bounded by maxRetryDelay, and the refusal above
+		// means clamping only ever shortens the exponential fallback.
 		delay := time.Duration(1<<attempt) * time.Second
 		if retryAfter > 0 {
 			delay = retryAfter

--- a/internal/notion/client_test.go
+++ b/internal/notion/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestClientRetrieveDataSourceSetsHeaders(t *testing.T) {
@@ -220,5 +221,143 @@ func TestResolveDataSourceReferenceFallsBackToDatabase(t *testing.T) {
 	}
 	if resolved.Database == nil || resolved.Database.ID != "429e5bf9-7fae-8080-bb4a-d94e1387655d" {
 		t.Fatalf("database = %+v", resolved.Database)
+	}
+}
+
+func TestClientQueryDataSourceRespectsConfiguredPageBound(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_, _ = io.ReadAll(r.Body)
+		// Never terminates: the bound is the only thing that can stop this.
+		_, _ = io.WriteString(w, `{"results":[{"id":"p"}],"has_more":true,"next_cursor":"c"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("secret-token").WithBaseURL(server.URL).WithMaxQueryPages(3)
+	_, err := client.QueryDataSource(context.Background(), "ds_123")
+	if err == nil {
+		t.Fatal("QueryDataSource succeeded, want pagination-bound error")
+	}
+	if calls != 3 {
+		t.Fatalf("requests = %d, want 3 (the configured bound)", calls)
+	}
+	// The row figure is the actionable half: it is what a caller compares
+	// against the size of their data source.
+	if !strings.Contains(err.Error(), "3 pages") || !strings.Contains(err.Error(), "300 rows") {
+		t.Fatalf("error should name the bound in pages and rows, got: %v", err)
+	}
+}
+
+func TestClientQueryDataSourceDefaultBoundUnchanged(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_, _ = io.ReadAll(r.Body)
+		_, _ = io.WriteString(w, `{"results":[{"id":"p"}],"has_more":true,"next_cursor":"c"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("secret-token").WithBaseURL(server.URL)
+	if _, err := client.QueryDataSource(context.Background(), "ds_123"); err == nil {
+		t.Fatal("QueryDataSource succeeded, want pagination-bound error")
+	}
+	if calls != maxQueryPages {
+		t.Fatalf("requests = %d, want the unchanged default %d", calls, maxQueryPages)
+	}
+}
+
+func TestClientRetriesRateLimitedRequestHonouringRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_, _ = io.ReadAll(r.Body)
+		if calls == 1 {
+			w.Header().Set("Retry-After", "2")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = io.WriteString(w, `{"code":"rate_limited","message":"Rate limited."}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"results":[{"id":"page-1"}],"has_more":false}`)
+	}))
+	defer server.Close()
+
+	var slept []time.Duration
+	client := NewClient("secret-token").WithBaseURL(server.URL)
+	client.sleep = func(d time.Duration) { slept = append(slept, d) }
+
+	pages, err := client.QueryDataSource(context.Background(), "ds_123")
+	if err != nil {
+		t.Fatalf("QueryDataSource returned error: %v", err)
+	}
+	if len(pages) != 1 {
+		t.Fatalf("pages = %d, want 1", len(pages))
+	}
+	if calls != 2 {
+		t.Fatalf("requests = %d, want 2 (one rate-limited, one retried)", calls)
+	}
+	if len(slept) != 1 || slept[0] != 2*time.Second {
+		t.Fatalf("slept = %v, want exactly the 2s the Retry-After header asked for", slept)
+	}
+}
+
+func TestClientDoesNotRetryServerErrorOnPost(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"code":"internal_server_error","message":"boom"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("secret-token").WithBaseURL(server.URL)
+	client.sleep = func(time.Duration) { t.Fatal("POST 5xx must not be retried") }
+
+	if _, err := client.QueryDataSource(context.Background(), "ds_123"); err == nil {
+		t.Fatal("QueryDataSource succeeded, want server error")
+	}
+	// Replaying a POST that may already have been applied server-side is how
+	// duplicates get made; one attempt is the correct behaviour.
+	if calls != 1 {
+		t.Fatalf("requests = %d, want 1", calls)
+	}
+}
+
+func TestClientRetriesServerErrorOnGet(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		_, _ = io.WriteString(w, `{"id":"user-1","name":"Ada"}`)
+	}))
+	defer server.Close()
+
+	var slept []time.Duration
+	client := NewClient("secret-token").WithBaseURL(server.URL)
+	client.sleep = func(d time.Duration) { slept = append(slept, d) }
+
+	if _, err := client.GetCurrentUser(context.Background()); err != nil {
+		t.Fatalf("GetCurrentUser returned error: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("requests = %d, want 2 (GET has no side effects, so it retries)", calls)
+	}
+	// No Retry-After on the 502, so the exponential fallback applies.
+	if len(slept) != 1 || slept[0] != time.Second {
+		t.Fatalf("slept = %v, want the 1s exponential fallback", slept)
 	}
 }

--- a/internal/notion/client_test.go
+++ b/internal/notion/client_test.go
@@ -271,7 +271,7 @@ func TestClientQueryDataSourceDefaultBoundUnchanged(t *testing.T) {
 	}
 }
 
-func TestClientRetriesRateLimitedRequestHonouringRetryAfter(t *testing.T) {
+func TestClientRetriesRateLimitedRequestHonoringRetryAfter(t *testing.T) {
 	t.Parallel()
 
 	calls := 0
@@ -326,7 +326,7 @@ func TestClientDoesNotRetryServerErrorOnPost(t *testing.T) {
 		t.Fatal("QueryDataSource succeeded, want server error")
 	}
 	// Replaying a POST that may already have been applied server-side is how
-	// duplicates get made; one attempt is the correct behaviour.
+	// duplicates get made; one attempt is the correct behavior.
 	if calls != 1 {
 		t.Fatalf("requests = %d, want 1", calls)
 	}

--- a/internal/notion/client_test.go
+++ b/internal/notion/client_test.go
@@ -538,6 +538,39 @@ func TestClientRetryWaitObservesContextCancellation(t *testing.T) {
 	}
 }
 
+// A Retry-After longer than the client is willing to wait is refused outright.
+// Clamping it down would spend the remaining attempts inside the window the
+// server asked us to stay out of, which is how that window gets extended.
+func TestClientRefusesRetryAfterLongerThanItWillWait(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("Retry-After", "3600")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"code":"rate_limited","message":"Rate limited."}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("secret-token").WithBaseURL(server.URL)
+	client.after = mustNotWait(t, "a Retry-After beyond maxRetryDelay must not be clamped and retried")
+
+	_, err := client.QueryDataSource(context.Background(), "ds_123")
+	if err == nil {
+		t.Fatal("QueryDataSource succeeded, want a refusal")
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("requests = %d, want 1 — no retry inside the window the server asked for", calls.Load())
+	}
+	// The operator needs the number the server actually asked for; without it
+	// there is nothing to act on.
+	if !strings.Contains(err.Error(), "1h0m0s") {
+		t.Fatalf("error should name the delay the server asked for, got: %v", err)
+	}
+}
+
 // Every retry path eventually exhausts. This pins the loop's exit: exactly
 // maxRequestAttempts requests, exactly one fewer wait, and the last attempt's
 // error handed back rather than a nil one. Without it the break-and-fall-through

--- a/internal/notion/client_test.go
+++ b/internal/notion/client_test.go
@@ -2,10 +2,13 @@ package notion
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -224,12 +227,39 @@ func TestResolveDataSourceReferenceFallsBackToDatabase(t *testing.T) {
 	}
 }
 
+// mustNotWait is the delay hook for a call that must make exactly one attempt.
+// It reports the violation and still hands back an elapsed channel: returning a
+// nil one would deadlock the select in wait, turning a clean failure into a
+// two-minute timeout.
+func mustNotWait(t *testing.T, msg string) func(time.Duration) <-chan time.Time {
+	t.Helper()
+	return func(time.Duration) <-chan time.Time {
+		t.Error(msg)
+		fired := make(chan time.Time, 1)
+		fired <- time.Now()
+		return fired
+	}
+}
+
+// firesImmediately swaps out the retry wait with one that is already elapsed and
+// records what was asked for, so backoff coverage costs no wall-clock time. It is
+// called from doRequest on the test's own goroutine, never from a handler, so the
+// recorded slice needs no synchronization.
+func firesImmediately(recorded *[]time.Duration) func(time.Duration) <-chan time.Time {
+	return func(d time.Duration) <-chan time.Time {
+		*recorded = append(*recorded, d)
+		fired := make(chan time.Time, 1)
+		fired <- time.Now()
+		return fired
+	}
+}
+
 func TestClientQueryDataSourceRespectsConfiguredPageBound(t *testing.T) {
 	t.Parallel()
 
-	calls := 0
+	var calls atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
+		calls.Add(1)
 		_, _ = io.ReadAll(r.Body)
 		// Never terminates: the bound is the only thing that can stop this.
 		_, _ = io.WriteString(w, `{"results":[{"id":"p"}],"has_more":true,"next_cursor":"c"}`)
@@ -241,22 +271,28 @@ func TestClientQueryDataSourceRespectsConfiguredPageBound(t *testing.T) {
 	if err == nil {
 		t.Fatal("QueryDataSource succeeded, want pagination-bound error")
 	}
-	if calls != 3 {
-		t.Fatalf("requests = %d, want 3 (the configured bound)", calls)
+	if calls.Load() != 3 {
+		t.Fatalf("requests = %d, want 3 (the configured bound)", calls.Load())
 	}
 	// The row figure is the actionable half: it is what a caller compares
 	// against the size of their data source.
 	if !strings.Contains(err.Error(), "3 pages") || !strings.Contains(err.Error(), "300 rows") {
 		t.Fatalf("error should name the bound in pages and rows, got: %v", err)
 	}
+	// The message reaches CLI operators, who cannot call a Go method — so it has
+	// to name a lever they can actually pull.
+	if !strings.Contains(err.Error(), "notion.max_query_pages") ||
+		!strings.Contains(err.Error(), "NOTION_MAX_QUERY_PAGES") {
+		t.Fatalf("error should name the config key and env var, got: %v", err)
+	}
 }
 
 func TestClientQueryDataSourceDefaultBoundUnchanged(t *testing.T) {
 	t.Parallel()
 
-	calls := 0
+	var calls atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
+		calls.Add(1)
 		_, _ = io.ReadAll(r.Body)
 		_, _ = io.WriteString(w, `{"results":[{"id":"p"}],"has_more":true,"next_cursor":"c"}`)
 	}))
@@ -266,19 +302,28 @@ func TestClientQueryDataSourceDefaultBoundUnchanged(t *testing.T) {
 	if _, err := client.QueryDataSource(context.Background(), "ds_123"); err == nil {
 		t.Fatal("QueryDataSource succeeded, want pagination-bound error")
 	}
-	if calls != maxQueryPages {
-		t.Fatalf("requests = %d, want the unchanged default %d", calls, maxQueryPages)
+	// Hardcoded rather than compared against maxQueryPages: pinned to the
+	// constant, this test would still pass if the default were lowered, which is
+	// the exact regression it exists to catch.
+	if calls.Load() != 50 {
+		t.Fatalf("requests = %d, want the unchanged default 50", calls.Load())
 	}
 }
 
 func TestClientRetriesRateLimitedRequestHonoringRetryAfter(t *testing.T) {
 	t.Parallel()
 
-	calls := 0
+	var calls atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
-		_, _ = io.ReadAll(r.Body)
-		if calls == 1 {
+		n := calls.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		// Every attempt must carry the payload. Reusing a drained reader would
+		// send an empty second body, which the server sees as valid JSON-less
+		// input and nothing else in this test would notice.
+		if len(body) == 0 {
+			t.Errorf("attempt %d sent an empty body — the reader was not rebuilt", n)
+		}
+		if n == 1 {
 			w.Header().Set("Retry-After", "2")
 			w.WriteHeader(http.StatusTooManyRequests)
 			_, _ = io.WriteString(w, `{"code":"rate_limited","message":"Rate limited."}`)
@@ -290,7 +335,7 @@ func TestClientRetriesRateLimitedRequestHonoringRetryAfter(t *testing.T) {
 
 	var slept []time.Duration
 	client := NewClient("secret-token").WithBaseURL(server.URL)
-	client.sleep = func(d time.Duration) { slept = append(slept, d) }
+	client.after = firesImmediately(&slept)
 
 	pages, err := client.QueryDataSource(context.Background(), "ds_123")
 	if err != nil {
@@ -299,8 +344,8 @@ func TestClientRetriesRateLimitedRequestHonoringRetryAfter(t *testing.T) {
 	if len(pages) != 1 {
 		t.Fatalf("pages = %d, want 1", len(pages))
 	}
-	if calls != 2 {
-		t.Fatalf("requests = %d, want 2 (one rate-limited, one retried)", calls)
+	if calls.Load() != 2 {
+		t.Fatalf("requests = %d, want 2 (one rate-limited, one retried)", calls.Load())
 	}
 	if len(slept) != 1 || slept[0] != 2*time.Second {
 		t.Fatalf("slept = %v, want exactly the 2s the Retry-After header asked for", slept)
@@ -310,9 +355,9 @@ func TestClientRetriesRateLimitedRequestHonoringRetryAfter(t *testing.T) {
 func TestClientDoesNotRetryServerErrorOnPost(t *testing.T) {
 	t.Parallel()
 
-	calls := 0
+	var calls atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
+		calls.Add(1)
 		_, _ = io.ReadAll(r.Body)
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = io.WriteString(w, `{"code":"internal_server_error","message":"boom"}`)
@@ -320,25 +365,106 @@ func TestClientDoesNotRetryServerErrorOnPost(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient("secret-token").WithBaseURL(server.URL)
-	client.sleep = func(time.Duration) { t.Fatal("POST 5xx must not be retried") }
+	client.after = mustNotWait(t, "POST 5xx must not be retried")
 
 	if _, err := client.QueryDataSource(context.Background(), "ds_123"); err == nil {
 		t.Fatal("QueryDataSource succeeded, want server error")
 	}
 	// Replaying a POST that may already have been applied server-side is how
 	// duplicates get made; one attempt is the correct behavior.
-	if calls != 1 {
-		t.Fatalf("requests = %d, want 1", calls)
+	if calls.Load() != 1 {
+		t.Fatalf("requests = %d, want 1", calls.Load())
+	}
+}
+
+// A 529 is Notion's overload status, and its edge can return it after the origin
+// has already accepted the write. Replaying a creating POST on it is how one bd
+// issue becomes two Notion rows.
+func TestClientDoesNotRetryOverloadedOnCreatingPost(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		_, _ = io.ReadAll(r.Body)
+		w.WriteHeader(statusNotionOverloaded)
+		_, _ = io.WriteString(w, `{"code":"service_unavailable","message":"overloaded"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("secret-token").WithBaseURL(server.URL)
+	client.after = mustNotWait(t, "a creating POST must not be replayed on 529")
+
+	if _, err := client.CreatePage(context.Background(), "ds_123", map[string]interface{}{}); err == nil {
+		t.Fatal("CreatePage succeeded, want overload error")
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("requests = %d, want 1", calls.Load())
+	}
+}
+
+func TestClientRetriesOverloadedOnGet(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(statusNotionOverloaded)
+			return
+		}
+		_, _ = io.WriteString(w, `{"id":"user-1","name":"Ada"}`)
+	}))
+	defer server.Close()
+
+	var slept []time.Duration
+	client := NewClient("secret-token").WithBaseURL(server.URL)
+	client.after = firesImmediately(&slept)
+
+	if _, err := client.GetCurrentUser(context.Background()); err != nil {
+		t.Fatalf("GetCurrentUser returned error: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("requests = %d, want 2 (a GET has no side effects, so 529 retries)", calls.Load())
+	}
+}
+
+// 429 stays verb-agnostic: Notion rejects a rate-limited request before
+// processing it, so replaying even a creating POST cannot duplicate anything.
+func TestClientRetriesRateLimitedCreatingPost(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		_, _ = io.ReadAll(r.Body)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = io.WriteString(w, `{"code":"rate_limited","message":"Rate limited."}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"id":"page-1"}`)
+	}))
+	defer server.Close()
+
+	var slept []time.Duration
+	client := NewClient("secret-token").WithBaseURL(server.URL)
+	client.after = firesImmediately(&slept)
+
+	if _, err := client.CreatePage(context.Background(), "ds_123", map[string]interface{}{}); err != nil {
+		t.Fatalf("CreatePage returned error: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("requests = %d, want 2 (429 is safe to replay on any verb)", calls.Load())
 	}
 }
 
 func TestClientRetriesServerErrorOnGet(t *testing.T) {
 	t.Parallel()
 
-	calls := 0
+	var calls atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
-		if calls == 1 {
+		if calls.Add(1) == 1 {
 			w.WriteHeader(http.StatusBadGateway)
 			return
 		}
@@ -348,16 +474,132 @@ func TestClientRetriesServerErrorOnGet(t *testing.T) {
 
 	var slept []time.Duration
 	client := NewClient("secret-token").WithBaseURL(server.URL)
-	client.sleep = func(d time.Duration) { slept = append(slept, d) }
+	client.after = firesImmediately(&slept)
 
 	if _, err := client.GetCurrentUser(context.Background()); err != nil {
 		t.Fatalf("GetCurrentUser returned error: %v", err)
 	}
-	if calls != 2 {
-		t.Fatalf("requests = %d, want 2 (GET has no side effects, so it retries)", calls)
+	if calls.Load() != 2 {
+		t.Fatalf("requests = %d, want 2 (GET has no side effects, so it retries)", calls.Load())
 	}
 	// No Retry-After on the 502, so the exponential fallback applies.
 	if len(slept) != 1 || slept[0] != time.Second {
 		t.Fatalf("slept = %v, want the 1s exponential fallback", slept)
+	}
+}
+
+// The retry wait must observe cancellation. A plain time.Sleep here would ignore
+// it for up to maxRetryDelay per attempt, and QueryDataSource pays that per page
+// — so the worst case scales with the very bound this client lets callers raise.
+func TestClientRetryWaitObservesContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"code":"rate_limited","message":"Rate limited."}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("secret-token").WithBaseURL(server.URL)
+	// Cancel from inside the delay hook, and hand back a channel that never
+	// elapses. That pins the cancellation to the one moment this test is about:
+	// the client is provably inside the wait, and only ctx can end the call.
+	// Canceling from the handler instead would abort the response read, and the
+	// call would return context.Canceled having never reached the wait at all —
+	// passing for a reason that has nothing to do with the fix.
+	client.after = func(time.Duration) <-chan time.Time {
+		cancel()
+		return make(chan time.Time)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.QueryDataSource(ctx, "ds_123")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+		if calls.Load() != 1 {
+			t.Fatalf("requests = %d, want 1 — the retry must not be attempted", calls.Load())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("QueryDataSource did not return after its context was canceled — the wait is not observing ctx.Done()")
+	}
+}
+
+// Every retry path eventually exhausts. This pins the loop's exit: exactly
+// maxRequestAttempts requests, exactly one fewer wait, and the last attempt's
+// error handed back rather than a nil one. Without it the break-and-fall-through
+// restructure could go off by one with nothing to catch it.
+func TestClientExhaustsRetriesAndReturnsTheLastError(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Each attempt answers differently, so the assertion below can tell the
+		// LAST attempt's error from a stale one carried over from an earlier
+		// round. With identical responses a stale lastErr reads as correct.
+		n := calls.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = fmt.Fprintf(w, `{"code":"bad_gateway","message":"failure on attempt %d"}`, n)
+	}))
+	defer server.Close()
+
+	var slept []time.Duration
+	client := NewClient("secret-token").WithBaseURL(server.URL)
+	client.after = firesImmediately(&slept)
+
+	_, err := client.GetCurrentUser(context.Background())
+	if err == nil {
+		t.Fatal("GetCurrentUser succeeded, want the last attempt's error")
+	}
+	if calls.Load() != maxRequestAttempts {
+		t.Fatalf("requests = %d, want %d", calls.Load(), maxRequestAttempts)
+	}
+	if len(slept) != maxRequestAttempts-1 {
+		t.Fatalf("waits = %d, want %d — one fewer than attempts", len(slept), maxRequestAttempts-1)
+	}
+	if !strings.Contains(err.Error(), "failure on attempt 5") {
+		t.Fatalf("error should carry the LAST attempt's body, got: %v", err)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{"absent", "", 0},
+		{"seconds", "7", 7 * time.Second},
+		{"surrounding whitespace", "  7 ", 7 * time.Second},
+		{"zero", "0", 0},
+		{"negative", "-3", 0},
+		{"fractional", "2.5", 0},
+		// The HTTP-date form is rejected rather than guessed at: a misparsed date
+		// yielding zero would retry immediately, the opposite of what was asked.
+		{"http-date", "Wed, 21 Oct 2026 07:28:00 GMT", 0},
+		{"garbage", "soon", 0},
+		{"long", "3600", time.Hour},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := parseRetryAfter(tc.value); got != tc.want {
+				t.Fatalf("parseRetryAfter(%q) = %v, want %v", tc.value, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/notion/tracker.go
+++ b/internal/notion/tracker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -35,8 +36,8 @@ type notionAPI interface {
 	ArchivePage(ctx context.Context, pageID string, inTrash bool) (*Page, error)
 }
 
-var newNotionClient = func(token string) notionAPI {
-	return NewClient(token)
+var newNotionClient = func(token string, maxQueryPages int) notionAPI {
+	return NewClient(token).WithMaxQueryPages(maxQueryPages)
 }
 
 func init() {
@@ -61,6 +62,24 @@ type Tracker struct {
 	lastCandidates  int
 }
 
+// maxQueryPages reads the pagination bound for the Notion query endpoint.
+// Unset returns 0, which leaves the client on its own default — a data source
+// under the default ceiling needs no configuration. A value that is set but
+// unusable is an error rather than a silent fallback: the operator sets this
+// key precisely because sync is already failing on the bound, and quietly
+// ignoring it would reproduce the identical failure with no clue why.
+func (t *Tracker) maxQueryPages(ctx context.Context) (int, error) {
+	raw := t.getConfig(ctx, "notion.max_query_pages", "NOTION_MAX_QUERY_PAGES")
+	if raw == "" {
+		return 0, nil
+	}
+	pages, err := strconv.Atoi(raw)
+	if err != nil || pages <= 0 {
+		return 0, fmt.Errorf("notion.max_query_pages must be a positive integer, got %q", raw)
+	}
+	return pages, nil
+}
+
 func (t *Tracker) Name() string         { return "notion" }
 func (t *Tracker) DisplayName() string  { return "Notion" }
 func (t *Tracker) ConfigPrefix() string { return "notion" }
@@ -81,8 +100,12 @@ func (t *Tracker) Init(ctx context.Context, store storage.Storage) error {
 		return fmt.Errorf("Notion data source not configured (run 'bd notion init --parent <page-id>', 'bd notion connect --url <notion-url>', or set notion.data_source_id)")
 	}
 	t.authSource = auth.Source
+	maxQueryPages, err := t.maxQueryPages(ctx)
+	if err != nil {
+		return err
+	}
 	if t.client == nil {
-		t.client = newNotionClient(auth.Token)
+		t.client = newNotionClient(auth.Token, maxQueryPages)
 	}
 	if t.config == nil {
 		t.config = DefaultMappingConfig()

--- a/internal/notion/tracker_test.go
+++ b/internal/notion/tracker_test.go
@@ -631,3 +631,108 @@ func TestGetConfig_YamlOnlyKeyBypassesStore(t *testing.T) {
 		}
 	})
 }
+
+func TestTrackerMaxQueryPages(t *testing.T) {
+	ctx := context.Background()
+
+	// Unset means "use the client's own default": a data source under the
+	// default ceiling needs no configuration at all.
+	t.Run("unset falls back to the client default", func(t *testing.T) {
+		t.Setenv("NOTION_MAX_QUERY_PAGES", "")
+		tr := &Tracker{}
+		got, err := tr.maxQueryPages(ctx)
+		if err != nil {
+			t.Fatalf("maxQueryPages returned error: %v", err)
+		}
+		if got != 0 {
+			t.Fatalf("maxQueryPages = %d, want 0 (unset)", got)
+		}
+	})
+
+	t.Run("a positive value is read", func(t *testing.T) {
+		t.Setenv("NOTION_MAX_QUERY_PAGES", "120")
+		tr := &Tracker{}
+		got, err := tr.maxQueryPages(ctx)
+		if err != nil {
+			t.Fatalf("maxQueryPages returned error: %v", err)
+		}
+		if got != 120 {
+			t.Fatalf("maxQueryPages = %d, want 120", got)
+		}
+	})
+
+	// Set-but-unusable is an error, not a silent fallback. The operator sets
+	// this key because sync is already failing on the bound; ignoring a bad
+	// value would reproduce the identical failure with nothing to explain it.
+	for _, bad := range []string{"lots", "0", "-5", "12.5"} {
+		t.Run("rejects "+bad, func(t *testing.T) {
+			t.Setenv("NOTION_MAX_QUERY_PAGES", bad)
+			tr := &Tracker{}
+			if _, err := tr.maxQueryPages(ctx); err == nil {
+				t.Fatalf("maxQueryPages(%q) succeeded, want an error", bad)
+			}
+		})
+	}
+}
+
+// The bound is useless if it stops at the config read, which is exactly what
+// this PR was first sent without. This pins the whole path: env var through
+// Init to the field the client paginates on.
+func TestTrackerInitAppliesMaxQueryPagesToClient(t *testing.T) {
+	t.Setenv("NOTION_TOKEN", "secret-token")
+	t.Setenv("NOTION_DATA_SOURCE_ID", "ds_123")
+	t.Setenv("NOTION_MAX_QUERY_PAGES", "120")
+
+	original := newNotionClient
+	defer func() { newNotionClient = original }()
+
+	var applied int
+	newNotionClient = func(token string, maxQueryPages int) notionAPI {
+		applied = maxQueryPages
+		return original(token, maxQueryPages)
+	}
+
+	tr := &Tracker{}
+	if err := tr.Init(context.Background(), nil); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if applied != 120 {
+		t.Fatalf("bound passed to the client = %d, want 120", applied)
+	}
+	client, ok := tr.client.(*Client)
+	if !ok {
+		t.Fatalf("client type = %T, want *Client", tr.client)
+	}
+	if client.maxQueryPages() != 120 {
+		t.Fatalf("client paginates at %d, want 120", client.maxQueryPages())
+	}
+}
+
+func TestTrackerInitRejectsUnusableMaxQueryPages(t *testing.T) {
+	t.Setenv("NOTION_TOKEN", "secret-token")
+	t.Setenv("NOTION_DATA_SOURCE_ID", "ds_123")
+	t.Setenv("NOTION_MAX_QUERY_PAGES", "lots")
+
+	tr := &Tracker{}
+	err := tr.Init(context.Background(), nil)
+	if err == nil {
+		t.Fatal("Init succeeded, want an error naming the bad value")
+	}
+	if !strings.Contains(err.Error(), "notion.max_query_pages") {
+		t.Fatalf("error should name the config key, got: %v", err)
+	}
+}
+
+// An unset bound must leave the client exactly where it was before this option
+// existed — 50 pages, hardcoded here so lowering the default fails the test.
+func TestNewNotionClientUnsetBoundKeepsDefault(t *testing.T) {
+	t.Parallel()
+
+	client, ok := newNotionClient("secret-token", 0).(*Client)
+	if !ok {
+		t.Fatalf("client type = %T, want *Client", client)
+	}
+	if client.maxQueryPages() != 50 {
+		t.Fatalf("client paginates at %d, want the unchanged default 50", client.maxQueryPages())
+	}
+}


### PR DESCRIPTION
Refs #6004.

### What this does

`QueryDataSource` paginates up to `maxQueryPages` (50) × `maxPageSize` (100). Past 5000 rows it returns an error rather than partial results, so sync stops working in **both** directions — and because every CLI narrowing flag (`--issues`, `--state`, `--dry-run`, `bd notion push/pull`) is applied *after* that call returns, none of them is a workaround.

Two changes, and the second is what makes the first safe to use:

1. **`Client.MaxQueryPages` / `WithMaxQueryPages`** — lets a caller raise the bound for a large data source. Unset behaviour is unchanged. The error at the bound now names the ceiling in rows as well as pages, because rows is the number a caller can actually compare against their own data source.

2. **`Retry-After`-honouring retries in `doRequest`** — 429 and 529 always; other 5xx only for `GET`/`DELETE`, since replaying a POST that may already have been applied server-side is how duplicates get made. Exponential fallback clamped at 30s.

(2) is not optional garnish. Notion enforces roughly 3 requests/second per connection, and the client currently has no retry, no backoff and no 429 handling at all — every non-2xx becomes a hard error. Raising the page bound without backoff would trade a clear, reproducible failure for an intermittent one.

The request body is now marshalled once and the reader rebuilt per attempt; a retry cannot reuse a drained body.

### What this deliberately does not do

It does not fix the underlying design, where one unfiltered whole-database fetch feeds both the pull and the push's create-vs-update index, so cost scales with total database size on every sync forever.

I had intended to send `last_edited_time on_or_after Since` into the query — `FetchOptions.Since` already exists, is populated from `<prefix>.last_sync`, and is currently applied client-side in `matchesFetchSince` *after* everything has been downloaded. On reading it properly that is not a safe drop-in: `FetchIssues` also relies on seeing the full remote set for `shouldBackfillNotionIssue`, which discovers pages that exist remotely but are missing locally. Filtering the fetch would silently stop that discovery. It needs a deliberate decision about backfill semantics, which felt like the maintainers' call rather than something to smuggle into this PR. I have written that up in #6004.

### Testing

New tests cover: the configured bound, the unchanged default, `Retry-After` being obeyed exactly, `GET` retrying on 5xx, and `POST` not retrying.

Verified the tests actually bite rather than merely pass:

- forcing `maxRequestAttempts` to 1 fails exactly the two retry tests, and nothing else;
- ignoring the configured bound fails exactly the bound test.

`make build` and `make fmt-check` pass. `internal/notion` and `internal/tracker` pass with `-tags gms_pure_go`. `golangci-lint` was **not** run locally — it isn't installed on this machine, so CI will be the first gate for it.

### Context

Our tracker crossed 5000 rows overnight and sync died in both directions for ~14 hours before anyone noticed, because a failing sync looks exactly like a quiet one. Operator-filed issues kept landing in Notion and never reached bd. Recovery meant trashing 1005 old rows by hand through the Notion API.
