### PR TITLE
fix(schema): dolt_ignore the __temp__ table-rebuild intermediates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already committed the seeded rows at their own transaction boundaries, and
   the previously unconditional `DOLT_COMMIT` died with "nothing to commit",
   killing the pass on exactly the under-seeded stores the heal targets.
+  Fenced deployments: adding a canonical pattern un-converges `dolt_ignore` for
+  every existing database, so the next write-mode open issues one
+  `INSERT IGNORE INTO dolt_ignore`; a hosted or box-fenced wire client that is
+  denied that INSERT fails its open until one privileged `bd` opens the store
+  and heals the pattern — self-healing, one privileged open per upgrade
+  (degrading a denied seed to a skip is tracked separately).
 
 - **`bd prime` says when it could NOT read the memory plane**
   ([#5877](https://github.com/gastownhall/beads/issues/5877)). A broken or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Table-rebuild `__temp__` intermediates can no longer materialize as
+  tracked tables on `@@dolt_transaction_commit=1` servers.** The
+  ignored-series rebuilds stage every clone-local table through a
+  `__temp__<table>` rename, but the intermediate names carried no
+  `dolt_ignore` pattern: against a transaction-commit server each
+  `CREATE TABLE __temp__X` auto-committed a real table at HEAD, and the
+  rename onto the ignored final name left an unstageable `__temp__X -> X`
+  half in `dolt_status` that wedged every later open behind the dirty-table
+  guard (observed in the field as a three-city shared hub wedging twice in
+  one day, each time ending in fleet-wide write refusal and a manual SQL
+  repair). `__temp__%` now ships in the canonical seeded pattern set —
+  asserted, like the events-journal patterns, before the series that creates
+  the tables — so intermediates are born ignored. The scoped seed commit also
+  gains `--skip-empty`: under `@@dolt_transaction_commit=1` the server has
+  already committed the seeded rows at their own transaction boundaries, and
+  the previously unconditional `DOLT_COMMIT` died with "nothing to commit",
+  killing the pass on exactly the under-seeded stores the heal targets.
+
 - **`bd prime` says when it could NOT read the memory plane**
   ([#5877](https://github.com/gastownhall/beads/issues/5877)). A broken or
   unreachable store made prime omit the memory section entirely, so a session

--- a/internal/storage/embeddeddolt/migrate_temp_intermediates_test.go
+++ b/internal/storage/embeddeddolt/migrate_temp_intermediates_test.go
@@ -1,0 +1,104 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// TestEmbeddedTempRebuildIntermediatesNeverReachHistory pins a shared-hub
+// contract: the ignored-series table rebuilds stage their work
+// through __temp__<table> intermediates (ignored/0001, ignored/0002). The
+// final names are dolt_ignored clone-local tables, but the intermediates
+// carried no ignore pattern, so against a @@dolt_transaction_commit=1 server
+// every CREATE __temp__X auto-committed a REAL table at HEAD; the later
+// RENAME to an ignored name then left rename halves in dolt_status that no
+// working-set shuffle could stage (content-inferred rename classification),
+// wedging every older bd behind the dirty-table guard until a manual repair.
+//
+// The store under test is shaped like the field case: a clone whose
+// dolt_ignore was seeded by binaries that predate the __temp__% pattern. The
+// fresh-box MigrateUp must assert the pattern itself, in the same pass,
+// before the ignored series runs — so no __temp__ intermediate ever lands in
+// committed history and the pass ends with a clean working set.
+func TestEmbeddedTempRebuildIntermediatesNeverReachHistory(t *testing.T) {
+	requireEmbedded(t)
+	ctx := t.Context()
+
+	dir := seedMainSchemaAt(t, ctx, schema.LatestVersion())
+	conn, closeConn := openPinnedConn(t, ctx, dir)
+	defer closeConn()
+	if _, err := schema.MigrateUp(ctx, conn); err != nil {
+		t.Fatalf("seed MigrateUp: %v", err)
+	}
+
+	// Shape the store like a real clone (the Door B dance from
+	// TestEmbeddedIgnoredSeriesConvergesWithFreshInitShape): committed history
+	// carries the main tables and the at-latest main cursor; the clone-local
+	// tables and the ignored cursor are working-set state a clone never
+	// receives.
+	for _, table := range []string{
+		"wisp_dependencies", "wisp_events", "wisp_comments", "wisp_labels",
+		"wisp_child_counters", "wisps", "events", "leases", "repo_mtimes",
+		"local_metadata", "bd_events_journal", "bd_events_seq",
+		"ignored_schema_migrations",
+	} {
+		execFrozenGuard(t, ctx, conn, "DROP TABLE IF EXISTS "+table)
+	}
+	execFrozenGuard(t, ctx, conn,
+		"DELETE FROM dolt_ignore WHERE pattern IN ('leases', 'bd_events_journal', 'bd_events_seq')")
+	// The field stores were seeded by binaries that predate the __temp__%
+	// pattern; strip it from the baseline so the pass under test has to
+	// assert it itself, before the ignored series runs.
+	execFrozenGuard(t, ctx, conn, "DELETE FROM dolt_ignore WHERE pattern = '__temp__%'")
+	mustDrain(t, ctx, conn, "CALL DOLT_ADD('-A')")
+	mustDrain(t, ctx, conn, "CALL DOLT_COMMIT('-m', 'test: clone-shaped baseline', '--skip-empty')")
+
+	// The hub that hit this twice runs @@dolt_transaction_commit=1: every
+	// transaction commit becomes a dolt commit of every non-ignored delta,
+	// which is the mechanism that materialized the intermediates.
+	if _, err := conn.ExecContext(ctx, "SET @@dolt_transaction_commit = 1"); err != nil {
+		t.Fatalf("enable dolt_transaction_commit: %v", err)
+	}
+
+	// The fresh-box open.
+	if _, err := schema.MigrateUp(ctx, conn); err != nil {
+		t.Fatalf("fresh-box MigrateUp: %v", err)
+	}
+
+	// No rebuild intermediate may exist in ANY commit.
+	rows, err := conn.QueryContext(ctx, "SELECT DISTINCT table_name FROM dolt_diff")
+	if err != nil {
+		t.Fatalf("read dolt_diff table names: %v", err)
+	}
+	defer rows.Close()
+	var leaked []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan dolt_diff table name: %v", err)
+		}
+		if strings.HasPrefix(name, "__temp__") {
+			leaked = append(leaked, name)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate dolt_diff table names: %v", err)
+	}
+	if len(leaked) > 0 {
+		t.Errorf("rebuild intermediates reached committed history: %v", leaked)
+	}
+
+	// And the pass must end clean — the incident's other half was the
+	// permanently-dirty status that wedged older binaries' opens.
+	dirty, err := statusTables(ctx, conn)
+	if err != nil {
+		t.Fatalf("read dolt_status: %v", err)
+	}
+	if len(dirty) > 0 {
+		t.Errorf("working set dirty after the fresh-box pass: %v", dirty)
+	}
+}

--- a/internal/storage/schema/dolt_ignore_seed_test.go
+++ b/internal/storage/schema/dolt_ignore_seed_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"regexp"
+	"slices"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -205,6 +206,23 @@ func TestSeedDoltIgnorePatternsDegradesToBlindWriteOnPartialRead(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet SQL expectations (a partial read must discard the probe and re-assert every pattern): %v", err)
+	}
+}
+
+// The ignored-series table rebuilds (ignored/0001, ignored/0002) stage their
+// work through __temp__<table> intermediates before renaming to the final
+// dolt_ignored names. Against a @@dolt_transaction_commit=1 server every
+// non-ignored CREATE auto-commits, so without this pattern the intermediates
+// materialize as real tables at HEAD and the rename halves wedge dolt_status
+// (field incident: three-city shared hub, twice in one day, fleet write
+// refusal behind the dirty-table guard). The canonical set must cover the
+// intermediates so they are born ignored; dolt's own matcher treats the
+// underscores literally (patterns support only ? * %), so the entry matches
+// exactly the __temp__ prefix. The engine-level contract is pinned by
+// TestEmbeddedTempRebuildIntermediatesNeverReachHistory in embeddeddolt.
+func TestDoltIgnorePatternsCoverRebuildIntermediates(t *testing.T) {
+	if !slices.Contains(doltIgnorePatterns, "__temp__%") {
+		t.Fatal("doltIgnorePatterns is missing \"__temp__%\": ignored-series rebuild intermediates would auto-commit as tracked tables on dolt_transaction_commit=1 servers")
 	}
 }
 

--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -249,7 +249,7 @@ func TestMigrateUpSeedsIgnorePatternsWhenNoWorkNeeded(t *testing.T) {
 	// MigrateUp must commit the heal itself, scoped and labeled.
 	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD('dolt_ignore')")).
 		WillReturnRows(sqlmock.NewRows([]string{"status"}))
-	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', 'schema: seed dolt_ignore patterns')")).
+	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', 'schema: seed dolt_ignore patterns', '--skip-empty')")).
 		WillReturnRows(sqlmock.NewRows([]string{"hash"}))
 
 	applied, err := MigrateUp(context.Background(), db)
@@ -368,7 +368,7 @@ func expectOnePendingMigration(t *testing.T, mock sqlmock.Sqlmock) {
 	// seed must not ride the per-step pass commits).
 	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD('dolt_ignore')")).
 		WillReturnRows(sqlmock.NewRows([]string{"status"}))
-	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', 'schema: seed dolt_ignore patterns')")).
+	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', 'schema: seed dolt_ignore patterns', '--skip-empty')")).
 		WillReturnRows(sqlmock.NewRows([]string{"hash"}))
 	expectDoltStatusRows(mock)
 	// MigrateUp probes the aux-rekey crash sentinel (bd-578h9.16); this

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -291,6 +291,18 @@ var (
 // pollutes dolt_status and feeds the dirty-table migration gates. MigrateUp
 // re-asserts the full set idempotently at the top of every write-mode open.
 var doltIgnorePatterns = []string{
+	// Table-rebuild intermediates: the ignored series stages every rebuild
+	// through a __temp__<table> that is renamed to the final (ignored) name.
+	// Like the journal tables below, __temp__ names never exist on the
+	// versioned plane, so the pattern is safe unconditionally — and it must
+	// be asserted before the ignored series runs: on a
+	// @@dolt_transaction_commit=1 server an unignored CREATE __temp__X
+	// auto-commits a real table at HEAD, and the rename to the ignored final
+	// name then leaves an unstageable "__temp__X -> X" rename half in
+	// dolt_status that wedges the store for every open behind the
+	// dirty-table guard. dolt matches ignore patterns with ? * % only —
+	// underscores are literal — so this covers exactly the __temp__ prefix.
+	"__temp__%",
 	// The events journal tables (bd-opisf) are seeded here rather than
 	// version-gated: they have never existed on the versioned plane, so
 	// asserting the pattern before 0064 runs is what keeps the CREATE from
@@ -453,11 +465,18 @@ func seedDoltIgnorePatterns(ctx context.Context, db DBConn) (bool, error) {
 // short-circuit nothing downstream would ever commit the seed, and on the
 // migration path the seed must be committed before the first step so an
 // interrupted pass leaves a clean working set (#4566 self-heal contract).
+//
+// --skip-empty because on a @@dolt_transaction_commit=1 server the seed's
+// INSERTs were already dolt-committed at their own transaction boundaries,
+// so there is nothing left to stage: without it the labeled commit dies with
+// "nothing to commit" and takes the whole pass down on exactly the stores an
+// under-seeded heal targets. The seed is durable either way; only the commit
+// label is lost on that path.
 func commitSeededDoltIgnore(ctx context.Context, db DBConn) error {
 	if err := DrainCall(ctx, db, "CALL DOLT_ADD('dolt_ignore')"); err != nil {
 		return fmt.Errorf("staging seeded dolt_ignore patterns: %w", err)
 	}
-	if err := DrainCall(ctx, db, "CALL DOLT_COMMIT('-m', 'schema: seed dolt_ignore patterns')"); err != nil {
+	if err := DrainCall(ctx, db, "CALL DOLT_COMMIT('-m', 'schema: seed dolt_ignore patterns', '--skip-empty')"); err != nil {
 		return fmt.Errorf("committing seeded dolt_ignore patterns: %w", err)
 	}
 	return nil

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -79,7 +79,7 @@ func TestMigrateUpReturnsDirtyTablesErrorForPreExistingDirtyTable(t *testing.T) 
 	// pre-existing tables are unstaged, before the dirty-table guards run.
 	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD('dolt_ignore')")).
 		WillReturnRows(sqlmock.NewRows([]string{"status"}))
-	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', 'schema: seed dolt_ignore patterns')")).
+	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', 'schema: seed dolt_ignore patterns', '--skip-empty')")).
 		WillReturnRows(sqlmock.NewRows([]string{"hash"}))
 	// committableDirtyTables -> dirtyTables(ctx, db, true): same dirty state.
 	expectDirtyDoltStatusRow(mock, "dependencies", false)


### PR DESCRIPTION
## Summary

- The ignored-series table rebuilds stage every clone-local table through a `__temp__<table>` intermediate (`ignored/0001`, `ignored/0002`, and the later journal/events rebuilds), then rename onto the final, dolt_ignored name — but the intermediate names carried no `dolt_ignore` pattern.
- Against a `@@dolt_transaction_commit=1` server, every `CREATE TABLE __temp__X` auto-commits a **real tracked table at HEAD**; the rename onto the ignored final name then leaves an unstageable `__temp__X -> X` rename half in `dolt_status` (content-inferred rename classification — `DOLT_ADD('-A')`, `dolt_commit -a`, and per-table adds all no-op on it), wedging every later open behind the dirty-table guard.
- Fix: ship `__temp__%` in the canonical `doltIgnorePatterns` set so intermediates are born ignored, and add `--skip-empty` to the scoped seed commit, which the new pattern would otherwise trip over on transaction-commit servers (details below).

Field impact: a three-city shared hub (dolt 2.2.4, `dolt_transaction_commit=1`) wedged this way twice in one day — each time a fleet-wide write refusal repaired by hand (capture schemas → drop tracked-named tables → recreate the family ignored-untracked).

## Why

`internal/storage/schema/schema.go` already states the governing principle on the events-journal entries in `doltIgnorePatterns`: *"they have never existed on the versioned plane, so asserting the pattern before 0064 runs is what keeps the CREATE from landing as tracked-at-HEAD in the first place."* `__temp__` intermediates are the same shape — rebuild-internal names that must never be tracked — so they get the same treatment: a canonical (not version-gated) pattern, asserted by `seedDoltIgnorePatterns` at the top of `MigrateUp`, before the ignored series runs.

Dolt matches `dolt_ignore` patterns with `?`/`*`/`%` only — underscores are literal (`doltdb.MatchTablePattern` uses `regexp.QuoteMeta` plus those three rewrites) — so `__temp__%` covers exactly the `__temp__` prefix on the plane that matters (dolt's own staging/auto-commit decisions). Note for completeness: bd's own dirty-table queries compare with SQL `LIKE`, where `_` is a single-char wildcard; that Go-side divergence predates this PR (`wisp_%` has the same property) and is not widened by it in any way that matters — a name would have to look like `??temp??…` to be affected.

`ShouldIgnoreDelta` only matches **adds and drops** — changes to tracked tables are always included — and bd stages schema tables with `DOLT_ADD('-f', …)`, which overrides ignore. So the pattern cannot strand a store that already carries tracked `__temp__` tables from a past incident; explicit repair still stages their deletions.

## The `--skip-empty` half

Shipping the new pattern makes `seedDoltIgnorePatterns` report a change on **every** store seeded before this fix — which exposed a latent bug on exactly the txc=1 servers this targets: the seed's `INSERT IGNORE`s are already dolt-committed at their own transaction boundaries, so `commitSeededDoltIgnore`'s unconditional `DOLT_COMMIT` died with `Error 1105: nothing to commit` and took the whole `MigrateUp` pass down. It now passes `--skip-empty`, the same treatment `migration_repairs.go` already uses for its repair commits (whose comments document this exact failure class). The seed is durable either way; only the commit label is lost on that path.

## Verification

- New engine-level regression test `TestEmbeddedTempRebuildIntermediatesNeverReachHistory` (embeddeddolt) drives the field sequence: clone-shaped store whose `dolt_ignore` predates the pattern, `@@dolt_transaction_commit=1`, fresh-box `MigrateUp` — asserts no `__temp__` table in any commit (`dolt_diff`) and a clean working set after the pass.
  - Before the fix it reproduces both failures in sequence: first `fresh-box MigrateUp: committing seeded dolt_ignore patterns: Error 1105: nothing to commit`, then (with only `--skip-empty` applied) `dolt add __temp__bd_events_journal -> bd_events_journal: Error 1105: … do not exist` — the exact unstageable-rename wedge from the field.
- New unit test `TestDoltIgnorePatternsCoverRebuildIntermediates` pins the pattern in the canonical set with the rationale.
- `BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 go test -tags gms_pure_go ./internal/storage/embeddeddolt/` — full package green (547s).
- `go test -tags gms_pure_go ./internal/storage/schema/` green, also under `-race`.
- `make test` green (exit 0). `make build` green.
- `make ci-pr-lint`: the 5 gosec findings it reports on my machine are identical on a clean `upstream/main` checkout (darwin/nonlinux platform files); zero new findings from this change.

## Notes for reviewers

- Existing sqlmock expectations pinning the literal seed-commit SQL were updated for `--skip-empty` (`lock_test.go`, `schema_test.go`) — mechanical.
- On txc=1 servers the scoped seed commit usually becomes a no-op (the server's transaction commit already carried the rows), so the labeled `schema: seed dolt_ignore patterns` commit may not appear there; the rows land under the server's own transaction commits instead.
- Deliberately **not** in this PR (filed as follow-ups on our side, happy to open issues):
  - `cmd/bd/doctor`'s `isIgnoredTable` keeps its own hardcoded list (already missing the journal pair). Post-fix, a `__temp__` row in `dolt_status` is a poisoned-store signature the doctor could flag loudly rather than suppress.
  - `stageSchemaTables` passes `dolt_status` rename rows (`old -> new` in `table_name`) verbatim to `DOLT_ADD('-f', ?)`, which cannot parse them — that's the "unsafe dolt status table name" failure mode older binaries hit. Hardening the status consumers is a separate change.
  - This PR prevents new materialization; it does not repair stores already carrying tracked `__temp__` tables (manual repair recipe exists and still works, since force-add bypasses ignore).

Reported from the field by our fleet operators (three-city shared-hub deployment); analysis and fix by the beads rig crew at quickserve-ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)