### PR TITLE
fix(storage): preflight exhausted read-only opens

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1637,6 +1637,10 @@ var rootCmd = &cobra.Command{
 				}
 				return SilentExit()
 			}
+			var filesystemFullErr *embeddeddolt.FilesystemFullError
+			if errors.As(err, &filesystemFullErr) {
+				return HandleError("%v", filesystemFullErr)
+			}
 			return HandleError("failed to open database: %v", err)
 		}
 

--- a/internal/storage/embeddeddolt/filesystem_space.go
+++ b/internal/storage/embeddeddolt/filesystem_space.go
@@ -1,0 +1,21 @@
+package embeddeddolt
+
+import "syscall"
+
+// FilesystemFullError reports that an embedded Dolt read-only open was
+// stopped before connector initialization because the database filesystem had
+// no space available to the current process.
+type FilesystemFullError struct {
+	Path string
+}
+
+func (e *FilesystemFullError) Error() string {
+	return "embedded Dolt read-only open stopped: no filesystem space is available; free space and retry"
+}
+
+// Unwrap lets callers use errors.Is(err, syscall.ENOSPC).
+func (e *FilesystemFullError) Unwrap() error {
+	return syscall.ENOSPC
+}
+
+type availableSpaceProbe func(path string) (bool, error)

--- a/internal/storage/embeddeddolt/filesystem_space_other.go
+++ b/internal/storage/embeddeddolt/filesystem_space_other.go
@@ -1,0 +1,9 @@
+//go:build cgo && !unix && !windows
+
+package embeddeddolt
+
+import "errors"
+
+func filesystemHasAvailableSpace(string) (bool, error) {
+	return false, errors.ErrUnsupported
+}

--- a/internal/storage/embeddeddolt/filesystem_space_unix.go
+++ b/internal/storage/embeddeddolt/filesystem_space_unix.go
@@ -1,0 +1,13 @@
+//go:build cgo && unix
+
+package embeddeddolt
+
+import "golang.org/x/sys/unix"
+
+func filesystemHasAvailableSpace(path string) (bool, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return false, err
+	}
+	return stat.Bavail != 0, nil
+}

--- a/internal/storage/embeddeddolt/filesystem_space_windows.go
+++ b/internal/storage/embeddeddolt/filesystem_space_windows.go
@@ -1,0 +1,17 @@
+//go:build cgo && windows
+
+package embeddeddolt
+
+import "golang.org/x/sys/windows"
+
+func filesystemHasAvailableSpace(path string) (bool, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return false, err
+	}
+	var availableBytes uint64
+	if err := windows.GetDiskFreeSpaceEx(pathPtr, &availableBytes, nil, nil); err != nil {
+		return false, err
+	}
+	return availableBytes != 0, nil
+}

