### PR TITLE
fix(init): recover empty server bootstrap

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -751,9 +751,31 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// Historical workspaces need an explicit sealed-copy bridge. This runs
 		// before init's existing-workspace checks so even --force cannot create
 		// or rewrite state beside a source that has not been preserved.
+		var legacyGuardErr error
+		var emptyServerWitness emptyServerInitWitnessQualification
 		if beadsDir := resolveInitBeadsDir(); beadsDir != "" {
 			if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
-				return err
+				if !isLegacyUpgradeRefusal(err) {
+					return err
+				}
+				explicitServer, _ := cmd.Flags().GetBool("server")
+				qualification, qualified := qualifyEmptyServerInitWitness(beadsDir, emptyServerInitWitnessInput{
+					ExplicitServer:   cmd.Flags().Changed("server") && explicitServer,
+					ExplicitDatabase: cmd.Flags().Changed("database"),
+					Database:         database,
+					ReinitLocal:      reinitLocal,
+					ProxiedServer:    initProxiedServer,
+					SharedServer:     sharedServer || doltserver.IsSharedServerMode(),
+					ExplicitHost:     cmd.Flags().Changed("server-host"),
+					ServerHost:       serverHost,
+					ExplicitPort:     cmd.Flags().Changed("server-port"),
+					ServerPort:       serverPort,
+				})
+				if !qualified {
+					return err
+				}
+				legacyGuardErr = err
+				emptyServerWitness = qualification
 			}
 		}
 
@@ -975,7 +997,11 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			plannedDBPathAbs = filepath.Dir(plannedDBPathAbs)
 		}
 		initGateHandle, gateErr := acquireInitMutationGate(rootCtx, beadsDirAbs, plannedDBPathAbs, func() error {
-			return runInitReinitPreflight(reinitLocal, destroyTokenPrefix, destroyToken)
+			// countExistingIssues opens and initializes a schema on a truly empty
+			// database. The recovery candidate already proved zero tables and is
+			// re-proved immediately before schema creation below, so skip only that
+			// mutating count while retaining the gate and every remote-safety check.
+			return runInitReinitPreflight(reinitLocal && legacyGuardErr == nil, destroyTokenPrefix, destroyToken)
 		})
 		if gateErr != nil {
 			return gateErr
@@ -1375,9 +1401,18 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		}
 		if serverSocket != "" {
 			doltCfg.ServerSocket = serverSocket
+		} else if cmd.Flags().Changed("server-host") && cmd.Flags().Changed("server-port") {
+			// An explicit TCP endpoint must not be shadowed by a socket left in
+			// workspace metadata from an earlier server incarnation.
+			doltCfg.ServerSocket = ""
 		}
 		if serverUser != "" {
 			doltCfg.ServerUser = serverUser
+		}
+		if legacyGuardErr != nil {
+			// Recovery must stay pinned to the exact TCP endpoint proved empty;
+			// never auto-start a different repo-local server after that proof.
+			doltCfg.AutoStart = false
 		}
 
 		// Route through the gateway credential machinery: when a credential
@@ -1387,6 +1422,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		if err := applyInitGatewayCredential(ctx, beadsDir, doltCfg); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: resolving dolt credential command: %v\n", err)
 			return &exitError{Code: 1}
+		}
+		if legacyGuardErr != nil {
+			if doltCfg.Gateway {
+				return legacyGuardErr
+			}
+			pinEmptyServerInitWitness(doltCfg, emptyServerWitness)
 		}
 
 		initLock, err := acquireEmbeddedLock(beadsDir, initServerMode || initProxiedServer)
@@ -1453,6 +1494,23 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}
 
+		// The initial read-only qualification happened before the normal init
+		// safety checks. Re-prove emptiness now, while the local workspace init
+		// gate is held and immediately before schema creation. The gate excludes
+		// competing bd init processes for this workspace, not arbitrary external
+		// SQL writers; the second proof narrows that unavoidable server-side race.
+		// If the database changed or another writer restored a witness, preserve
+		// the original legacy refusal rather than modifying either one.
+		if legacyGuardErr != nil {
+			empty, proofErr := selectedServerDatabaseIsEmpty(emptyServerWitness.dsn)
+			if proofErr != nil || !empty {
+				return legacyGuardErr
+			}
+			if err := createEmptyServerInitWitness(emptyServerWitness); err != nil {
+				return legacyGuardErr
+			}
+		}
+
 		store, err := newDoltStore(ctx, doltCfg)
 		if err != nil {
 			// #4259: the remote-migrate gate refused to auto-apply pending
@@ -1485,6 +1543,16 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 			fmt.Fprintf(os.Stderr, "Error: failed to open Dolt store: %v\n", err)
 			return &exitError{Code: 1}
+		}
+
+		// Write the completed witness as soon as the store/schema exists. If a
+		// later optional initialization step is interrupted, the next command
+		// sees a current-era witness rather than a stranded blank one.
+		if useLocalBeads || legacyGuardErr != nil {
+			localVersionPath := filepath.Join(beadsDir, localVersionFile)
+			if err := writeLocalVersion(localVersionPath, Version); err != nil && !quiet {
+				fmt.Fprintf(os.Stderr, "Warning: failed to initialize version tracking: %v\n", err)
+			}
 		}
 
 		// Initialize global database schema and config in shared-server mode.
@@ -1712,6 +1780,8 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					}
 					if serverSocket != "" {
 						cfg.DoltServerSocket = serverSocket
+					} else if cmd.Flags().Changed("server-host") && cmd.Flags().Changed("server-port") {
+						cfg.DoltServerSocket = ""
 					}
 					if serverUser != "" {
 						cfg.DoltServerUser = serverUser
@@ -2045,17 +2115,6 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				} else if !quiet {
 					fmt.Printf("  Hooks installed to: .beads/hooks/\n")
 				}
