### PR TITLE
fix(cli): expose update revision guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`bd update --if-version N` exposes the row revision as a CLI compare-and-swap guard**
+  ([#6029](https://github.com/gastownhall/beads/issues/6029)). Read the opaque
+  token from `bd show --json`; a matching update applies atomically, while a
+  stale token writes nothing and exits 13 like the existing assignee/status
+  guards. The embedded and proxied-server command paths share the same
+  lifecycle precondition, so external workflow coordinators can update
+  metadata without relying on process-local locks or a read-then-write race.
+
 - **The events journal records WHO performed each mutation.** `bd_events_journal`
   gains an `actor` column (migration 0066 plus its ignored-series twin 0025, so
   upgraded workspaces and fresh clones converge on the same shape), stamped

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -40,6 +40,7 @@ type commandUpdateMutation struct {
 	force            bool
 	expectedAssignee *string
 	expectedStatus   *issueops.Status
+	expectedVersion  *int64
 	// provenance names the history entry the write records. Empty takes the
 	// backend's default, which is what the direct route wants; the proxied
 	// route spells the message it has always written.
@@ -60,6 +61,7 @@ func runCommandUpdateMutation(ctx context.Context, updater commandIssueUpdater, 
 		ForceClosePolicy:      mutation.force,
 		ExpectedAssignee:      mutation.expectedAssignee,
 		ExpectedStatus:        mutation.expectedStatus,
+		ExpectedVersion:       mutation.expectedVersion,
 		Provenance:            mutation.provenance,
 	})
 }
@@ -82,7 +84,7 @@ fail, the remaining issues are still updated, every failed ID is reported on
 stderr, and the command exits nonzero.
 
 Exit codes: 1 for general failures; 13 when every failure is a stale
---if-assignee/--if-status guard (the precondition no longer held, nothing was
+--if-assignee/--if-status/--if-version guard (the precondition no longer held, nothing was
 written — another actor won the race, so retrying the same guard is
 pointless).`,
 	// The non-interactive no-ID refusal lives in argument validation, which
@@ -127,6 +129,9 @@ pointless).`,
 				return HandleErrorRespectJSON("no issue ID provided and no last touched issue")
 			}
 			args = []string{lastTouched}
+		}
+		if cmd.Flags().Changed("if-version") && len(args) != 1 {
+			return HandleErrorRespectJSON("--if-version requires exactly one issue ID")
 		}
 
 		updates := make(map[string]interface{})
@@ -402,7 +407,7 @@ pointless).`,
 		// status set as --status, mutually exclusive with --claim (which is
 		// its own compare-and-set), and only meaningful with a field update
 		// to ride on.
-		ifAssignee, ifStatus, err := updateGuardsFromFlags(cmd, claimFlag, updates)
+		ifAssignee, ifStatus, ifVersion, err := updateGuardsFromFlags(cmd, claimFlag, updates)
 		if err != nil {
 			return err
 		}
@@ -548,6 +553,7 @@ pointless).`,
 				force:            forceFlag,
 				expectedAssignee: ifAssignee,
 				expectedStatus:   expectedStatus,