--- a/internal/storage/embeddeddolt/open.go
+++ b/internal/storage/embeddeddolt/open.go
@@ -30,6 +30,21 @@ const (
 // OpenSQL opens an embedded Dolt database at dir. The returned cleanup
 // function closes both the *sql.DB and the underlying connector.
 func OpenSQL(ctx context.Context, dir, database, branch string) (*sql.DB, func() error, error) {
+	return openSQL(ctx, dir, database, branch, nil, doltembed.NewConnector)
+}
+
+type connectorFactory func(doltembed.Config) (*doltembed.Connector, error)
+
+func openReadOnlySQL(ctx context.Context, dir, database, branch string) (*sql.DB, func() error, error) {
+	return openSQL(ctx, dir, database, branch, filesystemHasAvailableSpace, doltembed.NewConnector)
+}
+
+func openSQL(
+	ctx context.Context,
+	dir, database, branch string,
+	spaceProbe availableSpaceProbe,
+	newConnector connectorFactory,
+) (*sql.DB, func() error, error) {
 	dsn := buildDSN(dir, database)
 
 	cfg, err := doltembed.ParseDSN(dsn)
@@ -42,7 +57,17 @@ func OpenSQL(ctx context.Context, dir, database, branch string) (*sql.DB, func()
 	bo.MaxInterval = 5 * time.Second
 	cfg.BackOff = bo
 
-	connector, err := doltembed.NewConnector(cfg)
+	if spaceProbe != nil {
+		available, probeErr := spaceProbe(dir)
+		// This guard only claims the exact, authoritative exhaustion signal.
+		// If the platform cannot report space, preserve the prior open behavior
+		// and let the connector return its own filesystem error.
+		if probeErr == nil && !available {
+			return nil, nil, &FilesystemFullError{Path: dir}
+		}
+	}
+
+	connector, err := newConnector(cfg)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/storage/embeddeddolt/open_space_test.go
+++ b/internal/storage/embeddeddolt/open_space_test.go
@@ -1,0 +1,105 @@
+//go:build cgo
+
+package embeddeddolt
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	doltembed "github.com/dolthub/driver/v2"
+)
+
+func TestOpenSQLReadOnlyExhaustionStopsConcurrentConnectorInitialization(t *testing.T) {
+	// Two callers are the minimum that proves concurrent behavior.
+	const callers = 2
+	var connectorCalls atomic.Int32
+	probe := func(string) (bool, error) { return false, nil }
+	connector := func(doltembed.Config) (*doltembed.Connector, error) {
+		connectorCalls.Add(1)
+		return nil, errors.New("connector must not be initialized")
+	}
+
+	dir := t.TempDir()
+	ctx := t.Context()
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _, err := openSQL(ctx, dir, "beads", "main", probe, connector)
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		var fullErr *FilesystemFullError
+		if !errors.As(err, &fullErr) {
+			t.Fatalf("openSQL error = %v, want *FilesystemFullError", err)
+		}
+		if fullErr.Path != dir {
+			t.Fatalf("FilesystemFullError.Path = %q, want %q", fullErr.Path, dir)
+		}
+		if got, want := err.Error(), "embedded Dolt read-only open stopped: no filesystem space is available; free space and retry"; got != want {
+			t.Fatalf("openSQL error = %q, want %q", got, want)
+		}
+		if !errors.Is(err, syscall.ENOSPC) {
+			t.Fatalf("openSQL error = %v, want syscall.ENOSPC", err)
+		}
+	}
+	if got := connectorCalls.Load(); got != 0 {
+		t.Fatalf("connector initialization calls = %d, want 0", got)
+	}
+}
+
+func TestOpenSQLReadOnlyHealthySpaceReachesConnector(t *testing.T) {
+	wantErr := errors.New("connector reached")
+	called := false
+	_, _, err := openSQL(
+		t.Context(),
+		t.TempDir(),
+		"beads",
+		"main",
+		func(string) (bool, error) { return true, nil },
+		func(doltembed.Config) (*doltembed.Connector, error) {
+			called = true
+			return nil, wantErr
+		},
+	)
+	if !called {
+		t.Fatal("healthy read-only open did not reach connector initialization")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("openSQL error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestOpenSQLWritableSkipsSpacePreflight(t *testing.T) {
+	wantErr := errors.New("connector reached")
+	called := false
+	_, _, err := openSQL(
+		t.Context(),
+		t.TempDir(),
+		"beads",
+		"main",
+		nil,
+		func(doltembed.Config) (*doltembed.Connector, error) {
+			called = true
+			return nil, wantErr
+		},
+	)
+	if !called {
+		t.Fatal("writable open did not reach connector initialization")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("openSQL error = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -190,7 +190,7 @@ func openReadOnly(ctx context.Context, beadsDir, database, branch string, checkB
 		readOnly: true,
 	}
 
-	db, cleanup, err := OpenSQL(ctx, dataDir, database, branch)
+	db, cleanup, err := openReadOnlySQL(ctx, dataDir, database, branch)
 	if err != nil {
 		return nil, fmt.Errorf("embeddeddolt: open db: %w", err)
 	}
@@ -226,7 +226,7 @@ func (s *EmbeddedDoltStore) withConn(ctx context.Context, commit bool, fn func(t
 
 	var db *sql.DB
 	var cleanup func() error
-	db, cleanup, err = OpenSQL(ctx, s.dataDir, s.database, s.branch)
+	db, cleanup, err = s.openSQL(ctx, s.database, s.branch)
 	if err != nil {
 		return
 	}
@@ -291,7 +291,7 @@ func (s *EmbeddedDoltStore) ApplySchemaMigrations(ctx context.Context) (int, err
 	if s.readOnly {
 		return 0, ErrReadOnly
 	}
-	db, cleanup, err := OpenSQL(ctx, s.dataDir, s.database, s.branch)
+	db, cleanup, err := s.openSQL(ctx, s.database, s.branch)
 	if err != nil {
 		return 0, fmt.Errorf("embeddeddolt: open db: %w", err)
 	}
@@ -307,7 +307,7 @@ func (s *EmbeddedDoltStore) ApplySchemaMigrations(ctx context.Context) (int, err
 }
 
 func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {
-	db, cleanup, err := OpenSQL(ctx, s.dataDir, "", "")
+	db, cleanup, err := s.openSQL(ctx, "", "")
 	if err != nil {
 		return fmt.Errorf("embeddeddolt: open db: %w", err)
 	}
@@ -453,6 +453,16 @@ func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// openSQL applies the exact-filesystem-exhaustion preflight only to stores
+// opened for logically read-only commands. Writable opens retain the existing
+// connector path unchanged.
+func (s *EmbeddedDoltStore) openSQL(ctx context.Context, database, branch string) (*sql.DB, func() error, error) {
+	if s.readOnly || s.intent == openReadOnlyCommand {
+		return openReadOnlySQL(ctx, s.dataDir, database, branch)
+	}
+	return OpenSQL(ctx, s.dataDir, database, branch)
 }
 
 // GetIssue is implemented in get_issue.go.

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -26,7 +26,7 @@ func (s *EmbeddedDoltStore) withDBConn(ctx context.Context, fn func(db versionco
 
 	var db *sql.DB
 	var cleanup func() error
-	db, cleanup, err = OpenSQL(ctx, s.dataDir, s.database, s.branch)
+	db, cleanup, err = s.openSQL(ctx, s.database, s.branch)
 	if err != nil {
 		return
 	}
@@ -57,7 +57,7 @@ func (s *EmbeddedDoltStore) withPinnedDBConn(ctx context.Context, fn func(db ver
 
 	var db *sql.DB
 	var cleanup func() error
-	db, cleanup, err = OpenSQL(ctx, s.dataDir, s.database, s.branch)
+	db, cleanup, err = s.openSQL(ctx, s.database, s.branch)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## What

Stop embedded-Dolt read-only opens before connector initialization when the database filesystem reports zero caller-available space. Return a typed recoverable ENOSPC error and keep concurrent reads from starting connectors.

## Why

Logically read-only commands can otherwise reach Dolt startup and journal/index/manifest work on an exhausted filesystem, turning a recoverable storage condition into mutation attempts and fatal cleanup behavior.

Fixes #6013. This is deliberately limited to exact exhaustion; it does not invent a near-full reserve threshold.

## Verification

- focused injected exact-exhaustion, healthy-read, and writable-open tests passed
- concurrent test passed under `go test -race`
- affected embedded-Dolt package tests passed
- Windows non-CGO compile shim passed
- `go vet ./internal/storage/embeddeddolt/...` passed
- `BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint` passed
- `make test` passed
- independent review passed

No `.beads/` data or generated files are included.