-			}
-		}
-
-		// Initialize version tracking: create .local_version file during bd init
-		// instead of deferring it to the first bd command.
-		// This ensures no "Version Tracking" warning from bd doctor after init.
-		if useLocalBeads {
-			localVersionPath := filepath.Join(beadsDir, ".local_version")
-			if err := writeLocalVersion(localVersionPath, Version); err != nil && !quiet {
-				fmt.Fprintf(os.Stderr, "Warning: failed to initialize version tracking: %v\n", err)
-				// Non-fatal - initialization still succeeded
 			}
 		}
 

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -997,10 +997,13 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			plannedDBPathAbs = filepath.Dir(plannedDBPathAbs)
 		}
 		initGateHandle, gateErr := acquireInitMutationGate(rootCtx, beadsDirAbs, plannedDBPathAbs, func() error {
-			// countExistingIssues opens and initializes a schema on a truly empty
-			// database. The recovery candidate already proved zero tables and is
-			// re-proved immediately before schema creation below, so skip only that
-			// mutating count while retaining the gate and every remote-safety check.
+			// countExistingIssues opens the configured store and initializes a
+			// schema on a truly empty database. Skipping it is admissible for the
+			// recovery candidate only because qualification proved that the
+			// configured store IS the proved empty database (same database name,
+			// no live persisted socket), so the count could only ever be zero;
+			// it is re-proved immediately before schema creation below. The gate
+			// and every remote-safety check are retained.
 			return runInitReinitPreflight(reinitLocal && legacyGuardErr == nil, destroyTokenPrefix, destroyToken)
 		})
 		if gateErr != nil {
@@ -1401,10 +1404,6 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		}
 		if serverSocket != "" {
 			doltCfg.ServerSocket = serverSocket
-		} else if cmd.Flags().Changed("server-host") && cmd.Flags().Changed("server-port") {
-			// An explicit TCP endpoint must not be shadowed by a socket left in
-			// workspace metadata from an earlier server incarnation.
-			doltCfg.ServerSocket = ""
 		}
 		if serverUser != "" {
 			doltCfg.ServerUser = serverUser
@@ -1499,14 +1498,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// gate is held and immediately before schema creation. The gate excludes
 		// competing bd init processes for this workspace, not arbitrary external
 		// SQL writers; the second proof narrows that unavoidable server-side race.
-		// If the database changed or another writer restored a witness, preserve
-		// the original legacy refusal rather than modifying either one.
+		// If any database under the root changed, preserve the original legacy
+		// refusal rather than modifying anything. The witness itself is created
+		// only after the store opens below.
 		if legacyGuardErr != nil {
-			empty, proofErr := selectedServerDatabaseIsEmpty(emptyServerWitness.dsn)
+			empty, proofErr := provedRootDatabasesAreEmpty(emptyServerWitness.beadsDir, emptyServerWitness.dsn)
 			if proofErr != nil || !empty {
-				return legacyGuardErr
-			}
-			if err := createEmptyServerInitWitness(emptyServerWitness); err != nil {
 				return legacyGuardErr
 			}
 		}
@@ -1545,10 +1542,21 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			return &exitError{Code: 1}
 		}
 
+		// The recovery witness is created exclusively, and only now that the
+		// store exists: a store-open failure above leaves the legacy guard armed
+		// with nothing initialized. A witness that appeared between the proof
+		// and this point (O_EXCL failure) makes the original refusal win.
+		if legacyGuardErr != nil {
+			if err := createEmptyServerInitWitness(emptyServerWitness); err != nil {
+				_ = store.Close()
+				return legacyGuardErr
+			}
+		}
+
 		// Write the completed witness as soon as the store/schema exists. If a
 		// later optional initialization step is interrupted, the next command
 		// sees a current-era witness rather than a stranded blank one.
