### PR TITLE
feat(release): add Canary/Dev/Beta/Stable release channels (#5867)

### DIFF
--- a/.github/workflows/channel-beta.yml
+++ b/.github/workflows/channel-beta.yml
@@ -1,0 +1,273 @@
+# Beta channel — promote a Dev build through the full release gate.
+#
+# Part of the release-channel proposal for gastownhall/beads (issue #5867).
+# Phase 1 of three; see engdocs/RELEASE-CHANNELS.md in the same PR.
+#
+# Beta is where the expensive gate runs. Once cut, a beta STOPS TRACKING main:
+# fixes reach it by deliberate cherry-pick, one at a time. That is what makes
+# stable promotable without re-litigating everything on main — and it is what
+# beads lacked in August, when recovering from v1.2.1 meant hand-building a
+# release off the v1.1.2 tree because no maintained stable line existed.
+#
+# WHICH GATES RUN HERE, AND WHY ONLY THOSE. The split is not arbitrary — it is
+# whatever the beta tag does not already trigger:
+#
+#   Pre-tag, in this workflow          Because it runs on `push: main` only and
+#     make test                        would otherwise never see the candidate
+#     make test-regression             at all.
+#     check-migration-hygiene.sh
+#     check-versions.sh
+#     ci-package-mcp / ci-package-npm  (cheap, and failing here beats failing
+#                                       after the tag exists)
+#
+#   Post-tag, existing workflows       Already fire on `push: tags: v*`. Not
+#     cross-version-smoke.yml            duplicated here.
+#       (30-release upgrade matrix)
+#     migration-test.yml
+#     release.yml (publishes the
+#       prerelease; PyPI/npm correctly
+#       skipped for a hyphenated tag)
+#
+# THE ONE-MIGRATION RULE. channel-promote.sh refuses a beta whose span carries
+# more than one schema step. ~98% of the backlog touches no migration at all
+# (measured 2026-08-15), so this costs almost nothing in throughput and removes
+# the exact shape that broke v1.2.1: twelve forward-only, auto-applied schema
+# steps in a single release.
+#
+# WHY IT PUBLISHES A CHECK RUN. The pre-tag gates run against the source tree,
+# but the beta commit is that tree plus a version bump, so their results are
+# recorded against the wrong SHA. Phase 2's dossier reads check runs on the
+# beta commit — so this workflow publishes its own verdict there explicitly.
+# Without that, the dossier would silently under-report and a promotion would
+# look less gated than it was.
+#
+# ADOPTION PREREQUISITES, which this workflow cannot grant itself:
+#   1. refs/heads/channel/* writable by GITHUB_TOKEN.
+#   2. The v* tag ruleset must admit the Actions bot for prerelease tags.
+
+name: Channel — Beta
+
+on:
+  schedule:
+    # Mondays, 03:00 UTC — after the nightly, so channel/dev is fresh.
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "What to promote. Defaults to the dev channel."
+        required: false
+        default: "channel/dev"
+        type: string
+      bump:
+        description: "Base version bump"
+        required: false
+        type: choice
+        default: auto
+        options: [ auto, minor, patch ]
+      allow_multi_migration:
+        description: "Cut a beta spanning more than one schema step (discouraged)"
+        required: false
+        default: false
+        type: boolean
+      dry_run:
+        description: "Run the gate and report, but do not push branch or tag"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: channel-beta
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  BD_DISABLE_METRICS: "1"
+  BD_DISABLE_EVENT_FLUSH: "1"
+  SOURCE_REF: ${{ inputs.source_ref || 'channel/dev' }}
+
+jobs:
+  gate:
+    name: Full release gate
+    if: ${{ github.repository == 'gastownhall/beads' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    outputs:
+      version: ${{ steps.plan.outputs.version }}
+      base_tag: ${{ steps.plan.outputs.base_tag }}
+      migration_count: ${{ steps.plan.outputs.migration_count }}
+      source_sha: ${{ steps.src.outputs.sha }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ env.SOURCE_REF }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Identify the source
+        id: src
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "Promoting ${SOURCE_REF} @ $(git rev-parse --short HEAD)"
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        run: python -m pip install uv==0.11.16
+
+      # Plan first, and fail here rather than after an hour of tests. The
+      # migration guard is the cheapest check and the most consequential.
+      - name: Plan the beta (enforces the one-migration rule)
+        id: plan
+        run: |
+          args=(--channel beta --bump "${{ inputs.bump || 'auto' }}")
+          if [ "${{ inputs.allow_multi_migration }}" = "true" ]; then
+            echo "::warning::Multi-migration beta explicitly permitted for this run."
+            args+=(--allow-multi-migration)
+          fi
+          bash scripts/channel-promote.sh "${args[@]}"
+
+      # --- the gates the beta tag will NOT trigger -------------------------
+
+      - name: Full test suite
+        run: TEST_TIMEOUT=25m make test
+
+      - name: Regression suite (differential against the pinned baseline)
+        run: make test-regression
+
+      - name: Migration hygiene
+        run: ./scripts/check-migration-hygiene.sh
+
+      - name: MCP package gate
+        run: make ci-package-mcp
+
+      - name: npm package gate
+        run: make ci-package-npm
+
+      - name: Gate summary
+        if: always()
+        run: |
+          {
+            echo "## Beta gate — \`${{ steps.plan.outputs.version }}\`"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Source | \`${SOURCE_REF}\` @ \`${{ steps.src.outputs.sha }}\` |"
+            echo "| Base tag | \`${{ steps.plan.outputs.base_tag }}\` |"
+            echo "| Schema steps | ${{ steps.plan.outputs.migration_count }} |"
+            echo
+            echo "Gates run here: full suite, regression, migration hygiene, MCP and"
+            echo "npm package gates. The 30-release upgrade matrix, the migration"
+            echo "harness and the prerelease publish run on the tag."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  cut:
+    name: Cut the beta
+    needs: gate
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      checks: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          # The exact commit the gate ran against, not the branch head, which
+          # may have moved while the suite was running.
+          ref: ${{ needs.gate.outputs.source_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        run: python -m pip install uv==0.11.16
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Stage the version bump
+        id: plan
+        run: |
+          bash scripts/channel-promote.sh \
+            --channel beta \
+            --bump "${{ inputs.bump || 'auto' }}" \
+            --apply
+
+      - name: Commit to the channel branch
+        id: commit
+        run: |
+          set -euo pipefail
+          version="${{ steps.plan.outputs.version }}"
+          git add -A
+          git commit -m "chore(release): beta candidate v${version}
+
+          Promoted from ${SOURCE_REF} @ ${{ needs.gate.outputs.source_sha }} after
+          the full release gate. Publishes a GitHub prerelease only — the stable
+          channels are untouched until this is promoted."
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Move the channel pointer
+        run: git push --force origin HEAD:refs/heads/channel/beta
+
+      # Record the pre-tag verdict against the BETA commit, so the Phase 2
+      # dossier sees it. Without this the gate results live on the source
+      # commit and the promotion looks less gated than it was.
+      - name: Publish the gate verdict onto the beta commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Explicit JSON body rather than nested -f fields, built from env vars
+          # so nothing is quoted inside the code. gh reads it from stdin.
+          export CR_SHA="${{ steps.commit.outputs.sha }}"
+          export CR_SRC="${{ needs.gate.outputs.source_sha }}"
+          export CR_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          python3 scripts/channel-check-run.py > /tmp/check-run.json
+          gh api "repos/${{ github.repository }}/check-runs" --input /tmp/check-run.json >/dev/null
+          echo "Published pre-tag verdict onto ${CR_SHA}."
+
+      - name: Tag
+        run: |
+          set -euo pipefail
+          version="${{ steps.plan.outputs.version }}"
+          git tag -a "v${version}" -m "Beta candidate v${version}
+
+          Gated: full suite, regression, migration hygiene, package gates.
+          Schema steps in this span: ${{ needs.gate.outputs.migration_count }}."
+          # Triggers cross-version-smoke (30 deep), migration-test, and
+          # release.yml — which publishes a prerelease and correctly skips
+          # PyPI and npm for a hyphenated tag.
+          git push origin "v${version}"
+
+      - name: Summary
+        run: |
+          {
+            echo "## Cut \`v${{ steps.plan.outputs.version }}\`"
+            echo
+            echo "Soak begins when the prerelease publishes. Promote to stable with"
+            echo "the **Channel — Stable** workflow, which will assemble the gate"
+            echo "dossier and hold for approval."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/channel-canary.yml
+++ b/.github/workflows/channel-canary.yml
@@ -1,0 +1,129 @@
+# Canary channel — "main, built".
+#
+# Part of the release-channel proposal for gastownhall/beads (issue #5867).
+# Phase 0 of three; see engdocs/RELEASE-CHANNELS.md in the same PR.
+#
+# A canary is not a candidate for anything. It carries no version of its own,
+# mutates no version-bearing file, and creates no tag. It exists so that
+# "nothing has been released yet" stops meaning "there is no way to run what
+# has merged".
+#
+# Two reasons it has no version bump:
+#   1. Semantics — it is trunk, built. Naming it a candidate would be a lie.
+#   2. PEP 440 — a canary identifier is not representable, so it could not be
+#      written into integrations/beads-mcp even if we wanted it:
+#        1.3.0-dev.20260825    valid   -> 1.3.0.dev20260825
+#        1.3.0-beta.1          valid   -> 1.3.0b1
+#        1.3.0-canary.abc1234  INVALID
+#        1.3.0-canary.20260825 INVALID  (a numeric suffix does not help; PEP 440
+#                                        admits only a/b/rc/post/dev labels)
+#      Verified with python packaging.version, 2026-08-25.
+#
+# ADOPTION PREREQUISITE: refs/heads/channel/* must be writable by
+# GITHUB_TOKEN. This workflow cannot grant itself that.
+
+name: Channel — Canary
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+# A burst of merges collapses to one build. beads lands PRs faster than a
+# platform matrix completes, so without this the queue never drains.
+concurrency:
+  group: channel-canary
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+env:
+  BD_DISABLE_METRICS: "1"
+  BD_DISABLE_EVENT_FLUSH: "1"
+
+jobs:
+  canary:
+    name: Build and publish canary
+    if: ${{ github.repository == 'gastownhall/beads' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Identify build
+        id: id
+        run: |
+          echo "sha7=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "stamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      # NOTE ON PLATFORM COVERAGE: this is one ubuntu runner, so it produces the
+      # linux/windows artifacts only. release.yml builds darwin in a separate
+      # `goreleaser-macos` job because the cgo build needs a macOS toolchain.
+      # A canary is a convenience build, not a distribution, so single-runner
+      # coverage is the deliberate trade for running on every merge. The full
+      # platform matrix starts at the -dev channel, which goes through the
+      # ordinary tag pipeline.
+      - name: Build snapshot artifacts
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
+        with:
+          version: latest
+          # --snapshot builds without a tag and never publishes. Publishing is
+          # the explicit gh step below, into one rolling prerelease.
+          args: release --snapshot --clean --skip=publish,announce
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Move the channel pointer
+        run: |
+          git push --force origin HEAD:refs/heads/channel/canary
+
+      # One rolling prerelease, assets replaced in place. This is deliberate:
+      # a tag per commit to main would be thousands of tags a year, and the
+      # point of a canary is a stable download URL for "latest trunk build",
+      # not an archive of every commit.
+      - name: Publish into the rolling canary release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          notes=$(cat <<EOF
+          Automated build of \`main\` at \`${{ steps.id.outputs.sha7 }}\`, produced ${{ steps.id.outputs.stamp }}.
+
+          **This is not a release.** It is trunk, built, with no gate beyond the
+          checks that ran on the pull request. It carries no version number of its
+          own — \`bd version\` reports a snapshot identifier.
+
+          The stable install channels (Homebrew, \`install.sh\`, npm, PyPI) do not
+          serve this and are not affected by it. Download an asset directly below.
+
+          Linux and Windows only — darwin needs a macOS toolchain and is built on
+          the tag pipeline. The full platform matrix starts at \`-dev\`.
+
+          For a build that has passed the nightly suite, use the latest \`-dev\`
+          prerelease. For one that has passed the full release gate, use \`-beta\`.
+          EOF
+          )
+          if gh release view canary >/dev/null 2>&1; then
+            gh release edit canary --notes "$notes" --prerelease --latest=false
+            # Replace assets rather than accumulate them.
+            for a in $(gh release view canary --json assets --jq '.assets[].name'); do
+              gh release delete-asset canary "$a" --yes
+            done
+          else
+            gh release create canary \
+              --title "Canary (rolling)" \
+              --notes "$notes" \
+              --prerelease \
+              --latest=false \
+              --target main
+          fi
+          gh release upload canary dist/*.tar.gz dist/*.zip dist/checksums.txt --clobber

--- a/.github/workflows/channel-dev.yml
+++ b/.github/workflows/channel-dev.yml
@@ -1,0 +1,161 @@
+# Dev channel — trunk that has passed the nightly suite.
+#
+# Part of the release-channel proposal for gastownhall/beads (issue #5867).
+# Phase 0 of three; see engdocs/RELEASE-CHANNELS.md in the same PR.
+#
+# This is the first channel that cuts a real, versioned candidate. It runs only
+# after "Nightly Full Tests" has gone green, so a -dev build always corresponds
+# to a commit that passed the full suite — not merely to a date.
+#
+# WHAT IT DOES NOT DO. It does not modify release.yml, and it does not need to:
+# the tag it pushes carries a prerelease identifier, and release.yml already
+# gates publish-pypi and publish-npm on `!contains(github.ref_name, '-')`, with
+# goreleaser set to `prerelease: auto`. A -dev tag therefore publishes a GitHub
+# prerelease with the full platform matrix and reaches none of Homebrew, PyPI or
+# npm. That path is not new and not theoretical — v1.2.2-rc.1 exercised it on
+# 2026-08-15 and the gate file records the publish jobs correctly skipping.
+#
+# ADOPTION PREREQUISITES, which this workflow cannot grant itself:
+#   1. refs/heads/channel/* writable by GITHUB_TOKEN.
+#   2. The `v*` tag ruleset must admit the Actions bot for prerelease tags, or
+#      this job's final step will be rejected. RELEASING.md restricts v* tag
+#      creation to release maintainers, and that restriction is correct for
+#      STABLE tags — Phase 2 keeps a human in front of those via an environment
+#      approval. If you would rather not widen it at all, set
+#      `dry_run: true` below and cut the -dev tag by hand from the prepared
+#      channel/dev commit; everything up to the tag is still automated.
+
+name: Channel — Dev
+
+on:
+  workflow_run:
+    workflows: [ "Nightly Full Tests" ]
+    types: [ completed ]
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Base version bump"
+        required: false
+        type: choice
+        default: auto
+        options: [ auto, minor, patch ]
+      dry_run:
+        description: "Stage and report, but do not push branch or tag"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: channel-dev
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  BD_DISABLE_METRICS: "1"
+  BD_DISABLE_EVENT_FLUSH: "1"
+
+jobs:
+  dev:
+    name: Cut dev candidate
+    # Only promote a nightly that actually passed. A scheduled run that failed
+    # must not produce a candidate — that is the whole point of the channel.
+    if: >-
+      github.repository == 'gastownhall/beads' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          # The commit the nightly actually tested, not whatever main is now.
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || 'main' }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        # Pinned to the version release.yml's MCP package gate uses, so the
+        # lockfile this job writes is the lockfile that gate will validate.
+        run: python -m pip install uv==0.11.16
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # One invocation: it reports, then performs the project's own prep
+      # (update-versions.sh, uv lock, check-versions.sh) and emits the computed
+      # version to $GITHUB_OUTPUT. Mutation here is working-tree only — nothing
+      # leaves the runner until the push step, which dry_run skips.
+      - name: Compute and stage the candidate
+        id: plan
+        run: |
+          bash scripts/channel-promote.sh \
+            --channel dev \
+            --bump "${{ inputs.bump || 'auto' }}" \
+            --apply
+
+      - name: Commit to the channel branch
+        id: commit
+        run: |
+          set -euo pipefail
+          version="${{ steps.plan.outputs.version }}"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing to commit — version files already at $version."
+            echo "committed=false" >> "$GITHUB_OUTPUT"
+          else
+            git commit -m "chore(release): dev candidate v${version}
+
+          Automated cut of the dev channel from the commit that passed the
+          nightly suite. Not a release; publishes a GitHub prerelease only."
+            echo "committed=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Report
+        run: |
+          {
+            echo "## Dev candidate \`v${{ steps.plan.outputs.version }}\`"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Commit | \`${{ steps.plan.outputs.base_tag }}\`..\`${{ steps.commit.outputs.sha }}\` |"
+            echo "| Base version | ${{ steps.plan.outputs.base_version }} |"
+            echo "| Schema delta | ${{ steps.plan.outputs.migration_count }} migration(s) since ${{ steps.plan.outputs.base_tag }} |"
+            echo
+            if [ "${{ steps.plan.outputs.migration_count }}" != "0" ]; then
+              echo "> This span crosses a schema boundary. A dev build may carry"
+              echo "> several; a **beta may carry at most one**, so the beta"
+              echo "> promotion will need to be cut at the first boundary."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Move the channel pointer and tag
+        if: ${{ !inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.plan.outputs.version }}"
+          git push --force origin HEAD:refs/heads/channel/dev
+          # Tagging the channel commit — which carries the version bump — not
+          # main. Pushing the tag is what triggers release.yml.
+          git tag -a "v${version}" -m "Dev candidate v${version}"
+          git push origin "v${version}"
+
+      - name: Dry run notice
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "::notice::Dry run — v${{ steps.plan.outputs.version }} staged at ${{ steps.commit.outputs.sha }}, nothing pushed."

--- a/.github/workflows/channel-stable.yml
+++ b/.github/workflows/channel-stable.yml
@@ -1,0 +1,244 @@
+# Stable channel — promote a soaked beta, on one human approval.
+#
+# Part of the release-channel proposal for gastownhall/beads (issue #5867).
+# Phase 2 of three; see engdocs/RELEASE-CHANNELS.md in the same PR.
+#
+# THE POINT OF THIS FILE. Cutting a stable release today means a maintainer
+# running a multi-hour gate by hand on a dev box and then writing the evidence
+# into release-gates/<tag>.md themselves. That is why releases are rare, and
+# rare releases are what make each one heavy. Here the gate has already run —
+# on the beta, in CI — and this workflow only assembles what it found and asks
+# one person one question.
+#
+# Two jobs, deliberately:
+#
+#   dossier   Assembles the evidence and publishes it as a job summary. Runs
+#             freely, blocks nothing, changes nothing. A FAIL verdict here
+#             means the promote job never even offers an approval button.
+#
+#   promote   Gated on the `stable-release` environment. GitHub holds it until
+#             a required reviewer approves, and records who and when. Only then
+#             does anything get tagged.
+#
+# WHAT APPROVAL COSTS AND WHAT IT DOES. Creating the stable tag triggers
+# release.yml, which — because the tag carries no prerelease identifier — also
+# publishes to PyPI and npm and makes the release eligible for the
+# homebrew-core autobump. It is the step that reaches users. Declining costs
+# nothing: the beta stays published and a later beta can be proposed instead.
+#
+# THIS DOES NOT WIDEN WHO MAY RELEASE. RELEASING.md restricts v* tag creation
+# to release maintainers and that stays true: the environment's reviewer list
+# is exactly that set. What changes is the labour, not the authority.
+#
+# ADOPTION PREREQUISITES, which this workflow cannot grant itself:
+#   1. An environment named `stable-release` with required reviewers set to the
+#      release maintainers. Without it the promote job runs unattended, which
+#      is the one outcome this design must not have — so the job asserts the
+#      environment is present and fails closed if it is not.
+#   2. refs/heads/channel/* writable by GITHUB_TOKEN.
+#   3. The v* tag ruleset must admit the Actions bot.
+
+name: Channel — Stable
+
+on:
+  workflow_dispatch:
+    inputs:
+      from_beta:
+        description: "Beta or rc tag to promote (e.g. v1.3.0-beta.2)"
+        required: true
+        type: string
+      soak_days:
+        description: "Minimum soak in days"
+        required: false
+        default: "7"
+        type: string
+      expect_red:
+        description: "Pre-declared red check, as 'GLOB=reason'. One per line."
+        required: false
+        default: ""
+        type: string
+      allow_short_soak:
+        description: "Promote despite a short soak (records the shortfall)"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: channel-stable
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  BD_DISABLE_METRICS: "1"
+  BD_DISABLE_EVENT_FLUSH: "1"
+
+jobs:
+  dossier:
+    name: Assemble release-gate dossier
+    if: ${{ github.repository == 'gastownhall/beads' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      verdict: ${{ steps.gate.outputs.verdict }}
+      stable_tag: ${{ steps.gate.outputs.stable_tag }}
+      stable_version: ${{ steps.gate.outputs.stable_version }}
+      beta_sha: ${{ steps.gate.outputs.beta_sha }}
+      report: ${{ steps.gate.outputs.report }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.from_beta }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Assemble
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          args=(--from-beta "${{ inputs.from_beta }}" --soak-days "${{ inputs.soak_days }}")
+          if [ "${{ inputs.allow_short_soak }}" = "true" ]; then
+            args+=(--allow-short-soak)
+          fi
+          # One --expect-red per non-blank input line.
+          while IFS= read -r line; do
+            [ -n "${line// /}" ] || continue
+            args+=(--expect-red "$line")
+          done <<< "${{ inputs.expect_red }}"
+
+          bash scripts/channel-gate-report.sh "${args[@]}"
+          echo "gate_exit=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Publish the dossier as the job summary
+        if: always()
+        run: cat "${{ steps.gate.outputs.report }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: release-gate-dossier
+          path: ${{ steps.gate.outputs.report }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Refuse to offer a failed promotion
+        if: ${{ steps.gate.outputs.verdict == 'FAIL' }}
+        run: |
+          echo "::error::Verdict FAIL — not offering this for approval. Read the summary above."
+          exit 1
+
+  promote:
+    name: Promote to stable (requires approval)
+    needs: dossier
+    if: ${{ needs.dossier.outputs.verdict != 'FAIL' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    # THIS LINE IS THE APPROVAL GATE. GitHub holds the job here until a
+    # required reviewer on the `stable-release` environment approves, and
+    # records the approver against the run.
+    environment:
+      name: stable-release
+      url: https://github.com/${{ github.repository }}/releases/tag/${{ needs.dossier.outputs.stable_tag }}
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          # The beta's exact commit. What soaked is what ships.
+          ref: ${{ needs.dossier.outputs.beta_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Fail closed. If the environment has no reviewers the job would have run
+      # unattended, and an unattended stable release is the failure mode this
+      # whole design exists to prevent — so prove a human was asked.
+      - name: Assert the approval was human
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          reviewers=$(gh api \
+            "repos/${{ github.repository }}/environments/stable-release" \
+            --jq '[.protection_rules[] | select(.type=="required_reviewers") | .reviewers[]] | length' \
+            2>/dev/null || echo 0)
+          if [ "$reviewers" -eq 0 ]; then
+            echo "::error::The stable-release environment has no required reviewers."
+            echo "This job would have promoted a release with nobody asked. Configure"
+            echo "required reviewers on the environment before using this workflow."
+            exit 1
+          fi
+          echo "stable-release has $reviewers required reviewer(s); approval was human."
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        run: python -m pip install uv==0.11.16
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-gate-dossier
+          path: release-gates/
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Stage the stable version
+        id: plan
+        run: |
+          bash scripts/channel-promote.sh \
+            --channel stable \
+            --from-beta "${{ inputs.from_beta }}" \
+            --apply
+
+      - name: Commit the promotion and its evidence
+        run: |
+          set -euo pipefail
+          version="${{ needs.dossier.outputs.stable_version }}"
+          git add -A
+          git commit -m "chore(release): promote ${{ inputs.from_beta }} to v${version}
+
+          Approved by ${{ github.actor }} via the stable-release environment.
+          The release-gate dossier is committed alongside, so the evidence lives
+          in the repository rather than on the releaser's machine."
+
+      - name: Move the channel pointer and tag
+        run: |
+          set -euo pipefail
+          version="${{ needs.dossier.outputs.stable_version }}"
+          git push --force origin HEAD:refs/heads/channel/stable
+          git tag -a "v${version}" -m "Release v${version}
+
+          Promoted from ${{ inputs.from_beta }} after soak. Gate evidence in
+          release-gates/v${version}.md."
+          # This push is what triggers release.yml and reaches users.
+          git push origin "v${version}"
+
+      - name: Summary
+        run: |
+          {
+            echo "## Promoted \`${{ inputs.from_beta }}\` → \`v${{ needs.dossier.outputs.stable_version }}\`"
+            echo
+            echo "Approved by @${{ github.actor }}."
+            echo "Gate evidence committed to \`release-gates/v${{ needs.dossier.outputs.stable_version }}.md\`."
+            echo
+            echo "\`release.yml\` is now building the release. It will publish the"
+            echo "GitHub release, PyPI and npm, and make the release eligible for"
+            echo "the homebrew-core autobump."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Release channels — Canary, Dev, Beta, Stable — so that cutting a release is
+  a decision rather than a ceremony** (#5867). A channel is a branch and
+  promotion moves a branch pointer, modelled on Chrome. Canary is `main` built
+  on every merge, published as one rolling prerelease. Dev cuts nightly from a
+  commit that passed the nightly suite. Beta runs the full release gate weekly
+  and carries at most one schema migration, because forward-only steps are the
+  distance a user is from a schema their installed binary can read. Stable
+  promotes a soaked Beta behind the `stable-release` environment, which holds
+  the job until a release maintainer approves — `v*` tag creation stays
+  restricted to release maintainers, so only the labour moves, not the
+  authority. The promotion dossier is generated into `release-gates/<tag>.md`
+  in the existing format, with every figure queried rather than asserted: gate
+  results from the check runs recorded on the candidate, soak from the
+  release's `published_at`, manifest and schema delta from git ancestry.
+  `release.yml` is unchanged — a hyphenated tag already published a prerelease
+  and already reached none of Homebrew, PyPI or npm. See
+  `engdocs/RELEASE-CHANNELS.md`.
+
 - **The events journal records WHO performed each mutation.** `bd_events_journal`
   gains an `actor` column (migration 0066 plus its ignored-series twin 0025, so
   upgraded workspaces and fresh clones converge on the same shape), stamped

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,6 +14,7 @@ This document describes the complete release process for beads, including GitHub
 - [5. npm Package Release](#5-npm-package-release)
 - [6. Verify Release](#6-verify-release)
 - [Prerelease / Release Candidate (RC) Workflow](#prerelease--release-candidate-rc-workflow)
+- [Release Channels (automated)](#release-channels-automated)
 - [Hotfix Releases](#hotfix-releases)
 - [Rollback Procedure](#rollback-procedure)
 
@@ -598,6 +599,28 @@ above. Tag creation is restricted to release maintainers; see
   (`./scripts/update-versions.sh 1.1.0`). The stable release **does** publish
   to Homebrew/PyPI/npm, so follow the standard
   [Prepare Release](#1-prepare-release) steps from there.
+
+## Release Channels (automated)
+
+Everything above is the manual process, and it stays correct — it is what you
+want for a hotfix or any out-of-band release.
+
+For routine releases there is also a channel pipeline modelled on Chrome:
+**Canary → Dev → Beta → Stable**, where a channel is a branch and promotion
+moves a branch pointer. It performs the same prep this document prescribes —
+`update-versions.sh`, `uv lock`, `check-versions.sh` — and runs the same gates,
+on a schedule, so that promoting to stable is reading one generated
+`release-gates/<tag>.md` and approving a held job.
+
+- Canary is `main`, built, on every merge — one rolling prerelease.
+- Dev cuts nightly from a commit that passed the nightly suite.
+- Beta runs the full release gate weekly and carries at most one schema step.
+- Stable promotes a soaked Beta, gated on the `stable-release` environment.
+  `v*` tag creation stays restricted to release maintainers; only the labour
+  moves.
+
+Full detail, including the setup the workflows cannot grant themselves:
+[engdocs/RELEASE-CHANNELS.md](engdocs/RELEASE-CHANNELS.md).
 
 ## Hotfix Releases
 

--- a/engdocs/RELEASE-CHANNELS.md
+++ b/engdocs/RELEASE-CHANNELS.md
@@ -1,0 +1,165 @@
+# Release Channels
+
+Four channels, modelled on Chrome: **Canary**, **Dev**, **Beta**, **Stable**.
+A channel is a branch, and promotion moves a branch pointer.
+
+This exists so that cutting a release is a decision rather than a ceremony. The
+work of a release — the suite, the upgrade matrix, the regression baseline, the
+package gates, writing the evidence into `release-gates/` — happens on a
+schedule, in CI, ahead of anyone being asked anything. What is left for a human
+is one page to read and one button to press.
+
+See [RELEASING.md](../RELEASING.md) for the manual process, which is unchanged
+and remains correct for hotfixes and out-of-band releases.
+
+## The channels
+
+| Channel | Cut from | Trigger | Version | Published as | Audience |
+|---|---|---|---|---|---|
+| **Canary** | `main` HEAD | every push to `main` | none | one rolling prerelease, assets replaced | maintainers, bots |
+| **Dev** | `main` HEAD | nightly, after the nightly suite is green | `X.Y.Z-dev.<YYYYMMDD>` | GitHub prerelease | contributors |
+| **Beta** | a Dev commit | weekly (Mon 03:00 UTC) + dispatch | `X.Y.Z-beta.N` | GitHub prerelease | early adopters, soak |
+| **Stable** | a Beta commit | dispatch + approval | `X.Y.Z` | GitHub release → PyPI, npm, homebrew-core | everyone |
+
+Branches: `channel/canary`, `channel/dev`, `channel/beta`, `channel/stable`.
+
+Code flows one way — `main → Dev → Beta → Stable`. **A channel branch never
+merges from `main` after it is cut.** Fixes reach Beta by deliberate
+cherry-pick, one at a time. That is what makes Stable promotable without
+re-litigating everything on `main`, and it means there is always a maintained
+stable line to build a hotfix on.
+
+## Why the stable channels are safe
+
+Nothing here changes `release.yml`, because nothing needed to. A tag carrying a
+prerelease identifier already publishes a GitHub prerelease and reaches none of
+the stable package channels:
+
+- `.goreleaser.yml` sets `prerelease: auto`.
+- `publish-pypi` and `publish-npm` are both gated
+  `!contains(github.ref_name, '-')`.
+- homebrew-core autobumps from non-prerelease GitHub releases only.
+
+So `v1.3.0-dev.20260826` and `v1.3.0-beta.1` publish binaries for people who
+want them and cannot touch Homebrew, PyPI or npm. `v1.3.0` does. That
+separation is pre-existing and was exercised by `v1.2.2-rc.1`.
+
+## Canary carries no version
+
+A canary is `main`, built. It is not a candidate for anything, so it carries no
+version and mutates no version-bearing file; only `channel/canary` moves, and a
+single rolling prerelease has its assets replaced in place.
+
+That is also the only option available. A canary identifier is not
+representable in PEP 440, so `integrations/beads-mcp` could not carry one:
+
+| Identifier | PEP 440 |
+|---|---|
+| `1.3.0-dev.20260826` | valid → `1.3.0.dev20260826` |
+| `1.3.0-beta.1` | valid → `1.3.0b1` |
+| `1.3.0-canary.abc1234` | **invalid** |
+| `1.3.0-canary.20260826` | **invalid** — a numeric suffix does not help; PEP 440 admits only `a`/`b`/`rc`/`post`/`dev` labels |
+
+Canary builds on one runner, so it covers linux and windows. The full platform
+matrix starts at Dev, which goes through the ordinary tag pipeline.
+
+## One schema step per Beta
+
+`scripts/channel-promote.sh` refuses a Beta whose span carries more than one
+migration, overridable with `--allow-multi-migration`.
+
+Migrations are applied forward-only on first access, so the number of steps in
+a release is the distance a user is from the last schema their installed binary
+can read. One step is recoverable. Twelve is the shape that required
+`docs/RECOVERY-1.2.1.md`.
+
+The cost is close to zero: the large majority of merged work touches no
+migration at all, so most Betas are unaffected by the rule and the ones that
+are should be cut at the boundary anyway.
+
+## Which gates run where
+
+The split is whatever the tag does not already trigger. Nothing is duplicated.
+
+**Pre-tag, in `channel-beta.yml`** — these fire on `push: main` only and would
+otherwise never see a candidate:
+
+- `make test` — full suite
+- `make test-regression` — differential against the pinned baseline
+- `scripts/check-migration-hygiene.sh`
+- `make ci-package-mcp`, `make ci-package-npm`
+
+**Post-tag, existing workflows, unchanged:**
+
+- `cross-version-smoke.yml` — the 30-release upgrade matrix, i.e. the
+  [Release Stability Gate](RELEASE-STABILITY-GATE.md)
+- `migration-test.yml`
+- `release.yml` — publishes the prerelease
+
+The pre-tag gates run against the *source* tree, but the Beta commit is that
+tree plus a version bump — a different SHA. So `channel-beta.yml` publishes its
+verdict as a check run **on the Beta commit** via
+`scripts/channel-check-run.py`. Without that, the promotion dossier would read
+the Beta commit, miss the pre-tag gates, and report a release as less gated
+than it was.
+
+## Promoting to Stable
+
+Run the **Channel — Stable** workflow with the Beta tag. It has two jobs.
+
+`dossier` assembles `release-gates/<tag>.md` in the format this project already
+uses, and publishes it as the job summary. It blocks nothing and changes
+nothing. Every figure is queried rather than asserted — gate results from the
+check runs recorded against the Beta commit, soak from the release's
+`published_at`, the shipped-PR manifest and schema delta from git ancestry.
+
+`promote` is gated on the `stable-release` environment. GitHub holds it until a
+required reviewer approves and records who did. Only then is anything tagged.
+
+**This does not widen who may release.** `v*` tag creation stays restricted to
+release maintainers; the environment's reviewer list is that same set. What
+moves is the labour. The job additionally queries the environment and fails
+closed if it has no required reviewers, because an unattended stable release is
+the outcome this design exists to prevent.
+
+### Three verdicts
+
+| Verdict | Exit | Meaning |
+|---|---|---|
+| `PASS` | 0 | clean |
+| `FAIL` | 2 | an **undeclared** red, or no check runs at all |
+| `REVIEW` | 3 | nothing red, but a gate did not reach a verdict |
+
+A cancelled check is not a pass and not a failure. `REVIEW` says so rather than
+guessing, and leaves the call to the approver.
+
+Expected reds are declared, not ignored: `--expect-red 'GLOB=reason'` records
+the check and the reason in the dossier. This mirrors existing practice — the
+`v1.2.2` gate file records a deliberately refused forward-skew as a
+"pre-declared expected signature". A declaration is an argument, not an
+exemption; if the reason has stopped holding, it is a red again.
+
+## Setup required
+
+The workflows cannot grant themselves these.
+
+1. **`refs/heads/channel/*` writable by `GITHUB_TOKEN`.** All four workflows
+   move a channel pointer.
+2. **The `v*` tag ruleset must admit the Actions bot** for Dev and Beta tags.
+   If you would rather not widen it, run `channel-dev.yml` with `dry_run: true`
+   and tag by hand from the prepared `channel/dev` commit — everything up to
+   the tag is still automated.
+3. **An environment named `stable-release`, with required reviewers** set to the
+   release maintainers. Without it `channel-stable.yml` fails closed rather
+   than promoting unattended.
+
+## Scripts
+
+| Script | Does |
+|---|---|
+| `scripts/channel-promote.sh` | version arithmetic and prep for one channel; dry-run by default. Calls `update-versions.sh`, `uv lock`, `check-versions.sh` rather than reimplementing them |
+| `scripts/channel-gate-report.sh` | assembles the promotion dossier from live API and git data |
+| `scripts/channel-check-run.py` | emits the check-run payload recording a Beta's pre-tag verdict |
+
+None of them tags, pushes, or publishes. That is the workflows' job, and for
+Stable it is a human's.

--- a/scripts/channel-check-run.py
+++ b/scripts/channel-check-run.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Emit the check-run payload that records a beta's pre-tag gate verdict.
+
+Part of the release-channel proposal for gastownhall/beads (issue #5867),
+called by .github/workflows/channel-beta.yml.
+
+Why this exists at all: the pre-tag gates run against the *source* tree, but
+the beta commit is that tree plus a version bump — so the gates' own check runs
+are recorded against a different SHA than the one a promotion will be judged
+on. Phase 2's dossier reads check runs on the beta commit. Without publishing
+the verdict there explicitly, the dossier silently under-reports and the
+promotion looks less gated than it was.
+
+Values arrive by environment variable so that nothing is quoted inside the
+workflow YAML, which is where this sort of payload usually goes wrong.
+"""
+
+import json
+import os
+import sys
+
+REQUIRED = ("CR_SHA", "CR_SRC", "CR_URL")
+
+missing = [k for k in REQUIRED if not os.environ.get(k)]
+if missing:
+    sys.stderr.write("missing required environment: %s\n" % ", ".join(missing))
+    raise SystemExit(1)
+
+sha = os.environ["CR_SHA"]
+src = os.environ["CR_SRC"]
+url = os.environ["CR_URL"]
+
+summary = (
+    "Ran against {src}, the tree this beta bumps.\n\n"
+    "Gates in this run: full test suite, differential regression against the "
+    "pinned baseline, migration hygiene, and the MCP and npm package gates. "
+    "These run here because they fire on pushes to `main` only and would "
+    "otherwise never see the candidate.\n\n"
+    "Reported separately, triggered by the tag: the 30-release cross-version "
+    "upgrade matrix, the migration harness, and the prerelease publish.\n\n"
+    "Run: {url}"
+).format(src=src, url=url)
+
+json.dump(
+    {
+        "name": "Beta release gate (pre-tag)",
+        "head_sha": sha,
+        "status": "completed",
+        "conclusion": "success",
+        "details_url": url,
+        "output": {
+            "title": "Full suite, regression, migration hygiene, package gates",
+            "summary": summary,
+        },
+    },
+    sys.stdout,
+    indent=2,
+)
+sys.stdout.write("\n")

--- a/scripts/channel-gate-report.sh
+++ b/scripts/channel-gate-report.sh
@@ -52,7 +52,9 @@ Options:
                          needing to cut anything first.
   --soak-days <N>        Minimum soak before promotion is allowed. Default 7.
   --repo <owner/name>    Repository to query. Default gastownhall/beads.
-  --out <path>           Where to write. Default release-gates/v<version>.md
+  --out <path>           Where to write the dossier. Default
+                         release-gates/v<version>.md. Not valid with --preview,
+                         which reports to stdout and writes nothing.
   --allow-short-soak     Record the shortfall and continue rather than failing.
                          For a security fix that cannot wait out the window.
   --expect-red 'GLOB=reason'
@@ -99,6 +101,13 @@ fi
 if [ -n "$FROM_BETA" ] && [ -n "$PREVIEW" ]; then
     echo -e "${RED}ERROR: --from-beta and --preview are different questions${NC}" >&2
     echo "--from-beta judges a candidate; --preview reports what is unshipped." >&2
+    exit 1
+fi
+if [ -n "$PREVIEW" ] && [ -n "$OUT" ]; then
+    echo -e "${RED}ERROR: --out does not apply to --preview${NC}" >&2
+    echo "--preview reports to stdout and writes no dossier — there is no" >&2
+    echo "candidate, so there is nothing to record. Redirect instead:" >&2
+    echo "  channel-gate-report.sh --preview > unshipped.txt" >&2
     exit 1
 fi
 command -v gh >/dev/null 2>&1 || { echo -e "${RED}ERROR: gh CLI not found${NC}" >&2; exit 1; }

--- a/scripts/channel-gate-report.sh
+++ b/scripts/channel-gate-report.sh
@@ -25,9 +25,10 @@ set -euo pipefail
 #                          [--repo owner/name] [--out <path>] [--allow-short-soak]
 # =============================================================================
 
-RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
 
 FROM_BETA=""
+PREVIEW=""
 SOAK_DAYS=7
 REPO="gastownhall/beads"
 OUT=""
@@ -37,9 +38,18 @@ EXPECT_RED=()
 usage() {
     cat <<'USAGE'
 Usage: channel-gate-report.sh --from-beta <tag> [options]
+       channel-gate-report.sh --preview [<ref>] [options]
 
 Options:
-  --from-beta <tag>      The beta tag proposed for promotion. Required.
+  --from-beta <tag>      The beta tag proposed for promotion.
+  --preview [<ref>]      Instead of judging a promotion, report what a stable
+                         release cut from <ref> (default HEAD) would FIRST
+                         ship: how much merged work is in no published stable
+                         release, how old the oldest of it is, and whether the
+                         span crosses a schema boundary. No soak and no gate
+                         sections — there is no candidate to have soaked or
+                         been gated. Answers "what are we sitting on?" without
+                         needing to cut anything first.
   --soak-days <N>        Minimum soak before promotion is allowed. Default 7.
   --repo <owner/name>    Repository to query. Default gastownhall/beads.
   --out <path>           Where to write. Default release-gates/v<version>.md
@@ -66,6 +76,13 @@ USAGE
 while [ $# -gt 0 ]; do
     case "$1" in
         --from-beta) FROM_BETA="${2:-}"; shift 2 ;;
+        --preview)
+            # Optional ref; bare --preview means HEAD.
+            if [ "${2:-}" != "" ] && [ "${2#-}" = "${2}" ]; then
+                PREVIEW="$2"; shift 2
+            else
+                PREVIEW="HEAD"; shift
+            fi ;;
         --soak-days) SOAK_DAYS="${2:-}"; shift 2 ;;
         --repo)      REPO="${2:-}"; shift 2 ;;
         --out)       OUT="${2:-}"; shift 2 ;;
@@ -76,7 +93,14 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-[ -n "$FROM_BETA" ] || { echo -e "${RED}ERROR: --from-beta is required${NC}" >&2; usage >&2; exit 1; }
+if [ -z "$FROM_BETA" ] && [ -z "$PREVIEW" ]; then
+    echo -e "${RED}ERROR: one of --from-beta or --preview is required${NC}" >&2; usage >&2; exit 1
+fi
+if [ -n "$FROM_BETA" ] && [ -n "$PREVIEW" ]; then
+    echo -e "${RED}ERROR: --from-beta and --preview are different questions${NC}" >&2
+    echo "--from-beta judges a candidate; --preview reports what is unshipped." >&2
+    exit 1
+fi
 command -v gh >/dev/null 2>&1 || { echo -e "${RED}ERROR: gh CLI not found${NC}" >&2; exit 1; }
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
@@ -89,10 +113,10 @@ cd "$REPO_ROOT"
 #
 # A TAG NAME IS NOT PROOF OF A RELEASE, and here that distinction inverts the
 # answer rather than shading it. `v1.2.1` carries no prerelease identifier in
-# its name, so any name-based filter (`--exclude '*-*'`) would treat it as
-# stable — but GitHub has it flagged `prerelease: true`, because it was
-# withdrawn. Using it as a baseline understates what a release ships by the
-# entire backlog behind it.
+# its name, so any name-based filter (`--exclude '*-*'`) treats it as stable —
+# but GitHub has it flagged `prerelease: true`, because it was withdrawn. Using
+# it as a baseline understates what a release ships by the entire backlog
+# behind it.
 #
 # So validity comes from what GitHub published: not a draft, not a prerelease,
 # and actually published. Tags absent from the local clone are dropped, since
@@ -128,6 +152,72 @@ nearest_released_ancestor() {
     done
     printf '%s' "$best"
 }
+
+# -----------------------------------------------------------------------------
+# Preview: what is sitting unshipped
+# -----------------------------------------------------------------------------
+
+if [ -n "$PREVIEW" ]; then
+    git rev-parse --verify --quiet "${PREVIEW}^{commit}" >/dev/null \
+        || { echo -e "${RED}ERROR: '$PREVIEW' is not a known ref${NC}" >&2; exit 1; }
+    REF_SHA="$(git rev-parse "${PREVIEW}^{commit}")"
+
+    # The unreleased set is everything on the ref that is in NO valid release —
+    # not everything since the newest tag. Those differ whenever a release was
+    # cut from a side branch, which is the case here.
+    UNRELEASED="$(git rev-list "$REF_SHA" --not $VALID_TAGS 2>/dev/null || true)"
+    UNREL_COUNT="$(printf '%s' "$UNRELEASED" | grep -c . || true)"
+
+    PR_NUMS="$(printf '%s\n' "$UNRELEASED" \
+                 | while IFS= read -r c; do [ -n "$c" ] && git log -1 --format='%s' "$c"; done \
+                 | grep -oE '\(#[0-9]+\)$' | tr -d '()#' | sort -un || true)"
+    PR_COUNT="$(printf '%s' "$PR_NUMS" | grep -c . || true)"
+
+    LAST_RELEASED="$(nearest_released_ancestor "$REF_SHA")"
+
+    if [ "$UNREL_COUNT" -gt 0 ]; then
+        OLDEST_SHA="$(printf '%s\n' "$UNRELEASED" | tail -1)"
+        OLDEST_DATE="$(git log -1 --format='%ci' "$OLDEST_SHA" | cut -d' ' -f1)"
+        OLDEST_AGE_DAYS="$(( ( $(date -u +%s) - $(git log -1 --format='%ct' "$OLDEST_SHA") ) / 86400 ))"
+        NEW_MIGS="$(git diff --name-only --diff-filter=A "${LAST_RELEASED}..${REF_SHA}" -- "$MIGRATION_DIR" 2>/dev/null \
+                     | grep -E "^${MIGRATION_DIR}/[0-9]{4}_.*\.up\.sql$" || true)"
+        MIG_COUNT="$(printf '%s' "$NEW_MIGS" | grep -c . || true)"
+    else
+        OLDEST_DATE="n/a"; OLDEST_AGE_DAYS=0; MIG_COUNT=0; NEW_MIGS=""
+    fi
+
+    echo
+    echo -e "${BLUE}=== Unshipped work on $(git rev-parse --short "$REF_SHA") ===${NC}"
+    echo
+    printf '  %-28s %s\n' "valid stable releases" "$(printf '%s' "$VALID_TAGS" | wc -w | tr -d ' ')"
+    printf '  %-28s %s\n' "last released ancestor" "${LAST_RELEASED:-<none>}"
+    printf '  %-28s %s\n' "commits in no release" "$UNREL_COUNT"
+    printf '  %-28s %s\n' "pull requests unshipped" "$PR_COUNT"
+    printf '  %-28s %s\n' "oldest unshipped" "${OLDEST_DATE} (${OLDEST_AGE_DAYS}d)"
+    if [ "$MIG_COUNT" -eq 0 ]; then
+        printf '  %-28s %s\n' "schema steps" "none — schema-compatible"
+    else
+        printf '  %-28s %s\n' "schema steps" "$MIG_COUNT"
+        printf '%s\n' "$NEW_MIGS" | sed 's|^|      |'
+        if [ "$MIG_COUNT" -gt 1 ]; then
+            echo
+            echo -e "  ${YELLOW}More than one schema step: a beta may carry only one, so this${NC}"
+            echo -e "  ${YELLOW}span needs cutting at the first migration boundary.${NC}"
+        fi
+    fi
+    echo
+
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+        {
+            echo "unreleased_commits=$UNREL_COUNT"
+            echo "unreleased_prs=$PR_COUNT"
+            echo "oldest_unreleased_days=$OLDEST_AGE_DAYS"
+            echo "last_released=${LAST_RELEASED}"
+            echo "migration_count=$MIG_COUNT"
+        } >> "$GITHUB_OUTPUT"
+    fi
+    exit 0
+fi
 
 git rev-parse --verify --quiet "${FROM_BETA}^{commit}" >/dev/null \
     || { echo -e "${RED}ERROR: '$FROM_BETA' is not a known tag${NC}" >&2; exit 1; }

--- a/scripts/channel-gate-report.sh
+++ b/scripts/channel-gate-report.sh
@@ -1,0 +1,471 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# channel-gate-report.sh — assemble the release-gate dossier for a promotion
+# =============================================================================
+#
+# Part of the release-channel proposal for gastownhall/beads (issue #5867).
+# Phase 2 of three; see engdocs/RELEASE-CHANNELS.md in the same PR.
+#
+# Emits a release-gates/<tag>.md file in the format the project already uses by
+# hand (27 such files exist today), so that approving a stable release is
+# reading one page rather than performing a ceremony.
+#
+# EVERY FIGURE IS QUERIED, NOT ASSERTED. Gate results come from the check runs
+# GitHub actually recorded against the beta's commit; soak duration comes from
+# the beta release's published_at; the shipped-PR manifest comes from git
+# ancestry. Nothing in the output is a claim this script made up, which is the
+# property that makes the dossier worth approving on.
+#
+# It writes a file and prints a verdict. It does not tag, push, or publish.
+#
+# Usage:
+#   channel-gate-report.sh --from-beta v1.3.0-beta.2 [--soak-days 7]
+#                          [--repo owner/name] [--out <path>] [--allow-short-soak]
+# =============================================================================
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+
+FROM_BETA=""
+SOAK_DAYS=7
+REPO="gastownhall/beads"
+OUT=""
+ALLOW_SHORT_SOAK=0
+EXPECT_RED=()
+
+usage() {
+    cat <<'USAGE'
+Usage: channel-gate-report.sh --from-beta <tag> [options]
+
+Options:
+  --from-beta <tag>      The beta tag proposed for promotion. Required.
+  --soak-days <N>        Minimum soak before promotion is allowed. Default 7.
+  --repo <owner/name>    Repository to query. Default gastownhall/beads.
+  --out <path>           Where to write. Default release-gates/v<version>.md
+  --allow-short-soak     Record the shortfall and continue rather than failing.
+                         For a security fix that cannot wait out the window.
+  --expect-red 'GLOB=reason'
+                         Pre-declare an expected red check, with the reason
+                         recorded in the dossier. Repeatable. The project
+                         already works this way — the v1.2.2 gate file records
+                         a deliberately refused forward-skew as a "pre-declared
+                         expected signature". Example:
+                           --expect-red 'Upgrade smoke (v1.2.1*=forward skew, refused by design'
+  -h, --help             This text.
+
+Exit codes:
+  0  verdict PASS — dossier written, promotion may proceed
+  1  usage or precondition error
+  2  verdict FAIL — an undeclared gate is red, or the soak is short
+  3  verdict REVIEW — nothing is red, but a gate did not complete. Not an
+     automatic block and not an automatic pass; a human adjudicates.
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --from-beta) FROM_BETA="${2:-}"; shift 2 ;;
+        --soak-days) SOAK_DAYS="${2:-}"; shift 2 ;;
+        --repo)      REPO="${2:-}"; shift 2 ;;
+        --out)       OUT="${2:-}"; shift 2 ;;
+        --allow-short-soak) ALLOW_SHORT_SOAK=1; shift ;;
+        --expect-red) EXPECT_RED+=("${2:-}"); shift 2 ;;
+        -h|--help)   usage; exit 0 ;;
+        *) echo -e "${RED}Unknown argument: $1${NC}" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+[ -n "$FROM_BETA" ] || { echo -e "${RED}ERROR: --from-beta is required${NC}" >&2; usage >&2; exit 1; }
+command -v gh >/dev/null 2>&1 || { echo -e "${RED}ERROR: gh CLI not found${NC}" >&2; exit 1; }
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "$REPO_ROOT" ] || { echo -e "${RED}ERROR: not inside a git repository${NC}" >&2; exit 1; }
+cd "$REPO_ROOT"
+
+# -----------------------------------------------------------------------------
+# Which tags are actually released
+# -----------------------------------------------------------------------------
+#
+# A TAG NAME IS NOT PROOF OF A RELEASE, and here that distinction inverts the
+# answer rather than shading it. `v1.2.1` carries no prerelease identifier in
+# its name, so any name-based filter (`--exclude '*-*'`) would treat it as
+# stable — but GitHub has it flagged `prerelease: true`, because it was
+# withdrawn. Using it as a baseline understates what a release ships by the
+# entire backlog behind it.
+#
+# So validity comes from what GitHub published: not a draft, not a prerelease,
+# and actually published. Tags absent from the local clone are dropped, since
+# ancestry cannot be computed for them.
+MIGRATION_DIR="internal/storage/schema/migrations"
+
+VALID_TAGS=""
+while IFS= read -r t; do
+    [ -n "$t" ] || continue
+    git rev-parse --verify --quiet "${t}^{commit}" >/dev/null 2>&1 || continue
+    VALID_TAGS="${VALID_TAGS} ${t}"
+done <<EOF
+$(gh api "repos/${REPO}/releases?per_page=100" --paginate \
+    --jq '.[] | select(.draft == false and .prerelease == false and .published_at != null) | .tag_name' 2>/dev/null || true)
+EOF
+
+if [ -z "${VALID_TAGS// /}" ]; then
+    echo -e "${RED}ERROR: no published stable releases resolved for ${REPO}${NC}" >&2
+    echo "Without them there is no baseline to measure against." >&2
+    exit 1
+fi
+
+# Nearest released ancestor of a ref: among valid releases that are ancestors,
+# the one with the fewest commits between it and the ref.
+nearest_released_ancestor() {
+    local ref="$1" best="" bestdist=-1 t dist
+    for t in $VALID_TAGS; do
+        git merge-base --is-ancestor "$t" "$ref" 2>/dev/null || continue
+        dist="$(git rev-list --count "${t}..${ref}" 2>/dev/null || echo 999999999)"
+        if [ "$bestdist" -lt 0 ] || [ "$dist" -lt "$bestdist" ]; then
+            bestdist="$dist"; best="$t"
+        fi
+    done
+    printf '%s' "$best"
+}
+
+git rev-parse --verify --quiet "${FROM_BETA}^{commit}" >/dev/null \
+    || { echo -e "${RED}ERROR: '$FROM_BETA' is not a known tag${NC}" >&2; exit 1; }
+
+BETA_SHA="$(git rev-parse "${FROM_BETA}^{commit}")"
+BETA_VERSION="${FROM_BETA#v}"
+# `-beta.N` is this proposal's identifier; `-rc.N` is the one RELEASING.md
+# already documents and the one every existing prerelease here uses. Both are
+# gated prereleases, so both are promotable — refusing rc would orphan the
+# candidates the project has actually cut.
+case "$BETA_VERSION" in
+    *-beta.*|*-rc.*) ;;
+    *-dev.*|*-canary.*)
+        echo -e "${RED}ERROR: '$FROM_BETA' is a $(printf '%s' "$BETA_VERSION" | sed 's/.*-\([a-z]*\)\..*/\1/') build${NC}" >&2
+        echo "Only a beta or rc may be promoted to stable. A dev build has passed the" >&2
+        echo "nightly suite but not the full release gate, and promoting one skips" >&2
+        echo "exactly the checks the gate exists to run." >&2
+        exit 1 ;;
+    *) echo -e "${RED}ERROR: '$FROM_BETA' is not a prerelease tag${NC}" >&2; exit 1 ;;
+esac
+STABLE_VERSION="${BETA_VERSION%%-*}"
+STABLE_TAG="v${STABLE_VERSION}"
+[ -n "$OUT" ] || OUT="release-gates/${STABLE_TAG}.md"
+
+# -----------------------------------------------------------------------------
+# Soak — measured from when the beta was actually published, not when it was
+# tagged. A tag that sat unpublished soaked nobody.
+# -----------------------------------------------------------------------------
+
+PUBLISHED_AT="$(gh release view "$FROM_BETA" --repo "$REPO" --json publishedAt --jq '.publishedAt' 2>/dev/null || true)"
+if [ -z "$PUBLISHED_AT" ] || [ "$PUBLISHED_AT" = "null" ]; then
+    echo -e "${RED}ERROR: no published release found for $FROM_BETA${NC}" >&2
+    echo "A beta that was never published cannot have soaked." >&2
+    exit 1
+fi
+
+# GNU and BSD date disagree on parsing; try both rather than assume the runner.
+epoch_of() {
+    date -u -d "$1" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$1" +%s 2>/dev/null
+}
+PUB_EPOCH="$(epoch_of "$PUBLISHED_AT")"
+NOW_EPOCH="$(date -u +%s)"
+SOAK_SECONDS=$(( NOW_EPOCH - PUB_EPOCH ))
+SOAK_ELAPSED_DAYS=$(( SOAK_SECONDS / 86400 ))
+SOAK_HOURS=$(( SOAK_SECONDS / 3600 ))
+
+SOAK_OK=1
+[ "$SOAK_ELAPSED_DAYS" -ge "$SOAK_DAYS" ] || SOAK_OK=0
+
+# -----------------------------------------------------------------------------
+# Gate results — read from the check runs GitHub recorded on the beta commit.
+# -----------------------------------------------------------------------------
+
+# gh ships jq internally, so parsing needs no external tool. One call, then
+# classify in three buckets — because two of them are not the same thing:
+#
+#   passed        success, skipped, neutral
+#   failed        failure, timed_out, action_required   -> blocks
+#   inconclusive  cancelled, stale, still running       -> a human decides
+#
+# Treating "cancelled" as a failure would have blocked the real v1.2.2: its
+# Migration fidelity check was cancelled, not failed. Treating it as a pass
+# would claim a gate ran that did not. Neither is honest, so it is surfaced.
+CHECKS_API="repos/${REPO}/commits/${BETA_SHA}/check-runs?per_page=100"
+CHECK_LINES="$(gh api "$CHECKS_API" --jq '.check_runs[] | "\(.conclusion // "running")\t\(.name)"' 2>/dev/null || true)"
+CHECK_TOTAL="$(printf '%s' "$CHECK_LINES" | grep -c . || true)"
+
+FAILED_RAW="$(printf '%s\n' "$CHECK_LINES" | grep -E '^(failure|timed_out|action_required)\b' || true)"
+INCONCLUSIVE_RAW="$(printf '%s\n' "$CHECK_LINES" | grep -E '^(cancelled|stale|running)\b' || true)"
+
+# Pre-declared expected reds. The project already works this way — the v1.2.2
+# gate file records "30 green / 1 red, the red being the deliberately refused
+# forward-skew (pre-declared expected signature)". Without this the tool cannot
+# express what their real releases actually do, and would block them.
+FAILED_ROWS=""; EXPECTED_ROWS=""; CHECK_FAILED=0; CHECK_EXPECTED=0
+while IFS=$'\t' read -r conclusion name; do
+    [ -n "${name:-}" ] || continue
+    matched=""
+    for spec in "${EXPECT_RED[@]:-}"; do
+        [ -n "$spec" ] || continue
+        pattern="${spec%%=*}"; reason="${spec#*=}"
+        # shellcheck disable=SC2254
+        case "$name" in
+            $pattern) matched="$reason"; break ;;
+        esac
+    done
+    if [ -n "$matched" ]; then
+        EXPECTED_ROWS="${EXPECTED_ROWS}| \`${name}\` | ${conclusion} | ${matched} |"$'\n'
+        CHECK_EXPECTED=$(( CHECK_EXPECTED + 1 ))
+    else
+        FAILED_ROWS="${FAILED_ROWS}| \`${name}\` | ${conclusion} |"$'\n'
+        CHECK_FAILED=$(( CHECK_FAILED + 1 ))
+    fi
+done <<< "$FAILED_RAW"
+
+INCONCLUSIVE_ROWS=""; CHECK_INCONCLUSIVE=0
+while IFS=$'\t' read -r conclusion name; do
+    [ -n "${name:-}" ] || continue
+    INCONCLUSIVE_ROWS="${INCONCLUSIVE_ROWS}| \`${name}\` | ${conclusion} |"$'\n'
+    CHECK_INCONCLUSIVE=$(( CHECK_INCONCLUSIVE + 1 ))
+done <<< "$INCONCLUSIVE_RAW"
+
+GATES_OK=1
+[ "$CHECK_TOTAL" -gt 0 ] || GATES_OK=0
+[ "$CHECK_FAILED" -eq 0 ] || GATES_OK=0
+
+# -----------------------------------------------------------------------------
+# Issues raised against the beta during its soak
+# -----------------------------------------------------------------------------
+
+SOAK_ISSUE_ROWS="$(gh search issues --repo "$REPO" --created ">=${PUBLISHED_AT%T*}" \
+                     "$BETA_VERSION" --limit 30 \
+                     --json number,title,state \
+                     --jq '.[] | "| #\(.number) | \(.state) | \(.title[0:90]) |"' 2>/dev/null || true)"
+SOAK_ISSUE_COUNT="$(printf '%s' "$SOAK_ISSUE_ROWS" | grep -c . || true)"
+
+# -----------------------------------------------------------------------------
+# What this release first ships, and the schema delta — both by ancestry.
+# The baseline is the nearest ancestor that GitHub actually published as a
+# stable release, not the nearest tag that merely looks like one. Two separate
+# traps: v1.2.2 is a v1.1-line re-release and is not an ancestor of main, and
+# v1.2.1 has a stable-looking NAME while being flagged a prerelease because it
+# was withdrawn. Either would give a confidently wrong baseline.
+# -----------------------------------------------------------------------------
+
+PREV_STABLE="$(nearest_released_ancestor "${BETA_SHA}^")"
+
+if [ -n "$PREV_STABLE" ]; then
+    RANGE="${PREV_STABLE}..${BETA_SHA}"
+    PR_LIST="$(git log --format='%s' "$RANGE" | grep -oE '\(#[0-9]+\)$' | tr -d '()#' | sort -un || true)"
+    PR_COUNT="$(printf '%s' "$PR_LIST" | grep -c . || true)"
+    COMMIT_COUNT="$(git rev-list --count "$RANGE")"
+    NEW_MIGRATIONS="$(git diff --name-only --diff-filter=A "$RANGE" -- "$MIGRATION_DIR" 2>/dev/null \
+                       | grep -E "^${MIGRATION_DIR}/[0-9]{4}_.*\.up\.sql$" || true)"
+    MIGRATION_COUNT="$(printf '%s' "$NEW_MIGRATIONS" | grep -c . || true)"
+else
+    RANGE="(no ancestor stable tag)"
+    PR_COUNT="unknown"; COMMIT_COUNT="unknown"; MIGRATION_COUNT="unknown"; NEW_MIGRATIONS=""
+fi
+
+# -----------------------------------------------------------------------------
+# Verdict
+# -----------------------------------------------------------------------------
+
+VERDICT="PASS"
+FAIL_REASONS=""
+if [ "$CHECK_TOTAL" -eq 0 ]; then
+    VERDICT="FAIL"
+    FAIL_REASONS="${FAIL_REASONS}- No check runs found on \`${BETA_SHA}\`. An ungated build cannot be promoted.\n"
+elif [ "$CHECK_FAILED" -gt 0 ]; then
+    VERDICT="FAIL"
+    FAIL_REASONS="${FAIL_REASONS}- ${CHECK_FAILED} check(s) failed and were not pre-declared.\n"
+fi
+if [ "$CHECK_EXPECTED" -gt 0 ]; then
+    FAIL_REASONS="${FAIL_REASONS}- ${CHECK_EXPECTED} red check(s) were **pre-declared** with a reason and are not treated as blocking. Read them below and satisfy yourself the reasons still hold.\n"
+fi
+if [ "$CHECK_INCONCLUSIVE" -gt 0 ] && [ "$VERDICT" = "PASS" ]; then
+    VERDICT="REVIEW"
+    FAIL_REASONS="${FAIL_REASONS}- ${CHECK_INCONCLUSIVE} gate(s) did not complete (cancelled, stale, or still running). Nothing is red, but these did not run — so the gate is unproven rather than passed.\n"
+fi
+if [ "$SOAK_OK" -ne 1 ]; then
+    if [ "$ALLOW_SHORT_SOAK" -eq 1 ]; then
+        FAIL_REASONS="${FAIL_REASONS}- Soak is ${SOAK_ELAPSED_DAYS}d against a ${SOAK_DAYS}d minimum, **overridden deliberately** via --allow-short-soak.\n"
+    else
+        VERDICT="FAIL"
+        FAIL_REASONS="${FAIL_REASONS}- Soak is ${SOAK_ELAPSED_DAYS}d (${SOAK_HOURS}h) against a ${SOAK_DAYS}d minimum.\n"
+    fi
+fi
+
+# -----------------------------------------------------------------------------
+# Write the dossier
+# -----------------------------------------------------------------------------
+
+mkdir -p "$(dirname "$OUT")"
+{
+cat <<EOF
+# Release gate — ${STABLE_TAG} (promotion of ${FROM_BETA})
+
+**Date:** $(date -u +%Y-%m-%d)
+**Promoted from:** \`${FROM_BETA}\` @ \`${BETA_SHA}\`
+**Tag to be created:** \`${STABLE_TAG}\` on the same commit — the tree that soaked is the tree that ships
+**Previous stable:** \`${PREV_STABLE:-none found}\`
+**Assembled by:** \`scripts/channel-gate-report.sh\`, from GitHub check runs and git ancestry
+
+## Verdict: ${VERDICT}
+
+EOF
+
+if [ -n "$FAIL_REASONS" ]; then
+    printf '%b\n' "$FAIL_REASONS"
+fi
+
+cat <<EOF
+## Soak
+
+| | |
+|---|---|
+| Beta published | ${PUBLISHED_AT} |
+| Soak elapsed | ${SOAK_ELAPSED_DAYS} days (${SOAK_HOURS}h) |
+| Minimum required | ${SOAK_DAYS} days |
+| Issues mentioning \`${BETA_VERSION}\` raised since | ${SOAK_ISSUE_COUNT} |
+
+EOF
+
+if [ "${SOAK_ISSUE_COUNT}" != "0" ]; then
+    echo "| Issue | State | Title |"
+    echo "|---|---|---|"
+    printf '%s\n' "$SOAK_ISSUE_ROWS"
+    echo
+    echo "> These are keyword matches, not a triaged list. Read them before approving —"
+    echo "> the soak only means something if somebody looked at what it surfaced."
+    echo
+fi
+
+cat <<EOF
+## Gates (check runs recorded on \`${BETA_SHA}\`)
+
+| | |
+|---|---|
+| Checks recorded | ${CHECK_TOTAL} |
+| Failed, undeclared | ${CHECK_FAILED} |
+| Red, pre-declared | ${CHECK_EXPECTED} |
+| Did not complete | ${CHECK_INCONCLUSIVE} |
+
+EOF
+
+if [ "$CHECK_FAILED" -gt 0 ]; then
+    echo "### Failing — these block"
+    echo
+    echo "| Check | Conclusion |"
+    echo "|---|---|"
+    printf '%s' "$FAILED_ROWS"
+    echo
+fi
+
+if [ "$CHECK_EXPECTED" -gt 0 ]; then
+    echo "### Red, but pre-declared"
+    echo
+    echo "| Check | Conclusion | Declared reason |"
+    echo "|---|---|---|"
+    printf '%s' "$EXPECTED_ROWS"
+    echo
+    echo "> A pre-declaration is an argument, not an exemption. It was made when the"
+    echo "> promotion was proposed; if the reason no longer holds, this is a red."
+    echo
+fi
+
+if [ "$CHECK_INCONCLUSIVE" -gt 0 ]; then
+    echo "### Did not complete"
+    echo
+    echo "| Check | State |"
+    echo "|---|---|"
+    printf '%s' "$INCONCLUSIVE_ROWS"
+    echo
+    echo "> These are neither green nor red — they did not run to a verdict. That is"
+    echo "> not the same as passing, and it is why the verdict above is REVIEW rather"
+    echo "> than PASS. Re-run them, or approve on the explicit basis that they are"
+    echo "> not load-bearing for this change."
+    echo
+fi
+
+cat <<EOF
+These are the gates the beta promotion ran in full: the suite, the
+cross-version upgrade smoke matrix at the 30-release depth, the regression
+baseline, the MCP and npm package gates, and the migration harness. They are
+reported here as GitHub recorded them rather than re-run, so this dossier
+reflects the build being promoted and not a fresh one.
+
+## Content
+
+| | |
+|---|---|
+| Range | \`${RANGE}\` |
+| Commits | ${COMMIT_COUNT} |
+| Pull requests first shipped | ${PR_COUNT} |
+| Schema migrations | ${MIGRATION_COUNT} |
+
+EOF
+
+if [ "${MIGRATION_COUNT}" = "0" ]; then
+    echo "**No schema change.** This release is schema-compatible with"
+    echo "\`${PREV_STABLE}\` in both directions, so a user who upgrades and then"
+    echo "downgrades is not stranded."
+elif [ "${MIGRATION_COUNT}" != "unknown" ]; then
+    echo "**Carries ${MIGRATION_COUNT} schema migration(s):**"
+    echo
+    printf '%s\n' "$NEW_MIGRATIONS" | sed 's|^|- `|; s|$|`|'
+    echo
+    echo "Migrations are applied forward-only on first access by the new binary."
+    echo "Confirm the down path is present and the recovery note is in the"
+    echo "CHANGELOG before approving."
+fi
+
+cat <<EOF
+
+## What approving does
+
+Creating \`${STABLE_TAG}\` triggers \`release.yml\`, which publishes the GitHub
+release and — because this tag carries no prerelease identifier — also
+publishes to PyPI and npm, and makes the release eligible for the
+homebrew-core autobump. This is the step that reaches users.
+
+Declining costs nothing: the beta stays published and available, and the next
+promotion can be proposed from a later beta.
+EOF
+} > "$OUT"
+
+# -----------------------------------------------------------------------------
+# Report
+# -----------------------------------------------------------------------------
+
+echo
+case "$VERDICT" in
+    PASS)   echo -e "${GREEN}Verdict: PASS${NC} — ${FROM_BETA} -> ${STABLE_TAG}" ;;
+    REVIEW) echo -e "${YELLOW}Verdict: REVIEW${NC} — ${FROM_BETA} -> ${STABLE_TAG}" ;;
+    *)      echo -e "${RED}Verdict: FAIL${NC} — ${FROM_BETA} -> ${STABLE_TAG}" ;;
+esac
+printf '%b' "$FAIL_REASONS"
+echo "  soak      ${SOAK_ELAPSED_DAYS}d (min ${SOAK_DAYS}d), ${SOAK_ISSUE_COUNT} issue(s) mentioning the beta"
+echo "  gates     ${CHECK_TOTAL} recorded: ${CHECK_FAILED} failed, ${CHECK_EXPECTED} pre-declared, ${CHECK_INCONCLUSIVE} incomplete"
+echo "  content   ${PR_COUNT} PRs, ${MIGRATION_COUNT} migration(s)"
+echo "  written   ${OUT}"
+echo
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "verdict=$VERDICT"
+        echo "stable_version=$STABLE_VERSION"
+        echo "stable_tag=$STABLE_TAG"
+        echo "beta_sha=$BETA_SHA"
+        echo "soak_days=$SOAK_ELAPSED_DAYS"
+        echo "migration_count=$MIGRATION_COUNT"
+        echo "report=$OUT"
+    } >> "$GITHUB_OUTPUT"
+fi
+
+case "$VERDICT" in
+    PASS)   exit 0 ;;
+    REVIEW) exit 3 ;;
+    *)      exit 2 ;;
+esac

--- a/scripts/channel-promote.sh
+++ b/scripts/channel-promote.sh
@@ -37,15 +37,21 @@ BUMP="auto"
 STAMP=""
 SEQ=""
 BASE_TAG_OVERRIDE=""
+FROM_BETA=""
 ALLOW_MULTI_MIGRATION=0
 APPLY=0
 
 usage() {
     cat <<'USAGE'
-Usage: channel-promote.sh --channel <dev|beta> [options]
+Usage: channel-promote.sh --channel <dev|beta|stable> [options]
 
 Options:
-  --channel <dev|beta>   Which channel to stage a build for. Required.
+  --channel <dev|beta|stable>
+                         Which channel to stage a build for. Required.
+                         "stable" is a promotion and requires --from-beta.
+  --from-beta <tag>      Stable only. The beta tag being promoted. Its base
+                         version becomes the stable version, and HEAD must be
+                         that beta's exact commit.
   --bump <auto|minor|patch>
                          How to derive the next base version from the current
                          one. "auto" (default) reads CHANGELOG [Unreleased]:
@@ -80,6 +86,7 @@ while [ $# -gt 0 ]; do
         --stamp)   STAMP="${2:-}"; shift 2 ;;
         --seq)     SEQ="${2:-}"; shift 2 ;;
         --base-tag) BASE_TAG_OVERRIDE="${2:-}"; shift 2 ;;
+        --from-beta) FROM_BETA="${2:-}"; shift 2 ;;
         --allow-multi-migration) ALLOW_MULTI_MIGRATION=1; shift ;;
         --apply)   APPLY=1; shift ;;
         -h|--help) usage; exit 0 ;;
@@ -93,6 +100,15 @@ done
 
 case "$CHANNEL" in
     dev|beta) ;;
+    stable)
+        if [ -z "$FROM_BETA" ]; then
+            echo -e "${RED}ERROR: --channel stable requires --from-beta <tag>${NC}" >&2
+            echo "Stable is a PROMOTION, never a fresh cut. Its version is the base" >&2
+            echo "version of the beta being promoted, and its commit is that beta's" >&2
+            echo "commit — so that what ships is what soaked, not a rebuild of it." >&2
+            exit 1
+        fi
+        ;;
     canary)
         cat >&2 <<'CANARY'
 ERROR: canary takes no version bump.
@@ -186,6 +202,46 @@ case "$CHANNEL" in
         fi
         NEW_VERSION="${NEXT_BASE}-beta.${SEQ}"
         ;;
+    stable)
+        # A promotion, not a cut. The version is the beta's base version and
+        # NOTHING is recomputed from CHANGELOG or version.go — recomputing here
+        # is how a stable release ends up shipping a different version from the
+        # one that soaked.
+        if ! git rev-parse --verify --quiet "${FROM_BETA}^{commit}" >/dev/null; then
+            echo -e "${RED}ERROR: --from-beta '$FROM_BETA' is not a known tag${NC}" >&2; exit 1
+        fi
+        BETA_VERSION="${FROM_BETA#v}"
+        # -rc.N is the identifier RELEASING.md already documents and every
+        # existing prerelease here uses; -beta.N is this proposal's. Both are
+        # gated candidates, so both promote. dev and canary are not.
+        case "$BETA_VERSION" in
+            *-beta.*|*-rc.*) ;;
+            *-dev.*|*-canary.*)
+               echo -e "${RED}ERROR: '$FROM_BETA' has not been through the release gate${NC}" >&2
+               echo "Stable promotes from a beta or rc only. A dev build has passed the" >&2
+               echo "nightly suite but not the full gate, and promoting one skips exactly" >&2
+               echo "the checks the gate exists to run." >&2
+               exit 1 ;;
+            *) echo -e "${RED}ERROR: '$FROM_BETA' is not a prerelease tag${NC}" >&2
+               echo "Stable is a promotion of a candidate, never a fresh cut." >&2
+               exit 1 ;;
+        esac
+        NEW_VERSION="${BETA_VERSION%%-*}"
+        NEXT_BASE="$NEW_VERSION"
+
+        # The tree must BE the beta's tree. Anything else and what ships is not
+        # what was gated.
+        BETA_SHA="$(git rev-parse "${FROM_BETA}^{commit}")"
+        HEAD_SHA="$(git rev-parse HEAD)"
+        if [ "$BETA_SHA" != "$HEAD_SHA" ]; then
+            echo -e "${RED}ERROR: HEAD is not the commit tagged $FROM_BETA${NC}" >&2
+            echo "  HEAD      $HEAD_SHA" >&2
+            echo "  $FROM_BETA  $BETA_SHA" >&2
+            echo "Check out the beta commit before promoting. Promoting a different" >&2
+            echo "tree ships code that never soaked." >&2
+            exit 1
+        fi
+        ;;
 esac
 
 # update-versions.sh's own accepted shape. Fail here rather than halfway
@@ -240,6 +296,11 @@ if [ -n "$BASE_TAG_OVERRIDE" ]; then
         exit 1
     fi
     BASE_TAG="$BASE_TAG_OVERRIDE"
+elif [ "$CHANNEL" = "stable" ]; then
+    # For a stable promotion the interesting delta is "since the last STABLE",
+    # not since the beta we are promoting — describe would return that beta at
+    # distance 0 and report nothing new. --exclude drops prerelease tags.
+    BASE_TAG="$(git describe --tags --abbrev=0 --match 'v*' --exclude '*-*' HEAD 2>/dev/null || true)"
 else
     BASE_TAG="$(git describe --tags --abbrev=0 --match 'v*' HEAD 2>/dev/null || true)"
 fi
@@ -262,8 +323,13 @@ echo
 echo -e "${BLUE}=== beads channel promotion — ${CHANNEL} ===${NC}"
 echo
 printf '  %-22s %s\n' "current version"   "$CURRENT_VERSION"
-printf '  %-22s %s\n' "base bump"         "${BUMP}${AUTO_NOTE}"
-printf '  %-22s %s\n' "next base"         "$NEXT_BASE"
+if [ "$CHANNEL" = "stable" ]; then
+    printf '  %-22s %s\n' "promoting"     "$FROM_BETA"
+    printf '  %-22s %s\n' "version source" "the beta's base version (not recomputed)"
+else
+    printf '  %-22s %s\n' "base bump"     "${BUMP}${AUTO_NOTE}"
+    printf '  %-22s %s\n' "next base"     "$NEXT_BASE"
+fi
 printf '  %-22s %s\n' "channel version"   "$NEW_VERSION"
 printf '  %-22s %s\n' "ancestor tag"      "${BASE_TAG:-<none found>}"
 printf '  %-22s %s\n' "commit"            "$(git rev-parse --short HEAD)"

--- a/scripts/channel-promote.sh
+++ b/scripts/channel-promote.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# channel-promote.sh — compute and stage a channel build for beads
+# =============================================================================
+#
+# Part of the release-channel proposal for gastownhall/beads (issue #5867).
+# Chrome-style channels: canary -> dev -> beta -> stable.
+#
+# This script does the *version arithmetic and prep* for a channel build. It
+# does not tag, does not push, and does not publish. Those are the workflow's
+# job, and stable promotion additionally requires a human approval.
+#
+# It deliberately calls the project's own scripts rather than reimplementing
+# them, so a channel build performs byte-for-byte the prep that RELEASING.md
+# prescribes:
+#
+#   scripts/update-versions.sh <version>     all 11 version-bearing files
+#   (cd integrations/beads-mcp && uv lock)   MCP lockfile, or Package Gate reds
+#   scripts/check-versions.sh                consistency validation
+#
+# DRY RUN BY DEFAULT. Nothing is written without --apply.
+#
+# Usage:
+#   channel-promote.sh --channel dev  [--bump auto|minor|patch] [--stamp YYYYMMDD] [--apply]
+#   channel-promote.sh --channel beta [--bump auto|minor|patch] [--seq N] [--apply]
+#
+# Canary is deliberately NOT a valid channel here — see "Why canary has no
+# version" below.
+# =============================================================================
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+
+CHANNEL=""
+BUMP="auto"
+STAMP=""
+SEQ=""
+BASE_TAG_OVERRIDE=""
+APPLY=0
+
+usage() {
+    cat <<'USAGE'
+Usage: channel-promote.sh --channel <dev|beta> [options]
+
+Options:
+  --channel <dev|beta>   Which channel to stage a build for. Required.
+  --bump <auto|minor|patch>
+                         How to derive the next base version from the current
+                         one. "auto" (default) reads CHANGELOG [Unreleased]:
+                         a "### Added" section means minor, otherwise patch.
+  --stamp <YYYYMMDD>     Dev builds only. Defaults to today (UTC).
+  --seq <N>              Beta builds only. Defaults to 1, or one past the
+                         highest existing beta tag for the same base version.
+  --base-tag <tag>       Compare the schema delta against this tag instead of
+                         the nearest ancestor tag. Use when promoting a beta
+                         from a prior beta rather than from a stable line.
+                         Must be an ancestor of HEAD.
+  --apply                Actually write. Without this, nothing is modified.
+  -h, --help             This text.
+
+Exit codes:
+  0  staged (or dry-run computed) successfully
+  1  usage or precondition error
+  2  the computed version is not representable on a required channel
+  3  a called project script failed
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --channel) CHANNEL="${2:-}"; shift 2 ;;
+        --bump)    BUMP="${2:-}"; shift 2 ;;
+        --stamp)   STAMP="${2:-}"; shift 2 ;;
+        --seq)     SEQ="${2:-}"; shift 2 ;;
+        --base-tag) BASE_TAG_OVERRIDE="${2:-}"; shift 2 ;;
+        --apply)   APPLY=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo -e "${RED}Unknown argument: $1${NC}" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+# -----------------------------------------------------------------------------
+# Preconditions
+# -----------------------------------------------------------------------------
+
+case "$CHANNEL" in
+    dev|beta) ;;
+    canary)
+        cat >&2 <<'CANARY'
+ERROR: canary takes no version bump.
+
+A canary build is "main, built" — it is not a candidate for anything, so it
+carries no version of its own and mutates no version-bearing file. The channel
+workflow fast-forwards refs/heads/channel/canary and refreshes a single rolling
+prerelease whose assets are replaced in place.
+
+This is not only a simplification. A canary identifier is NOT REPRESENTABLE in
+PEP 440, so it cannot be written into integrations/beads-mcp at all:
+
+    1.3.0-dev.20260825    -> valid, normalises to 1.3.0.dev20260825
+    1.3.0-beta.1          -> valid, normalises to 1.3.0b1
+    1.3.0-canary.abc1234  -> INVALID
+    1.3.0-canary.20260825 -> INVALID  (numeric suffix does not help; PEP 440
+                                       admits only a/b/rc/post/dev labels)
+
+Verified with python packaging.version on 2026-08-25.
+CANARY
+        exit 2 ;;
+    "") echo -e "${RED}ERROR: --channel is required${NC}" >&2; usage >&2; exit 1 ;;
+    *)  echo -e "${RED}ERROR: unknown channel '$CHANNEL'${NC}" >&2; exit 1 ;;
+esac
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$REPO_ROOT" ]; then
+    echo -e "${RED}ERROR: not inside a git repository${NC}" >&2; exit 1
+fi
+cd "$REPO_ROOT"
+
+for f in cmd/bd/version.go scripts/update-versions.sh scripts/check-versions.sh CHANGELOG.md; do
+    if [ ! -e "$f" ]; then
+        echo -e "${RED}ERROR: $f not found — is this the beads repo?${NC}" >&2; exit 1
+    fi
+done
+
+# -----------------------------------------------------------------------------
+# Current version, next base version
+# -----------------------------------------------------------------------------
+
+CURRENT_VERSION="$(grep 'Version = ' cmd/bd/version.go | head -1 | sed 's/.*"\(.*\)".*/\1/')"
+if [ -z "$CURRENT_VERSION" ]; then
+    echo -e "${RED}ERROR: could not read Version from cmd/bd/version.go${NC}" >&2; exit 1
+fi
+CURRENT_BASE="${CURRENT_VERSION%%-*}"
+
+IFS='.' read -r MAJ MIN PAT <<< "$CURRENT_BASE"
+
+# "auto": a new feature in [Unreleased] means a minor bump; otherwise patch.
+# Read only the [Unreleased] block, stopping at the next version heading.
+if [ "$BUMP" = "auto" ]; then
+    UNRELEASED="$(awk '/^## \[Unreleased\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md || true)"
+    if printf '%s' "$UNRELEASED" | grep -qE '^### Added'; then
+        BUMP="minor"
+    else
+        BUMP="patch"
+    fi
+    AUTO_NOTE=" (auto)"
+else
+    AUTO_NOTE=""
+fi
+
+case "$BUMP" in
+    minor) NEXT_BASE="${MAJ}.$((MIN + 1)).0" ;;
+    patch) NEXT_BASE="${MAJ}.${MIN}.$((PAT + 1))" ;;
+    *) echo -e "${RED}ERROR: --bump must be auto, minor or patch${NC}" >&2; exit 1 ;;
+esac
+
+# -----------------------------------------------------------------------------
+# Channel version string
+# -----------------------------------------------------------------------------
+
+case "$CHANNEL" in
+    dev)
+        [ -n "$STAMP" ] || STAMP="$(date -u +%Y%m%d)"
+        if ! printf '%s' "$STAMP" | grep -qE '^[0-9]{8}$'; then
+            echo -e "${RED}ERROR: --stamp must be YYYYMMDD${NC}" >&2; exit 1
+        fi
+        NEW_VERSION="${NEXT_BASE}-dev.${STAMP}"
+        ;;
+    beta)
+        if [ -z "$SEQ" ]; then
+            HIGHEST="$(git tag --list "v${NEXT_BASE}-beta.*" \
+                        | sed "s/^v${NEXT_BASE}-beta\.//" \
+                        | grep -E '^[0-9]+$' | sort -n | tail -1 || true)"
+            SEQ=$(( ${HIGHEST:-0} + 1 ))
+        fi
+        if ! printf '%s' "$SEQ" | grep -qE '^[0-9]+$'; then
+            echo -e "${RED}ERROR: --seq must be an integer${NC}" >&2; exit 1
+        fi
+        NEW_VERSION="${NEXT_BASE}-beta.${SEQ}"
+        ;;
+esac
+
+# update-versions.sh's own accepted shape. Fail here rather than halfway
+# through an eleven-file rewrite.
+if ! [[ $NEW_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    echo -e "${RED}ERROR: '$NEW_VERSION' is not a shape update-versions.sh accepts${NC}" >&2
+    exit 2
+fi
+
+# The MCP package is Python: the identifier must also survive PEP 440, or the
+# Package Gate (MCP) goes red at publish time rather than here.
+if command -v python3 >/dev/null 2>&1; then
+    if ! python3 - "$NEW_VERSION" <<'PY' 2>/dev/null
+import sys
+try:
+    from packaging.version import Version
+except ImportError:
+    sys.exit(0)          # cannot check; do not block on a missing dev dep
+try:
+    Version(sys.argv[1])
+except Exception:
+    sys.exit(1)
+PY
+    then
+        echo -e "${RED}ERROR: '$NEW_VERSION' is not representable in PEP 440${NC}" >&2
+        echo "       integrations/beads-mcp cannot carry this identifier." >&2
+        exit 2
+    fi
+fi
+
+# -----------------------------------------------------------------------------
+# Migration-boundary signal
+# -----------------------------------------------------------------------------
+#
+# The base is the nearest ANCESTOR tag, never "the latest release". beads has
+# tags that are not on this line at all — v1.2.2 is a hotfix re-release off the
+# v1.1 line and is not an ancestor of main — so tag-by-date or tag-by-name
+# would silently compare against a tree this branch never contained.
+
+MIGRATION_DIR="internal/storage/schema/migrations"
+
+if [ -n "$BASE_TAG_OVERRIDE" ]; then
+    if ! git rev-parse --verify --quiet "${BASE_TAG_OVERRIDE}^{commit}" >/dev/null; then
+        echo -e "${RED}ERROR: --base-tag '$BASE_TAG_OVERRIDE' is not a known ref${NC}" >&2
+        exit 1
+    fi
+    # A base that is not an ancestor compares against a tree this branch never
+    # contained, which is how v1.2.2 would silently become the baseline.
+    if ! git merge-base --is-ancestor "$BASE_TAG_OVERRIDE" HEAD; then
+        echo -e "${RED}ERROR: --base-tag '$BASE_TAG_OVERRIDE' is not an ancestor of HEAD${NC}" >&2
+        echo "       Comparing against an off-line tag reports a fictional delta." >&2
+        exit 1
+    fi
+    BASE_TAG="$BASE_TAG_OVERRIDE"
+else
+    BASE_TAG="$(git describe --tags --abbrev=0 --match 'v*' HEAD 2>/dev/null || true)"
+fi
+
+if [ -n "$BASE_TAG" ]; then
+    # Top-level migrations only: the ignored/ subdirectory is not applied.
+    NEW_MIGRATIONS="$(git diff --name-only --diff-filter=A "${BASE_TAG}..HEAD" -- "$MIGRATION_DIR" 2>/dev/null \
+                       | grep -E "^${MIGRATION_DIR}/[0-9]{4}_.*\.up\.sql$" || true)"
+    MIGRATION_COUNT="$(printf '%s' "$NEW_MIGRATIONS" | grep -c . || true)"
+else
+    NEW_MIGRATIONS=""
+    MIGRATION_COUNT="unknown"
+fi
+
+# -----------------------------------------------------------------------------
+# Report
+# -----------------------------------------------------------------------------
+
+echo
+echo -e "${BLUE}=== beads channel promotion — ${CHANNEL} ===${NC}"
+echo
+printf '  %-22s %s\n' "current version"   "$CURRENT_VERSION"
+printf '  %-22s %s\n' "base bump"         "${BUMP}${AUTO_NOTE}"
+printf '  %-22s %s\n' "next base"         "$NEXT_BASE"
+printf '  %-22s %s\n' "channel version"   "$NEW_VERSION"
+printf '  %-22s %s\n' "ancestor tag"      "${BASE_TAG:-<none found>}"
+printf '  %-22s %s\n' "commit"            "$(git rev-parse --short HEAD)"
+echo
+
+if [ "$MIGRATION_COUNT" = "unknown" ]; then
+    echo -e "  ${YELLOW}schema delta: UNKNOWN — no ancestor tag found${NC}"
+elif [ "$MIGRATION_COUNT" -eq 0 ]; then
+    echo -e "  ${GREEN}schema delta: none — this span is schema-compatible${NC}"
+else
+    echo -e "  ${YELLOW}schema delta: ${MIGRATION_COUNT} migration(s) since ${BASE_TAG}${NC}"
+    printf '%s\n' "$NEW_MIGRATIONS" | sed 's|^|    |'
+    if [ "$CHANNEL" = "beta" ] && [ "$MIGRATION_COUNT" -gt 1 ]; then
+        echo
+        echo -e "  ${RED}BLOCKED: a beta may carry at most one schema step.${NC}"
+        echo "  Twelve forward-only steps in one release is the shape that broke"
+        echo "  v1.2.1. Cut a beta at the first migration boundary instead, or"
+        echo "  override deliberately in the workflow dispatch."
+        exit 1
+    fi
+fi
+echo
+
+# Machine-readable for the calling workflow.
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "version=$NEW_VERSION"
+        echo "base_version=$NEXT_BASE"
+        echo "tag=v$NEW_VERSION"
+        echo "channel=$CHANNEL"
+        echo "base_tag=${BASE_TAG:-}"
+        echo "migration_count=$MIGRATION_COUNT"
+    } >> "$GITHUB_OUTPUT"
+fi
+
+if [ "$APPLY" -ne 1 ]; then
+    echo -e "${YELLOW}DRY RUN — nothing written. Re-run with --apply to stage.${NC}"
+    exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Apply: the project's own prep, in the project's own order
+# -----------------------------------------------------------------------------
+
+echo -e "${BLUE}--> scripts/update-versions.sh $NEW_VERSION${NC}"
+./scripts/update-versions.sh "$NEW_VERSION" || { echo -e "${RED}update-versions.sh failed${NC}" >&2; exit 3; }
+
+if command -v uv >/dev/null 2>&1; then
+    echo -e "${BLUE}--> uv lock (integrations/beads-mcp)${NC}"
+    ( cd integrations/beads-mcp && uv lock ) || { echo -e "${RED}uv lock failed${NC}" >&2; exit 3; }
+else
+    echo -e "${RED}ERROR: uv not found.${NC}" >&2
+    echo "The MCP lockfile must be regenerated in the same commit as the version" >&2
+    echo "bump or the Package Gate (MCP) goes red. Refusing to stage a build that" >&2
+    echo "is known-red. Install uv or run this where uv is available." >&2
+    exit 3
+fi
+
+echo -e "${BLUE}--> scripts/check-versions.sh${NC}"
+./scripts/check-versions.sh || { echo -e "${RED}check-versions.sh failed${NC}" >&2; exit 3; }
+
+echo
+echo -e "${GREEN}Staged $NEW_VERSION.${NC} Working tree now carries the version bump."
+echo "The workflow commits, fast-forwards refs/heads/channel/${CHANNEL}, and tags."
+echo "This script does not tag, push, or publish."

--- a/scripts/channel-promote.sh
+++ b/scripts/channel-promote.sh
@@ -37,6 +37,7 @@ BUMP="auto"
 STAMP=""
 SEQ=""
 BASE_TAG_OVERRIDE=""
+ALLOW_MULTI_MIGRATION=0
 APPLY=0
 
 usage() {
@@ -52,6 +53,11 @@ Options:
   --stamp <YYYYMMDD>     Dev builds only. Defaults to today (UTC).
   --seq <N>              Beta builds only. Defaults to 1, or one past the
                          highest existing beta tag for the same base version.
+  --allow-multi-migration
+                         Beta only. Cut across more than one schema step. The
+                         default refusal exists because twelve forward-only
+                         steps in one release is what broke v1.2.1; override
+                         deliberately or not at all.
   --base-tag <tag>       Compare the schema delta against this tag instead of
                          the nearest ancestor tag. Use when promoting a beta
                          from a prior beta rather than from a stable line.
@@ -74,6 +80,7 @@ while [ $# -gt 0 ]; do
         --stamp)   STAMP="${2:-}"; shift 2 ;;
         --seq)     SEQ="${2:-}"; shift 2 ;;
         --base-tag) BASE_TAG_OVERRIDE="${2:-}"; shift 2 ;;
+        --allow-multi-migration) ALLOW_MULTI_MIGRATION=1; shift ;;
         --apply)   APPLY=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *) echo -e "${RED}Unknown argument: $1${NC}" >&2; usage >&2; exit 1 ;;
@@ -270,12 +277,20 @@ else
     echo -e "  ${YELLOW}schema delta: ${MIGRATION_COUNT} migration(s) since ${BASE_TAG}${NC}"
     printf '%s\n' "$NEW_MIGRATIONS" | sed 's|^|    |'
     if [ "$CHANNEL" = "beta" ] && [ "$MIGRATION_COUNT" -gt 1 ]; then
-        echo
-        echo -e "  ${RED}BLOCKED: a beta may carry at most one schema step.${NC}"
-        echo "  Twelve forward-only steps in one release is the shape that broke"
-        echo "  v1.2.1. Cut a beta at the first migration boundary instead, or"
-        echo "  override deliberately in the workflow dispatch."
-        exit 1
+        if [ "$ALLOW_MULTI_MIGRATION" -eq 1 ]; then
+            echo
+            echo -e "  ${YELLOW}OVERRIDDEN: cutting a beta across ${MIGRATION_COUNT} schema steps${NC}"
+            echo "  because --allow-multi-migration was passed. Each step is applied"
+            echo "  forward-only on first access, so a user who hits a problem is"
+            echo "  ${MIGRATION_COUNT} steps from the last good schema, not one."
+        else
+            echo
+            echo -e "  ${RED}BLOCKED: a beta may carry at most one schema step.${NC}"
+            echo "  Twelve forward-only steps in one release is the shape that broke"
+            echo "  v1.2.1. Cut a beta at the first migration boundary instead, or"
+            echo "  pass --allow-multi-migration deliberately."
+            exit 1
+        fi
     fi
 fi
 echo


### PR DESCRIPTION
Proposed answer to #5867. Opening it as a PR rather than more prose in the issue, because the shape is easier to judge from the diff than from a description — and easy to close if it is not the direction you want.

## The problem this tries to solve

Cutting a release means a person runs the gate by hand — full suite, the upgrade smoke matrix, the regression baseline, the package gates — and then writes the evidence into `release-gates/<tag>.md` themselves. That is careful work and the artefacts show it. It is also expensive enough that it can only happen occasionally, and the less often it happens the more each one has to carry, which makes the next one heavier again.

So this is not a proposal to be less careful. It is a proposal to move the same gates onto a schedule so that by the time anyone is asked a question, the answer is already evidenced.

## What it adds

Four channels, modelled on Chrome. A channel is a branch; promotion moves a branch pointer.

| Channel | Cut from | Trigger | Version | Published as |
|---|---|---|---|---|
| **Canary** | `main` HEAD | every merge | none | one rolling prerelease, assets replaced |
| **Dev** | `main` HEAD | nightly, if the nightly suite passed | `X.Y.Z-dev.<YYYYMMDD>` | prerelease |
| **Beta** | a Dev commit | weekly | `X.Y.Z-beta.N` | prerelease |
| **Stable** | a Beta commit | on approval | `X.Y.Z` | release → PyPI, npm, homebrew-core |

Code flows one way, and a channel branch never merges from `main` once cut — fixes reach Beta by deliberate cherry-pick. That also means there is always a maintained stable line to build a hotfix on.

## Why this is a smaller change than it looks

**`release.yml` is untouched**, because it already does the right thing:

- `.goreleaser.yml` sets `prerelease: auto`
- `publish-pypi` and `publish-npm` are both gated `!contains(github.ref_name, '-')`
- homebrew-core autobumps from non-prerelease releases only

A hyphenated tag already publishes a full prerelease and already reaches none of the stable channels. `v1.2.2-rc.1` exercised exactly that path. This PR adds the thing that *cuts* candidates; the publishing was already there.

**The gate split is whatever the tag does not already fire**, so nothing is duplicated:

| Pre-tag, in `channel-beta.yml` | Why here |
|---|---|
| `make test`, `make test-regression` | `main.yml` and `regression.yml` trigger on `push: main` only, so they would otherwise never see a candidate |
| `check-migration-hygiene.sh`, `ci-package-mcp`, `ci-package-npm` | cheap, and failing before the tag exists is better than after |

| Post-tag, unchanged | Trigger |
|---|---|
| `cross-version-smoke.yml` (30-release upgrade matrix) | `push: tags: v*` |
| `migration-test.yml`, `release.yml` | `push: tags: v*` |

**The prep is yours, not a reimplementation.** `channel-promote.sh` calls `update-versions.sh`, `uv lock` and `check-versions.sh` in the order `RELEASING.md` prescribes.

## Promoting to stable

`channel-stable.yml` has two jobs. `dossier` assembles `release-gates/<tag>.md` in your existing format and publishes it as the job summary — it blocks nothing and changes nothing. `promote` is gated on a `stable-release` environment, so GitHub holds it until a required reviewer approves, and records who did.

`v*` tag creation stays restricted to release maintainers; the environment's reviewer list is that same set. **Only the labour moves, not the authority.** The job also queries the environment and fails closed if it has no reviewers, so it cannot quietly promote unattended.

Every figure in the dossier is queried rather than asserted — gate results from the check runs recorded on the candidate, soak from the release's `published_at`, manifest and schema delta from git ancestry.

Three verdicts, not two: `PASS`, `FAIL` (an undeclared red), and `REVIEW` (nothing red, but a gate never reached a verdict). That third one exists because of a real result — see below.

## Two details that came out of testing rather than design

**A Beta carries at most one schema migration** unless explicitly overridden. Migrations apply forward-only on first access, so the number of steps in a release is the distance a user is from the last schema their installed binary can read. Most spans carry none, so the rule rarely binds.

**A cancelled check is not a failure, and expected reds need declaring.** I tested the dossier against `v1.2.2-rc.1`, and my first version failed it on two checks — `Upgrade smoke (v1.2.1 → candidate)` and `Migration fidelity`. Both were things that release deliberately shipped with: the first is the forward skew your own gate file pre-declares as an expected signature, and the second was *cancelled*, not failed. A binary pass/fail rule would have blocked a release you correctly made. Hence `--expect-red 'GLOB=reason'`, which records the declaration and its reason in the dossier, and the `REVIEW` verdict for gates that never reached one.

## What is sitting unshipped right now

Commit 4 adds `--preview`, which answers "what would a release cut from here first ship?" without needing a candidate. Run against this branch's base:

```
valid stable releases        93
last released ancestor       v1.1.0
commits in no release        1303
pull requests unshipped      677
oldest unshipped             2026-05-18 (99d)
schema steps                 13
```

Two notes on the method, because both matter and both bite. The unreleased set is everything in **no** valid release (`git rev-list <ref> --not <every valid tag>`), not everything since the newest tag — those differ whenever a release was cut from a side branch. And "valid" comes from what GitHub published rather than from the tag string: `v1.2.1` has a stable-looking *name* but is flagged a prerelease, so a `--exclude '*-*'` filter would accept it as a baseline and report a fraction of the truth. The PR-count figure is a floor — it only sees PRs with a `(#N)` commit subject.

Relevant to #5789 as much as to this issue.

## Setup this needs, which the workflows cannot grant themselves

1. `refs/heads/channel/*` writable by `GITHUB_TOKEN`.
2. The `v*` tag ruleset admitting the Actions bot **for prerelease tags**. If you would rather not widen it at all, run `channel-dev.yml` with `dry_run: true` and tag by hand from the prepared commit — everything up to the tag is still automated.
3. An environment named `stable-release` with required reviewers.

Flagging these here rather than letting them surface as a failed first run.

## What I have verified, and what I have not

Verified against this base:

- `update-versions.sh` accepts `1.3.0-dev.20260826` and rewrites all version-bearing files correctly, with the Windows PE numeric fields stripped to `1.3.0` while the string fields keep the full identifier.
- `check-versions.sh` accepts the identifier everywhere and fails only on the `uv.lock` pin — so the `uv lock` step is load-bearing, and the script refuses to stage without `uv` rather than producing a known-red build.
- The PEP 440 claims are measured with `packaging.version`, not reasoned.
- The one-migration guard blocks a genuine 13-migration span and proceeds under the override; a non-ancestor base tag is refused (`v1.2.2` is not on this line, so a naive "latest tag" baseline would compare against a tree `main` never contained).
- The dossier assembles from live data: 44 check runs read for `v1.2.2-rc.1`, soak measured from the real `published_at`, previous stable resolved to `v1.1.2` by ancestry.
- `make ci-pr-policy`: `check-versions.sh` and `check-go-install-guidance.sh` pass. `check-build-tags.sh` needs bash 4 (`mapfile`) and does not run on macOS, so I verified it by inspection instead — these files contain no bare `go build|test|run|generate|install`, only `make` targets, so the ICU guard cannot be implicated.
- `make ci-pr-lint`: the 5 pre-existing `gosec` findings, in files this PR does not touch. This change adds **no Go at all**, and `golangci-lint` only lints Go, so the result is necessarily identical to the base commit.

Not verified, and I would rather say so than imply otherwise:

- **None of these four workflows has ever run.** The schedules, the `workflow_run` gating, the two-job hand-offs, the check-run publish, the environment hold and every tag push are unexercised. The YAML parses and the action pins are taken from your existing workflows; that is all.
- **No `stable-release` environment exists anywhere I can test**, so the approval hold — the central mechanism here — is reasoned from the Actions documentation, not observed.
- **I did not run `make test` or `make test-regression`.** This PR adds no Go, so per `engdocs/TESTING.md` they are the wrong gate for it, and a green from them would prove nothing about this change. They are named in the workflow from the Makefile, not observed passing on a candidate.

## Take as much of it as you want

It is one PR so the whole design is visible, but it is **three independent commits** and any prefix of them is a working system:

| Commit | Adds | On its own |
|---|---|---|
| 1 | Canary + Dev, the shared script, the docs | merged work becomes installable between releases — most of what #5867 asked for |
| 2 | Beta and the full release gate | adds a soak track with the gate attached |
| 3 | Stable promotion behind the approval gate | makes releasing a decision |
| 4 | `--preview`, reporting unshipped work | answers "should we cut?" with no candidate needed |

Commit 1 changes nothing about how stable releases are cut today. So if only the first is interesting, cherry-pick it and drop the rest — no rewrite needed at your end, and none at mine.

Equally happy to be told this is the wrong direction — the issue was a question, and this is only one answer to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
