### PR TITLE
feat(count): support --metadata-field filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`bd count` supports repeatable `--metadata-field key=value` filters**
+  ([#6023](https://github.com/gastownhall/beads/issues/6023)), so callers can
+  count the same metadata-scoped set `bd list` returns without fetching every
+  row.
+
 - **The events journal records WHO performed each mutation.** `bd_events_journal`
   gains an `actor` column (migration 0066 plus its ignored-series twin 0025, so
   upgraded workspaces and fresh clones converge on the same shape), stamped

--- a/cmd/bd/count.go
+++ b/cmd/bd/count.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/metrics"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/issueops"
 )
 
@@ -88,6 +90,7 @@ func parseCountRequest(cmd *cobra.Command) (issueops.CountRequest, issueops.Coun
 	noAssignee, _ := cmd.Flags().GetBool("no-assignee")
 	noLabels, _ := cmd.Flags().GetBool("no-labels")
 	includeInfra, _ := cmd.Flags().GetBool("include-infra")
+	metadataFieldFlags, _ := cmd.Flags().GetStringArray("metadata-field")
 
 	request := issueops.CountRequest{
 		Status:        status,
@@ -104,6 +107,19 @@ func parseCountRequest(cmd *cobra.Command) (issueops.CountRequest, issueops.Coun
 		NoAssignee:    noAssignee,
 		NoLabels:      noLabels,
 		IncludeInfra:  includeInfra,
+	}
+	if len(metadataFieldFlags) > 0 {
+		request.MetadataFields = make(map[string]string, len(metadataFieldFlags))
+		for _, mf := range metadataFieldFlags {
+			k, v, ok := strings.Cut(mf, "=")
+			if !ok || k == "" {
+				return issueops.CountRequest{}, "", HandleErrorRespectJSON("invalid --metadata-field: expected key=value, got %q", mf)
+			}
+			if err := storage.ValidateMetadataKey(k); err != nil {
+				return issueops.CountRequest{}, "", HandleErrorRespectJSON("invalid --metadata-field key: %v", err)
+			}
+			request.MetadataFields[k] = v
+		}
 	}
 
 	if cmd.Flags().Changed("priority") {
@@ -262,6 +278,7 @@ func registerCountFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("empty-description", false, "Filter issues with empty description")
 	cmd.Flags().Bool("no-assignee", false, "Filter issues with no assignee")
 	cmd.Flags().Bool("no-labels", false, "Filter issues with no labels")
+	cmd.Flags().StringArray("metadata-field", nil, "Filter by metadata field (key=value, repeatable)")
 
 	// Priority ranges
 	cmd.Flags().Int("priority-min", 0, "Filter by minimum priority (inclusive)")

--- a/cmd/bd/count_embedded_test.go
+++ b/cmd/bd/count_embedded_test.go
@@ -95,7 +95,7 @@ func TestEmbeddedCount(t *testing.T) {
 
 	t.Run("basic_count_no_filters", func(t *testing.T) {
 		out := strings.TrimSpace(bdCount(t, bd, dir))
-		// Should return a number >= 8 (we created 8 issues)
+		// Should return a number >= 9 (we created 9 issues)
 		if out == "0" {
 			t.Error("expected non-zero count")
 		}
@@ -168,6 +168,8 @@ func TestEmbeddedCount(t *testing.T) {
 			t.Errorf("expected at least 2 issues with either label, got %d", count)
 		}
 	})
+
+	// ===== Metadata filter =====
 
 	t.Run("filter_by_metadata_field", func(t *testing.T) {
 		got := int(bdCountJSON(t, bd, dir, "--metadata-field", "count_scope=matching")["count"].(float64))

--- a/cmd/bd/count_embedded_test.go
+++ b/cmd/bd/count_embedded_test.go
@@ -89,6 +89,7 @@ func TestEmbeddedCount(t *testing.T) {
 	bdCreate(t, bd, dir, "Count labeled", "--type", "task", "--label", "frontend", "--label", "urgent")
 	bdCreate(t, bd, dir, "Count labeled two", "--type", "task", "--label", "backend")
 	bdCreate(t, bd, dir, "Count notes issue", "--type", "task", "--description", "notes keyword here")
+	bdCreate(t, bd, dir, "Count metadata issue", "--type", "task", "--metadata", `{"count_scope":"matching"}`)
 
 	// ===== Basic count =====
 
@@ -165,6 +166,14 @@ func TestEmbeddedCount(t *testing.T) {
 		count := int(m["count"].(float64))
 		if count < 2 {
 			t.Errorf("expected at least 2 issues with either label, got %d", count)
+		}
+	})
+
+	t.Run("filter_by_metadata_field", func(t *testing.T) {
+		got := int(bdCountJSON(t, bd, dir, "--metadata-field", "count_scope=matching")["count"].(float64))
+		want := len(bdListJSON(t, bd, dir, "--all", "--limit", "0", "--metadata-field", "count_scope=matching"))
+		if got != want || got != 1 {
+			t.Errorf("count --metadata-field = %d, want list cardinality %d and fixture count 1", got, want)
 		}
 	})
 

--- a/cmd/bd/count_filter_test.go
+++ b/cmd/bd/count_filter_test.go
@@ -64,6 +64,7 @@ func TestParseCountRequestCarriesEveryFilterFlag(t *testing.T) {
 		"empty-description": "true",
 		"no-assignee":       "true",
 		"no-labels":         "true",
+		"metadata-field":    "team=platform",
 		"priority":          "1",
 		"priority-min":      "0",
 		"priority-max":      "4",
@@ -94,32 +95,47 @@ func TestParseCountRequestCarriesEveryFilterFlag(t *testing.T) {
 	}
 	priority, min, max := 1, 0, 4
 	want := issueops.CountRequest{
-		Status:        "closed",
-		IssueType:     "bug",
-		Assignee:      "alice",
-		Priority:      &priority,
-		PriorityMin:   &min,
-		PriorityMax:   &max,
-		Labels:        []string{"alpha", "beta"},
-		LabelsAny:     []string{"gamma"},
-		TitleSearch:   "needle",
-		IDFilter:      "bd-1,bd-2",
-		TitleContains: "tc",
-		DescContains:  "dc",
-		NotesContains: "nc",
-		CreatedAfter:  day(1),
-		CreatedBefore: day(2),
-		UpdatedAfter:  day(3),
-		UpdatedBefore: day(4),
-		ClosedAfter:   day(5),
-		ClosedBefore:  day(6),
-		EmptyDesc:     true,
-		NoAssignee:    true,
-		NoLabels:      true,
-		IncludeInfra:  true,
+		Status:         "closed",
+		IssueType:      "bug",
+		Assignee:       "alice",
+		Priority:       &priority,
+		PriorityMin:    &min,
+		PriorityMax:    &max,
+		Labels:         []string{"alpha", "beta"},
+		LabelsAny:      []string{"gamma"},
+		TitleSearch:    "needle",
+		IDFilter:       "bd-1,bd-2",
+		TitleContains:  "tc",
+		DescContains:   "dc",
+		NotesContains:  "nc",
+		CreatedAfter:   day(1),
+		CreatedBefore:  day(2),
+		UpdatedAfter:   day(3),
+		UpdatedBefore:  day(4),
+		ClosedAfter:    day(5),
+		ClosedBefore:   day(6),
+		EmptyDesc:      true,
+		NoAssignee:     true,
+		NoLabels:       true,
+		MetadataFields: map[string]string{"team": "platform"},
+		IncludeInfra:   true,
 	}
 	if !reflect.DeepEqual(request, want) {
 		t.Errorf("parseCountRequest built\n %#v\nwant\n %#v", request, want)
+	}
+}
+
+func TestParseCountRequestRejectsInvalidMetadataField(t *testing.T) {
+	for _, value := range []string{"team", "bad$key=value"} {
+		t.Run(value, func(t *testing.T) {
+			flags := newCountFlagSet(t)
+			if err := flags.Flags().Set("metadata-field", value); err != nil {
+				t.Fatalf("set --metadata-field: %v", err)
+			}
+			if _, _, err := parseCountRequest(flags); err == nil {
+				t.Fatalf("parseCountRequest accepted --metadata-field %q", value)
+			}
+		})
 	}
 }
 

--- a/cmd/bd/count_proxied_integration_test.go
+++ b/cmd/bd/count_proxied_integration_test.go
@@ -30,6 +30,7 @@ func TestProxiedServerCount(t *testing.T) {
 	bdProxiedCreate(t, bd, p.dir, "Count labeled", "--type", "task", "--label", "frontend", "--label", "urgent")
 	bdProxiedCreate(t, bd, p.dir, "Count labeled two", "--type", "task", "--label", "backend")
 	bdProxiedCreate(t, bd, p.dir, "Count notes issue", "--type", "task", "--description", "notes keyword here")
+	bdProxiedCreate(t, bd, p.dir, "Count metadata issue", "--type", "task", "--metadata", `{"count_scope":"matching"}`)
 
 	// countInt runs "count <args>" and parses the plain integer stdout.
 	countInt := func(t *testing.T, args ...string) int {
@@ -118,6 +119,13 @@ func TestProxiedServerCount(t *testing.T) {
 		}
 		if got < 1 {
 			t.Errorf("expected at least 1 closed issue, got %d", got)
+		}
+	})
+
+	t.Run("filter_by_metadata_field", func(t *testing.T) {
+		got := countJSONInt(t, "--metadata-field", "count_scope=matching")
+		if want := listCount("--metadata-field", "count_scope=matching"); got != want || got != 1 {
+			t.Errorf("count --metadata-field = %d, want list cardinality %d and fixture count 1", got, want)
 		}
 	})
 

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -2315,6 +2315,9 @@ type CountIssuesParams struct {
 	// NoLabels Only issues carrying no label.
 	NoLabels *bool `form:"no_labels,omitempty" json:"no_labels,omitempty"`
 
+	// MetadataField Top-level metadata equality filter in `key=value` form. Repeat the parameter to require every pair. The value is everything after the first `=`; an invalid key is a `400`.
+	MetadataField *[]string `form:"metadata_field,omitempty" json:"metadata_field,omitempty"`
+
 	// IncludeInfra Count the cardinality of `bd list --include-infra --all` instead of the durable plane. IT CHANGES FOUR THINGS AT ONCE, and they are listed rather than summarized because a caller reading "include infra" would expect one:
 	//
 	// the ephemeral wisps tier is MERGED IN, picking up both wisps and the `no_history` beads that are durable work stored in that tier; template molecules are EXCLUDED, which a default count includes; gate beads are EXCLUDED unless `type=gate` asks for them by name; and a `type` this workspace calls infra ROUTES the count to the ephemeral tier instead of the durable one.

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -2315,7 +2315,7 @@ type CountIssuesParams struct {
 	// NoLabels Only issues carrying no label.
 	NoLabels *bool `form:"no_labels,omitempty" json:"no_labels,omitempty"`
 
-	// MetadataField Top-level metadata equality filter in `key=value` form. Repeat the parameter to require every pair. The value is everything after the first `=`; an invalid key is a `400`.
+	// MetadataField Top-level metadata equality filter as `key=value`, split on the first `=`. Repeatable. An invalid key is a 400.
 	MetadataField *[]string `form:"metadata_field,omitempty" json:"metadata_field,omitempty"`
 
 	// IncludeInfra Count the cardinality of `bd list --include-infra --all` instead of the durable plane. IT CHANGES FOUR THINGS AT ONCE, and they are listed rather than summarized because a caller reading "include infra" would expect one:

--- a/internal/httpapi/count_test.go
+++ b/internal/httpapi/count_test.go
@@ -537,14 +537,12 @@ func TestCountParametersMatchTheHandler(t *testing.T) {
 // constants so the server and the role cannot drift; this compares that list
 // against the DOCUMENT, which is the third party to the agreement.
 //
-// IT IS ALSO WHAT MAKES THIS ROLE ErrValidation UNREACHABLE FROM THE WIRE:
-// this handler refuses an unknown group at the edge. Metadata-key validation
-// is likewise repeated at the edge by q.metadataFields. So every
-// `invalid_argument` this operation emits is the transport's, and the shared
-// read failure path never sees a role refusal. If the enum here and the role's
-// constants ever diverged, a value this server accepted and the role refused
-// would arrive as an unclassified 500, which is the regression this comparison
-// prevents.
+// It also keeps the role's group refusal unreachable from the wire: the
+// handler refuses an unknown group at the edge. Metadata validation is a
+// separate path. An invalid key reaches BuildCountFilter, whose role refusal
+// failReadErr classifies as a 400 on `metadata_field`. This test guards only the
+// group vocabulary; if that enum and the role's constants diverged, a value the
+// server accepted and the role refused would arrive as an unclassified 500.
 func TestCountGroupEnumMatchesTheRolesVocabulary(t *testing.T) {
 	doc := loadSpec(t)
 	so := specOps(t, doc)["countIssues"]

--- a/internal/httpapi/count_test.go
+++ b/internal/httpapi/count_test.go
@@ -113,6 +113,7 @@ func TestCountForwardsEveryDocumentedParameter(t *testing.T) {
 		"empty_description": {"true"},
 		"no_assignee":       {"true"},
 		"no_labels":         {"true"},
+		"metadata_field":    {"team=platform", "env=prod"},
 		"include_infra":     {"true"},
 	}.Encode())
 	if resp.StatusCode != http.StatusOK {
@@ -158,9 +159,10 @@ func TestCountForwardsEveryDocumentedParameter(t *testing.T) {
 		ClosedAfter:   at("2026-05-01T00:00:00Z"),
 		ClosedBefore:  at("2026-06-01T00:00:00Z"),
 
-		EmptyDesc:  true,
-		NoAssignee: true,
-		NoLabels:   true,
+		EmptyDesc:      true,
+		NoAssignee:     true,
+		NoLabels:       true,
+		MetadataFields: map[string]string{"team": "platform", "env": "prod"},
 
 		IncludeInfra: true,
 	}
@@ -535,15 +537,14 @@ func TestCountParametersMatchTheHandler(t *testing.T) {
 // constants so the server and the role cannot drift; this compares that list
 // against the DOCUMENT, which is the third party to the agreement.
 //
-// IT IS ALSO WHAT MAKES THE ROLE'S OWN ErrValidation UNREACHABLE FROM THIS
-// OPERATION, which is a fact worth pinning rather than discovering. The count
-// role has exactly one validation refusal — ValidateCountGroup's unknown
-// dimension; BuildCountFilter cannot fail at all — and this handler refuses
-// that dimension at the edge. So every `invalid_argument` this operation emits
-// is the transport's, and the shared read failure path never sees a role
-// refusal. If the enum here and the role's constants ever diverged, a value
-// this server accepted and the role refused would arrive as an unclassified
-// 500, which is the regression this comparison prevents.
+// IT IS ALSO WHAT MAKES THIS ROLE ErrValidation UNREACHABLE FROM THE WIRE:
+// this handler refuses an unknown group at the edge. Metadata-key validation
+// is likewise repeated at the edge by q.metadataFields. So every
+// `invalid_argument` this operation emits is the transport's, and the shared
+// read failure path never sees a role refusal. If the enum here and the role's
+// constants ever diverged, a value this server accepted and the role refused
+// would arrive as an unclassified 500, which is the regression this comparison
+// prevents.
 func TestCountGroupEnumMatchesTheRolesVocabulary(t *testing.T) {
 	doc := loadSpec(t)
 	so := specOps(t, doc)["countIssues"]
@@ -600,11 +601,12 @@ var countFieldForParameter = map[string]string{
 	"empty_description": "EmptyDesc",
 	"no_assignee":       "NoAssignee",
 	"no_labels":         "NoLabels",
+	"metadata_field":    "MetadataFields",
 	"include_infra":     "IncludeInfra",
 }
 
-// TestEveryCountRequestFieldIsPublished: the role publishes 23 filters and the
-// wire publishes all 23. A field added to issueops.CountRequest fails here and
+// TestEveryCountRequestFieldIsPublished: the role publishes 24 filters and the
+// wire publishes all 24. A field added to issueops.CountRequest fails here and
 // NAMES itself, so the choice is made deliberately — publish it, or record why
 // it is withheld — rather than by nobody noticing.
 //

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -712,23 +712,16 @@ var operationCodes = map[string][]Code{
 	// and can refuse them the same way. limit=0's mode-dependent refusal has no
 	// analog here because there is no limit to pass.
 	OpCountReadyWork: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
-	// The ready count's vocabulary exactly, and for the same reasons: a
-	// cardinality has no page, so there is no cursor to invalidate and no
-	// unlimited-read refusal to make; and no 404, because a predicate matching
-	// nothing is 0 — the role has no ErrNotFound at all, which its own doc
-	// states, since a question about a set has an answer even when the set is
-	// empty.
+	// A cardinality has no page, so there is no cursor or unlimited-read
+	// refusal. It has no 404 either: a predicate matching nothing is 0.
 	//
-	// Its 400 is ENTIRELY THE TRANSPORT'S, which is the one way this row differs
-	// from the listings' beside it: a malformed boolean, integer or timestamp, a
-	// repeated single-valued parameter, and a `group_by` outside the closed set.
-	//
-	// No ROLE refusal is reachable. countGroupOf refuses an unknown group and
-	// q.metadataFields refuses a malformed metadata key at the edge, before the
-	// role can reject either. The shared read failure path therefore never
-	// classifies a count. An unrecognized status or type is not a refusal at all
-	// here; the role promises it matches nothing and answers 0.
-	// TestCountGroupEnumMatchesTheRolesVocabulary is what keeps that true.
+	// Its 400s come from both the transport and the ROLE. The transport refuses
+	// malformed values, repeated single-valued parameters and a `group_by`
+	// outside the closed set. countGroupOf stops that last case at the edge.
+	// The role has exactly one reachable refusal: BuildCountFilter rejects an
+	// invalid metadata key. failReadErr classifies it through invalidFilterParam
+	// as a 400 on `metadata_field`. An unrecognized status or type is not a
+	// refusal; the role promises it matches nothing and answers 0.
 	OpCountIssues: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The listing's vocabulary minus the cursor: this operation has none, so
 	// invalid_cursor cannot arise. An unparseable EXPRESSION is an

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -723,12 +723,11 @@ var operationCodes = map[string][]Code{
 	// from the listings' beside it: a malformed boolean, integer or timestamp, a
 	// repeated single-valued parameter, and a `group_by` outside the closed set.
 	//
-	// No ROLE refusal is reachable. issueops.Counter has exactly one
-	// ErrValidation — ValidateCountGroup's unknown dimension, since
-	// BuildCountFilter cannot fail — and countGroupOf refuses that dimension at
-	// the edge, so the shared read failure path never classifies a count. An
-	// unrecognized status or type is not a refusal at all here; the role
-	// promises it matches nothing and answers 0.
+	// No ROLE refusal is reachable. countGroupOf refuses an unknown group and
+	// q.metadataFields refuses a malformed metadata key at the edge, before the
+	// role can reject either. The shared read failure path therefore never
+	// classifies a count. An unrecognized status or type is not a refusal at all
+	// here; the role promises it matches nothing and answers 0.
 	// TestCountGroupEnumMatchesTheRolesVocabulary is what keeps that true.
 	OpCountIssues: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The listing's vocabulary minus the cursor: this operation has none, so

--- a/internal/httpapi/reads.go
+++ b/internal/httpapi/reads.go
@@ -213,9 +213,10 @@ func countFilters(q *query) issueops.CountRequest {
 		ClosedAfter:   q.timestamp("closed_after"),
 		ClosedBefore:  q.timestamp("closed_before"),
 
-		EmptyDesc:  q.boolean("empty_description"),
-		NoAssignee: q.boolean("no_assignee"),
-		NoLabels:   q.boolean("no_labels"),
+		EmptyDesc:      q.boolean("empty_description"),
+		NoAssignee:     q.boolean("no_assignee"),
+		NoLabels:       q.boolean("no_labels"),
+		MetadataFields: q.metadataFields("metadata_field"),
 
 		// The plane switch, forwarded as the boolean the caller sent. What it
 		// MEANS — merge the wisps tier, drop templates, drop gates, and route an

--- a/internal/httpapi/reads_test.go
+++ b/internal/httpapi/reads_test.go
@@ -159,6 +159,7 @@ func TestABuilderRefusalIsTheDocumentedBadRequest(t *testing.T) {
 		{"a has-metadata key the query layer cannot spell", "/v0/beads/issues?has_metadata_key=1bad", "has_metadata_key"},
 		{"a metadata field key on the ready surface", "/v0/beads/ready?metadata_field=1bad=x", "metadata_field"},
 		{"a has-metadata key on the ready surface", "/v0/beads/ready?has_metadata_key=1bad", "has_metadata_key"},
+		{"a metadata field key on the count surface", "/v0/beads/issues:count?metadata_field=1bad=x", "metadata_field"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ts, _ := newReadServer(t, Config{})

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -1859,9 +1859,8 @@ paths:
         - name: metadata_field
           in: query
           description: >-
-            Top-level metadata equality filter in `key=value` form. Repeat the
-            parameter to require every pair. The value is everything after the
-            first `=`; an invalid key is a `400`.
+            Top-level metadata equality filter as `key=value`, split on the
+            first `=`. Repeatable. An invalid key is a 400.
           style: form
           explode: true
           schema:
@@ -1938,11 +1937,12 @@ paths:
             set.
 
 
-            EVERY REFUSAL HERE IS THE TRANSPORT'S. The two predicates the count
-            role can reject are also refused at the edge: an invalid metadata
-            key by `metadata_field`, and an unknown bucketing dimension by
-            `group_by`. An unrecognized `status` or `type` is not a refusal; it
-            matches nothing and answers `0`.
+            A malformed `metadata_field` shape and an unknown `group_by` are
+            transport refusals. An invalid metadata key passes query decoding,
+            then `BuildCountFilter` rejects it and `failReadErr` classifies the
+            role's error as a `400` on `metadata_field`. An unrecognized
+            `status` or `type` is not a refusal; it matches nothing and answers
+            `0`.
           x-bd-codes: [invalid_argument]
           content:
             application/problem+json:

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -1856,6 +1856,18 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: metadata_field
+          in: query
+          description: >-
+            Top-level metadata equality filter in `key=value` form. Repeat the
+            parameter to require every pair. The value is everything after the
+            first `=`; an invalid key is a `400`.
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
         - name: include_infra
           in: query
           description: >-
@@ -1922,15 +1934,15 @@ paths:
           description: >-
             Invalid request: an unknown query parameter, a repeated
             single-valued one, a malformed boolean, integer or RFC 3339 instant,
-            or a `group_by` outside the closed set.
+            a malformed `metadata_field`, or a `group_by` outside the closed
+            set.
 
 
-            EVERY REFUSAL HERE IS THE TRANSPORT'S. Unlike the listings, this
-            operation has no predicate its library surface can turn down: an
-            unrecognized `status` or `type` matches nothing and answers `0`, and
-            the one refusal the count role does make — an unknown bucketing
-            dimension — is refused at the edge above, so it never reaches the
-            role at all.
+            EVERY REFUSAL HERE IS THE TRANSPORT'S. The two predicates the count
+            role can reject are also refused at the edge: an invalid metadata
+            key by `metadata_field`, and an unknown bucketing dimension by
+            `group_by`. An unrecognized `status` or `type` is not a refusal; it
+            matches nothing and answers `0`.
           x-bd-codes: [invalid_argument]
           content:
             application/problem+json:

--- a/internal/workapi/count.go
+++ b/internal/workapi/count.go
@@ -63,6 +63,10 @@ func BuildCountFilter(in issueops.CountRequest, cfg ListConfig) (types.IssueFilt
 		Priority:            in.Priority,
 		PriorityMin:         in.PriorityMin,
 		PriorityMax:         in.PriorityMax,
+		MetadataFields:      in.MetadataFields,
+	}
+	if err := ValidateMetadataFilters(in.MetadataFields, ""); err != nil {
+		return types.IssueFilter{}, err
 	}
 
 	// Status and IssueType are taken as written. Neither is validated against

--- a/internal/workapi/count.go
+++ b/internal/workapi/count.go
@@ -63,7 +63,9 @@ func BuildCountFilter(in issueops.CountRequest, cfg ListConfig) (types.IssueFilt
 		Priority:            in.Priority,
 		PriorityMin:         in.PriorityMin,
 		PriorityMax:         in.PriorityMax,
-		MetadataFields:      in.MetadataFields,
+	}
+	if len(in.MetadataFields) > 0 {
+		filter.MetadataFields = in.MetadataFields
 	}
 	if err := ValidateMetadataFilters(in.MetadataFields, ""); err != nil {
 		return types.IssueFilter{}, err

--- a/internal/workapi/count_test.go
+++ b/internal/workapi/count_test.go
@@ -158,6 +158,21 @@ func TestBuildCountFilterNormalizesLabelsAndIDs(t *testing.T) {
 	}
 }
 
+func TestBuildCountFilterCarriesMetadataFields(t *testing.T) {
+	fields := map[string]string{"team": "platform", "env": "prod"}
+	got, err := BuildCountFilter(issueops.CountRequest{MetadataFields: fields}, ListConfig{})
+	if err != nil {
+		t.Fatalf("BuildCountFilter: %v", err)
+	}
+	if !reflect.DeepEqual(got.MetadataFields, fields) {
+		t.Errorf("MetadataFields = %#v, want %#v", got.MetadataFields, fields)
+	}
+
+	if _, err := BuildCountFilter(issueops.CountRequest{MetadataFields: map[string]string{"bad$key": "value"}}, ListConfig{}); err == nil {
+		t.Fatal("BuildCountFilter accepted an invalid metadata key")
+	}
+}
+
 // TestBuildCountFilterTakesStatusAndTypeAsWritten pins the deliberate absence
 // of validation: an unrecognized status or type reaches the filter as written
 // and matches nothing, rather than failing. A scripted caller counting a

--- a/issueops/counter.go
+++ b/issueops/counter.go
@@ -92,6 +92,8 @@ type CountRequest struct {
 	TitleContains string
 	DescContains  string
 	NotesContains string
+	// MetadataFields requires equality for every top-level key/value pair.
+	MetadataFields map[string]string
 
 	CreatedAfter  *time.Time
 	CreatedBefore *time.Time


### PR DESCRIPTION
## What

- Add repeatable `bd count --metadata-field key=value` parsing with the same syntax and key validation as `bd list`.
- Carry metadata equality filters through `issueops.CountRequest` and `workapi.BuildCountFilter` into the existing storage filter.
- Publish and forward the shared request field through `GET /v0/beads/issues:count` so native and proxied counts stay equivalent.
- Document the count endpoint's validation split: malformed `key=value` shape fails during query decoding, while an invalid key is a role refusal classified as a 400 on `metadata_field`.
- Add parser, work API, HTTP contract, embedded Dolt, and proxied regression coverage. Count assertions use JSON and compare with the equivalent list cardinality.

## Why

`bd list --metadata-field k=v` filters correctly, but `bd count --metadata-field k=v` rejects the flag. Callers currently have to fetch and count the full JSON list.

This is the remaining count half related to #5680. #5724 already uses that issue for the separate `bd ready --flat` fix, so #6023 tracks this count gap.

Fixes #6023

## Verification

- `./scripts/test.sh -run '^(TestParseCountRequestCarriesEveryFilterFlag|TestParseCountRequestRejectsInvalidMetadataField)$' ./cmd/bd/...`
- `./scripts/test.sh -run '^(TestBuildCountFilterCarriesMetadataFields|TestCountForwardsEveryDocumentedParameter|TestCountParametersMatchTheHandler|TestEveryCountRequestFieldIsPublished|TestABuilderRefusalIsTheDocumentedBadRequest)$' ./internal/workapi/... ./internal/httpapi/...`
- `./scripts/test.sh ./cmd/bd/...`
- `./scripts/test.sh ./issueops/... ./internal/workapi/... ./internal/httpapi/...`
- `BEADS_TEST_EMBEDDED_DOLT=1 ./scripts/test.sh -run '^TestEmbeddedCount$' ./cmd/bd/...`
- `make test`
- `make api-check`
- `./scripts/check-cli-docs-drift.sh --base main`
- Scrubbed-environment binary check: `bd count --metadata-field k=v --json` returned 2 and the equivalent JSON list contained 2 rows.

Two independent reviews were adjudicated after the initial build. The accepted findings corrected the role-versus-transport refusal docs, added the count-surface 400 guard case, aligned the builder with list and ready, and added the #6023 changelog entry. Decoder-level key validation and repeated-key behavior were left unchanged to preserve list/ready parity.

`make ci-pr-lint` is blocked on current `main` before linting by three pre-existing gofmt mismatches in the role fixture kits. With those files temporarily formatted, golangci-lint v2.10.1 reports two pre-existing darwin-only gosec findings: G304 in `internal/config/permissions_open_nonlinux.go` and G103 in `internal/utils/path_case_darwin.go`. Both results were reproduced with the feature diff stashed.

Current upstream base `2043fb25` also has an unrelated CI failure in `TestZZStdioNotLeaked`; the base run completed 18,033 tests with that one stdio-leak failure.