+				expectedVersion:  ifVersion,
 			})
 			if updateErr != nil {
 				fmt.Fprintf(os.Stderr, "Error updating %s: %v\n", id, updateErr)
@@ -813,7 +819,7 @@ func warnNotesReplacement(id string) {
 }
 
 // ExitGuardMismatch is the exit code when a `bd update` run failed solely
-// because --if-assignee/--if-status guards did not match: the precondition no
+// because --if-assignee/--if-status/--if-version guards did not match: the precondition no
 // longer held, nothing was written, and retrying is pointless — another actor
 // won the race. Scripts branch on it to tell "racer won, skip gracefully"
 // (13) from infra failure (1, retry/abort). Mixed batches — any failure that
@@ -822,11 +828,11 @@ func warnNotesReplacement(id string) {
 // text ("assignee mismatch" / "status mismatch") either way.
 const ExitGuardMismatch = 13
 
-// isGuardMismatch reports whether err is a bd-wsqvw conditional-update guard
-// refusal (stale --if-assignee/--if-status), the failure class that exits
+// isGuardMismatch reports whether err is a conditional-update guard refusal
+// (stale --if-assignee/--if-status/--if-version), the failure class that exits
 // ExitGuardMismatch instead of 1.
 func isGuardMismatch(err error) bool {
-	return errors.Is(err, storage.ErrAssigneeMismatch) || errors.Is(err, storage.ErrStatusMismatch)
+	return errors.Is(err, storage.ErrAssigneeMismatch) || errors.Is(err, storage.ErrStatusMismatch) || errors.Is(err, storage.ErrVersionMismatch)
 }
 
 // updateIDFailure records one issue ID that could not be updated and why.
@@ -924,8 +930,8 @@ func toJSONValue(s string) json.RawMessage {
 	return storage.MetadataEditValue(s)
 }
 
-// updateGuardsFromFlags reads the bd-wsqvw conditional-update guards
-// (--if-assignee/--if-status) with presence detected via Changed(), so
+// updateGuardsFromFlags reads the conditional-update guards
+// (--if-assignee/--if-status/--if-version) with presence detected via Changed(), so
 // `--if-assignee ""` is a real guard meaning "expected unassigned" rather than
 // "no guard" (the unclaim.go idiom). It rejects combining guards with --claim
 // (--claim is its own compare-and-set with claim-pool semantics; the guards
@@ -933,8 +939,9 @@ func toJSONValue(s string) json.RawMessage {
 // update to ride on (the CAS applies to the issues-row UPDATE; label and
 // parent edits run outside it and would not be guarded). An --if-status value
 // is validated against the same built-in + custom status set as --status, so a
-// typo fails fast instead of mismatching forever.
-func updateGuardsFromFlags(cmd *cobra.Command, claimFlag bool, updates map[string]interface{}) (ifAssignee, ifStatus *string, err error) {
+// typo fails fast instead of mismatching forever. The opaque version guard may
+// accompany --claim because it is an independent whole-row precondition.
+func updateGuardsFromFlags(cmd *cobra.Command, claimFlag bool, updates map[string]interface{}) (ifAssignee, ifStatus *string, ifVersion *int64, err error) {
 	if cmd.Flags().Changed("if-assignee") {
 		v, _ := cmd.Flags().GetString("if-assignee")
 		ifAssignee = &v
@@ -948,15 +955,19 @@ func updateGuardsFromFlags(cmd *cobra.Command, claimFlag bool, updates map[strin
 			}
 		}
 		if !types.Status(v).IsValidWithCustom(customStatuses) {
-			return nil, nil, HandleErrorRespectJSON("invalid --if-status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", v)
+			return nil, nil, nil, HandleErrorRespectJSON("invalid --if-status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", v)
 		}
 		ifStatus = &v
 	}
-	if ifAssignee == nil && ifStatus == nil {
-		return nil, nil, nil
+	if cmd.Flags().Changed("if-version") {
+		v, _ := cmd.Flags().GetInt64("if-version")
+		ifVersion = &v
 	}
-	if claimFlag {
-		return nil, nil, HandleErrorRespectJSON("cannot combine --if-assignee/--if-status with --claim (--claim is already an atomic compare-and-set)")
+	if ifAssignee == nil && ifStatus == nil && ifVersion == nil {
+		return nil, nil, nil, nil
+	}
+	if claimFlag && (ifAssignee != nil || ifStatus != nil) {
+		return nil, nil, nil, HandleErrorRespectJSON("cannot combine --if-assignee/--if-status with --claim (--claim is already an atomic compare-and-set)")
 	}
 	hasFieldUpdate := false
 	for k := range updates {
@@ -966,10 +977,10 @@ func updateGuardsFromFlags(cmd *cobra.Command, claimFlag bool, updates map[strin
 			hasFieldUpdate = true
 		}
 	}
-	if !hasFieldUpdate {
-		return nil, nil, HandleErrorRespectJSON("--if-assignee/--if-status require at least one field update (e.g. -a, -s); label and parent edits are not covered by the guard")
+	if !hasFieldUpdate && !claimFlag {
+		return nil, nil, nil, HandleErrorRespectJSON("--if-assignee/--if-status/--if-version require at least one field update (e.g. -a, -s); label and parent edits are not covered by the guard")
 	}
-	return ifAssignee, ifStatus, nil
+	return ifAssignee, ifStatus, ifVersion, nil
 }
 
 func init() {
@@ -994,6 +1005,7 @@ func init() {
 	// Conditional (compare-and-set) update guards (bd-wsqvw)
 	updateCmd.Flags().String("if-assignee", "", "Apply the update only if the current assignee equals this value (--if-assignee '' requires unassigned); a mismatch writes nothing and exits 13 (vs 1 for other failures). Requires a field update; cannot combine with --claim")
 	updateCmd.Flags().String("if-status", "", "Apply the update only if the current status equals this value; a mismatch writes nothing and exits 13 (vs 1 for other failures). Requires a field update; cannot combine with --claim")
+	updateCmd.Flags().Int64("if-version", 0, "Apply the update only if the current revision from 'bd show --json' equals this value; a mismatch writes nothing and exits 13 (vs 1 for other failures). Requires a field update")
 	// --force (unconditional bypass of the reassign fence) and --if-assignee
 	// (write only while a specific assignee still holds it) encode
 	// contradictory intent — same rationale as unclaim's pairing. Rejecting the

--- a/cmd/bd/update_conditional_embedded_test.go
+++ b/cmd/bd/update_conditional_embedded_test.go
@@ -3,14 +3,41 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/types"
 )
+
+func revisionFromShowJSON(t *testing.T, raw []byte) int64 {
+	t.Helper()
+	start := strings.IndexByte(string(raw), '{')
+	if start < 0 {
+		t.Fatalf("show output has no JSON object:\n%s", raw)
+	}
+	var details types.IssueDetails
+	if err := json.NewDecoder(strings.NewReader(string(raw[start:]))).Decode(&details); err != nil {
+		t.Fatalf("decode show details: %v\n%s", err, raw)
+	}
+	return details.Revision
+}
+
+func bdShowRevision(t *testing.T, bd, dir, id string) int64 {
+	t.Helper()
+	cmd := exec.Command(bd, "show", id, "--json")
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bd show %s --json failed: %v\n%s", id, err, out)
+	}
+	return revisionFromShowJSON(t, out)
+}
 
 // bdUpdateFailCode runs "bd update" expecting failure and returns the combined
 // output plus the process exit code, so guard tests can assert the
@@ -136,6 +163,42 @@ func TestUpdateIfGuardsCLI(t *testing.T) {
 			t.Errorf("mixed guard+lookup failure exit code = %d, want 1\n%s", code, out)
 		}
 	})
+}
+
+// TestUpdateIfVersionCLI proves the revision emitted by `bd show --json` is a
+// usable cross-process compare-and-swap token for `bd update`. A matching token
+// applies, a later independent write remints it, and replaying the stale token
+// exits 13 without clobbering that winner.
+func TestUpdateIfVersionCLI(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "uv")
+	issue := bdCreate(t, bd, dir, "Version guarded update", "--type", "task")
+
+	first := bdShowRevision(t, bd, dir, issue.ID)
+	bdUpdate(t, bd, dir, issue.ID, "--if-version", strconv.FormatInt(first, 10), "--priority", "1")
+	second := bdShowRevision(t, bd, dir, issue.ID)
+	if second == first {
+		t.Fatalf("revision did not change after write: %d", first)
+	}
+
+	// A different process wins after the caller's read.
+	bdUpdate(t, bd, dir, issue.ID, "--priority", "2")
+	out, code := bdUpdateFailCode(t, bd, dir, issue.ID,
+		"--if-version", strconv.FormatInt(second, 10), "--priority", "3")
+	if code != ExitGuardMismatch {
+		t.Fatalf("stale version exit = %d, want %d\n%s", code, ExitGuardMismatch, out)
+	}
+	if !strings.Contains(out, "version mismatch") {
+		t.Errorf("stale version output lacks mismatch sentinel:\n%s", out)
+	}
+	if got := bdShow(t, bd, dir, issue.ID).Priority; got != 2 {
+		t.Errorf("stale version clobbered winner: priority=%d, want 2", got)
+	}
 }
 
 // TestUpdateIfGuardsFlagValidation drives the CLI-surface rules that keep the

--- a/cmd/bd/update_conditional_proxied_test.go
+++ b/cmd/bd/update_conditional_proxied_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"errors"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -103,4 +104,40 @@ func TestProxiedServerUpdateIfGuards(t *testing.T) {
 			t.Errorf("expected the --claim exclusion in the error, got:\n%s", out)
 		}
 	})
+}
+
+// TestProxiedServerUpdateIfVersion pins parity with the embedded CLI: the
+// revision read through the proxied show path guards the same lifecycle update
+// transaction, and a stale token is the same exit-13/no-write verdict.
+func TestProxiedServerUpdateIfVersion(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "uvp")
+	issue := bdProxiedCreate(t, bd, p.dir, "Version guard via proxy")
+
+	first := revisionFromShowJSON(t, []byte(bdProxiedShowRaw(t, bd, p.dir, issue.ID, "--json")))
+	if out, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID,
+		"--if-version", strconv.FormatInt(first, 10), "--priority", "1"); err != nil {
+		t.Fatalf("matching version update failed: %v\n%s", err, out)
+	}
+	second := revisionFromShowJSON(t, []byte(bdProxiedShowRaw(t, bd, p.dir, issue.ID, "--json")))
+	if second == first {
+		t.Fatalf("revision did not change after proxied write: %d", first)
+	}
+	if out, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID, "--priority", "2"); err != nil {
+		t.Fatalf("competing update failed: %v\n%s", err, out)
+	}
+
+	out, code := bdProxiedUpdateFailCode(t, bd, p.dir, issue.ID,
+		"--if-version", strconv.FormatInt(second, 10), "--priority", "3")
+	if code != ExitGuardMismatch {
+		t.Fatalf("stale proxied version exit = %d, want %d\n%s", code, ExitGuardMismatch, out)
+	}
+	if !strings.Contains(out, "version mismatch") {
+		t.Errorf("stale proxied version output lacks mismatch sentinel:\n%s", out)
+	}
+	if got := bdProxiedShow(t, bd, p.dir, issue.ID).Priority; got != 2 {
+		t.Errorf("stale proxied version clobbered winner: priority=%d, want 2", got)
+	}
 }

