### PR TITLE
fix(export): fail loudly when auto-export cannot even read the existing JSONL

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -130,8 +130,8 @@ func maybeAutoExport(ctx context.Context, allowEmptyOverwrite bool) error {
 
 	if !allowEmptyOverwrite {
 		if skip, existingCount, err := shouldSkipEmptyAutoExport(ctx, fullPath); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to check existing JSONL: %v\n", err)
-			return nil
+			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to check existing JSONL %s: %v\n", fullPath, err)
+			return fmt.Errorf("auto-export skipped: failed to check existing JSONL %s: %w", fullPath, err)
 		} else if skip {
 			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: current database would export 0 issues, but %s already contains %d issue(s); refusing to overwrite. Run `bd init --from-jsonl` to import the JSONL file, or move it aside and retry.\n", fullPath, existingCount)
 			return nil
@@ -139,8 +139,8 @@ func maybeAutoExport(ctx context.Context, allowEmptyOverwrite bool) error {
 	}
 	if !allowEmptyOverwrite {
 		if missingIDs, err := missingJSONLIssueIDsInStore(ctx, fullPath, state.LastDiffAnchor); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to compare existing JSONL against local store: %v\n", err)
-			return nil
+			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to compare existing JSONL %s against local store: %v\n", fullPath, err)
+			return fmt.Errorf("auto-export skipped: failed to compare existing JSONL %s against local store: %w", fullPath, err)
 		} else if len(missingIDs) > 0 {
 			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: %s contains %d JSONL-only issue record(s) absent from the local Dolt store (%s); refusing to overwrite. Run `bd init --from-jsonl` to import the JSONL file, or move it aside and retry.\n", fullPath, len(missingIDs), strings.Join(sampleStrings(missingIDs, 5), ", "))
 			return nil

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/testutil"
 	"github.com/steveyegge/beads/internal/types"
@@ -408,6 +409,96 @@ func TestMaybeAutoExportFallsBackToHeadCommit(t *testing.T) {
 
 	if fake.currentCommitCalls != 1 {
 		t.Fatalf("GetCurrentCommit calls = %d, want 1 (fallback when StateHasher is absent)", fake.currentCommitCalls)
+	}
+}
+
+func TestMaybeAutoExportFailsWhenExistingJSONLIsInvalid(t *testing.T) {
+	initConfigForTest(t)
+	config.Set("export.auto", true)
+
+	saveAndRestoreGlobals(t)
+	store = &fakeStateHashStore{stateHash: "changed-state"}
+
+	dir := autoExportTestDir(t)
+	path := filepath.Join(dir, ".beads", "issues.jsonl")
+	conflictMarkers := "<<<<<<< HEAD\n{\"id\":\"bd-main\"}\n=======\n{\"id\":\"bd-branch\"}\n>>>>>>> branch\n"
+	if err := os.WriteFile(path, []byte(conflictMarkers), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := maybeAutoExport(context.Background(), false)
+	if err == nil {
+		t.Fatal("maybeAutoExport succeeded with an invalid existing JSONL file")
+	}
+	if !strings.Contains(err.Error(), "failed to check existing JSONL") {
+		t.Fatalf("maybeAutoExport error = %q, want existing JSONL check context", err)
+	}
+}
+
+func TestMaybeAutoExport_WorktreeRedirectWarningUsesResolvedPath(t *testing.T) {
+	initConfigForTest(t)
+	config.Set("export.auto", true)
+	saveAndRestoreGlobals(t)
+	store = &fakeStateHashStore{stateHash: "changed-state"}
+
+	mainRepo := filepath.Join(t.TempDir(), "main")
+	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit(mainRepo, "init", "-q")
+	runGit(mainRepo, "config", "user.email", "test@example.com")
+	runGit(mainRepo, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(mainRepo, "README.md"), []byte("# Test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(mainRepo, "add", "README.md")
+	runGit(mainRepo, "commit", "-qm", "initial")
+
+	mainBeadsDir := filepath.Join(mainRepo, ".beads")
+	if err := os.MkdirAll(mainBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mainBeadsDir, "metadata.json"), []byte(`{"database":"beads","backend":"dolt"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	worktree := filepath.Join(filepath.Dir(mainRepo), "worktree")
+	runGit(mainRepo, "worktree", "add", "-q", "-b", "redirect-test", worktree)
+	t.Cleanup(func() {
+		_ = exec.Command("git", "-C", mainRepo, "worktree", "remove", "--force", worktree).Run()
+	})
+	worktreeBeadsDir := filepath.Join(worktree, ".beads")
+	if err := os.MkdirAll(worktreeBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreeBeadsDir, "redirect"), []byte(mainBeadsDir+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(mainBeadsDir, "issues.jsonl")
+	if err := os.WriteFile(path, []byte("<<<<<<< HEAD\n=======\n>>>>>>> branch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(worktree)
+	t.Setenv("BEADS_DIR", "")
+	git.ResetCaches()
+	t.Cleanup(git.ResetCaches)
+
+	var err error
+	stderr := captureStderr(t, func() { err = maybeAutoExport(context.Background(), false) })
+	if err == nil {
+		t.Fatal("maybeAutoExport succeeded with an invalid redirected JSONL file")
+	}
+	if !strings.Contains(stderr, path) {
+		t.Fatalf("warning path = %q, want resolved checked path %q", stderr, path)
 	}
 }
 


### PR DESCRIPTION
## Summary

`maybeAutoExport` (`cmd/bd/export_auto.go`) currently swallows a genuine
pre-check failure — e.g. the existing JSONL export file cannot even be
parsed, because it contains unresolved git merge-conflict markers or is
truncated — into a `Warning:` on stderr and `return nil`. That means `bd`
exits 0 with no downstream signal that auto-export silently did not run.
Any workflow that can leave the export file in that state — a linked
git-worktree setup with concurrent writers, for instance — hits this
silently.

This is distinct from the two legitimate "these two data sources
genuinely disagree, refuse to overwrite" safety refusals a few lines
below (`shouldSkipEmptyAutoExport`'s `skip` branch and
`missingJSONLIssueIDsInStore`'s non-empty-`missingIDs` branch), which are
working as designed and are unchanged by this PR — they stay
warning-and-`nil`.

## Fix

The two pre-check error branches (where the check itself failed with an
`error`, not where it succeeded and disagreed) now return a real, wrapped
error instead of `nil`. `main.go`'s existing `HandleError` path — already
exercised for other `maybeAutoExport` error classes in the same code
block — then surfaces a non-zero exit code. The warning text is
preserved, with the checked path added for clarity.

## Investigated, did not reproduce

A second suspected issue was investigated: whether the printed warning
path could disagree with the path actually checked, in a worktree with a
`.beads` redirect to a shared main-tree store. A dedicated test
constructs a real main-repo + linked-worktree-with-redirect fixture and
confirms the printed warning already names the resolved, checked path
correctly — so no fix was needed there.

## Test plan
- [x] `TestMaybeAutoExportFailsWhenExistingJSONLIsInvalid` — new test, writes a JSONL file with
      unresolved merge-conflict markers, asserts `maybeAutoExport` returns a non-nil error.
- [x] `TestMaybeAutoExport_WorktreeRedirectWarningUsesResolvedPath` — new test proving the
      worktree-redirect warning path claim above.
- [x] `go build ./...`, `go vet ./...`, `go test ./...` — all pass (full suite, including
      `cmd/bd` at 132.8s).

https://claude.ai/code/session_017np8jY3VvadSump42sMdC4