### PR TITLE
fix(storage/dolt): run DOLT_ADD/DOLT_COMMIT after the SQL transaction commits (lost updates in server mode) (#5740 carry)

### DIFF
--- a/internal/storage/dolt/batch_applier.go
+++ b/internal/storage/dolt/batch_applier.go
@@ -36,6 +36,14 @@ var _ issueops.BatchApplier = (*batchApplier)(nil)
 // The message is composed inside the body because its default names how much
 // LANDED, which is not knowable until every item has run — an update that
 // matched and an edge that was already there both land nothing.
+//
+// Durability contract: a nil error means the applied updates and edges are
+// durable in the branch working set. The Dolt history commit runs after the
+// SQL transaction (runIssueOperationTxWithMessage) and may be deferred — if it
+// fails after retries the changes still landed and ride the next Dolt commit;
+// the only signal is the bd.db.post_tx_commit_dropped counter, since the batch
+// path has no verify-by-re-read recovery. A nil return is therefore not a retry
+// signal: the mutations already applied, and retrying would double-apply.
 func (o *batchApplier) ApplyBatch(ctx context.Context, request issueops.ApplyBatchRequest) (issueops.ApplyBatchResult, error) {
 	plan, err := storage.PlanApplyBatch(request)
 	if err != nil {

--- a/internal/storage/dolt/batch_closer.go
+++ b/internal/storage/dolt/batch_closer.go
@@ -29,6 +29,15 @@ type batchCloser struct{ store *DoltStore }
 // CloseBatch runs every close, and the optional claim, in ONE transaction with
 // one commit. The message is composed inside the body because it names what
 // LANDED, which is not knowable until the last item has been tried.
+//
+// Durability contract: a nil error means the closes (and the optional claim)
+// are durable in the branch working set. The Dolt history commit runs after
+// the SQL transaction (runIssueOperationTxWithMessage) and may be deferred — if
+// it fails after retries the change still landed and rides the next Dolt
+// commit; the only signal is the bd.db.post_tx_commit_dropped counter, since
+// the batch path has no verify-by-re-read recovery. A nil return is therefore
+// not a retry signal: the closes already applied, and retrying would
+// double-apply.
 func (o *batchCloser) CloseBatch(ctx context.Context, request issueops.CloseBatchRequest) (issueops.CloseBatchResult, error) {
 	if err := storageissueops.ValidateCloseBatchRequest(request); err != nil {
 		return issueops.CloseBatchResult{}, err

--- a/internal/storage/dolt/batch_creator.go
+++ b/internal/storage/dolt/batch_creator.go
@@ -28,6 +28,14 @@ type batchCreator struct{ store *DoltStore }
 // message is composed inside the body because its default names how much
 // LANDED, which is not knowable until every item has been prepared and routed
 // to its plane.
+//
+// Durability contract: a nil error means the batch's data is durable in the
+// branch working set. The Dolt history commit runs after the SQL transaction
+// (runIssueOperationTxWithMessage) and may be deferred — if it fails after
+// retries the creates still landed and ride the next Dolt commit; the only
+// signal is the bd.db.post_tx_commit_dropped counter, since the batch path has
+// no verify-by-re-read recovery. A nil return is therefore not a retry signal:
+// the creates already applied, and retrying would double-create.
 func (o *batchCreator) CreateBatch(ctx context.Context, request issueops.CreateBatchRequest) (issueops.CreateBatchResult, error) {
 	if err := storageissueops.ValidateCreateBatchRequest(request); err != nil {
 		return issueops.CreateBatchResult{}, err

--- a/internal/storage/dolt/dolt_commit_ordering_test.go
+++ b/internal/storage/dolt/dolt_commit_ordering_test.go
@@ -1,0 +1,171 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	storageissueops "github.com/steveyegge/beads/internal/storage/issueops"
+)
+
+// Regression test for the server-mode lost-update bug
+// (LatentLabsSpace/NEXUS#92): the issue-mutation path used to run
+// CALL DOLT_ADD / CALL DOLT_COMMIT inside the still-open SQL transaction.
+// DOLT_ADD stages the whole table from the session's BEGIN-time root, so a
+// Dolt commit built before the transaction's commit-time merge writes every
+// concurrently-committed row back to its BEGIN-time value.
+//
+// The fix is an ordering contract: the Dolt add/commit MUST execute strictly
+// after driver-level tx.Commit(). This test pins that contract with a
+// sequence-capturing driver, so it needs no running Dolt server and holds
+// for embedded and server mode alike.
+
+// --- sequence-capturing driver --------------------------------------------
+
+type seqRecorder struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (r *seqRecorder) add(ev string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, ev)
+}
+
+func (r *seqRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+type seqConnector struct{ rec *seqRecorder }
+
+func (c *seqConnector) Connect(context.Context) (driver.Conn, error) {
+	return &seqConn{rec: c.rec}, nil
+}
+func (c *seqConnector) Driver() driver.Driver { return seqDriver{} }
+
+type seqDriver struct{}
+
+func (seqDriver) Open(string) (driver.Conn, error) { return nil, driver.ErrSkip }
+
+type seqConn struct{ rec *seqRecorder }
+
+func (c *seqConn) Prepare(string) (driver.Stmt, error) { return nil, driver.ErrSkip }
+func (c *seqConn) Close() error                        { return nil }
+func (c *seqConn) Begin() (driver.Tx, error)           { return c.BeginTx(context.Background(), driver.TxOptions{}) }
+
+func (c *seqConn) BeginTx(context.Context, driver.TxOptions) (driver.Tx, error) {
+	c.rec.add("BEGIN")
+	return &seqTx{rec: c.rec}, nil
+}
+
+func (c *seqConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	c.rec.add(query)
+	return driver.RowsAffected(1), nil
+}
+
+func (c *seqConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	c.rec.add(query)
+	return &seqRows{}, nil
+}
+
+type seqTx struct{ rec *seqRecorder }
+
+func (t *seqTx) Commit() error   { t.rec.add("COMMIT"); return nil }
+func (t *seqTx) Rollback() error { t.rec.add("ROLLBACK"); return nil }
+
+type seqRows struct{}
+
+func (*seqRows) Columns() []string              { return []string{} }
+func (*seqRows) Close() error                   { return nil }
+func (*seqRows) Next(dest []driver.Value) error { return io.EOF }
+
+// --- the ordering contract -------------------------------------------------
+
+func TestIssueOperationDoltCommitRunsAfterTxCommit(t *testing.T) {
+	rec := &seqRecorder{}
+	db := sql.OpenDB(&seqConnector{rec: rec})
+	defer func() { _ = db.Close() }()
+
+	s := &DoltStore{db: db}
+
+	err := s.runIssueOperationTx(context.Background(), "bd: update test-1", func(tx *sql.Tx) (storageissueops.ChangedTables, error) {
+		if _, err := tx.ExecContext(context.Background(), "UPDATE issues SET status = 'in_progress' WHERE id = 'test-1'"); err != nil {
+			return nil, err
+		}
+		return storageissueops.ChangedTables{"issues": true}, nil
+	})
+	if err != nil {
+		t.Fatalf("runIssueOperationTx: %v", err)
+	}
+
+	events := rec.snapshot()
+	idx := func(pred func(string) bool) int {
+		for i, ev := range events {
+			if pred(ev) {
+				return i
+			}
+		}
+		return -1
+	}
+
+	commitIdx := idx(func(ev string) bool { return ev == "COMMIT" })
+	doltAddIdx := idx(func(ev string) bool { return strings.Contains(ev, "DOLT_ADD") })
+	doltCommitIdx := idx(func(ev string) bool { return strings.Contains(ev, "DOLT_COMMIT") })
+
+	if commitIdx == -1 {
+		t.Fatalf("no driver-level tx COMMIT recorded; events: %v", events)
+	}
+	if doltAddIdx == -1 || doltCommitIdx == -1 {
+		t.Fatalf("DOLT_ADD/DOLT_COMMIT not recorded; events: %v", events)
+	}
+	if doltAddIdx < commitIdx {
+		t.Errorf("DOLT_ADD ran INSIDE the open transaction (index %d < COMMIT index %d) — lost-update ordering regression; events: %v",
+			doltAddIdx, commitIdx, events)
+	}
+	if doltCommitIdx < commitIdx {
+		t.Errorf("DOLT_COMMIT ran INSIDE the open transaction (index %d < COMMIT index %d) — lost-update ordering regression; events: %v",
+			doltCommitIdx, commitIdx, events)
+	}
+	if doltCommitIdx < doltAddIdx {
+		t.Errorf("DOLT_COMMIT before DOLT_ADD; events: %v", events)
+	}
+
+	// No transaction may still be open when the Dolt commit runs: assert no
+	// BEGIN after the data COMMIT and before the DOLT_COMMIT.
+	for i := commitIdx + 1; i < doltCommitIdx; i++ {
+		if events[i] == "BEGIN" {
+			t.Errorf("unexpected BEGIN between tx COMMIT and DOLT_COMMIT at index %d; events: %v", i, events)
+		}
+	}
+}
+
+// TestIssueOperationNoTablesSkipsDoltCommit pins the no-op contract: an
+// operation reporting no changed tables must not create a Dolt commit.
+func TestIssueOperationNoTablesSkipsDoltCommit(t *testing.T) {
+	rec := &seqRecorder{}
+	db := sql.OpenDB(&seqConnector{rec: rec})
+	defer func() { _ = db.Close() }()
+
+	s := &DoltStore{db: db}
+
+	err := s.runIssueOperationTx(context.Background(), "bd: noop", func(tx *sql.Tx) (storageissueops.ChangedTables, error) {
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("runIssueOperationTx: %v", err)
+	}
+	for _, ev := range rec.snapshot() {
+		if strings.Contains(ev, "DOLT_COMMIT") {
+			t.Errorf("no-op operation produced a DOLT_COMMIT; events: %v", rec.snapshot())
+		}
+	}
+}

--- a/internal/storage/dolt/dolt_commit_ordering_test.go
+++ b/internal/storage/dolt/dolt_commit_ordering_test.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"io"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
+	mysql "github.com/go-sql-driver/mysql"
+
+	"github.com/steveyegge/beads/internal/storage"
 	storageissueops "github.com/steveyegge/beads/internal/storage/issueops"
 )
 
@@ -29,12 +34,14 @@ import (
 type seqRecorder struct {
 	mu     sync.Mutex
 	events []string
+	conns  []int // conns[i] is the driver connection that produced events[i]
 }
 
-func (r *seqRecorder) add(ev string) {
+func (r *seqRecorder) add(conn int, ev string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.events = append(r.events, ev)
+	r.conns = append(r.conns, conn)
 }
 
 func (r *seqRecorder) snapshot() []string {
@@ -45,10 +52,32 @@ func (r *seqRecorder) snapshot() []string {
 	return out
 }
 
-type seqConnector struct{ rec *seqRecorder }
+// snapshotConns returns the events with the connection id each ran on.
+func (r *seqRecorder) snapshotConns() ([]string, []int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	evs := make([]string, len(r.events))
+	copy(evs, r.events)
+	cs := make([]int, len(r.conns))
+	copy(cs, r.conns)
+	return evs, cs
+}
+
+type seqConnector struct {
+	rec    *seqRecorder
+	nextID atomic.Int64
+	// queryErr, when set, can fail a statement after it is recorded (the
+	// driver routes CALL statements through QueryContext via DrainCall).
+	queryErr func(query string) error
+	// rows, when set, serves a canned result set for matching queries.
+	rows func(query string) (driver.Rows, bool)
+	// commitErr, when set, can fail the driver-level tx COMMIT after it is
+	// recorded (for exercising the ambiguous commit-phase path).
+	commitErr func() error
+}
 
 func (c *seqConnector) Connect(context.Context) (driver.Conn, error) {
-	return &seqConn{rec: c.rec}, nil
+	return &seqConn{parent: c, id: int(c.nextID.Add(1))}, nil
 }
 func (c *seqConnector) Driver() driver.Driver { return seqDriver{} }
 
@@ -56,37 +85,90 @@ type seqDriver struct{}
 
 func (seqDriver) Open(string) (driver.Conn, error) { return nil, driver.ErrSkip }
 
-type seqConn struct{ rec *seqRecorder }
+type seqConn struct {
+	parent *seqConnector
+	id     int
+}
 
 func (c *seqConn) Prepare(string) (driver.Stmt, error) { return nil, driver.ErrSkip }
 func (c *seqConn) Close() error                        { return nil }
-func (c *seqConn) Begin() (driver.Tx, error)           { return c.BeginTx(context.Background(), driver.TxOptions{}) }
+func (c *seqConn) Begin() (driver.Tx, error) {
+	return c.BeginTx(context.Background(), driver.TxOptions{})
+}
 
 func (c *seqConn) BeginTx(context.Context, driver.TxOptions) (driver.Tx, error) {
-	c.rec.add("BEGIN")
-	return &seqTx{rec: c.rec}, nil
+	c.parent.rec.add(c.id, "BEGIN")
+	return &seqTx{rec: c.parent.rec, conn: c.id, commitErr: c.parent.commitErr}, nil
 }
 
 func (c *seqConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
-	c.rec.add(query)
+	c.parent.rec.add(c.id, query)
+	if c.parent.queryErr != nil {
+		if err := c.parent.queryErr(query); err != nil {
+			return nil, err
+		}
+	}
 	return driver.RowsAffected(1), nil
 }
 
 func (c *seqConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
-	c.rec.add(query)
+	c.parent.rec.add(c.id, query)
+	if c.parent.queryErr != nil {
+		if err := c.parent.queryErr(query); err != nil {
+			return nil, err
+		}
+	}
+	if c.parent.rows != nil {
+		if rows, ok := c.parent.rows(query); ok {
+			return rows, nil
+		}
+	}
+	if strings.Contains(query, "FROM dolt_status") {
+		// doltAddAndCommit's empty-commit guard: report one staged row so the
+		// post-tx sequence under test still reaches DOLT_COMMIT.
+		return &valRows{cols: []string{"count"}, vals: [][]driver.Value{{int64(1)}}}, nil
+	}
 	return &seqRows{}, nil
 }
 
-type seqTx struct{ rec *seqRecorder }
+type seqTx struct {
+	rec       *seqRecorder
+	conn      int
+	commitErr func() error
+}
 
-func (t *seqTx) Commit() error   { t.rec.add("COMMIT"); return nil }
-func (t *seqTx) Rollback() error { t.rec.add("ROLLBACK"); return nil }
+func (t *seqTx) Commit() error {
+	t.rec.add(t.conn, "COMMIT")
+	if t.commitErr != nil {
+		return t.commitErr()
+	}
+	return nil
+}
+func (t *seqTx) Rollback() error { t.rec.add(t.conn, "ROLLBACK"); return nil }
 
 type seqRows struct{}
 
 func (*seqRows) Columns() []string              { return []string{} }
 func (*seqRows) Close() error                   { return nil }
 func (*seqRows) Next(dest []driver.Value) error { return io.EOF }
+
+// valRows serves one canned row, for tests that need a re-read to see state.
+type valRows struct {
+	cols []string
+	vals [][]driver.Value
+	i    int
+}
+
+func (r *valRows) Columns() []string { return r.cols }
+func (r *valRows) Close() error      { return nil }
+func (r *valRows) Next(dest []driver.Value) error {
+	if r.i >= len(r.vals) {
+		return io.EOF
+	}
+	copy(dest, r.vals[r.i])
+	r.i++
+	return nil
+}
 
 // --- the ordering contract -------------------------------------------------
 
@@ -167,5 +249,233 @@ func TestIssueOperationNoTablesSkipsDoltCommit(t *testing.T) {
 		if strings.Contains(ev, "DOLT_COMMIT") {
 			t.Errorf("no-op operation produced a DOLT_COMMIT; events: %v", rec.snapshot())
 		}
+	}
+}
+
+// TestPostTxDoltAddCommitSharesOneConnection pins the connection contract:
+// the post-tx DOLT_ADD…DOLT_COMMIT sequence must run on ONE pinned pool
+// connection (GH#2455). With MaxIdleConns(0) every bare s.db statement gets a
+// fresh driver connection, so an unpinned sequence deterministically shows
+// distinct connection ids — including a DOLT_COMMIT on a different session
+// than the DOLT_ADD it depends on, which under a multi-branch pool commits
+// the wrong branch's staged root or degrades to nothing-to-commit.
+func TestPostTxDoltAddCommitSharesOneConnection(t *testing.T) {
+	rec := &seqRecorder{}
+	db := sql.OpenDB(&seqConnector{rec: rec})
+	defer func() { _ = db.Close() }()
+	db.SetMaxIdleConns(0)
+
+	s := &DoltStore{db: db}
+
+	err := s.runIssueOperationTx(context.Background(), "bd: update test-1", func(tx *sql.Tx) (storageissueops.ChangedTables, error) {
+		if _, err := tx.ExecContext(context.Background(), "UPDATE issues SET status = 'in_progress' WHERE id = 'test-1'"); err != nil {
+			return nil, err
+		}
+		return storageissueops.ChangedTables{"issues": true, "events": true}, nil
+	})
+	if err != nil {
+		t.Fatalf("runIssueOperationTx: %v", err)
+	}
+
+	events, conns := rec.snapshotConns()
+	doltConn := 0
+	for i, ev := range events {
+		if !strings.Contains(ev, "DOLT_ADD") && !strings.Contains(ev, "DOLT_COMMIT") {
+			continue
+		}
+		if doltConn == 0 {
+			doltConn = conns[i]
+			continue
+		}
+		if conns[i] != doltConn {
+			t.Fatalf("post-tx dolt statement %q ran on connection %d, want pinned connection %d; events: %v conns: %v",
+				ev, conns[i], doltConn, events, conns)
+		}
+	}
+	if doltConn == 0 {
+		t.Fatalf("no DOLT_ADD/DOLT_COMMIT recorded; events: %v", events)
+	}
+}
+
+// TestPostTxDoltCommitFailureDoesNotFailMutation pins the swallow contract:
+// a post-tx DOLT_ADD/DOLT_COMMIT failure happens after the data transaction
+// committed, so the mutation IS applied and the operation must report
+// success (the failure is logged; the change rides the next dolt commit).
+// Surfacing it would make callers treat an applied mutation as failed —
+// automated retries double-apply, hooks are skipped, and claim callers
+// abandon claims they hold (the wy-x543k inversion).
+func TestPostTxDoltCommitFailureDoesNotFailMutation(t *testing.T) {
+	rec := &seqRecorder{}
+	connector := &seqConnector{rec: rec}
+	connector.queryErr = func(query string) error {
+		if strings.Contains(query, "DOLT_COMMIT") {
+			return errors.New("boom: injected dolt commit failure")
+		}
+		return nil
+	}
+	db := sql.OpenDB(connector)
+	defer func() { _ = db.Close() }()
+
+	s := &DoltStore{db: db}
+
+	err := s.runIssueOperationTx(context.Background(), "bd: update test-1", func(tx *sql.Tx) (storageissueops.ChangedTables, error) {
+		return storageissueops.ChangedTables{"issues": true}, nil
+	})
+	if err != nil {
+		t.Fatalf("post-tx dolt commit failure must not fail the mutation (data committed); got: %v", err)
+	}
+
+	// The data COMMIT and the DOLT_COMMIT attempt must both have run.
+	events := rec.snapshot()
+	sawCommit, sawDoltCommit := false, false
+	for _, ev := range events {
+		if ev == "COMMIT" {
+			sawCommit = true
+		}
+		if strings.Contains(ev, "DOLT_COMMIT") {
+			sawDoltCommit = true
+		}
+	}
+	if !sawCommit {
+		t.Fatalf("data transaction never committed; events: %v", events)
+	}
+	if !sawDoltCommit {
+		t.Fatalf("post-tx DOLT_COMMIT never attempted; events: %v", events)
+	}
+}
+
+// TestPostTxDoltCommitRetriesSerializationConflict pins the retry contract:
+// Dolt's rollback-guaranteed commit conflicts (1213/1205, 1105 autocommit
+// rollback) were retried when the dolt commit ran inside withRetryTx, and
+// they are routine under the concurrent-writer load the post-tx ordering
+// targets — so the post-tx sequence must retry them too, not fail (and lose
+// the audit commit) on first conflict.
+func TestPostTxDoltCommitRetriesSerializationConflict(t *testing.T) {
+	rec := &seqRecorder{}
+	connector := &seqConnector{rec: rec}
+	failures := 0
+	connector.queryErr = func(query string) error {
+		if strings.Contains(query, "DOLT_COMMIT") && failures == 0 {
+			failures++
+			return &mysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock"}
+		}
+		return nil
+	}
+	db := sql.OpenDB(connector)
+	defer func() { _ = db.Close() }()
+
+	s := &DoltStore{db: db}
+
+	if err := s.doltAddAndCommitPostTx(context.Background(), []string{"issues"}, "bd: update test-1"); err != nil {
+		t.Fatalf("serialization conflict must be retried to success, got: %v", err)
+	}
+	doltCommits := 0
+	for _, ev := range rec.snapshot() {
+		if strings.Contains(ev, "DOLT_COMMIT") {
+			doltCommits++
+		}
+	}
+	if doltCommits < 2 {
+		t.Fatalf("expected the DOLT_COMMIT to be retried after 1213, saw %d attempt(s)", doltCommits)
+	}
+}
+
+// TestPostTxDoltCommitSurvivesCallerCancellation pins the detached-context
+// contract: the data transaction has already committed when the post-tx
+// dolt commit runs, so the caller's request-scoped cancellation (deadline,
+// shutdown, Ctrl-C) must not skip the audit commit — the post-tx phase runs
+// on a detached context with its own budget.
+func TestPostTxDoltCommitSurvivesCallerCancellation(t *testing.T) {
+	rec := &seqRecorder{}
+	db := sql.OpenDB(&seqConnector{rec: rec})
+	defer func() { _ = db.Close() }()
+
+	s := &DoltStore{db: db}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before the post-tx commit starts
+
+	if err := s.doltAddAndCommitPostTx(ctx, []string{"issues"}, "bd: update test-1"); err != nil {
+		t.Fatalf("post-tx dolt commit must survive caller cancellation, got: %v", err)
+	}
+	sawDoltCommit := false
+	for _, ev := range rec.snapshot() {
+		if strings.Contains(ev, "DOLT_COMMIT") {
+			sawDoltCommit = true
+		}
+	}
+	if !sawDoltCommit {
+		t.Fatalf("DOLT_COMMIT never ran under a cancelled caller context; events: %v", rec.snapshot())
+	}
+}
+
+// TestAmbiguousTxCommitDoesNotMintDoltCommit pins the ErrCommitIndeterminate
+// contract: a connection loss during the SQL COMMIT is ambiguous — and NO
+// post-tx dolt commit may be attempted off that error. In server mode the
+// branch working set is shared, so staging it after a commit that actually
+// rolled back would mint a dolt commit of a CONCURRENT writer's pending rows
+// under this operation's message — phantom audit evidence for a mutation
+// the caller is simultaneously told did not land. The error must surface
+// unchanged so the claim-verify protocol resolves the true outcome.
+func TestAmbiguousTxCommitDoesNotMintDoltCommit(t *testing.T) {
+	rec := &seqRecorder{}
+	connector := &seqConnector{rec: rec}
+	connector.commitErr = func() error { return errors.New("invalid connection") }
+	db := sql.OpenDB(connector)
+	defer func() { _ = db.Close() }()
+
+	s := &DoltStore{db: db}
+
+	err := s.runIssueOperationTx(context.Background(), "bd: update test-1", func(tx *sql.Tx) (storageissueops.ChangedTables, error) {
+		return storageissueops.ChangedTables{"issues": true}, nil
+	})
+	if err == nil {
+		t.Fatal("ambiguous commit loss must surface its error to the caller")
+	}
+	if !errors.Is(err, storage.ErrCommitIndeterminate) {
+		t.Fatalf("commit-phase connection loss must carry ErrCommitIndeterminate, got: %v", err)
+	}
+	for _, ev := range rec.snapshot() {
+		if strings.Contains(ev, "DOLT_ADD") || strings.Contains(ev, "DOLT_COMMIT") {
+			t.Fatalf("no dolt staging/commit may be attempted after an ambiguous tx commit (phantom audit hazard); events: %v", rec.snapshot())
+		}
+	}
+}
+
+// TestVerifiedClaimResolvesPostTxCommitFailureAsApplied pins the end-to-end
+// recovery: a claim whose data transaction committed but whose trailing dolt
+// commit failed must resolve as SUCCESS via verify-by-re-read — not surface
+// an error for a claim the caller actually holds (the wy-x543k inversion).
+func TestVerifiedClaimResolvesPostTxCommitFailureAsApplied(t *testing.T) {
+	rec := &seqRecorder{}
+	connector := &seqConnector{rec: rec}
+	connector.queryErr = func(query string) error {
+		if strings.Contains(query, "DOLT_COMMIT") {
+			return errors.New("boom: injected dolt commit failure")
+		}
+		return nil
+	}
+	connector.rows = func(query string) (driver.Rows, bool) {
+		// The verify re-read: report the claim as applied.
+		if strings.Contains(query, "SELECT assignee, status FROM issues") {
+			return &valRows{
+				cols: []string{"assignee", "status"},
+				vals: [][]driver.Value{{"claim-actor", "in_progress"}},
+			}, true
+		}
+		return nil, false
+	}
+	db := sql.OpenDB(connector)
+	defer func() { _ = db.Close() }()
+
+	s := &DoltStore{db: db, serverMode: true}
+
+	write := func() error {
+		return s.runIssueOperationTx(context.Background(), "bd: claim test-1 by claim-actor", func(tx *sql.Tx) (storageissueops.ChangedTables, error) {
+			return storageissueops.ChangedTables{"issues": true}, nil
+		})
+	}
+	if err := s.verifiedClaimWrite(context.Background(), "test-1", claimedBy("claim-actor"), write); err != nil {
+		t.Fatalf("post-tx dolt commit failure must resolve as applied via re-read, got: %v", err)
 	}
 }

--- a/internal/storage/dolt/dolt_commit_ordering_test.go
+++ b/internal/storage/dolt/dolt_commit_ordering_test.go
@@ -344,6 +344,75 @@ func TestPostTxDoltCommitFailureDoesNotFailMutation(t *testing.T) {
 	}
 }
 
+// TestBatchMutatorPostTxDoltCommitFailureReturnsSuccess pins the batch-path
+// facet of the swallow contract (PR #6040 review, cat-4 gap). CreateBatch,
+// ApplyBatch, and CloseBatch all funnel through runIssueOperationTxWithMessage
+// — the message-composing entry point — and, unlike the claim paths, have NO
+// verify-by-re-read recovery. So a post-tx DOLT_COMMIT failure on a batch must
+// still report success: the batch's data COMMITted (durable in the branch
+// working set) and was staged by DOLT_ADD before the trailing history commit
+// was attempted, and surfacing the audit-commit failure would make a batch
+// caller retry an already-applied batch (double-apply/double-create). This
+// drives that exact entry point with the commit message composed from what
+// "landed", exactly as the batch mutators do.
+func TestBatchMutatorPostTxDoltCommitFailureReturnsSuccess(t *testing.T) {
+	rec := &seqRecorder{}
+	connector := &seqConnector{rec: rec}
+	connector.queryErr = func(query string) error {
+		if strings.Contains(query, "DOLT_COMMIT") {
+			return errors.New("boom: injected dolt commit failure")
+		}
+		return nil
+	}
+	db := sql.OpenDB(connector)
+	defer func() { _ = db.Close() }()
+
+	s := &DoltStore{db: db}
+
+	// Mirror a batch mutator: run the item work in the tx, then compose the
+	// commit message from what landed. CreateBatch/ApplyBatch/CloseBatch all
+	// build their message inside the body for exactly this reason, which is why
+	// they use runIssueOperationTxWithMessage rather than runIssueOperationTx.
+	err := s.runIssueOperationTxWithMessage(context.Background(), func(tx *sql.Tx) (storageissueops.ChangedTables, string, error) {
+		if _, err := tx.ExecContext(context.Background(), "INSERT INTO issues (id) VALUES ('batch-1')"); err != nil {
+			return nil, "", err
+		}
+		return storageissueops.ChangedTables{"issues": true}, "bd: create 1 issue (batch)", nil
+	})
+	if err != nil {
+		t.Fatalf("batch post-tx dolt commit failure must not fail the mutation (data committed); got: %v", err)
+	}
+
+	// Durability proof: the batch data must have COMMITted and been staged by
+	// DOLT_ADD before the swallowed DOLT_COMMIT — i.e. it is in the working set,
+	// not lost — and the operation still returned success above.
+	events := rec.snapshot()
+	idx := func(pred func(string) bool) int {
+		for i, ev := range events {
+			if pred(ev) {
+				return i
+			}
+		}
+		return -1
+	}
+	commitIdx := idx(func(ev string) bool { return ev == "COMMIT" })
+	doltAddIdx := idx(func(ev string) bool { return strings.Contains(ev, "DOLT_ADD") })
+	doltCommitIdx := idx(func(ev string) bool { return strings.Contains(ev, "DOLT_COMMIT") })
+	if commitIdx == -1 {
+		t.Fatalf("batch data transaction never committed; events: %v", events)
+	}
+	if doltAddIdx == -1 {
+		t.Fatalf("post-tx DOLT_ADD never staged the batch working set; events: %v", events)
+	}
+	if doltCommitIdx == -1 {
+		t.Fatalf("post-tx DOLT_COMMIT never attempted; events: %v", events)
+	}
+	if !(commitIdx < doltAddIdx && doltAddIdx < doltCommitIdx) {
+		t.Fatalf("batch durability ordering violated: want COMMIT(%d) < DOLT_ADD(%d) < DOLT_COMMIT(%d); events: %v",
+			commitIdx, doltAddIdx, doltCommitIdx, events)
+	}
+}
+
 // TestPostTxDoltCommitRetriesSerializationConflict pins the retry contract:
 // Dolt's rollback-guaranteed commit conflicts (1213/1205, 1105 autocommit
 // rollback) were retried when the dolt commit ran inside withRetryTx, and

--- a/internal/storage/dolt/ephemeral_routing.go
+++ b/internal/storage/dolt/ephemeral_routing.go
@@ -3,8 +3,14 @@ package dolt
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/issueops"
@@ -337,9 +343,20 @@ func (s *DoltStore) demoteToWispInTx(ctx context.Context, tx *sql.Tx, id string,
 // Dolt commit writes every concurrently-changed row in the staged tables
 // back to its BEGIN-time value (lost update). The main issue-mutation path
 // (runIssueOperationTxWithMessage) no longer uses this; it commits the SQL
-// transaction first and then calls doltAddAndCommitPostTx. Remaining callers
-// (wisp promote/demote, legacy reopen, branch transaction wrapper) accept
-// the hazard for now and should migrate to the post-tx ordering.
+// transaction first and then calls doltAddAndCommitPostTx.
+//
+// The hazard remains LIVE everywhere the in-tx ordering survives — a larger
+// surface than this helper's callers: wisp promote/demote (this file),
+// legacy reopen (issues.go), RunInIssueLifecycleTransaction
+// (transaction.go), AND the same DOLT_ADD/DOLT_COMMIT-inside-tx pattern
+// inlined directly in the legacy DoltStore write methods in issues.go and
+// slots.go (UpdateIssue, UpdateIssueChecked, ClaimIssue, ClaimReadyIssue,
+// UnclaimIssue, UnclaimIssueIfAssignee, ReclaimExpiredLeases, CloseIssue*,
+// DeleteIssue*, MergeMetadata, SlotClear) — several reachable from live CLI
+// paths (bd edit/note/priority/defer/unclaim, linear sync) and from the
+// uow/domain claim surfaces. Every one of these should migrate to the
+// post-tx ordering; until then any of them racing a concurrent writer can
+// still silently revert that writer's committed rows.
 func (s *DoltStore) doltAddAndCommitInTx(ctx context.Context, tx *sql.Tx, tables []string, commitMsg string) error {
 	// Batch/off auto-commit (bd-4wamg): leave the writes in the working set
 	// for a later explicit commit point (bd dolt commit / CommitPending)
@@ -380,6 +397,21 @@ func (s *DoltStore) doltAddAndCommitInTx(ctx context.Context, tx *sql.Tx, tables
 	return nil
 }
 
+const (
+	// postTxCommitMaxElapsed is deliberately short: the caller swallows the
+	// final error, so a long fight for a best-effort commit buys nothing and
+	// a stuck server (migration lock, read-only manifest) would otherwise
+	// stall EVERY mutation for the full outage. The 25ms initial interval
+	// mirrors withRetryTx's conflict tuning so routine 1213/1205 races retry
+	// promptly.
+	postTxCommitMaxElapsed = 5 * time.Second
+	// postTxCommitGrace pads the detached context past the backoff budget.
+	// The two bounds are NOT redundant: MaxElapsedTime only stops SCHEDULING
+	// further attempts, while the ctx deadline is the only thing that can
+	// cancel an attempt already hung in-flight (stuck server mid-statement).
+	postTxCommitGrace = 2 * time.Second
+)
+
 // doltAddAndCommitPostTx stages and Dolt-commits tables OUTSIDE any open SQL
 // transaction, against the session's current — post-merge — root. This is
 // the safe ordering for operations whose data transaction has already
@@ -388,20 +420,66 @@ func (s *DoltStore) doltAddAndCommitInTx(ctx context.Context, tx *sql.Tx, tables
 // with concurrent writers (see runIssueOperationTxWithMessage).
 //
 // If this fails, the data change has still landed: it remains in the branch
-// working set and is carried into the next Dolt commit on the branch. The
-// error wrapping states that explicitly so callers and users do not retry
-// the mutation itself.
+// working set and is carried into the next Dolt commit on the branch
+// (runIssueOperationTxWithMessage logs and swallows the failure for exactly
+// that reason — see the failure-mode note there).
+//
+// Division of labor with doltAddAndCommit (#5740 review, blocking item 3):
+// that helper owns everything about publishing — deferral (VersionCommitDeferred),
+// the pinned connection (GH#2455), the staged-set guard, circuit admission,
+// and publication-failure accounting via recordDoltPublicationFailure. This
+// wrapper adds exactly two things and no second copy of any of them: a
+// detached context, and a retry over the conflicts that helper does not
+// retry.
+//
+// The retry is deliberately narrower than withRetryTx's classifier was when
+// the dolt commit still ran in-tx. It covers only Dolt's rollback-guaranteed
+// commit conflicts (1213/1205 serialization, 1105 autocommit rollback) —
+// routine under the concurrent-writer load this path exists for, carrying no
+// breaker accounting of their own, and safe to replay because re-staging is
+// idempotent and a replayed DOLT_COMMIT whose first attempt actually landed
+// degrades to nothing-to-commit, which doltAddAndCommit swallows. Connection
+// losses are NOT retried here: doltAddAndCommit has already recorded them
+// against the circuit breaker, so replaying would count one failed
+// publication through the breaker several times and could trip it for
+// unrelated operations — for a trailing commit whose data is already
+// durable. Those failures go straight back to the caller, which swallows and
+// counts them once (bd.db.post_tx_commit_dropped).
 func (s *DoltStore) doltAddAndCommitPostTx(ctx context.Context, tables []string, commitMsg string) error {
-	for _, table := range tables {
-		if err := schema.DrainCall(ctx, s.db, "CALL DOLT_ADD(?)", table); err != nil {
-			return fmt.Errorf("dolt add %s (post-tx; data already committed, change rides the next dolt commit): %w", table, err)
+	// Detach from the caller's cancellation: the data transaction has already
+	// committed, so a request deadline or shutdown landing in this window
+	// must not deterministically skip the audit commit (values — tracing —
+	// are preserved). The commit gets its own budget instead.
+	ctx = context.WithoutCancel(ctx)
+	ctx, cancel := context.WithTimeout(ctx, postTxCommitMaxElapsed+postTxCommitGrace)
+	defer cancel()
+
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 25 * time.Millisecond
+	bo.MaxElapsedTime = postTxCommitMaxElapsed
+	var lastErr error
+	err := backoff.Retry(func() error {
+		err := s.doltAddAndCommit(ctx, tables, commitMsg)
+		if err == nil {
+			return nil
 		}
+		lastErr = err
+		// Mirror withRetryTx's accounting so conflict pressure that moved out
+		// of it stays visible on the same counters.
+		if isSerializationError(err) || isDoltAutocommitRollbackError(err) {
+			doltMetrics.serializationErrors.Add(ctx, 1)
+			doltMetrics.writeRetries.Add(ctx, 1, metric.WithAttributes(attribute.String("type", "serialization")))
+			return err
+		}
+		return backoff.Permanent(err)
+	}, backoff.WithContext(bo, ctx))
+	if err != nil && lastErr != nil && !errors.Is(err, lastErr) {
+		// backoff.Retry returns the bare ctx error when the deadline expires
+		// mid-sleep, discarding the last real Dolt failure — the only
+		// diagnostic for a swallowed audit commit. Keep both.
+		return fmt.Errorf("%w (last attempt: %w)", err, lastErr)
 	}
-	if err := schema.DrainCall(ctx, s.db, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit (post-tx; data already committed, change rides the next dolt commit): %w", err)
-	}
-	return nil
+	return err
 }
 
 // getAllWispDependencyRecords returns all wisp dependency records, keyed by issue_id.

--- a/internal/storage/dolt/ephemeral_routing.go
+++ b/internal/storage/dolt/ephemeral_routing.go
@@ -328,6 +328,18 @@ func (s *DoltStore) demoteToWispInTx(ctx context.Context, tx *sql.Tx, id string,
 	return s.doltAddAndCommitInTx(ctx, tx, permanentIssueAuxTables, fmt.Sprintf("bd: demote %s to wisp", id))
 }
 
+// doltAddAndCommitInTx stages and Dolt-commits INSIDE a still-open SQL
+// transaction.
+//
+// HAZARD (LatentLabsSpace/NEXUS#92): DOLT_ADD stages the whole table from
+// this session's BEGIN-time root, and DOLT_COMMIT here runs before the
+// transaction's commit-time merge — so under concurrent writers the produced
+// Dolt commit writes every concurrently-changed row in the staged tables
+// back to its BEGIN-time value (lost update). The main issue-mutation path
+// (runIssueOperationTxWithMessage) no longer uses this; it commits the SQL
+// transaction first and then calls doltAddAndCommitPostTx. Remaining callers
+// (wisp promote/demote, legacy reopen, branch transaction wrapper) accept
+// the hazard for now and should migrate to the post-tx ordering.
 func (s *DoltStore) doltAddAndCommitInTx(ctx context.Context, tx *sql.Tx, tables []string, commitMsg string) error {
 	// Batch/off auto-commit (bd-4wamg): leave the writes in the working set
 	// for a later explicit commit point (bd dolt commit / CommitPending)
@@ -364,6 +376,30 @@ func (s *DoltStore) doltAddAndCommitInTx(ctx context.Context, tx *sql.Tx, tables
 	if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
 		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
 		return wrapSQLCommitError("dolt commit", err)
+	}
+	return nil
+}
+
+// doltAddAndCommitPostTx stages and Dolt-commits tables OUTSIDE any open SQL
+// transaction, against the session's current — post-merge — root. This is
+// the safe ordering for operations whose data transaction has already
+// committed: staging whole tables here cannot resurrect pre-transaction row
+// states, because the working set already reflects the commit-time merge
+// with concurrent writers (see runIssueOperationTxWithMessage).
+//
+// If this fails, the data change has still landed: it remains in the branch
+// working set and is carried into the next Dolt commit on the branch. The
+// error wrapping states that explicitly so callers and users do not retry
+// the mutation itself.
+func (s *DoltStore) doltAddAndCommitPostTx(ctx context.Context, tables []string, commitMsg string) error {
+	for _, table := range tables {
+		if err := schema.DrainCall(ctx, s.db, "CALL DOLT_ADD(?)", table); err != nil {
+			return fmt.Errorf("dolt add %s (post-tx; data already committed, change rides the next dolt commit): %w", table, err)
+		}
+	}
+	if err := schema.DrainCall(ctx, s.db, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+		return fmt.Errorf("dolt commit (post-tx; data already committed, change rides the next dolt commit): %w", err)
 	}
 	return nil
 }

--- a/internal/storage/dolt/issue_operations_tx.go
+++ b/internal/storage/dolt/issue_operations_tx.go
@@ -19,20 +19,45 @@ func (s *DoltStore) runIssueOperationTx(ctx context.Context, commitMsg string, f
 // commit message is only known once the body has run. A ready claim names the
 // id it won, and nothing outside the transaction can predict which one that
 // is, so the message is composed where the selection happens.
+//
+// Ordering contract (lost-update fix, LatentLabsSpace/NEXUS#92): the Dolt
+// commit MUST run after the SQL transaction commits, never inside it.
+// DOLT_ADD stages the ENTIRE table from the session's transaction root; when
+// it ran inside the still-open transaction, the Dolt commit was built from
+// the pre-merge BEGIN-time snapshot with the then-current branch HEAD as its
+// parent — so every row a concurrent writer had committed inside the
+// transaction's window was silently written back to its BEGIN-time value
+// (observed in production as reverted claims). Committing the SQL
+// transaction first lets Dolt's commit-time three-way merge reconcile this
+// session's changes with concurrent writers; the post-commit DOLT_ADD then
+// stages the merged state, which cannot resurrect stale rows.
+//
+// Failure mode note: if the post-commit Dolt commit fails, the data change
+// HAS landed — it remains in the branch working set and rides the next Dolt
+// commit. Callers must not treat that error as "nothing happened".
 func (s *DoltStore) runIssueOperationTxWithMessage(ctx context.Context, fn func(*sql.Tx) (storageissueops.ChangedTables, string, error)) error {
-	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		tables, commitMsg, err := fn(tx)
+	var staged []string
+	var commitMsg string
+	err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		// Reset on every attempt: a retried transaction re-runs the body and
+		// must not accumulate tables from a rolled-back attempt.
+		staged, commitMsg = nil, ""
+		tables, msg, err := fn(tx)
 		if err != nil {
 			return err
 		}
-		if len(tables) == 0 {
-			return nil
-		}
-		staged := make([]string, 0, len(tables))
 		for table := range tables {
 			staged = append(staged, table)
 		}
 		sort.Strings(staged)
-		return s.doltAddAndCommitInTx(ctx, tx, staged, commitMsg)
+		commitMsg = msg
+		return nil
 	})
+	if err != nil {
+		return err
+	}
+	if len(staged) == 0 {
+		return nil
+	}
+	return s.doltAddAndCommitPostTx(ctx, staged, commitMsg)
 }

--- a/internal/storage/dolt/issue_operations_tx.go
+++ b/internal/storage/dolt/issue_operations_tx.go
@@ -3,7 +3,7 @@ package dolt
 import (
 	"context"
 	"database/sql"
-	"sort"
+	"log"
 
 	storageissueops "github.com/steveyegge/beads/internal/storage/issueops"
 )
@@ -32,32 +32,63 @@ func (s *DoltStore) runIssueOperationTx(ctx context.Context, commitMsg string, f
 // session's changes with concurrent writers; the post-commit DOLT_ADD then
 // stages the merged state, which cannot resurrect stale rows.
 //
-// Failure mode note: if the post-commit Dolt commit fails, the data change
-// HAS landed — it remains in the branch working set and rides the next Dolt
-// commit. Callers must not treat that error as "nothing happened".
+// Failure mode note: if the post-commit Dolt commit fails (after retries),
+// the data change HAS landed — it remains in the branch working set and
+// rides the next Dolt commit on the branch. That failure is therefore
+// logged and NOT propagated: the mutation succeeded, and surfacing an error
+// here would make every caller treat an applied mutation as failed —
+// automated retries double-apply (duplicate creates/comments), completion
+// hooks are skipped for a persisted state change, and the claim verify
+// wrappers report claims the caller actually holds as failed (the wy-x543k
+// inversion). The only cost of a swallowed failure is a missing dolt-log
+// audit line until the next commit.
+//
+// Audit-trail caveat (server mode): sessions on one branch share the working
+// set, so a concurrent writer's DOLT_COMMIT can absorb this operation's rows
+// under its own message; this operation's commit then degrades to
+// nothing-to-commit and its message never reaches dolt log. The data is
+// intact — doltAddAndCommit logs the absorption so the missing audit line is
+// explicable.
 func (s *DoltStore) runIssueOperationTxWithMessage(ctx context.Context, fn func(*sql.Tx) (storageissueops.ChangedTables, string, error)) error {
-	var staged []string
+	var tables storageissueops.ChangedTables
 	var commitMsg string
 	err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		// Reset on every attempt: a retried transaction re-runs the body and
-		// must not accumulate tables from a rolled-back attempt.
-		staged, commitMsg = nil, ""
-		tables, msg, err := fn(tx)
-		if err != nil {
-			return err
-		}
-		for table := range tables {
-			staged = append(staged, table)
-		}
-		sort.Strings(staged)
-		commitMsg = msg
-		return nil
+		// Plain assignment (not append-into-captured-state): a retried
+		// transaction re-runs the body and overwrites both values, so a
+		// rolled-back attempt cannot leak tables into the commit.
+		var err error
+		tables, commitMsg, err = fn(tx)
+		return err
 	})
 	if err != nil {
+		// Includes ErrCommitIndeterminate (ambiguous commit loss): NO post-tx
+		// dolt commit is attempted there. If the ambiguous commit actually
+		// landed, its audit entry is lost (the change rides the next dolt
+		// commit) — accepted, because attempting one would stage the SHARED
+		// branch working set, and when the commit actually rolled back that
+		// mints a dolt commit of a concurrent writer's pending rows under
+		// THIS operation's message (phantom audit evidence), fires even for
+		// definite rollbacks (a caller cancellation during tx.Commit is also
+		// tagged indeterminate), and delays the claim-verify re-read that
+		// resolves the true outcome.
 		return err
 	}
+	staged := sortedDirtyTables(tables)
 	if len(staged) == 0 {
 		return nil
 	}
-	return s.doltAddAndCommitPostTx(ctx, staged, commitMsg)
+	if commitMsg == "" {
+		// A body can dirty tables without composing a message (e.g. a ready
+		// claim whose side effects landed but which claimed nothing); never
+		// mint a Dolt commit with an empty message.
+		commitMsg = "bd: issue operation"
+	}
+	if err := s.doltAddAndCommitPostTx(ctx, staged, commitMsg); err != nil {
+		// See the failure-mode note above: the mutation is applied and
+		// durable; only the trailing history commit is missing, and the
+		// change rides the next dolt commit on the branch.
+		doltMetrics.postTxCommitDropped.Add(ctx, 1)
+		log.Printf("dolt: post-tx dolt commit failed for %q (data already committed; change rides the next dolt commit): %v", commitMsg, err)
+	}
+	return nil
 }

--- a/internal/storage/dolt/issue_operations_tx.go
+++ b/internal/storage/dolt/issue_operations_tx.go
@@ -43,6 +43,15 @@ func (s *DoltStore) runIssueOperationTx(ctx context.Context, commitMsg string, f
 // inversion). The only cost of a swallowed failure is a missing dolt-log
 // audit line until the next commit.
 //
+// Caller contract (non-verified batch mutators): CreateBatch, ApplyBatch, and
+// CloseBatch route through here and, unlike the claim paths, have no
+// verify-by-re-read recovery — so for them a nil error means "data durable in
+// the branch working set; the trailing Dolt history commit may be deferred and
+// is observable only via bd.db.post_tx_commit_dropped." That is the conscious,
+// documented contract: a nil return is not a retry signal, and propagating a
+// publish-failure sentinel to those callers would reintroduce the double-apply
+// inversion this reorder exists to prevent.
+//
 // Audit-trail caveat (server mode): sessions on one branch share the working
 // set, so a concurrent writer's DOLT_COMMIT can absorb this operation's rows
 // under its own message; this operation's commit then degrades to

--- a/internal/storage/dolt/ready_claimer.go
+++ b/internal/storage/dolt/ready_claimer.go
@@ -59,6 +59,11 @@ func (c *readyClaimer) ClaimNext(ctx context.Context, request issueops.ClaimNext
 		write := func() (*types.Issue, error) {
 			var claimed *types.Issue
 			err := c.store.runIssueOperationTxWithMessage(ctx, func(tx *sql.Tx) (storageissueops.ChangedTables, string, error) {
+				// Reset on every attempt: withRetryTx replays this body, and a
+				// replay that finds nothing ready must not leak the previous
+				// attempt's selection into the verify pass (which would verify an
+				// issue this call did not claim and fail loudly and falsely).
+				claimed = nil
 				attempt, tables, err := storageissueops.ExecuteClaimNext(ctx, tx, request.Actor, filter)
 				if err != nil {
 					return nil, "", err
@@ -71,6 +76,10 @@ func (c *readyClaimer) ClaimNext(ctx context.Context, request issueops.ClaimNext
 				// The message names the claimed issue because that is the one `bd
 				// dolt log` affordance callers actually grep, and it is what the
 				// store's own ClaimReadyIssue wrote before the claim moved here.
+				// Post-tx ordering caveat: a concurrent writer's commit can absorb
+				// this one (nothing-to-commit), in which case the claim appears
+				// under the OTHER writer's message — the grep is best-effort
+				// evidence of a claim, and its absence is not proof of failure.
 				return tables, storageissueops.ClaimNextCommitMessage(attempt.Claimed.ID), nil
 			})
 			return claimed, err

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -867,6 +867,7 @@ var doltMetrics struct {
 	circuitRejected      metric.Int64Counter
 	serializationErrors  metric.Int64Counter
 	writeRetries         metric.Int64Counter
+	postTxCommitDropped  metric.Int64Counter
 	connAcquireMs        metric.Float64Histogram
 	poolWaitCount        metric.Int64Counter
 	poolWaitMs           metric.Float64Histogram
@@ -900,6 +901,10 @@ func init() {
 	doltMetrics.writeRetries, _ = m.Int64Counter("bd.write_retries_total",
 		metric.WithDescription("Write-tx retries in withRetryTx (label: type=serialization|connection)"),
 		metric.WithUnit("{retry}"),
+	)
+	doltMetrics.postTxCommitDropped, _ = m.Int64Counter("bd.db.post_tx_commit_dropped",
+		metric.WithDescription("Post-tx dolt commits abandoned after retries; the data landed but no dolt commit was minted (change rides the next commit on the branch)"),
+		metric.WithUnit("{commit}"),
 	)
 	doltMetrics.connAcquireMs, _ = m.Float64Histogram("bd.db.conn_acquire_ms",
 		metric.WithDescription("Time to acquire a pooled connection for a Dolt transaction"),
@@ -1120,6 +1125,16 @@ func (s *DoltStore) withReadTxLongTimeout(ctx context.Context, fn func(tx *sql.T
 	})
 }
 
+// withRetryTx runs fn in a write transaction, replaying the WHOLE body on
+// rollback-guaranteed conflicts (1213/1205 serialization, Dolt's exact 1105
+// autocommit rollback) and on pre-commit transient connection errors.
+//
+// Contract for closures: fn may run multiple times. Any state the closure
+// captures must be re-derived on EVERY attempt — unconditional assignment,
+// or an explicit reset at the top of the body when an assignment is
+// conditional — otherwise a rolled-back attempt's values leak into post-tx
+// logic (verify passes, hooks, return values). See ready_claimer.ClaimNext's
+// `claimed = nil` reset for the canonical example.
 func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) error {
 	// Keep circuit admission at the transaction retry boundary. Calling
 	// withRetry from here would multiply retries and could replay a write after
@@ -3315,9 +3330,23 @@ func (s *DoltStore) doltAddAndCommit(ctx context.Context, tables []string, commi
 		}
 
 		if err := schema.DrainCall(ctx, conn, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return s.recordDoltPublicationFailure(ctx,
-				fmt.Errorf("dolt commit after SQL mutation: %w: %w", err, ErrCommitIndeterminate))
+			commitMsg, s.commitAuthorString()); err != nil {
+			if !isDoltNothingToCommit(err) {
+				return s.recordDoltPublicationFailure(ctx,
+					fmt.Errorf("dolt commit after SQL mutation: %w: %w", err, ErrCommitIndeterminate))
+			}
+			// Reaching nothing-to-commit past the staged guard above means the
+			// staged set was swept between the guard and the commit, and the
+			// server cannot say by what: absorption — sessions on one branch
+			// share the working set, so a concurrent writer's DOLT_COMMIT can
+			// sweep this operation's rows under ITS message — or a retried
+			// commit whose first attempt actually landed. The data is intact
+			// either way; log neutrally (server mode only: embedded has no
+			// concurrent sessions) so a missing audit line is explicable
+			// without asserting a concurrent writer that may not exist.
+			if s.serverMode {
+				log.Printf("dolt: commit %q made no dolt commit (nothing to commit): change absorbed into a concurrent writer's commit, or an already-committed retry", commitMsg)
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
Carries @nova-submodules' #5740 onto `release/1.3.0`. All the analysis, the
design, and the tests are theirs; this PR is the rebase round the review asked
for, done on our side because the contributor's branch is not writable by us.

## Root cause

In server mode the issue-mutation path ran `CALL DOLT_ADD` / `CALL DOLT_COMMIT`
**inside the still-open SQL transaction**. Two Dolt behaviours combine badly
there:

1. `DOLT_ADD` stages the **entire table** as of the session's transaction root
   — the BEGIN-time snapshot — not just the rows this transaction touched.
2. Dolt reconciles concurrent writers with a commit-time three-way merge, which
   by definition has not happened yet while the transaction is open.

So the Dolt commit was materialized from the pre-merge BEGIN-time snapshot with
the then-current branch HEAD as its parent, writing every row a concurrent
session had committed inside this transaction's window back to its BEGIN-time
value. The wider the transaction (retries, claim-verify re-reads), the larger
the blast radius. @nova-submodules observed this in production as claims
reverting minutes after being made, reproduced on `dolt sql-server` 2.2.3.

The fix is an ordering contract: the transaction body only *records* the
changed tables and the commit message; `DOLT_ADD`/`DOLT_COMMIT` run **after**
the SQL transaction commits, staging the post-merge working set, which cannot
resurrect stale rows.

## What was carried

Two commits, both authored by the contributor:

| Commit | Origin |
| --- | --- |
| `fix(dolt): run DOLT_ADD/DOLT_COMMIT after the SQL transaction commits` | clean `git cherry-pick -x` of `78494c9`, message and authorship untouched |
| `fix(dolt): harden the post-tx dolt commit for release/1.3.0` | net of `a2467d9`, `de77bf8`, `f37ec11`, `afbbb8e`, `346260d` (review rounds 1–4), authored `Nova's Ghost <nova+ghost@latentlabs.space>` with `Co-authored-by:` trailers |

Rounds 1–4 add a sentinel error and verify-wrapper ladders and then revert them
wholesale in a later round, so replaying them one by one would have meant
resolving conflicts against `errCommitPhase`-era code that the series itself
deletes two commits later. They are carried as their net result instead — which
is exactly what `gh pr diff 5740` shows.

Everything the review said to keep is intact: the sequence-capturing driver
test, the `claimed = nil` reset in `ready_claimer` plus the `withRetryTx`
closure-replay contract comment, the no-dolt-staging-off-an-ambiguous-COMMIT
rule, and the swallow-not-propagate contract for post-tx commit failure.

## Conflicts resolved

`internal/storage/dolt/issue_operations_tx.go` was byte-identical between the
contributor's base and this branch, so the core ordering change applied
untouched. The other four files needed work:

- **`ready_claimer.go`** — `ClaimNext` was restructured on our side: the `write`
  closure now lives inside `withCircuitWrite` so circuit success is recorded
  once at the boundary. Took our structure and applied the contributor's two
  changes into the moved closure: the `claimed = nil` reset at the top of the
  replayed body, and the audit-grep caveat on the commit message.

- **`store.go`** — the patch landed the neutral nothing-to-commit log in
  `recordDoltPublicationFailure` (a function that did not exist on the
  contributor's base, and whose body happens to look like the old
  `doltAddAndCommit` tail). Kept `recordDoltPublicationFailure` as-is and moved
  the log to its intended home, `doltAddAndCommit`'s `DOLT_COMMIT` error branch,
  reworded for the `HasStagedChanges` guard that now sits in front of it — past
  that guard, nothing-to-commit means absorption by a concurrent writer's commit
  or an already-landed retry, not a no-op write.

- **`ephemeral_routing.go`** / **`issue_operations_tx.go`** — the two items the
  review called blocking, below.

### Review blocking item 2 — `errCommitPhase` is gone

#5341 replaced it with the public `storage.ErrCommitIndeterminate` plus
`wrapSQLCommitError` / `recordDoltPublicationFailure`. The guard the contributor
wrote against `errCommitPhase` needs no sentinel in the new vocabulary at all:
if `withRetryTx` returned an error, no post-tx Dolt commit is attempted, full
stop. The comment and the regression test now name
`storage.ErrCommitIndeterminate`, and the test still proves the real contract —
no `DOLT_ADD`/`DOLT_COMMIT` is issued off an ambiguous commit, so we never mint
phantom audit evidence out of a concurrent writer's pending rows.

### Review blocking item 3 — compose with the evolved `doltAddAndCommit`

On this branch `doltAddAndCommit` already honors `VersionCommitDeferred`, runs
under `withCircuitWrite`, pins one connection (#2455), guards on
`HasStagedChanges`, and accounts failures through `recordDoltPublicationFailure`
tagged `ErrCommitIndeterminate`. `doltAddAndCommitPostTx` is now a thin wrapper
over it rather than a second scheme beside it, and the division of labour is
written down on the function:

- **Publication, deferral, pinning, circuit admission and failure accounting**
  stay in `doltAddAndCommit`. One copy.
- **Retry** narrows to the rollback-guaranteed commit conflicts (1213/1205
  serialization, Dolt's exact 1105 autocommit rollback) — routine under the
  concurrent-writer load this path exists for, previously retried by
  `withRetryTx` when the commit ran in-tx, and safe to replay because re-staging
  is idempotent and a replayed `DOLT_COMMIT` degrades to nothing-to-commit.
  Connection losses are **not** retried here: `doltAddAndCommit` has already
  recorded them against the circuit breaker, so replaying would count one failed
  publication through the breaker several times and could trip it for unrelated
  operations, for a trailing commit whose data is already durable. That is the
  "don't double-count, don't report through two channels" call the review asked
  us to make deliberately.
- **The detached context** stays: the data transaction has committed by then, so
  a request deadline or shutdown landing in that window must not
  deterministically skip the audit commit.
- **`bd.db.post_tx_commit_dropped`** counts an abandoned post-tx commit once, at
  the swallow site, so a missing `dolt log` line has a signal beyond stderr.

Review blocking item 4 is #5752, which this PR references rather than solves.
The `doltAddAndCommitInTx` hazard comment enumerating the remaining in-tx
surface is carried as written.

## Why a replacement PR

#5740's head branch lives on the **organization** fork `LatentLabsSpace/beads`,
where GitHub refuses maintainer edits regardless of the "allow edits" box
(`maintainerCanModify: false`). Rebases are maintainer work
([PR_MAINTAINER_GUIDELINES.md](PR_MAINTAINER_GUIDELINES.md)), and when the
branch cannot be pushed to, the guidelines' replacement-PR route with preserved
attribution is the sanctioned path. #5740 stays **open**; a comment there
explains what was preserved and links here.

`origin/main` and `origin/release/1.3.0` are the same commit right now, so this
carry is not release-branch-only work — it is the rebase round #5740 was waiting
on.

## Test plan

- `go build ./...` — clean.
- `go vet ./...` — clean.
- `gofmt -l internal/storage/dolt/` — clean (the contributor's test file needed
  one wrap; applied).
- `golangci-lint run --new-from-rev=HEAD --fix` via the pre-commit hook — 0 issues.
- The eight carried contracts, against `dolthub/dolt-sql-server:2.2.0`
  (testcontainers), all pass:
  - `TestIssueOperationDoltCommitRunsAfterTxCommit` — `DOLT_ADD`/`DOLT_COMMIT`
    strictly after driver-level `COMMIT`, no `BEGIN` in between
  - `TestIssueOperationNoTablesSkipsDoltCommit`
  - `TestPostTxDoltAddCommitSharesOneConnection` — the whole sequence on one
    pinned connection (#2455)
  - `TestPostTxDoltCommitFailureDoesNotFailMutation`
  - `TestPostTxDoltCommitRetriesSerializationConflict`
  - `TestPostTxDoltCommitSurvivesCallerCancellation`
  - `TestAmbiguousTxCommitDoesNotMintDoltCommit`
  - `TestVerifiedClaimResolvesPostTxCommitFailureAsApplied`
- The whole `internal/storage/dolt` package against a live
  `dolthub/dolt-sql-server:2.2.0` (`BEADS_TEST_ENV_RUN_DOLT=1`, run through
  `.github/scripts/server-storage-test-shard.sh` in 8 shards): **1150 pass, 0
  fail**, 7 skips, all environment-gated and skipped on this branch's parent too.
- `TestConformance` (the suite the shard script excludes, run separately):
  **99 subtests pass, exit 0**.
- `go test ./internal/storage/issueops/... ./internal/storage/schema/...
  ./issueops/...` — ok.

## Proposed changelog line

`CHANGELOG.md` is left untouched here because release prep owns it. For that PR,
under `### Fixed`:

- **Server-mode issue mutations no longer revert concurrent writers' committed
  rows** ([#5740](https://github.com/gastownhall/beads/pull/5740)). The
  issue-mutation path ran `DOLT_ADD`/`DOLT_COMMIT` inside its still-open SQL
  transaction; `DOLT_ADD` stages the whole table as of the transaction's
  BEGIN-time root, and the Dolt commit was minted before the commit-time merge
  that reconciles concurrent writers — so a mutation could silently write every
  row another session had committed during its window back to that session's
  BEGIN-time value, seen in production as claims reverting minutes after they
  were made. The Dolt commit now runs after the SQL transaction commits, against
  the post-merge working set. Its failure is logged rather than returned: the
  data is durably committed by then and rides the next Dolt commit, and treating
  an applied mutation as failed is what made retries double-apply and claim
  verification disown claims the caller held. Reported and fixed by
  @nova-submodules.

---

Full credit to @nova-submodules for the diagnosis, the fix, the review rounds,
and the test design; and to @steveyegge for the review that traced this to
dolthub/dolt#5205 and the dolthub/dolt#5608 → dolthub/dolt#5621 staged-root-merge
family and set the three integration conditions this carry satisfies.

_claude-code-claude-opus-5[1m]-unknown-reasoning on behalf of Julian Knutsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