--- a/cmd/bd/update_input.go
+++ b/cmd/bd/update_input.go
@@ -35,6 +35,7 @@ type updateInput struct {
 	// guard).
 	ifAssignee *string
 	ifStatus   *string
+	ifVersion  *int64
 	// bd-98s5c: --force bypasses the live-claim reassign fence (mutually
 	// exclusive with --if-assignee at the flag-group level).
 	force bool
@@ -275,6 +276,10 @@ func gatherUpdateInput(ctx context.Context, cmd *cobra.Command) (*updateInput, e
 		}
 		in.ifStatus = &v
 	}
+	if cmd.Flags().Changed("if-version") {
+		v, _ := cmd.Flags().GetInt64("if-version")
+		in.ifVersion = &v
+	}
 	if in.ifAssignee != nil || in.ifStatus != nil {
 		if in.claim {
 			return nil, HandleErrorRespectJSON("cannot combine --if-assignee/--if-status with --claim (--claim is already an atomic compare-and-set)")
@@ -282,6 +287,9 @@ func gatherUpdateInput(ctx context.Context, cmd *cobra.Command) (*updateInput, e
 		if len(in.fields) == 0 && !in.hasAppendNotes && len(in.mergeMetadataIn) == 0 && len(in.setMetadata) == 0 && len(in.unsetMetadata) == 0 {
 			return nil, HandleErrorRespectJSON("--if-assignee/--if-status require at least one field update (e.g. -a, -s); label and parent edits are not covered by the guard")
 		}
+	}
+	if in.ifVersion != nil && !in.claim && len(in.fields) == 0 && !in.hasAppendNotes && len(in.mergeMetadataIn) == 0 && len(in.setMetadata) == 0 && len(in.unsetMetadata) == 0 {
+		return nil, HandleErrorRespectJSON("--if-version requires at least one field update (e.g. -a, -s); label and parent edits are not covered by the guard")
 	}
 	return in, nil
 }

--- a/cmd/bd/update_lifecycle_test.go
+++ b/cmd/bd/update_lifecycle_test.go
@@ -26,6 +26,7 @@ func (u *recordingDirectIssueUpdater) Update(_ context.Context, request issueops
 func TestRunDirectUpdateMutationBuildsLifecycleRequest(t *testing.T) {
 	expectedAssignee := "current-owner"
 	expectedStatus := issueops.StatusOpen
+	expectedVersion := int64(41)
 	tests := []struct {
 		name     string
 		mutation commandUpdateMutation
@@ -41,6 +42,7 @@ func TestRunDirectUpdateMutationBuildsLifecycleRequest(t *testing.T) {
 				force:            true,
 				expectedAssignee: &expectedAssignee,
 				expectedStatus:   &expectedStatus,
+				expectedVersion:  &expectedVersion,
 			},
 			want: issueops.UpdateRequest{
 				Actor:            "writer",
@@ -50,6 +52,7 @@ func TestRunDirectUpdateMutationBuildsLifecycleRequest(t *testing.T) {
 				ForceClosePolicy: true,
 				ExpectedAssignee: &expectedAssignee,
 				ExpectedStatus:   &expectedStatus,
+				ExpectedVersion:  &expectedVersion,
 			},
 		},
 		{

--- a/cmd/bd/update_proxied_server.go
+++ b/cmd/bd/update_proxied_server.go
@@ -24,6 +24,9 @@ func runUpdateProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 	if err != nil {
 		return err
 	}
+	if in.ifVersion != nil && len(args) != 1 {
+		return HandleErrorRespectJSON("--if-version requires exactly one issue ID")
+	}
 	if isUpdateInputNoop(in) {
 		fmt.Println("No updates specified")
 		return nil
@@ -129,6 +132,7 @@ func applyUpdateProxiedOne(ctx context.Context, id string, in *updateInput) (*ty
 		force:            in.force,
 		expectedAssignee: in.ifAssignee,
 		expectedStatus:   expectedStatus,
+		expectedVersion:  in.ifVersion,
 		provenance:       fmt.Sprintf("bd: update %s", id),
 	})
 	if err != nil {


### PR DESCRIPTION
Closes #6029.

## What changed

- Adds `bd update --if-version N`, using the opaque `revision` from `bd show --json`.
- Routes the guard through the existing `issueops.UpdateRequest.ExpectedVersion` transaction on both embedded and proxied-server command paths.
- Classifies a stale revision like the existing update guards: no write, exit 13.
- Rejects multi-ID use because one opaque row token cannot safely describe multiple targets.
- Adds real separate-process embedded and proxied Dolt regressions.

This adapts the revision-CAS direction contributed by @julianknutsen in #4682 to the narrower storage/HTTP primitives already present on current main; it does not bring forward that stale branch’s broader storage changes.

## Why

External workflow coordinators need a real cross-process CAS for metadata transitions. Read-then-update and process-local locks cannot prevent two independent workers from overwriting each other. The underlying row-revision contract already exists; only the CLI surface was missing.

## Validation

- `BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd -run ^TestUpdateIfVersionCLI$ -count=1 -v`
- `BEADS_TEST_PROXIED_SERVER=1 go test ./cmd/bd -run ^TestProxiedServerUpdateIfVersion$ -count=1 -v`
- `go test ./cmd/bd -count=1`
- `make test`
- `BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint`
- `go vet ./cmd/bd ./issueops ./internal/httpapi`
- `git diff --check`

The unscoped whole-tree lint also reported only three pre-existing G602 findings in backend/conformance; the PR-scoped lint is clean.