### PR TITLE
chore(api): mark new exported packages experimental before v1.3.0

### DIFF
--- a/beadserrors/errors.go
+++ b/beadserrors/errors.go
@@ -26,6 +26,12 @@
 //
 // The package imports stdlib and nothing else, and it must stay that way: it
 // sits beneath every leaf, so anything it imports is imported by all of them.
+//
+// # Stability
+//
+// EXPERIMENTAL. This package is not yet covered by the project's compatibility
+// promise and may change in a minor release. Every leaf re-exports from here,
+// so a change to this vocabulary reaches all of them at once.
 package beadserrors
 
 import (

--- a/issueops/issueops.go
+++ b/issueops/issueops.go
@@ -1,4 +1,9 @@
 // Package issueops declares the public values used for guarded issue mutations.
+//
+// # Stability
+//
+// EXPERIMENTAL. This package is not yet covered by the project's compatibility
+// promise and may change in a minor release. Pin an exact beads version.
 package issueops
 
 import (

--- a/journalops/doc.go
+++ b/journalops/doc.go
@@ -64,4 +64,10 @@
 // matches by identity. If a validation refusal ever appears here it aliases
 // beadserrors.ErrValidation rather than minting a twin, for the reasons
 // memoryops/errors.go gives.
+//
+// # Stability
+//
+// EXPERIMENTAL. This package is not yet covered by the project's compatibility
+// promise and may change in a minor release. A consumer replaying the feed
+// should pin an exact beads version.
 package journalops

--- a/memoryops/doc.go
+++ b/memoryops/doc.go
@@ -45,4 +45,9 @@
 // cursor. A front door that prints them sorts the keys, and both do today. If
 // this plane ever grows to thousands of rows, a paged reader is a new role
 // conversation and not a retrofit of this one.
+//
+// # Stability
+//
+// EXPERIMENTAL. This package is not yet covered by the project's compatibility
+// promise and may change in a minor release. Pin an exact beads version.
 package memoryops

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,6 +1,12 @@
 // Package schema is the public wrapper around bd's schema migration engine,
 // re-exporting the minimal surface external tools need to create or upgrade a
 // beads database over a standard database/sql connection.
+//
+// # Stability
+//
+// EXPERIMENTAL. This package is not yet covered by the project's compatibility
+// promise and may change in a minor release. The migration set it wraps grows
+// every release; pin an exact beads version.
 package schema
 
 import (

--- a/test/conformance/profiles.go
+++ b/test/conformance/profiles.go
@@ -8,6 +8,12 @@
 // isolated workspace for each backend. Adding a backend is one Profiles entry; the
 // runner and scripts/conformance.sh pick it up automatically. The suite is behind
 // the `e2e` build tag because it shells out to a freshly built bd.
+//
+// # Stability
+//
+// EXPERIMENTAL, same terms as the backend package: this harness tracks the
+// evolving storage contract and its registry may change in a minor release.
+// Pin an exact beads version.
 package conformance
 
 // Workspace is one isolated place a backend can be `bd init`-ed. Dir is the working


### PR DESCRIPTION
## What

Adds a `# Stability` section marking the new exported Go packages as experimental, ahead of the v1.3.0 tag. Doc comments only — no behavior change, no API change.

## Why — maintainer decision D-7

The exported Go surface added since `v1.2.2` is ~52k lines across 100 files (`git diff --stat v1.2.2..origin/main -- backend beadserrors issueops journalops memoryops schema` → `100 files changed, 51422 insertions(+)`). Tagging 1.3.0 with that surface unmarked would implicitly freeze it as a v1 compatibility commitment for out-of-tree consumers.

These packages are the extension door for out-of-tree backends and external tooling, and the contracts behind them are still moving — the engine interface still gains required methods, the migration set grows every release, and the role leaves are still being split. D-7 is that the surface should ship *usable* but *explicitly unfrozen*, so the door stays open without a v2 to walk back through.

## Packages touched

| Package | Change |
|---|---|
| `beadserrors/` | `# Stability` added to package comment (`errors.go`) |
| `issueops/` | `# Stability` added to package comment (`issueops.go`) |
| `journalops/` | `# Stability` added to `doc.go` |
| `memoryops/` | `# Stability` added to `doc.go` |
| `schema/` | `# Stability` added to package comment (`schema.go`) |
| `test/conformance/` | `# Stability` added to package comment (`profiles.go`) |

### Already marked — deliberately untouched

`backend/` and `backend/conformance/` already carry a `# Stability` section reading `EXPERIMENTAL … no compatibility promise beyond that is made yet` / `EXPERIMENTAL, same terms as the backend package`. Those set the house style this PR follows, and re-wording them would be churn, so they are left as-is.

### Scope notes

The list was derived by diffing the root-level tree at `v1.2.2` against `HEAD` and keeping only new, non-`internal/`, non-`main` importable packages. Excluded on purpose:

- `format/`, `plugins/beads`, and the root `beads` package — all existed at `v1.2.2`, so they are not part of the new surface.
- `cmd/…`, `tools/docsmint`, and the `scripts/…` binaries — `package main` or repo tooling, not an importable API.
- `test/docsync`, `test/testmainconvention` — test-only, no non-`_test.go` files.
- `test/conformance` **is** included: `profiles.go` is a non-test file an out-of-tree backend author is expected to import (adding a backend is "one `Profiles` entry"), so it is part of the new exported surface even though it lives under `test/`. Flagging as a judgment call — happy to drop it if you'd rather scope this to the root planes only.

## Proposed CHANGELOG line

`CHANGELOG.md` is deliberately **not** touched here, to keep this clean against the release branch. Suggested entry for the 1.3.0 section:

```
- The newly exported Go packages (`backend`, `backend/conformance`, `beadserrors`,
  `issueops`, `journalops`, `memoryops`, `schema`, `test/conformance`) are marked
  EXPERIMENTAL: they are not yet covered by the project's compatibility promise and
  may change in a minor release. Pin an exact beads version and re-run the
  conformance suite on every bump.
```

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l` on all touched packages — clean
- `golangci-lint` (pre-commit hook) — 0 issues
- `go doc ./schema` etc. confirmed the `# Stability` heading renders as a godoc section

Incidental `go.sum` churn from the build was reverted; the commit is the six doc files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