-		if useLocalBeads || legacyGuardErr != nil {
+		if useLocalBeads && legacyGuardErr == nil {
 			localVersionPath := filepath.Join(beadsDir, localVersionFile)
 			if err := writeLocalVersion(localVersionPath, Version); err != nil && !quiet {
 				fmt.Fprintf(os.Stderr, "Warning: failed to initialize version tracking: %v\n", err)
@@ -1780,7 +1788,10 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					}
 					if serverSocket != "" {
 						cfg.DoltServerSocket = serverSocket
-					} else if cmd.Flags().Changed("server-host") && cmd.Flags().Changed("server-port") {
+					} else if legacyGuardErr != nil {
+						// Recovery pinned the explicit TCP endpoint; a socket
+						// persisted from an earlier server incarnation must
+						// not outrank it on later commands.
 						cfg.DoltServerSocket = ""
 					}
 					if serverUser != "" {

--- a/cmd/bd/init_guard.go
+++ b/cmd/bd/init_guard.go
@@ -5,11 +5,15 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/ui"
 )
@@ -29,6 +33,9 @@ type initGuardDBCheck struct {
 // Returns Reachable=false when the server cannot be reached (FR-030), so the
 // caller can fall through to existing "already initialized" behavior.
 func checkDatabaseOnServer(host string, port int, user, password, dbName string, tls bool) initGuardDBCheck {
+	// init promotes explicit --server-* flags into these getters before the
+	// legacy guard runs, so the qualified identity includes an explicit user
+	// and TLS choice rather than silently falling back to persisted metadata.
 	dsn := doltutil.ServerDSN{
 		Host:     host,
 		Port:     port,
@@ -74,6 +81,172 @@ func checkDatabaseOnServer(host string, port int, user, password, dbName string,
 	}
 
 	return initGuardDBCheck{Exists: false, Reachable: true}
+}
+
+// emptyServerInitWitnessInput describes the only server-init shape that may
+// pass the legacy guard without an existing version witness. It is deliberately
+// narrower than normal server init: the caller must name both the server and
+// database, and must request a local re-init explicitly.
+type emptyServerInitWitnessInput struct {
+	ExplicitServer   bool
+	ExplicitDatabase bool
+	Database         string
+	ReinitLocal      bool
+	ProxiedServer    bool
+	SharedServer     bool
+	ExplicitHost     bool
+	ServerHost       string
+	ExplicitPort     bool
+	ServerPort       int
+}
+
+func (in emptyServerInitWitnessInput) qualifies() bool {
+	if !in.ExplicitServer || !in.ExplicitDatabase || in.Database == "" || !in.ReinitLocal || in.ProxiedServer || in.SharedServer {
+		return false
+	}
+	return in.ExplicitHost && in.ServerHost != "" && in.ExplicitPort && in.ServerPort > 0
+}
+
+// emptyServerInitWitnessQualification is an immutable, explicit server
+// endpoint plus credentials. It is obtained with read-only SQL before init's
+// normal safety checks, then proved again under the mutation gate immediately
+// before schema initialization.
+type emptyServerInitWitnessQualification struct {
+	beadsDir string
+	dsn      doltutil.ServerDSN
+}
+
+// qualifyEmptyServerInitWitness performs no filesystem mutation. It admits
+// only an explicit native server re-init whose selected database is proven
+// empty by read-only SQL. An ambient socket is never used for an explicit TCP
+// endpoint, so stale workspace configuration cannot redirect this proof.
+func qualifyEmptyServerInitWitness(beadsDir string, in emptyServerInitWitnessInput) (emptyServerInitWitnessQualification, bool) {
+	if !in.qualifies() {
+		return emptyServerInitWitnessQualification{}, false
+	}
+
+	cfg, err := configfile.LoadForDiscovery(beadsDir)
+	if err != nil {
+		return emptyServerInitWitnessQualification{}, false
+	}
+	if cfg == nil {
+		cfg = configfile.DefaultConfig()
+	}
+	if !strings.EqualFold(cfg.DoltMode, configfile.DoltModeServer) || !hasLegacyDoltRoot(beadsDir) {
+		return emptyServerInitWitnessQualification{}, false
+	}
+	// The exception is only for a genuinely missing witness. A historical,
+	// malformed, non-regular, or otherwise pre-existing path must stay on the
+	// ordinary guard path; the later O_EXCL check closes the race after this
+	// read-only qualification.
+	if _, err := os.Lstat(filepath.Join(beadsDir, localVersionFile)); !os.IsNotExist(err) {
+		return emptyServerInitWitnessQualification{}, false
+	}
+	// Never execute a credential command merely to make a legacy workspace
+	// admissible. Gateway/proxied initialization stays on the ordinary guard.
+	if cfg.GetDoltCredentialCommand() != "" {
+		return emptyServerInitWitnessQualification{}, false
+	}
+
+	dsn := doltutil.ServerDSN{
+		Host:     in.ServerHost,
+		Port:     in.ServerPort,
+		User:     cfg.GetDoltServerUser(),
+		Database: in.Database,
+		TLS:      cfg.GetDoltServerTLS(),
+	}
+	// Explicit TCP intentionally bypasses both persisted and ambient sockets.
+	// Only user/password/TLS come from configuration or env.
+	dsn.Password = configfile.LookupCredentialsPassword(dsn.Host, dsn.Port)
+	if password := os.Getenv("BEADS_DOLT_PASSWORD"); password != "" {
+		dsn.Password = password
+	}
+
+	empty, err := selectedServerDatabaseIsEmpty(dsn)
+	if err != nil || !empty {
+		return emptyServerInitWitnessQualification{}, false
+	}
+	return emptyServerInitWitnessQualification{beadsDir: beadsDir, dsn: dsn}, true
+}
+
+// createEmptyServerInitWitness records that the current binary has begun
+// initializing this workspace after re-proving the exact database empty. The
+// version witness identifies the release era; it is not an init-completion
+// marker. Keeping the current version after a later store-open failure is safe
+// and lets ordinary current-era recovery retry instead of misclassifying the
+// partial workspace as pre-1.0 data.
+//
+// O_EXCL is essential: a historical witness created between the two proofs
+// must be left byte-for-byte intact and cause the original guard refusal to
+// win.
+func createEmptyServerInitWitness(qualification emptyServerInitWitnessQualification) error {
+	witnessPath := filepath.Join(qualification.beadsDir, localVersionFile)
+	// #nosec G304 -- witnessPath is the fixed version file beneath the selected workspace.
+	f, err := os.OpenFile(witnessPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := f.WriteString(Version + "\n"); err != nil {
+		_ = f.Close()
+		_ = os.Remove(witnessPath)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(witnessPath)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(witnessPath)
+		return err
+	}
+	return nil
+}
+
+// pinEmptyServerInitWitness keeps schema creation on precisely the endpoint
+// qualified above. It runs after normal config and gateway setup, and prevents
+// any later defaulting from selecting a stale socket or a different server.
+func pinEmptyServerInitWitness(cfg *dolt.Config, qualification emptyServerInitWitnessQualification) {
+	dsn := qualification.dsn
+	cfg.ServerSocket = ""
+	cfg.ServerHost = dsn.Host
+	cfg.ServerPort = dsn.Port
+	cfg.ServerUser = dsn.User
+	cfg.ServerPassword = dsn.Password
+	cfg.ServerTLS = dsn.TLS
+	cfg.Database = dsn.Database
+	cfg.AutoStart = false
+}
+
+// selectedServerDatabaseIsEmpty verifies both that the DSN selected the exact
+// requested database and that it has no tables. It never creates a database,
+// table, or schema; callers treat every error as a failed qualification.
+func selectedServerDatabaseIsEmpty(dsn doltutil.ServerDSN) (bool, error) {
+	db, err := sql.Open("mysql", dsn.String())
+	if err != nil {
+		return false, err
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		return false, err
+	}
+
+	var selected string
+	if err := db.QueryRowContext(ctx, "SELECT DATABASE()").Scan(&selected); err != nil {
+		return false, err
+	}
+	if selected != dsn.Database {
+		return false, nil
+	}
+
+	var tables int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE()").Scan(&tables); err != nil {
+		return false, err
+	}
+	return tables == 0, nil
 }
 
 // initGuardServerMessage builds the error message for the init guard when the

--- a/cmd/bd/init_guard.go
+++ b/cmd/bd/init_guard.go
@@ -135,6 +135,12 @@ func qualifyEmptyServerInitWitness(beadsDir string, in emptyServerInitWitnessInp
 	if !strings.EqualFold(cfg.DoltMode, configfile.DoltModeServer) || !hasLegacyDoltRoot(beadsDir) {
 		return emptyServerInitWitnessQualification{}, false
 	}
+	// The destroy-count gate is skipped later only because the counted store
+	// is the proved one; a configuration that would open anything else must
+	// keep the ordinary guard.
+	if !configuredIdentityMatchesProof(cfg, in) {
+		return emptyServerInitWitnessQualification{}, false
+	}
 	// The exception is only for a genuinely missing witness. A historical,
 	// malformed, non-regular, or otherwise pre-existing path must stay on the
 	// ordinary guard path; the later O_EXCL check closes the race after this
@@ -162,19 +168,154 @@ func qualifyEmptyServerInitWitness(beadsDir string, in emptyServerInitWitnessInp
 		dsn.Password = password
 	}
 
-	empty, err := selectedServerDatabaseIsEmpty(dsn)
+	empty, err := provedRootDatabasesAreEmpty(beadsDir, dsn)
 	if err != nil || !empty {
 		return emptyServerInitWitnessQualification{}, false
 	}
 	return emptyServerInitWitnessQualification{beadsDir: beadsDir, dsn: dsn}, true
 }
 
-// createEmptyServerInitWitness records that the current binary has begun
-// initializing this workspace after re-proving the exact database empty. The
-// version witness identifies the release era; it is not an init-completion
-// marker. Keeping the current version after a later store-open failure is safe
-// and lets ordinary current-era recovery retry instead of misclassifying the
-// partial workspace as pre-1.0 data.
+// configuredIdentityMatchesProof reports whether the store the workspace
+// configuration would open — the one countExistingIssues counts — is the
+// database the qualification proves empty. Explicit --server-host and
+// --server-port are promoted into BEADS_DOLT_SERVER_* before the guard runs,
+// so host and port cannot diverge here; --database is not promoted, so the
+// database name is what makes the counted store the proved one.
+//
+// The persisted socket is checked for a different reason: countExistingIssues
+// never reads metadata's dolt_server_socket (dolt.NewFromConfig only honors
+// BEADS_DOLT_SERVER_SOCKET, which the flag promotion unsets), but every
+// post-recovery command does (resolveDoltServerConnection), so a socket that
+// is still live would route the recovered workspace to whatever it serves
+// instead of the proved HOST:PORT database.
+func configuredIdentityMatchesProof(cfg *configfile.Config, in emptyServerInitWitnessInput) bool {
+	if cfg.GetDoltDatabase() != in.Database {
+		return false
+	}
+	if cfg.DoltServerSocket == "" {
+		return true
+	}
+	// A dead persisted socket falls back to the explicit TCP endpoint on later
+	// commands and is cleared from metadata on success; a live one refuses.
+	return dolt.ResolveSocketTransport(cfg.DoltServerSocket, in.ServerHost, in.ServerPort, 500*time.Millisecond) == ""
+}
+
+// localDoltRootDatabases lists the databases materialized beneath the legacy
+// Dolt root as the server names them: every immediate subdirectory holding a
+// .dolt, plus the root itself when bd's own `dolt init` (ensureDoltInit) left
+// a .dolt there, which the server serves under the directory's name.
+func localDoltRootDatabases(beadsDir string) ([]string, error) {
+	root := filepath.Join(beadsDir, "dolt")
+	var names []string
+	if _, err := os.Lstat(filepath.Join(root, ".dolt")); err == nil {
+		names = append(names, sanitizeDBName(filepath.Base(root)))
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := os.Lstat(filepath.Join(root, entry.Name(), ".dolt")); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		names = append(names, sanitizeDBName(entry.Name()))
+	}
+	return names, nil
+}
+
+// provedRootDatabasesAreEmpty widens the emptiness proof from the selected
+// database to the whole server root the witness disarms: every database the
+// server lists must have zero tables, the selected database must be among
+// them, and every database materialized under the local root must be served
+// (an unlisted one cannot be proved empty). The selected-database proof runs
+// last so the DSN is also verified to select exactly the requested database.
+// It never creates a database, table, or schema; callers treat every error
+// as a failed qualification.
+func provedRootDatabasesAreEmpty(beadsDir string, dsn doltutil.ServerDSN) (bool, error) {
+	local, err := localDoltRootDatabases(beadsDir)
+	if err != nil {
+		return false, err
+	}
+
+	rootDSN := dsn
+	rootDSN.Database = ""
+	db, err := sql.Open("mysql", rootDSN.String())
+	if err != nil {
+		return false, err
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		return false, err
+	}
+
+	listed, err := listServerDatabases(ctx, db)
+	if err != nil {
+		return false, err
+	}
+
+	if !listed[dsn.Database] {
+		return false, nil
+	}
+	for _, name := range local {
+		if !listed[name] {
+			return false, nil
+		}
+	}
+	for name := range listed {
+		var tables int
+		if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ?", name).Scan(&tables); err != nil {
+			return false, err
+		}
+		if tables != 0 {
+			return false, nil
+		}
+	}
+	return selectedServerDatabaseIsEmpty(dsn)
+}
+
+// listServerDatabases returns every database the server lists, minus the
+// built-in system schemas.
+func listServerDatabases(ctx context.Context, db *sql.DB) (map[string]bool, error) {
+	rows, err := db.QueryContext(ctx, "SHOW DATABASES")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	listed := make(map[string]bool)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		if name == "information_schema" || name == "mysql" || name == "performance_schema" {
+			continue
+		}
+		listed[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return listed, nil
+}
+
+// createEmptyServerInitWitness records that the current binary has
+// initialized this workspace: it runs only after the root was re-proved empty
+// and the store has been opened, so a store-open failure never leaves a
+// current-era witness beside nothing initialized. The version witness
+// identifies the release era; it is not an init-completion marker, and
+// keeping it after a later optional step fails lets ordinary current-era
+// recovery retry instead of misclassifying the workspace as pre-1.0 data.
 //
 // O_EXCL is essential: a historical witness created between the two proofs
 // must be left byte-for-byte intact and cause the original guard refusal to

--- a/cmd/bd/init_guard_test.go
+++ b/cmd/bd/init_guard_test.go
@@ -1,12 +1,131 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage/doltutil"
 )
+
+func TestEmptyServerInitWitnessInputQualifies(t *testing.T) {
+	valid := emptyServerInitWitnessInput{
+		ExplicitServer:   true,
+		ExplicitDatabase: true,
+		Database:         "hq",
+		ReinitLocal:      true,
+		ExplicitHost:     true,
+		ServerHost:       "127.0.0.1",
+		ExplicitPort:     true,
+		ServerPort:       3307,
+	}
+	tests := map[string]struct {
+		input emptyServerInitWitnessInput
+		want  bool
+	}{
+		"explicit TCP":              {input: valid, want: true},
+		"missing explicit server":   {input: withEmptyServerInput(valid, func(in *emptyServerInitWitnessInput) { in.ExplicitServer = false })},
+		"missing explicit database": {input: withEmptyServerInput(valid, func(in *emptyServerInitWitnessInput) { in.ExplicitDatabase = false })},
+		"missing reinit":            {input: withEmptyServerInput(valid, func(in *emptyServerInitWitnessInput) { in.ReinitLocal = false })},
+		"proxied server":            {input: withEmptyServerInput(valid, func(in *emptyServerInitWitnessInput) { in.ProxiedServer = true })},
+		"shared server":             {input: withEmptyServerInput(valid, func(in *emptyServerInitWitnessInput) { in.SharedServer = true })},
+		"missing explicit TCP port": {input: withEmptyServerInput(valid, func(in *emptyServerInitWitnessInput) { in.ExplicitPort = false })},
+		"missing explicit TCP host": {input: withEmptyServerInput(valid, func(in *emptyServerInitWitnessInput) { in.ExplicitHost = false })},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tt.input.qualifies(); got != tt.want {
+				t.Fatalf("qualifies() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func withEmptyServerInput(in emptyServerInitWitnessInput, mutate func(*emptyServerInitWitnessInput)) emptyServerInitWitnessInput {
+	mutate(&in)
+	return in
+}
+
+func TestCreateEmptyServerInitWitnessDoesNotReplaceExistingWitness(t *testing.T) {
+	beadsDir := t.TempDir()
+	witnessPath := filepath.Join(beadsDir, localVersionFile)
+	historicalWitness := []byte("0.62.0\n")
+	if err := os.WriteFile(witnessPath, historicalWitness, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := createEmptyServerInitWitness(emptyServerInitWitnessQualification{beadsDir: beadsDir})
+	if err == nil {
+		t.Fatal("createEmptyServerInitWitness() succeeded over an existing historical witness")
+	}
+	got, err := os.ReadFile(witnessPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, historicalWitness) {
+		t.Fatalf("historical witness was modified: got %q, want %q", got, historicalWitness)
+	}
+}
+
+func TestCreateEmptyServerInitWitnessWritesCurrentVersionExclusively(t *testing.T) {
+	beadsDir := t.TempDir()
+	qualification := emptyServerInitWitnessQualification{beadsDir: beadsDir}
+	if err := createEmptyServerInitWitness(qualification); err != nil {
+		t.Fatalf("createEmptyServerInitWitness() error = %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(beadsDir, localVersionFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != Version+"\n" {
+		t.Fatalf("witness = %q, want %q", got, Version+"\n")
+	}
+}
+
+func TestPinEmptyServerInitWitnessPinsQualifiedTCPConnection(t *testing.T) {
+	cfg := &dolt.Config{
+		ServerSocket:   "/tmp/stale.sock",
+		ServerHost:     "wrong-host",
+		ServerPort:     3307,
+		ServerUser:     "wrong-user",
+		ServerPassword: "wrong-password",
+		ServerTLS:      false,
+		Database:       "wrong_database",
+		AutoStart:      true,
+	}
+	qualification := emptyServerInitWitnessQualification{dsn: doltutil.ServerDSN{
+		Host:     "127.0.0.1",
+		Port:     43123,
+		User:     "qualified-user",
+		Password: "qualified-password",
+		Database: "qualified_database",
+		TLS:      true,
+	}}
+
+	pinEmptyServerInitWitness(cfg, qualification)
+
+	if cfg.ServerSocket != "" || cfg.ServerHost != "127.0.0.1" || cfg.ServerPort != 43123 ||
+		cfg.ServerUser != "qualified-user" || cfg.ServerPassword != "qualified-password" ||
+		!cfg.ServerTLS || cfg.Database != "qualified_database" || cfg.AutoStart {
+		t.Fatalf("pin did not preserve the qualified TCP connection: %+v", cfg)
+	}
+}
+
+func TestSelectedServerDatabaseIsEmptyFailsClosedWhenUnreachable(t *testing.T) {
+	empty, err := selectedServerDatabaseIsEmpty(doltutil.ServerDSN{
+		Host:     "127.0.0.1",
+		Port:     1,
+		User:     "root",
+		Database: "missing",
+	})
+	if err == nil || empty {
+		t.Fatalf("selectedServerDatabaseIsEmpty() = (%v, %v), want false with an error", empty, err)
+	}
+}
 
 func TestInitGuardServerMessage(t *testing.T) {
 	tests := map[string]struct {

--- a/cmd/bd/init_guard_test.go
+++ b/cmd/bd/init_guard_test.go
@@ -3,11 +3,14 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 )
@@ -112,6 +115,97 @@ func TestPinEmptyServerInitWitnessPinsQualifiedTCPConnection(t *testing.T) {
 		cfg.ServerUser != "qualified-user" || cfg.ServerPassword != "qualified-password" ||
 		!cfg.ServerTLS || cfg.Database != "qualified_database" || cfg.AutoStart {
 		t.Fatalf("pin did not preserve the qualified TCP connection: %+v", cfg)
+	}
+}
+
+func TestConfiguredIdentityMatchesProof(t *testing.T) {
+	// The explicit TCP endpoint is live so a dead persisted socket can fall
+	// back to it; the live unix socket stands in for an earlier server
+	// incarnation that would outrank TCP.
+	tcp, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tcp.Close()
+	port := tcp.Addr().(*net.TCPAddr).Port
+	// Unix socket paths are length-limited, so avoid the long t.TempDir() name.
+	sockDir, err := os.MkdirTemp("", "bd-sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(sockDir)
+	liveSocket := filepath.Join(sockDir, "live.sock")
+	unixListener, err := net.Listen("unix", liveSocket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unixListener.Close()
+
+	in := emptyServerInitWitnessInput{Database: "proved", ServerHost: "127.0.0.1", ServerPort: port}
+	tests := map[string]struct {
+		cfg   configfile.Config
+		envDB string
+		want  bool
+	}{
+		"same database":              {cfg: configfile.Config{DoltDatabase: "proved"}, want: true},
+		"different database":         {cfg: configfile.Config{DoltDatabase: "configured"}, want: false},
+		"env override equals flag":   {cfg: configfile.Config{DoltDatabase: "configured"}, envDB: "proved", want: true},
+		"persisted live unix socket": {cfg: configfile.Config{DoltDatabase: "proved", DoltServerSocket: liveSocket}, want: false},
+		"persisted dead socket path": {cfg: configfile.Config{DoltDatabase: "proved", DoltServerSocket: filepath.Join(sockDir, "dead.sock")}, want: true},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("BEADS_DOLT_SERVER_DATABASE", tt.envDB)
+			cfg := tt.cfg
+			if got := configuredIdentityMatchesProof(&cfg, in); got != tt.want {
+				t.Fatalf("configuredIdentityMatchesProof() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLocalDoltRootDatabases(t *testing.T) {
+	beadsDir := t.TempDir()
+	for _, dir := range []string{"a/.dolt", "b-c/.dolt", "plain"} {
+		if err := os.MkdirAll(filepath.Join(beadsDir, "dolt", dir), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := localDoltRootDatabases(beadsDir)
+	if err != nil {
+		t.Fatalf("localDoltRootDatabases() error = %v", err)
+	}
+	if want := []string{"a", "b_c"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("localDoltRootDatabases() = %v, want %v", got, want)
+	}
+
+	// bd's own server start runs `dolt init` in the root, and the server serves
+	// that repository under the directory's name; it must be proved too.
+	if err := os.Mkdir(filepath.Join(beadsDir, "dolt", ".dolt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	got, err = localDoltRootDatabases(beadsDir)
+	if err != nil {
+		t.Fatalf("localDoltRootDatabases() with root .dolt error = %v", err)
+	}
+	if want := []string{"dolt", "a", "b_c"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("localDoltRootDatabases() with root .dolt = %v, want %v", got, want)
+	}
+}
+
+func TestProvedRootDatabasesAreEmptyFailsClosedWhenUnreachable(t *testing.T) {
+	beadsDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(beadsDir, "dolt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	empty, err := provedRootDatabasesAreEmpty(beadsDir, doltutil.ServerDSN{
+		Host:     "127.0.0.1",
+		Port:     1,
+		User:     "root",
+		Database: "missing",
+	})
+	if err == nil || empty {
+		t.Fatalf("provedRootDatabasesAreEmpty() = (%v, %v), want false with an error", empty, err)
 	}
 }
 

--- a/cmd/bd/init_safety_help.go
+++ b/cmd/bd/init_safety_help.go
@@ -70,6 +70,14 @@ DESTROY-TOKEN (non-interactive only)
   deliberate guard against pattern-matched one-liners (see
   engdocs/adr/0002-init-safety-invariants.md).
 
+LEGACY WORKSPACE RECOVERY
+
+  An unwitnessed server workspace (.beads/dolt/ present, no .local_version)
+  admits only bd init --force --server --server-host H --server-port P
+  --database D, and only when D is the configured database, no live
+  persisted socket redirects the connection, and every database the server
+  lists (plus every one under .beads/dolt/) is proven to have zero tables.
+
 EXIT CODES
 
   10    refused: remote has Dolt history and you selected local history

--- a/cmd/bd/legacy_upgrade_guard_e2e_test.go
+++ b/cmd/bd/legacy_upgrade_guard_e2e_test.go
@@ -6,8 +6,10 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,8 +19,150 @@ import (
 	"testing"
 	"time"
 
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/testutil"
 )
+
+func TestLegacyUpgradeGuardAdmitsAffirmativelyEmptyServerDatabase(t *testing.T) {
+	testutil.RequireDoltCLIOnly(t)
+	repoDir := t.TempDir()
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("start native Dolt server: %v", err)
+	}
+	t.Cleanup(func() { _ = doltserver.Stop(beadsDir) })
+	database := uniqueTestDBName(t)
+	// Deliberately retain a stale socket in metadata. Gas City names TCP with
+	// --server-host/--server-port, so the qualification and init must use those
+	// exact flags rather than silently routing through this stale endpoint.
+	cfg := &configfile.Config{Database: "dolt", Backend: configfile.BackendDolt, DoltMode: configfile.DoltModeServer, DoltDatabase: database, DoltServerHost: "127.0.0.1", DoltServerPort: state.Port, DoltServerSocket: filepath.Join(t.TempDir(), "stale.sock")}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("dolt.mode: server\ndolt.auto-start: false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dsn := doltutil.ServerDSN{Host: "127.0.0.1", Port: state.Port, User: "root"}.String()
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE `%s`", database)); err != nil {
+		t.Fatalf("create empty database: %v", err)
+	}
+	t.Cleanup(func() { dropTestDatabase(database, state.Port) })
+	t.Setenv("BEADS_DIR", beadsDir)
+	if err := guardLegacyUpgradeWorkspace(beadsDir); !isLegacyUpgradeRefusal(err) {
+		t.Fatalf("fixture guard = %v, want legacy refusal before fix", err)
+	}
+	empty, err := selectedServerDatabaseIsEmpty(doltutil.ServerDSN{Host: "127.0.0.1", Port: state.Port, User: "root", Database: database})
+	if err != nil || !empty {
+		t.Fatalf("fixture empty-database proof = (%v, %v), want (true, nil)", empty, err)
+	}
+	if _, qualified := qualifyEmptyServerInitWitness(beadsDir, emptyServerInitWitnessInput{
+		ExplicitServer: true, ExplicitDatabase: true, Database: database, ReinitLocal: true,
+		ExplicitHost: true, ServerHost: "127.0.0.1", ExplicitPort: true, ServerPort: state.Port,
+	}); !qualified {
+		t.Fatal("fixture did not qualify for the narrow empty-server init recovery")
+	}
+	// Explicit host/port flags must suppress an ambient socket all the way
+	// through dolt.New's defaulting, or schema creation would be redirected
+	// after the TCP database was proved empty.
+	t.Setenv("BEADS_DOLT_SERVER_SOCKET", filepath.Join(t.TempDir(), "stale.sock"))
+	bd := buildBDUnderTest(t)
+	cmdCtx, cmdCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cmdCancel()
+	cmd := exec.CommandContext(cmdCtx, bd, "init", "--force", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents", "--server", "--server-host", "127.0.0.1", "--server-port", fmt.Sprint(state.Port), "--database", database)
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir, "BD_DISABLE_METRICS=1", "BEADS_DOLT_AUTO_START=0")
+	var output bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &output, &output
+	if err := cmd.Run(); err != nil {
+		witness, witnessErr := os.ReadFile(filepath.Join(beadsDir, localVersionFile))
+		t.Fatalf("bd init --force empty server DB = %v, want success (witness=%q, witnessErr=%v):\n%s", err, witness, witnessErr, output.String())
+	}
+	got, err := os.ReadFile(filepath.Join(beadsDir, localVersionFile))
+	if err != nil {
+		t.Fatalf("read version witness: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != Version {
+		t.Fatalf("version witness = %q, want %q", strings.TrimSpace(string(got)), Version)
+	}
+	inspectCtx, inspectCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer inspectCancel()
+	var tableCount int
+	if err := db.QueryRowContext(inspectCtx, "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ?", database).Scan(&tableCount); err != nil {
+		t.Fatalf("inspect proved database schema: %v", err)
+	}
+	if tableCount == 0 {
+		t.Fatalf("proved database %q has no schema tables after init", database)
+	}
+}
+
+func TestLegacyUpgradeGuardRefusesNonEmptyServerDatabaseWithoutWitness(t *testing.T) {
+	testutil.RequireDoltCLIOnly(t)
+	repoDir := t.TempDir()
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("start native Dolt server: %v", err)
+	}
+	t.Cleanup(func() { _ = doltserver.Stop(beadsDir) })
+	database := uniqueTestDBName(t)
+	cfg := &configfile.Config{Database: "dolt", Backend: configfile.BackendDolt, DoltMode: configfile.DoltModeServer, DoltDatabase: database, DoltServerHost: "127.0.0.1", DoltServerPort: state.Port}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("dolt.mode: server\ndolt.auto-start: false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dsn := doltutil.ServerDSN{Host: "127.0.0.1", Port: state.Port, User: "root"}.String()
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE `%s`", database)); err != nil {
+		t.Fatalf("create server database: %v", err)
+	}
+	t.Cleanup(func() { dropTestDatabase(database, state.Port) })
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("USE `%s`; CREATE TABLE preserved (id INT PRIMARY KEY)", database)); err != nil {
+		t.Fatalf("create preserved table: %v", err)
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+	bd := buildBDUnderTest(t)
+	cmdCtx, cmdCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cmdCancel()
+	cmd := exec.CommandContext(cmdCtx, bd, "init", "--force", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents", "--server", "--server-host", "127.0.0.1", "--server-port", fmt.Sprint(state.Port), "--database", database)
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir, "BD_DISABLE_METRICS=1", "BEADS_DOLT_AUTO_START=0")
+	var output bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &output, &output
+	if err := cmd.Run(); err == nil {
+		t.Fatalf("bd init --force non-empty server DB succeeded, want legacy refusal:\n%s", output.String())
+	} else if !strings.Contains(output.String(), "legacy Dolt server workspace detected") {
+		t.Fatalf("bd init --force non-empty server DB output = %q, want legacy refusal", output.String())
+	}
+	if _, err := os.Lstat(filepath.Join(beadsDir, localVersionFile)); !os.IsNotExist(err) {
+		t.Fatalf("version witness was changed for non-empty server DB: %v", err)
+	}
+}
 
 func TestLegacyUpgradeGuardRefusesBeforeMutatingHistoricalWorkspace(t *testing.T) {
 	bd := buildBDUnderTest(t)

--- a/cmd/bd/legacy_upgrade_guard_e2e_test.go
+++ b/cmd/bd/legacy_upgrade_guard_e2e_test.go
@@ -108,6 +108,160 @@ func TestLegacyUpgradeGuardAdmitsAffirmativelyEmptyServerDatabase(t *testing.T) 
 	if tableCount == 0 {
 		t.Fatalf("proved database %q has no schema tables after init", database)
 	}
+	// The recovered workspace is current-era for every later command, and the
+	// stale socket must not outrank the pinned TCP endpoint on those commands.
+	if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+		t.Fatalf("guard after recovery = %v, want nil", err)
+	}
+	recovered, err := configfile.Load(beadsDir)
+	if err != nil {
+		t.Fatalf("load recovered metadata: %v", err)
+	}
+	if recovered.DoltServerSocket != "" {
+		t.Fatalf("recovered metadata dolt_server_socket = %q, want empty", recovered.DoltServerSocket)
+	}
+}
+
+// legacyEmptyServerFixture is a workspace whose metadata selects native
+// server mode for configuredDB beneath a legacy .beads/dolt root with no
+// version witness, served by a per-test Dolt server.
+type legacyEmptyServerFixture struct {
+	repoDir  string
+	beadsDir string
+	port     int
+	db       *sql.DB
+}
+
+func newLegacyEmptyServerFixture(t *testing.T, configuredDB string, databases ...string) legacyEmptyServerFixture {
+	t.Helper()
+	testutil.RequireDoltCLIOnly(t)
+	repoDir := t.TempDir()
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("start native Dolt server: %v", err)
+	}
+	t.Cleanup(func() { _ = doltserver.Stop(beadsDir) })
+	cfg := &configfile.Config{Database: "dolt", Backend: configfile.BackendDolt, DoltMode: configfile.DoltModeServer, DoltDatabase: configuredDB, DoltServerHost: "127.0.0.1", DoltServerPort: state.Port}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("dolt.mode: server\ndolt.auto-start: false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("mysql", doltutil.ServerDSN{Host: "127.0.0.1", Port: state.Port, User: "root"}.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for _, database := range databases {
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE `%s`", database)); err != nil {
+			t.Fatalf("create database %q: %v", database, err)
+		}
+		t.Cleanup(func() { dropTestDatabase(database, state.Port) })
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+	return legacyEmptyServerFixture{repoDir: repoDir, beadsDir: beadsDir, port: state.Port, db: db}
+}
+
+func (f legacyEmptyServerFixture) createTable(t *testing.T, database string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := f.db.ExecContext(ctx, fmt.Sprintf("USE `%s`; CREATE TABLE preserved (id INT PRIMARY KEY)", database)); err != nil {
+		t.Fatalf("create preserved table in %q: %v", database, err)
+	}
+}
+
+func (f legacyEmptyServerFixture) tableCount(t *testing.T, database string) int {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var count int
+	if err := f.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ?", database).Scan(&count); err != nil {
+		t.Fatalf("count tables in %q: %v", database, err)
+	}
+	return count
+}
+
+// runRecoveryInit runs the exact explicit native server re-init shape that
+// the empty-server recovery admits, naming database on the command line.
+func (f legacyEmptyServerFixture) runRecoveryInit(t *testing.T, database string) (string, error) {
+	t.Helper()
+	bd := buildBDUnderTest(t)
+	cmdCtx, cmdCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cmdCancel()
+	cmd := exec.CommandContext(cmdCtx, bd, "init", "--force", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents", "--server", "--server-host", "127.0.0.1", "--server-port", fmt.Sprint(f.port), "--database", database)
+	cmd.Dir = f.repoDir
+	cmd.Env = append(os.Environ(), "BEADS_DIR="+f.beadsDir, "BD_DISABLE_METRICS=1", "BEADS_DOLT_AUTO_START=0")
+	var output bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &output, &output
+	err := cmd.Run()
+	return output.String(), err
+}
+
+func (f legacyEmptyServerFixture) requireLegacyRefusal(t *testing.T, output string, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("bd init --force succeeded, want legacy refusal:\n%s", output)
+	}
+	if !strings.Contains(output, "legacy Dolt server workspace detected") {
+		t.Fatalf("bd init --force output = %q, want legacy refusal", output)
+	}
+	if _, err := os.Lstat(filepath.Join(f.beadsDir, localVersionFile)); !os.IsNotExist(err) {
+		t.Fatalf("version witness was created despite refusal: %v", err)
+	}
+}
+
+func TestLegacyUpgradeGuardRefusesEmptyDatabaseBesideNonEmptySibling(t *testing.T) {
+	database := uniqueTestDBName(t)
+	const sibling = "legacy_sibling"
+	f := newLegacyEmptyServerFixture(t, database, database, sibling)
+	f.createTable(t, sibling)
+
+	// One Dolt root serves every database beneath it, and the witness disarms
+	// the guard for the whole workspace, so an empty selected database beside
+	// a non-empty sibling must not qualify.
+	output, err := f.runRecoveryInit(t, database)
+	f.requireLegacyRefusal(t, output, err)
+	if got := f.tableCount(t, database); got != 0 {
+		t.Fatalf("proved database %q has %d tables after refusal, want 0", database, got)
+	}
+	if got := f.tableCount(t, sibling); got != 1 {
+		t.Fatalf("sibling database %q has %d tables after refusal, want 1", sibling, got)
+	}
+}
+
+func TestLegacyUpgradeGuardRefusesRepointingToEmptySiblingWithoutWitness(t *testing.T) {
+	configured := uniqueTestDBName(t)
+	const empty = "empty_sibling"
+	f := newLegacyEmptyServerFixture(t, configured, configured, empty)
+
+	// Both databases are empty, so the root proof alone would admit this
+	// shape: only the identity check refuses. countExistingIssues counts the
+	// configured database, so a flag naming a different database must not be
+	// allowed to skip the destroy gate and repoint metadata away from the
+	// store it never counted.
+	output, err := f.runRecoveryInit(t, empty)
+	f.requireLegacyRefusal(t, output, err)
+	if got := f.tableCount(t, configured); got != 0 {
+		t.Fatalf("configured database %q has %d tables after refusal, want 0", configured, got)
+	}
+	if got := f.tableCount(t, empty); got != 0 {
+		t.Fatalf("empty database %q has %d tables after refusal, want 0", empty, got)
+	}
+	cfg, err := configfile.Load(f.beadsDir)
+	if err != nil {
+		t.Fatalf("load metadata after refusal: %v", err)
+	}
+	if cfg.DoltDatabase != configured {
+		t.Fatalf("metadata dolt_database = %q after refusal, want %q", cfg.DoltDatabase, configured)
+	}
 }
 
 func TestLegacyUpgradeGuardRefusesNonEmptyServerDatabaseWithoutWitness(t *testing.T) {

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -258,6 +258,7 @@ server selection is not overridden by a stale `.beads/embeddeddolt/` repository.
 | Explicit server metadata plus `.local_version` from v0.55.4 through v0.62.0, whether or not `.beads/dolt/` exists | Explicit legacy Dolt export/import |
 | Explicit server metadata plus `.beads/dolt/` and a witness whose major version is 1 or newer | Normal current server-mode upgrade |
 | Explicit server metadata plus `.beads/dolt/` and a missing or pre-v1 witness | Explicit legacy Dolt export/import |
+| Explicit server metadata plus `.beads/dolt/`, no witness, and every database the named server lists (plus every one under that root) proven to have zero tables | Narrow empty-server recovery via explicit `bd init --force --server --server-host … --server-port … --database …` (see below) |
 | Explicit server metadata plus `.beads/dolt/` and a witness that is present but unreadable | Normal current server-mode upgrade, with a warning |
 | Explicit server metadata without `.beads/dolt/`, and a missing, malformed, or non-historical witness | Normal current server-mode compatibility path |
 | `.beads/dolt/` with missing metadata or persisted `dolt_mode` blank/`embedded` | Explicit legacy Dolt export/import, except for the configured shared-server compatibility path described below |
@@ -270,6 +271,19 @@ they name. A witness that is present but unreadable is not treated as a legacy
 marker — no pre-v1 `bd` could have written one — so `bd` warns and continues
 rather than refusing every command. A *missing* witness stays ambiguous and is
 still refused.
+
+One narrow exception covers an unwitnessed server workspace whose Dolt root was
+never populated (for example, a bootstrap that created the database but was
+interrupted before the witness). `bd init --force --server --server-host HOST
+--server-port PORT --database NAME` is admitted only when `NAME` is the database
+the workspace configuration already selects, no live persisted socket would
+redirect the connection elsewhere, and read-only SQL proves that every database
+the server lists — plus every database materialized under `.beads/dolt/` — has
+zero tables. The proof is repeated under init's mutation gate, and the
+current-era `.local_version` witness is created exclusively only after the store
+opens. A non-empty sibling database, a different configured database, a proxied
+or shared server, a credential command, or a witness that appears in the
+meantime all keep the ordinary refusal. See `bd help init-safety`.
 
 Current `bd` refuses recognized historical SQLite and legacy Dolt layouts before
 opening storage or rewriting metadata. This is intentional: preserve the source

--- a/docs/recovery/init-safety.md
+++ b/docs/recovery/init-safety.md
@@ -3,7 +3,7 @@ title: Recovery Playbooks
 description: Step-by-step recovery for bd init and bd dolt push/pull refusals, including the primary-key fork playbook
 ---
 
-Last reviewed: 2026-06-09
+Last reviewed: 2026-09-04
 
 Freshness source: `cmd/bd/init.go`, `cmd/bd/init_safety.go`,
 `cmd/bd/init_safety_test.go`, and `cmd/bd/dolt.go`.
@@ -20,6 +20,7 @@ See also: `bd help init-safety`, and
 - [init-force-refused — `bd init --force`/`--reinit-local` refused because origin has Dolt history](#init-force-refused)
 - [init-token-missing — `--discard-remote` refused because `--destroy-token` is missing or wrong](#init-token-missing)
 - [init-local-exists — `bd init` refused because local data already exists](#init-local-exists)
+- [legacy-empty-server-recovery — `bd init` refused on an unwitnessed server workspace whose database was never populated](#legacy-empty-server-recovery)
 - [pk-fork-refused — `bd dolt pull`/`push` refused because a table has different primary keys in its common ancestor](#pk-fork-refused)
 
 ---
@@ -157,6 +158,63 @@ enough to create a restorable backup before reinitializing.
 If you did NOT expect `bd init` to be the right command here, run
 `bd doctor` first — you may be looking at a server config issue that a
 re-init won't fix.
+
+---
+
+## legacy-empty-server-recovery
+
+**Symptom**
+
+```
+legacy Dolt server workspace detected; explicit migration is required before this bd version can open or modify the workspace. Preserve .beads unchanged and follow docs/getting-started/upgrading.md#cross-era-upgrades
+```
+
+on a workspace whose `metadata.json` selects `dolt_mode: server`, whose
+`.beads/dolt/` root exists, and which has no `.local_version` — typically a
+bootstrap that created the server database but was interrupted before the
+witness was written, so the database is still empty.
+
+**Why this happens**
+
+A missing witness is ambiguous: the guard cannot tell a never-populated
+current-era workspace from pre-1.0 data, so every command refuses. Only one
+narrow init shape may proceed without a witness, and only after proving there
+is nothing to destroy.
+
+**Recovery path**
+
+```
+bd init --force --server --server-host HOST --server-port PORT --database NAME
+```
+
+This is admitted only when all of the following hold; otherwise the refusal
+above is preserved unchanged:
+
+1. `NAME` is the database `metadata.json` (or `BEADS_DOLT_SERVER_DATABASE`)
+   already selects, so the destroy-count gate is skipped only for the store it
+   would have counted.
+2. No live `dolt_server_socket` persisted in `metadata.json` would route the
+   commands run after recovery away from `HOST:PORT` (the init's own count
+   ignores that socket; every later command honors it). A dead socket path
+   is tolerated and cleared from `metadata.json` on success.
+3. Read-only SQL proves that every database the server lists, and every
+   database materialized under `.beads/dolt/`, has zero tables. One Dolt root
+   serves many databases and the witness disarms the guard for the whole
+   workspace, so a non-empty sibling database refuses.
+4. The init is a native server init: not `--proxied-server`, not shared-server
+   mode, and no `dolt.credential-command` is configured.
+
+The proof is repeated under `bd init`'s mutation gate, and the current-era
+`.local_version` is created exclusively (`O_EXCL`) only after the store opens.
+If a witness appears in between, or the store fails to open, no witness is
+written and the original refusal wins. If the exclusive witness write itself
+fails after the store opened, the store has already created its schema, so the
+proved database is no longer empty: later runs refuse, and the workspace must
+be recovered through the explicit export/import path below.
+
+If any condition fails, or the database was ever populated, follow the
+explicit legacy Dolt export/import path in
+[Cross-era Upgrades](../getting-started/upgrading.md#cross-era-upgrades).
 
 ---
 


### PR DESCRIPTION
## What

Allow an explicit native server re-init to recover a missing `.beads/.local_version` only when Beads can prove that the exact selected database is empty.

This unblocks fresh Gas City bootstrap without weakening the legacy-workspace guard. Ambiguous, unreachable, shared, proxied, implicit, and non-empty configurations still fail closed.

Fixes #5682

## Why this deadlocks today

Gas City and Beads each make a reasonable local decision:

1. Gas City starts a managed Dolt server and creates an empty database for the City.
2. Gas City invokes `bd init --server --force` with an explicit host, port, and database.
3. Beads sees a local Dolt root but no `.local_version` witness.
4. The legacy guard refuses to proceed because that shape might contain pre-1.0 data.
5. The guard returns before Beads checks the selected server database, so the fact that it is empty cannot resolve the ambiguity.

```mermaid
sequenceDiagram
    participant GC as Gas City
    participant DB as Managed Dolt database
    participant Init as bd init
    participant Guard as Legacy guard

    GC->>DB: Create an empty City database
    GC->>Init: Start explicit native server init
    Init->>Guard: Inspect local workspace
    Guard-->>Init: Dolt root exists and version witness is missing
    Guard-->>Init: Refuse possible legacy workspace
    Note over Init,DB: The empty selected database is never considered
```

The result is a bootstrap deadlock: Gas City cannot finish until Beads initializes the database, while Beads cannot initialize because it cannot distinguish a fresh interrupted bootstrap from a legacy workspace.

## Safety invariant

The fix does not treat `--force` as permission to bypass the guard. It admits one state that Beads can establish from evidence:

> An explicit native TCP re-init may proceed only when the exact selected database is reachable and has zero tables, the version witness is genuinely absent, and the same connection identity is used for schema creation.

```mermaid
flowchart TD
    A[Legacy guard refuses the workspace] --> B{Explicit native TCP re-init with a named database?}
    B -- No --> Z[Preserve the legacy refusal]
    B -- Yes --> C{Exact selected database is reachable and has zero tables?}
    C -- No --> Z
    C -- Yes --> D[Run the normal init safety checks]
    D --> E[Re-prove the same database immediately before schema creation]
    E --> F{Still empty and witness still absent?}
    F -- No --> Z
    F -- Yes --> G[Create the current-version witness with O_EXCL]
    G --> H[Open the store pinned to the proved DSN]
    H --> I[Continue native City bootstrap]
```

The recovery path preserves these boundaries:

- **Exact identity:** schema creation is pinned to the proved host, port, database, user, password, and TLS configuration.
- **No fallback:** recovery disables auto-start and clears socket routing so initialization cannot drift to another server.
- **Two proofs:** Beads checks for zero tables during qualification and again immediately before schema creation.
- **No overwrite:** `O_EXCL` prevents recovery from replacing a historical or concurrently created witness.
- **Release-era evidence:** `.local_version` records that the current Beads release began initialization; it is not an init-completion marker.
- **Fail closed elsewhere:** non-empty, unreachable, shared, proxied, implicit, or credential-command configurations keep the original refusal.

## Verification

- Added a native regression that fails on `main` at the legacy guard for the Gas City-shaped bootstrap and passes with this change.
- Added refusal coverage for a non-empty selected database.
- Added unit coverage for qualification, unreachable-server behavior, connection pinning, current-version witness creation, and preservation of an existing witness.
- Passed the focused native regression suite.
- Passed the complete `cmd/bd/...` package suite.
- Passed `BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint`.
- Passed documentation freshness, `testing.Short` boundary, and OpenAPI drift checks. The aggregate local policy target stopped on a stale `integrations/beads-mcp/uv.lock` that is unchanged from `origin/main`.
- Ran the race-enabled PR core suite. Its `cmd/bd` package reached the 10-minute timeout while `TestMain` was probing Docker; the named test never began. The same test executed and passed under the repository's hermetic `BEADS_TEST_SKIP=dolt` environment.
- Initialized two fresh disposable native Gas Cities with the patched `bd`. Both wrote `.local_version` `1.2.2`; direct and City-routed `bd list --json` calls succeeded; both managed Dolt listeners were then stopped.
