### PR TITLE
fix(scripts): make check-doc-flags portable to BSD grep

### DIFF
--- a/scripts/check-doc-flags.sh
+++ b/scripts/check-doc-flags.sh
@@ -93,8 +93,16 @@ echo ""
 # --- Check 2: bd init flags ---
 echo "=== Check 2: bd init flags ==="
 
-# Get actual init flags
-INIT_FLAGS=$($BD init --help 2>&1 | grep -oP '^\s+--[a-z][a-z0-9-]*' | sed 's/^\s*//' || true)
+# Get actual init flags. Match both long-only rows and rows with a short alias.
+INIT_FLAGS_OK=1
+if ! INIT_FLAGS=$("$BD" init --help 2>&1 \
+    | grep -E '^[[:space:]]+(-[[:alnum:]], )?--[a-z]' \
+    | grep -oE -- '--[a-z][a-z0-9-]*' \
+    | sort -u); then
+    echo "FAIL: Could not extract flags from 'bd init --help'"
+    ERRORS=$((ERRORS + 1))
+    INIT_FLAGS_OK=0
+fi
 
 # Check for --branch on init (removed)
 BRANCH_REFS=$(grep -rn 'bd init.*--branch' \
@@ -107,7 +115,11 @@ BRANCH_REFS=$(grep -rn 'bd init.*--branch' \
     | grep -v 'CHANGELOG\|removed\|was removed\|no longer\|deprecated' \
     || true)
 
-if [ -n "$BRANCH_REFS" ]; then
+if [ "$INIT_FLAGS_OK" -ne 1 ]; then
+    echo "SKIP: Cannot validate 'bd init --branch' without the live init flag list"
+elif printf '%s\n' "$INIT_FLAGS" | grep -qx -- '--branch'; then
+    echo "PASS: 'bd init --branch' is a live flag"
+elif [ -n "$BRANCH_REFS" ]; then
     echo "FAIL: Found references to removed 'bd init --branch' flag:"
     echo "$BRANCH_REFS" | head -20
     ERRORS=$((ERRORS + 1))


### PR DESCRIPTION
## What

Replace the GNU-only `grep -P` init-flag extraction with portable ERE patterns. Treat an extraction failure as a gate failure, and use the extracted live flags when deciding whether `bd init --branch` references are stale.

## Why

BSD grep rejects `-P`. On macOS the script printed grep's usage message, swallowed the pipeline error with `|| true`, labeled Check 2 PASS, and exited 0. The extracted value was also unused, so the extraction did not affect the check on Linux either.

Fixes #6025

## Verification

- `bash -n scripts/check-doc-flags.sh`
- Clean macOS run: `./scripts/check-doc-flags.sh` passes without a grep usage error
- Planted `bd init --branch` README reference: script exits 1 and names the line
- No-init-flags fixture: script exits 1 with `Could not extract flags from 'bd init --help'`
- `make check-docs`
- `make ci-pr-policy`
- `git diff --check`

GNU grep was not installed locally. The replacement uses POSIX ERE syntax supported by both BSD and GNU grep; the Linux PR check will provide the GNU runtime confirmation.
