### PR TITLE
fix(storage): persist provenance ingest times in UTC

### DIFF
--- a/internal/storage/dolt/provenance_utc_test.go
+++ b/internal/storage/dolt/provenance_utc_test.go
@@ -1,0 +1,106 @@
+package dolt
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestRecordProvenanceCreatedAtUsesUTC proves that provenance ingest time does
+// not inherit the database session's local wall clock. DATETIME has no zone,
+// so the producer must bind an explicit UTC value rather than rely on
+// DEFAULT CURRENT_TIMESTAMP.
+func TestRecordProvenanceCreatedAtUsesUTC(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	// Keep SET @@session.time_zone and the write on the same connection so the
+	// regression would fail if the insert fell back to CURRENT_TIMESTAMP.
+	store.db.SetMaxOpenConns(1)
+	store.db.SetMaxIdleConns(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if _, err := store.db.ExecContext(ctx, "SET @@session.time_zone = '-04:00'"); err != nil {
+		t.Fatalf("set DST-equivalent non-UTC session time zone: %v", err)
+	}
+
+	issue := &types.Issue{
+		ID:        "prov-utc-subject",
+		Title:     "UTC provenance subject",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	ref := "0123456789abcdef0123456789abcdef01234567"
+	refKind := "git-sha"
+	event := types.ProvenanceEvent{
+		IssueID: issue.ID,
+		Kind:    types.ProvLand,
+		Source:  "utc-regression",
+		Ref:     &ref,
+		RefKind: &refKind,
+	}
+
+	var utcBefore time.Time
+	if err := store.db.QueryRowContext(ctx, "SELECT UTC_TIMESTAMP()").Scan(&utcBefore); err != nil {
+		t.Fatalf("read UTC time before provenance creation: %v", err)
+	}
+
+	id1, inserted1, err := store.RecordProvenanceEvent(ctx, event)
+	if err != nil {
+		t.Fatalf("record provenance: %v", err)
+	}
+	id2, inserted2, err := store.RecordProvenanceEvent(ctx, event)
+	if err != nil {
+		t.Fatalf("replay provenance: %v", err)
+	}
+	if !inserted1 || inserted2 || id1 != id2 {
+		t.Fatalf("replay not idempotent: ids=%q/%q inserted=%v/%v", id1, id2, inserted1, inserted2)
+	}
+
+	var createdAt, sessionNow, utcAfter time.Time
+	var rowCount int
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT MIN(created_at), NOW(), UTC_TIMESTAMP(), COUNT(*)
+		FROM provenance_events
+		WHERE id = ?
+	`, id1).Scan(&createdAt, &sessionNow, &utcAfter, &rowCount); err != nil {
+		t.Fatalf("read provenance timestamp: %v", err)
+	}
+	if rowCount != 1 {
+		t.Fatalf("idempotent replay left %d rows, want 1", rowCount)
+	}
+	if offset := utcAfter.Truncate(time.Second).Sub(sessionNow); offset != 4*time.Hour {
+		t.Fatalf("session time zone offset = %v, want 4h", offset)
+	}
+	if createdAt.Nanosecond() != 0 {
+		t.Fatalf("created_at nanoseconds = %d, want whole seconds", createdAt.Nanosecond())
+	}
+	if createdAt.Before(utcBefore.Add(-time.Second)) || createdAt.After(utcAfter.Add(time.Second)) {
+		t.Fatalf("created_at = %v, want UTC ingest time between %v and %v", createdAt, utcBefore, utcAfter)
+	}
+
+	logged, err := store.GetProvenanceEvents(ctx, issue.ID, "")
+	if err != nil {
+		t.Fatalf("read provenance log: %v", err)
+	}
+	if len(logged) != 1 {
+		t.Fatalf("provenance log returned %d rows, want 1", len(logged))
+	}
+	if !logged[0].CreatedAt.Equal(createdAt) {
+		t.Fatalf("created_at round-trip = %v, want %v", logged[0].CreatedAt, createdAt)
+	}
+	if logged[0].CreatedAt.Location() != time.UTC {
+		t.Fatalf("created_at location = %v, want UTC", logged[0].CreatedAt.Location())
+	}
+	if logged[0].OccurredAt != nil {
+		t.Fatalf("missing caller event-time was fabricated as %v", logged[0].OccurredAt)
+	}
+}

--- a/internal/storage/issueops/provenance.go
+++ b/internal/storage/issueops/provenance.go
@@ -127,13 +127,18 @@ func RecordProvenanceEventInTx(ctx context.Context, tx *sql.Tx, ev types.Provena
 		// (the occurred_at column is bare DATETIME, second precision).
 		occurredAt = ev.OccurredAt.UTC().Truncate(time.Second)
 	}
+	// Bind ingest time explicitly in UTC. provenance_events.created_at is a
+	// timezone-less DATETIME, so relying on DEFAULT CURRENT_TIMESTAMP would
+	// persist the database session's local wall clock and later readers could
+	// mislabel that value as UTC. Whole-second precision matches DATETIME(0).
+	createdAt := time.Now().UTC().Truncate(time.Second)
 
 	result, err := tx.ExecContext(ctx, `
 		INSERT IGNORE INTO provenance_events
-			(id, issue_id, kind, actor, ref, ref_kind, payload, source, occurred_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			(id, issue_id, kind, actor, ref, ref_kind, payload, source, occurred_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, id, ev.IssueID, string(ev.Kind), NullStringPtr(ev.Actor), NullStringPtr(ev.Ref),
-		NullStringPtr(ev.RefKind), NullStringPtr(ev.Payload), ev.Source, occurredAt)
+		NullStringPtr(ev.RefKind), NullStringPtr(ev.Payload), ev.Source, occurredAt, createdAt)
 	if err != nil {
 		return "", false, fmt.Errorf("recording provenance event: %w", err)
 	}

--- a/internal/storage/issueops/provenance_test.go
+++ b/internal/storage/issueops/provenance_test.go
@@ -1,0 +1,115 @@
+package issueops
+
+import (
+	"context"
+	"database/sql/driver"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+type recentUTCWholeSecond struct{}
+
+func (recentUTCWholeSecond) Match(value driver.Value) bool {
+	stamp, ok := value.(time.Time)
+	if !ok || stamp.Location() != time.UTC || stamp.Nanosecond() != 0 {
+		return false
+	}
+	now := time.Now().UTC()
+	return !stamp.Before(now.Add(-5*time.Second)) && !stamp.After(now.Add(5*time.Second))
+}
+
+func TestRecordProvenanceBindsExplicitUTCIngestTime(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+
+	ref := "0123456789abcdef0123456789abcdef01234567"
+	refKind := "git-sha"
+	event := types.ProvenanceEvent{
+		IssueID: "bd-provenance-utc",
+		Kind:    types.ProvLand,
+		Source:  "utc-regression",
+		Ref:     &ref,
+		RefKind: &refKind,
+	}
+	id := ProvenanceEventID(event)
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+		INSERT IGNORE INTO provenance_events
+			(id, issue_id, kind, actor, ref, ref_kind, payload, source, occurred_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`)).WithArgs(
+		id, event.IssueID, string(event.Kind), nil, ref, refKind, nil, event.Source, nil,
+		recentUTCWholeSecond{},
+	).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	gotID, inserted, err := RecordProvenanceEventInTx(context.Background(), tx, event)
+	if err != nil {
+		t.Fatalf("record provenance: %v", err)
+	}
+	if !inserted || gotID != id {
+		t.Fatalf("record result = (%q, %v), want (%q, true)", gotID, inserted, id)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("SQL expectations: %v", err)
+	}
+}
+
+func TestRecordProvenancePreservesCallerOccurredAt(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+
+	location := time.FixedZone("EDT", -4*60*60)
+	callerTime := time.Date(2026, time.August, 25, 13, 48, 59, 987654321, location)
+	wantOccurredAt := callerTime.UTC().Truncate(time.Second)
+	ref := "fedcba9876543210fedcba9876543210fedcba98"
+	refKind := "git-sha"
+	event := types.ProvenanceEvent{
+		IssueID:    "bd-provenance-at",
+		Kind:       types.ProvCommit,
+		Source:     "utc-regression",
+		Ref:        &ref,
+		RefKind:    &refKind,
+		OccurredAt: &callerTime,
+	}
+	id := ProvenanceEventID(event)
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+		INSERT IGNORE INTO provenance_events
+			(id, issue_id, kind, actor, ref, ref_kind, payload, source, occurred_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`)).WithArgs(
+		id, event.IssueID, string(event.Kind), nil, ref, refKind, nil, event.Source,
+		wantOccurredAt, recentUTCWholeSecond{},
+	).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if _, _, err := RecordProvenanceEventInTx(context.Background(), tx, event); err != nil {
+		t.Fatalf("record provenance: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("SQL expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- bind provenance_events.created_at explicitly as UTC whole-second ingest time
- preserve caller-supplied occurred_at as a separate UTC-normalized event time
- preserve NULL occurred_at and deterministic replay/idempotence semantics
- add unit SQL binding tests and a real Dolt session test under a -04:00 database timezone

## Root cause

The provenance table uses a timezone-less DATETIME. Relying on the database CURRENT_TIMESTAMP default allowed a non-UTC session to persist local wall time; later JSON readers serialized that value with a Z suffix, creating a false UTC timestamp.

## Verification

- fail-first issueops tests proved the insert omitted created_at
- fresh issueops package tests pass
- fresh real Dolt -04:00 session UTC/idempotence round-trip passes
- affected issueops and dolt packages pass
- existing cmd/bd provenance tests pass
- affected-package golangci-lint reports zero findings
- exact staged and committed candidate diff checks pass
- signed commit: 694732c955b08058a2afc80a26cf951e755496aa

## Baseline exceptions

Repository-wide ci-pr-lint remains red on five pre-existing gosec findings outside the changed packages. The full test run has one reproducible cmd/bd failure, TestServeAnswersFromTheStoreTheRootCommandOpened, caused by the test backend lacking events-journal support; the exact test fails identically on unchanged main at 7505e173f2659ba6e1f955b86d81a4f9e21810ca. All other listed packages passed.

No schema migration or immutable-row rewrite is included.