### PR TITLE
fix(schema): convergent dependency rekey — merge duplicate typed edges instead of aborting half-applied (#5268)

### DIFF
--- a/internal/storage/embeddeddolt/migrate_dep_rekey_dedup_test.go
+++ b/internal/storage/embeddeddolt/migrate_dep_rekey_dedup_test.go
@@ -5,30 +5,51 @@ package embeddeddolt_test
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"path/filepath"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/storage/depid"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/storage/schema"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // Real-Dolt coverage for the merge-aware dependency-id re-key
-// (rekeyDependencyTable, internal/storage/schema/dep_id_backfill.go) and its
+// (rekeyDependencyIDs, internal/storage/schema/dep_id_backfill.go) and its
 // completion marker, ignored migration 0026 (gastownhall/beads#5268).
 //
 // Why this cannot be a sqlmock test. The bug IS Dolt's primary-key enforcement:
 // the old row-at-a-time rewrite issued statements a statement-echo mock happily
 // accepts, and only a real engine answers the second one with "duplicate primary
 // key given" and leaves the table half-re-keyed. The same reason
-// migrate_wisp_dep_forward_repair_test.go exists. These tests also exercise the
-// marker end to end -- that a pending 0026 forces a pass on a database whose
-// main cursor is already at latest, and that an aborted re-key leaves 0026
-// unrecorded so the next open retries -- which is a property of MigrateUp's step
-// order, not of any single statement.
+// migrate_wisp_dep_forward_repair_test.go exists. These tests also exercise
+// properties of MigrateUp's step ORDER rather than of any single statement: that
+// a pending 0026 forces a pass on a database whose main cursor is already at
+// latest, that an aborted re-key leaves 0026 unrecorded so the next open retries,
+// and that the ON UPDATE CASCADE on the typed target columns is what makes a
+// plain rename leave a stale primary key behind.
 
 // depRekeyMarkerVersion is ignored migration 0026, the clone-local marker whose
 // pending state forces the one repair pass.
 const depRekeyMarkerVersion = 26
+
+// TestDepRekeyMarkerIsLatestIgnored keeps the fixtures in this file honest. They
+// force the repair pass by unrecording the marker, which only works while the
+// pass is genuinely pending afterwards. If a later ignored migration lands, this
+// fails first with an actionable message instead of the marker-driven tests
+// failing with assertions that indict the repair code.
+func TestDepRekeyMarkerIsLatestIgnored(t *testing.T) {
+	if got := schema.LatestIgnoredVersion(); got != depRekeyMarkerVersion {
+		t.Fatalf("latest ignored migration is %d, not the dep-rekey marker %d; "+
+			"if you added ignored %d, point depRekeyMarkerVersion at 0026 anyway and confirm "+
+			"unrecordIgnoredVersionsFrom still leaves the marker pending", got, depRekeyMarkerVersion, got)
+	}
+}
 
 // TestEmbeddedDepRekeyRepairsHalfRekeyedDuplicateEdge is the victim repair: a
 // database that a pre-1.3.0 binary left half-re-keyed and then declared
@@ -43,11 +64,8 @@ func TestEmbeddedDepRekeyRepairsHalfRekeyedDuplicateEdge(t *testing.T) {
 	requireEmbedded(t)
 	ctx := t.Context()
 
-	dataDir := seedMainSchemaAt(t, ctx, schema.LatestVersion())
-	conn, closeConn := openPinnedConn(t, ctx, dataDir)
-	if _, err := schema.MigrateUp(ctx, conn); err != nil {
-		t.Fatalf("MigrateUp on the seed store: %v", err)
-	}
+	dataDir := seedMigratedStore(t, ctx)
+	conn, closeConn := openDepConn(t, ctx, dataDir)
 
 	const source, target = "hq-cv-vvnmq", "ops-w05"
 	want := depid.New(source, target)
@@ -64,11 +82,10 @@ func TestEmbeddedDepRekeyRepairsHalfRekeyedDuplicateEdge(t *testing.T) {
 	// What makes this database a class-2b victim: the main cursor is at latest
 	// and every numbered migration is recorded, so without a pending marker
 	// migrationWorkNeeded short-circuits and the re-key never runs again.
-	unrecordIgnoredVersion(t, ctx, conn, depRekeyMarkerVersion)
+	unrecordIgnoredVersionsFrom(t, ctx, conn, depRekeyMarkerVersion)
 	closeConn()
 
-	conn2, closeConn2 := openPinnedConn(t, ctx, dataDir)
-	defer closeConn2()
+	conn2, _ := openDepConn(t, ctx, dataDir)
 
 	// Pre-fix this returns "rekey dependency ids: dependencies: re-key id
 	// random-issue-row -> ...: duplicate primary key given".
@@ -77,7 +94,7 @@ func TestEmbeddedDepRekeyRepairsHalfRekeyedDuplicateEdge(t *testing.T) {
 	}
 
 	wantRows := []depRow{{id: want, issueID: source, dependsOnIssueID: target}}
-	if got := readDeps(t, ctx, conn2); !sameDepRows(got, wantRows) {
+	if got := readDeps(t, ctx, conn2); !slices.Equal(got, wantRows) {
 		t.Fatalf("dependencies = %v, want %v", got, wantRows)
 	}
 	if !ignoredVersionRecorded(t, ctx, conn2, depRekeyMarkerVersion) {
@@ -100,7 +117,7 @@ func TestEmbeddedDepRekeyRepairsHalfRekeyedDuplicateEdge(t *testing.T) {
 		{id: want, issueID: source, dependsOnIssueID: target},
 		{id: "steady-random-id", issueID: "steady-src", dependsOnExternal: "external:e1"},
 	}
-	if got := readDeps(t, ctx, conn2); !sameDepRows(got, wantSteady) {
+	if got := readDeps(t, ctx, conn2); !slices.Equal(got, wantSteady) {
 		t.Fatalf("after the steady-state open dependencies = %v, want %v", got, wantSteady)
 	}
 }
@@ -115,7 +132,7 @@ func TestEmbeddedDepRekeyMergesFreshDuplicateEdges(t *testing.T) {
 
 	t.Run("dependencies, main cursor behind", func(t *testing.T) {
 		dataDir := seedMainSchemaAt(t, ctx, 53)
-		conn, closeConn := openPinnedConn(t, ctx, dataDir)
+		conn, closeConn := openDepConn(t, ctx, dataDir)
 
 		seedIssue(t, ctx, conn, "src")
 		seedIssue(t, ctx, conn, "tgt")
@@ -128,9 +145,7 @@ func TestEmbeddedDepRekeyMergesFreshDuplicateEdges(t *testing.T) {
 		commitSeed(t, ctx, conn, "test: duplicate typed edges before the 54..latest jump")
 		closeConn()
 
-		conn2, closeConn2 := openPinnedConn(t, ctx, dataDir)
-		defer closeConn2()
-
+		conn2, _ := openDepConn(t, ctx, dataDir)
 		if _, err := schema.MigrateUp(ctx, conn2); err != nil {
 			t.Fatalf("MigrateUp over duplicate typed edges: %v", err)
 		}
@@ -142,7 +157,7 @@ func TestEmbeddedDepRekeyMergesFreshDuplicateEdges(t *testing.T) {
 			{id: depid.New("other", "tgt"), issueID: "other", dependsOnIssueID: "tgt"},
 			{id: depid.New("src", "tgt"), issueID: "src", dependsOnIssueID: "tgt"},
 		}
-		if got := readDeps(t, ctx, conn2); !sameDepRows(got, want) {
+		if got := readDeps(t, ctx, conn2); !slices.Equal(got, want) {
 			t.Fatalf("dependencies = %v, want %v", got, want)
 		}
 	})
@@ -150,11 +165,8 @@ func TestEmbeddedDepRekeyMergesFreshDuplicateEdges(t *testing.T) {
 	t.Run("wisp_dependencies", func(t *testing.T) {
 		// The clone-local twin of the same table. Its re-key never syncs, but it
 		// aborts the whole pass just as loudly, so it needs the same merge.
-		dataDir := seedMainSchemaAt(t, ctx, schema.LatestVersion())
-		conn, closeConn := openPinnedConn(t, ctx, dataDir)
-		if _, err := schema.MigrateUp(ctx, conn); err != nil {
-			t.Fatalf("MigrateUp on the seed store: %v", err)
-		}
+		dataDir := seedMigratedStore(t, ctx)
+		conn, closeConn := openDepConn(t, ctx, dataDir)
 
 		seedWisp(t, ctx, conn, "w1")
 		seedIssue(t, ctx, conn, "wt")
@@ -162,20 +174,161 @@ func TestEmbeddedDepRekeyMergesFreshDuplicateEdges(t *testing.T) {
 		seedWispDependency(t, ctx, conn, "rand-w-b", "w1", nil, nil, strptr("wt"))
 		commitSeed(t, ctx, conn, "test: duplicate typed wisp edges")
 
-		unrecordIgnoredVersion(t, ctx, conn, depRekeyMarkerVersion)
+		unrecordIgnoredVersionsFrom(t, ctx, conn, depRekeyMarkerVersion)
 		closeConn()
 
-		conn2, closeConn2 := openPinnedConn(t, ctx, dataDir)
-		defer closeConn2()
-
+		conn2, _ := openDepConn(t, ctx, dataDir)
 		if _, err := schema.MigrateUp(ctx, conn2); err != nil {
 			t.Fatalf("MigrateUp over duplicate typed wisp edges: %v", err)
 		}
 		want := []depRow{{id: depid.New("w1", "wt"), issueID: "w1", dependsOnIssueID: "wt"}}
-		if got := readDepTable(t, ctx, conn2, "wisp_dependencies"); !sameDepRows(got, want) {
+		if got := readDepTable(t, ctx, conn2, "wisp_dependencies"); !slices.Equal(got, want) {
 			t.Fatalf("wisp_dependencies = %v, want %v", got, want)
 		}
 	})
+}
+
+// TestEmbeddedDepRekeyConvergesRenameChain is the state a rename leaves behind
+// on any binary that predates the issueops fix in this change: the FK's ON UPDATE
+// CASCADE retargets depends_on_issue_id before the rewrite can match the old
+// value, so the row keeps an id derived from the pre-rename target. Rename a
+// second issue INTO the freed name and two rows contend for one deterministic
+// id, with neither row corrupt.
+//
+// This is mechanically convergible -- vacate the occupant first -- and refusing
+// it would fail every open of an ordinary workspace, so the planner orders the
+// chain instead.
+func TestEmbeddedDepRekeyConvergesRenameChain(t *testing.T) {
+	requireEmbedded(t)
+	ctx := t.Context()
+
+	dataDir := seedMigratedStore(t, ctx)
+	conn, closeConn := openDepConn(t, ctx, dataDir)
+
+	for _, id := range []string{"src", "name-a", "name-b"} {
+		seedIssue(t, ctx, conn, id)
+	}
+	// src -> name-b, keyed as if its target had been renamed a -> b.
+	seedDependency(t, ctx, conn, depid.New("src", "name-a"), "src", strptr("name-b"), nil, nil)
+	// src -> name-a, keyed as if its target had been renamed c -> a. It wants
+	// the id the row above is currently sitting on.
+	seedDependency(t, ctx, conn, depid.New("src", "name-c"), "src", strptr("name-a"), nil, nil)
+	commitSeed(t, ctx, conn, "test: two renames leaving a re-key chain")
+
+	unrecordIgnoredVersionsFrom(t, ctx, conn, depRekeyMarkerVersion)
+	closeConn()
+
+	conn2, _ := openDepConn(t, ctx, dataDir)
+	if _, err := schema.MigrateUp(ctx, conn2); err != nil {
+		t.Fatalf("MigrateUp over a re-key chain: %v", err)
+	}
+	want := []depRow{
+		{id: depid.New("src", "name-a"), issueID: "src", dependsOnIssueID: "name-a"},
+		{id: depid.New("src", "name-b"), issueID: "src", dependsOnIssueID: "name-b"},
+	}
+	got := readDeps(t, ctx, conn2)
+	slices.SortFunc(got, func(a, b depRow) int { return strings.Compare(a.id, b.id) })
+	slices.SortFunc(want, func(a, b depRow) int { return strings.Compare(a.id, b.id) })
+	if !slices.Equal(got, want) {
+		t.Fatalf("dependencies = %v, want %v", got, want)
+	}
+}
+
+// TestEmbeddedRenameKeepsDependencyIDsDeterministic closes the chain state at
+// its source. updateIssueIDInTx renames the issues row first, so
+// fk_dep_issue_target's ON UPDATE CASCADE has already moved depends_on_issue_id
+// by the time replaceDependencyTargetInTx looks for the old value -- it matched
+// nothing, and the row kept a primary key derived from the old name. After the
+// fix the id is re-derived, so no rename mints a stale key for the migration
+// pass to untangle later.
+func TestEmbeddedRenameKeepsDependencyIDsDeterministic(t *testing.T) {
+	requireEmbedded(t)
+	ctx := t.Context()
+
+	dataDir := seedMigratedStore(t, ctx)
+	conn, _ := openDepConn(t, ctx, dataDir)
+
+	for _, id := range []string{"src", "old-target"} {
+		seedIssue(t, ctx, conn, id)
+	}
+	seedDependency(t, ctx, conn, depid.New("src", "old-target"), "src", strptr("old-target"), nil, nil)
+	commitSeed(t, ctx, conn, "test: an edge whose target is about to be renamed")
+
+	renameIssue(t, ctx, conn, "old-target", "new-target")
+
+	want := []depRow{{id: depid.New("src", "new-target"), issueID: "src", dependsOnIssueID: "new-target"}}
+	if got := readDeps(t, ctx, conn); !slices.Equal(got, want) {
+		t.Fatalf("after renaming the target, dependencies = %v, want %v", got, want)
+	}
+
+	// The source side already had this property (rekeyDependencySourceInTx);
+	// assert it too so the two halves cannot drift apart.
+	renameIssue(t, ctx, conn, "src", "new-src")
+	want = []depRow{{id: depid.New("new-src", "new-target"), issueID: "new-src", dependsOnIssueID: "new-target"}}
+	if got := readDeps(t, ctx, conn); !slices.Equal(got, want) {
+		t.Fatalf("after renaming the source, dependencies = %v, want %v", got, want)
+	}
+}
+
+// TestEmbeddedDepRekeyRefusesToWriteIntoDirtyDependencies covers the
+// marker-versus-guard hazard. MigrateUp's changed-signature guard runs AFTER
+// ignoredSource.migrate has durably recorded 0026, so a re-key that wrote into a
+// pre-existing dirty table would fail the open once and then never retry: the
+// heal would sit uncommitted and ride an unrelated user commit. The re-key
+// refuses at plan time instead -- nothing written, marker unrecorded -- and the
+// documented DirtyTablesError recovery converges it.
+func TestEmbeddedDepRekeyRefusesToWriteIntoDirtyDependencies(t *testing.T) {
+	requireEmbedded(t)
+	ctx := t.Context()
+
+	dataDir := seedMigratedStore(t, ctx)
+	conn, closeConn := openDepConn(t, ctx, dataDir)
+
+	seedIssue(t, ctx, conn, "d-src")
+	seedIssue(t, ctx, conn, "d-tgt")
+	commitSeed(t, ctx, conn, "test: issues for the dirty-dependencies victim")
+	// Deliberately NOT committed: this is the working-set state a batch-mode
+	// session, or a pre-1.3.0 aborted re-key, leaves behind.
+	seedDependency(t, ctx, conn, "dirty-random-id", "d-src", strptr("d-tgt"), nil, nil)
+	unrecordIgnoredVersionsFrom(t, ctx, conn, depRekeyMarkerVersion)
+	closeConn()
+
+	conn2, closeConn2 := openDepConn(t, ctx, dataDir)
+	before := readDeps(t, ctx, conn2)
+
+	_, err := schema.MigrateUp(ctx, conn2)
+	if err == nil {
+		t.Fatal("MigrateUp re-keyed a pre-existing dirty dependencies table")
+	}
+	var dirtyErr *schema.DirtyTablesError
+	if !errors.As(err, &dirtyErr) {
+		t.Fatalf("error %v is not a *schema.DirtyTablesError", err)
+	}
+	if !slices.Contains(dirtyErr.Tables, "dependencies") {
+		t.Errorf("dirtyErr.Tables = %v, want it to name dependencies", dirtyErr.Tables)
+	}
+	if got := readDeps(t, ctx, conn2); !slices.Equal(got, before) {
+		t.Fatalf("dependencies = %v, want the pre-pass rows %v untouched", got, before)
+	}
+	if ignoredVersionRecorded(t, ctx, conn2, depRekeyMarkerVersion) {
+		t.Fatalf("ignored migration %d recorded despite the refusal", depRekeyMarkerVersion)
+	}
+
+	// The documented recovery: commit the working set, re-open, converge.
+	commitSeed(t, ctx, conn2, "test: commit the dirty dependency row")
+	closeConn2()
+
+	conn3, _ := openDepConn(t, ctx, dataDir)
+	if _, err := schema.MigrateUp(ctx, conn3); err != nil {
+		t.Fatalf("MigrateUp after committing the working set: %v", err)
+	}
+	want := []depRow{{id: depid.New("d-src", "d-tgt"), issueID: "d-src", dependsOnIssueID: "d-tgt"}}
+	if got := readDeps(t, ctx, conn3); !slices.Equal(got, want) {
+		t.Fatalf("dependencies = %v, want %v", got, want)
+	}
+	if !ignoredVersionRecorded(t, ctx, conn3, depRekeyMarkerVersion) {
+		t.Fatalf("ignored migration %d not recorded after the retried pass", depRekeyMarkerVersion)
+	}
 }
 
 // TestEmbeddedDepRekeyAbortLeavesMarkerUnrecorded pins the retry guarantee that
@@ -183,33 +336,38 @@ func TestEmbeddedDepRekeyMergesFreshDuplicateEdges(t *testing.T) {
 // the pass BEFORE ignoredSource.migrate records 0026, so the database does not
 // claim it migrated and the next open tries again. This is the property whose
 // absence turned #5268 from a loud error into silent half-applied state.
+//
+// The unconvergible shape is a rotation: two rows each holding exactly the id
+// the other needs, with no free id to move through. Unlike the chain above there
+// is no ordering that works, and unlike a malformed squatter it is insertable
+// under every constraint the live schema carries.
 func TestEmbeddedDepRekeyAbortLeavesMarkerUnrecorded(t *testing.T) {
 	requireEmbedded(t)
 	ctx := t.Context()
 
-	dataDir := seedMainSchemaAt(t, ctx, schema.LatestVersion())
-	conn, closeConn := openPinnedConn(t, ctx, dataDir)
-	if _, err := schema.MigrateUp(ctx, conn); err != nil {
-		t.Fatalf("MigrateUp on the seed store: %v", err)
-	}
+	dataDir := seedMigratedStore(t, ctx)
+	conn, closeConn := openDepConn(t, ctx, dataDir)
 
-	for _, id := range []string{"c1", "c2", "c3", "c4"} {
+	for _, id := range []string{"c-src", "c1", "c2"} {
 		seedIssue(t, ctx, conn, id)
 	}
-	// c3 -> c4 is squatting on the id that c1 -> c2 must move to: a distinct
-	// edge, so the pass cannot merge them and must refuse instead of guessing.
-	squatted := depid.New("c1", "c2")
-	seedDependency(t, ctx, conn, "rand-c1", "c1", strptr("c2"), nil, nil)
-	seedDependency(t, ctx, conn, squatted, "c3", strptr("c4"), nil, nil)
-	commitSeed(t, ctx, conn, "test: a foreign row squatting a deterministic dependency id")
+	seedDependency(t, ctx, conn, depid.New("c-src", "c2"), "c-src", strptr("c1"), nil, nil)
+	seedDependency(t, ctx, conn, depid.New("c-src", "c1"), "c-src", strptr("c2"), nil, nil)
+	commitSeed(t, ctx, conn, "test: two dependency rows holding each other's deterministic id")
 
-	unrecordIgnoredVersion(t, ctx, conn, depRekeyMarkerVersion)
+	unrecordIgnoredVersionsFrom(t, ctx, conn, depRekeyMarkerVersion)
 	closeConn()
 
-	conn2, closeConn2 := openPinnedConn(t, ctx, dataDir)
+	conn2, closeConn2 := openDepConn(t, ctx, dataDir)
+	before := readDeps(t, ctx, conn2)
+
 	_, err := schema.MigrateUp(ctx, conn2)
 	if err == nil {
-		t.Fatal("MigrateUp succeeded over a squatted deterministic id")
+		t.Fatal("MigrateUp succeeded over an unconvergible rotation")
+	}
+	var conflict *schema.DependencyRekeyConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("error %v is not a *schema.DependencyRekeyConflictError", err)
 	}
 	if !strings.Contains(err.Error(), "bd doctor") {
 		t.Errorf("error %q does not point at bd doctor", err)
@@ -218,30 +376,46 @@ func TestEmbeddedDepRekeyAbortLeavesMarkerUnrecorded(t *testing.T) {
 		t.Fatalf("ignored migration %d recorded despite the failed re-key", depRekeyMarkerVersion)
 	}
 	// Nothing was written: the plan is validated before the first statement.
-	before := readDeps(t, ctx, conn2)
-	if len(before) != 2 {
-		t.Fatalf("dependencies = %v, want the two seeded rows untouched", before)
+	// Compared by value, since a row COUNT cannot see a pre-validation write.
+	if got := readDeps(t, ctx, conn2); !slices.Equal(got, before) {
+		t.Fatalf("dependencies = %v, want the seeded rows %v untouched", got, before)
 	}
 
-	// Repair the way `bd doctor` would -- give the squatter its own
-	// deterministic id -- and prove the retried pass converges.
-	mustExecConn(t, ctx, conn2, "UPDATE dependencies SET id = ? WHERE id = ?", depid.New("c3", "c4"), squatted)
-	commitSeed(t, ctx, conn2, "test: repair the squatted dependency id")
+	// A read-only command must still open. The re-key is a convergence repair,
+	// not a precondition for reading, and before it existed this clone opened
+	// fine; bricking `bd list` on latent id corruption the user cannot inspect
+	// without it would be the worse outcome. Nothing is lost: the marker is
+	// still unrecorded, so the next strict open retries.
 	closeConn2()
+	store, err := embeddeddolt.OpenForReadOnlyCommand(ctx, filepath.Dir(dataDir), "testdb", "main")
+	if err != nil {
+		t.Fatalf("OpenForReadOnlyCommand over an unconvergible re-key: %v", err)
+	}
+	store.Close()
 
-	conn3, closeConn3 := openPinnedConn(t, ctx, dataDir)
-	defer closeConn3()
-	if _, err := schema.MigrateUp(ctx, conn3); err != nil {
-		t.Fatalf("MigrateUp after the repair: %v", err)
+	// Repair the way `bd doctor` would -- break the rotation by giving one row
+	// a free id -- and prove the retried pass converges.
+	conn3, closeConn3 := openDepConn(t, ctx, dataDir)
+	mustExecConn(t, ctx, conn3, "UPDATE dependencies SET id = ? WHERE id = ?",
+		"interim-free-id", depid.New("c-src", "c2"))
+	commitSeed(t, ctx, conn3, "test: break the re-key rotation")
+	closeConn3()
+
+	conn4, _ := openDepConn(t, ctx, dataDir)
+	if _, err := schema.MigrateUp(ctx, conn4); err != nil {
+		t.Fatalf("MigrateUp after breaking the rotation: %v", err)
 	}
 	want := []depRow{
-		{id: depid.New("c1", "c2"), issueID: "c1", dependsOnIssueID: "c2"},
-		{id: depid.New("c3", "c4"), issueID: "c3", dependsOnIssueID: "c4"},
+		{id: depid.New("c-src", "c1"), issueID: "c-src", dependsOnIssueID: "c1"},
+		{id: depid.New("c-src", "c2"), issueID: "c-src", dependsOnIssueID: "c2"},
 	}
-	if got := readDeps(t, ctx, conn3); !sameDepRows(got, want) {
+	got := readDeps(t, ctx, conn4)
+	slices.SortFunc(got, func(a, b depRow) int { return strings.Compare(a.id, b.id) })
+	slices.SortFunc(want, func(a, b depRow) int { return strings.Compare(a.id, b.id) })
+	if !slices.Equal(got, want) {
 		t.Fatalf("dependencies = %v, want %v", got, want)
 	}
-	if !ignoredVersionRecorded(t, ctx, conn3, depRekeyMarkerVersion) {
+	if !ignoredVersionRecorded(t, ctx, conn4, depRekeyMarkerVersion) {
 		t.Fatalf("ignored migration %d not recorded after the retried pass succeeded", depRekeyMarkerVersion)
 	}
 }
@@ -256,6 +430,34 @@ type depRow struct {
 	dependsOnExternal string
 }
 
+// seedMigratedStore returns the dataDir of a store that has completed a full
+// MigrateUp, i.e. one whose main AND ignored cursors are both at latest -- the
+// state every marker-driven fixture below starts from.
+func seedMigratedStore(t *testing.T, ctx context.Context) string {
+	t.Helper()
+	dataDir := seedMainSchemaAt(t, ctx, schema.LatestVersion())
+	conn, closeConn := openDepConn(t, ctx, dataDir)
+	if _, err := schema.MigrateUp(ctx, conn); err != nil {
+		t.Fatalf("MigrateUp on the seed store: %v", err)
+	}
+	closeConn()
+	return dataDir
+}
+
+// openDepConn is openPinnedConn with a guarded t.Cleanup. These tests reopen the
+// store mid-test to force a fresh migration pass, so the close has to be
+// callable explicitly AND be idempotent: without the cleanup, any t.Fatal
+// between open and close leaks the pinned connection and the embedded Dolt
+// engine behind it for the rest of the test binary.
+func openDepConn(t *testing.T, ctx context.Context, dataDir string) (*sql.Conn, func()) {
+	t.Helper()
+	conn, cleanup := openPinnedConn(t, ctx, dataDir)
+	var once sync.Once
+	closeOnce := func() { once.Do(cleanup) }
+	t.Cleanup(closeOnce)
+	return conn, closeOnce
+}
+
 func seedDependency(t *testing.T, ctx context.Context, conn *sql.Conn, id, issueID string, issueTarget, wispTarget, externalTarget *string) {
 	t.Helper()
 	seedDepTable(t, ctx, conn, "dependencies", id, issueID, issueTarget, wispTarget, externalTarget)
@@ -266,15 +468,36 @@ func seedWispDependency(t *testing.T, ctx context.Context, conn *sql.Conn, id, i
 	seedDepTable(t, ctx, conn, "wisp_dependencies", id, issueID, issueTarget, wispTarget, externalTarget)
 }
 
-// seedDepTable inserts an edge with an explicit id, which is the whole point:
+// seedDepTable inserts an edge with an EXPLICIT id, which is the whole point:
 // the affected rows predate the deterministic derivation, so they cannot be
-// created through AddDependency.
+// created through AddDependency. It deliberately does not replace
+// migrate_wisp_dep_forward_repair_test.go's seedWispDep, which seeds the LEGACY
+// wisp_dependencies shape -- that table has no id column at all, so the two
+// helpers cannot share an INSERT.
 func seedDepTable(t *testing.T, ctx context.Context, conn *sql.Conn, table, id, issueID string, issueTarget, wispTarget, externalTarget *string) {
 	t.Helper()
 	mustExecConn(t, ctx, conn, `
 INSERT INTO `+table+` (id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata)
 VALUES (?, ?, ?, ?, ?, 'blocks', NOW(), 'tester', JSON_OBJECT())`,
 		id, issueID, nullable(issueTarget), nullable(wispTarget), nullable(externalTarget))
+}
+
+// renameIssue drives the real rename path (issueops.UpdateIssueIDInTx), so the
+// FK's ON UPDATE CASCADE fires exactly as it does for `bd rename`.
+func renameIssue(t *testing.T, ctx context.Context, conn *sql.Conn, oldID, newID string) {
+	t.Helper()
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin rename tx: %v", err)
+	}
+	issue := &types.Issue{ID: newID, Title: "i", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := issueops.UpdateIssueIDInTx(ctx, tx, oldID, newID, issue, "tester"); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("rename %s -> %s: %v", oldID, newID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit rename %s -> %s: %v", oldID, newID, err)
+	}
 }
 
 func readDeps(t *testing.T, ctx context.Context, conn *sql.Conn) []depRow {
@@ -310,32 +533,20 @@ ORDER BY issue_id, id`)
 	return out
 }
 
-func sameDepRows(got, want []depRow) bool {
-	if len(got) != len(want) {
-		return false
-	}
-	for i := range got {
-		if got[i] != want[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// unrecordIgnoredVersion removes one ignored-series cursor row, reproducing the
-// state a clone is in before it has run the marker's pass. The cursor table is
+// unrecordIgnoredVersionsFrom removes the ignored-series cursor rows from
+// version upward, reproducing the state a clone is in before it has run the
+// marker's pass. It deletes a RANGE rather than the single row because the
+// cursor is COALESCE(MAX(version), 0) and migrate only applies versions above
+// it: with a later ignored migration present, dropping only 0026 would leave the
+// cursor at latest and the pass would silently never run. The cursor table is
 // dolt-ignored, so this needs no commit.
-func unrecordIgnoredVersion(t *testing.T, ctx context.Context, conn *sql.Conn, version int) {
+func unrecordIgnoredVersionsFrom(t *testing.T, ctx context.Context, conn *sql.Conn, version int) {
 	t.Helper()
-	mustExecConn(t, ctx, conn, "DELETE FROM ignored_schema_migrations WHERE version = ?", version)
+	mustExecConn(t, ctx, conn, "DELETE FROM ignored_schema_migrations WHERE version >= ?", version)
 }
 
 func ignoredVersionRecorded(t *testing.T, ctx context.Context, conn *sql.Conn, version int) bool {
 	t.Helper()
-	var n int
-	if err := conn.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM ignored_schema_migrations WHERE version = ?", version).Scan(&n); err != nil {
-		t.Fatalf("read ignored_schema_migrations: %v", err)
-	}
-	return n > 0
+	return scalarInt(t, ctx, conn,
+		"SELECT COUNT(*) FROM ignored_schema_migrations WHERE version = ?", version) > 0
 }

--- a/internal/storage/embeddeddolt/migrate_dep_rekey_dedup_test.go
+++ b/internal/storage/embeddeddolt/migrate_dep_rekey_dedup_test.go
@@ -1,0 +1,341 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/depid"
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// Real-Dolt coverage for the merge-aware dependency-id re-key
+// (rekeyDependencyTable, internal/storage/schema/dep_id_backfill.go) and its
+// completion marker, ignored migration 0026 (gastownhall/beads#5268).
+//
+// Why this cannot be a sqlmock test. The bug IS Dolt's primary-key enforcement:
+// the old row-at-a-time rewrite issued statements a statement-echo mock happily
+// accepts, and only a real engine answers the second one with "duplicate primary
+// key given" and leaves the table half-re-keyed. The same reason
+// migrate_wisp_dep_forward_repair_test.go exists. These tests also exercise the
+// marker end to end -- that a pending 0026 forces a pass on a database whose
+// main cursor is already at latest, and that an aborted re-key leaves 0026
+// unrecorded so the next open retries -- which is a property of MigrateUp's step
+// order, not of any single statement.
+
+// depRekeyMarkerVersion is ignored migration 0026, the clone-local marker whose
+// pending state forces the one repair pass.
+const depRekeyMarkerVersion = 26
+
+// TestEmbeddedDepRekeyRepairsHalfRekeyedDuplicateEdge is the victim repair: a
+// database that a pre-1.3.0 binary left half-re-keyed and then declared
+// migrated, because the per-step commits had already carried the main cursor to
+// latest before the re-key aborted.
+//
+// The seeded shape is the reporter's, minus the 5,336-row haystack: one logical
+// edge recorded twice, once as an issue ref and once as an external ref -- legal,
+// since the unique keys are per typed column -- with the external twin already
+// moved onto the deterministic id by the aborted pass.
+func TestEmbeddedDepRekeyRepairsHalfRekeyedDuplicateEdge(t *testing.T) {
+	requireEmbedded(t)
+	ctx := t.Context()
+
+	dataDir := seedMainSchemaAt(t, ctx, schema.LatestVersion())
+	conn, closeConn := openPinnedConn(t, ctx, dataDir)
+	if _, err := schema.MigrateUp(ctx, conn); err != nil {
+		t.Fatalf("MigrateUp on the seed store: %v", err)
+	}
+
+	const source, target = "hq-cv-vvnmq", "ops-w05"
+	want := depid.New(source, target)
+	seedIssue(t, ctx, conn, source)
+	seedIssue(t, ctx, conn, target)
+	// The surviving orientation, still carrying its 0043-minted random id.
+	seedDependency(t, ctx, conn, "random-issue-row", source, strptr(target), nil, nil)
+	// The twin the aborted pass already moved onto the deterministic id. It is
+	// the loser anyway: the survivor rule is the typed column, not who got there
+	// first, so the repair has to free this id before reusing it.
+	seedDependency(t, ctx, conn, want, source, nil, nil, strptr(target))
+	commitSeed(t, ctx, conn, "test: reproduce the #5268 half-re-keyed duplicate edge")
+
+	// What makes this database a class-2b victim: the main cursor is at latest
+	// and every numbered migration is recorded, so without a pending marker
+	// migrationWorkNeeded short-circuits and the re-key never runs again.
+	unrecordIgnoredVersion(t, ctx, conn, depRekeyMarkerVersion)
+	closeConn()
+
+	conn2, closeConn2 := openPinnedConn(t, ctx, dataDir)
+	defer closeConn2()
+
+	// Pre-fix this returns "rekey dependency ids: dependencies: re-key id
+	// random-issue-row -> ...: duplicate primary key given".
+	if _, err := schema.MigrateUp(ctx, conn2); err != nil {
+		t.Fatalf("MigrateUp over a half-re-keyed duplicate edge: %v", err)
+	}
+
+	wantRows := []depRow{{id: want, issueID: source, dependsOnIssueID: target}}
+	if got := readDeps(t, ctx, conn2); !sameDepRows(got, wantRows) {
+		t.Fatalf("dependencies = %v, want %v", got, wantRows)
+	}
+	if !ignoredVersionRecorded(t, ctx, conn2, depRekeyMarkerVersion) {
+		t.Fatalf("ignored migration %d not recorded after a successful pass", depRekeyMarkerVersion)
+	}
+
+	// With the marker recorded and both cursors at latest, migrationWorkNeeded
+	// is false and MigrateUp short-circuits before the re-key. Prove that
+	// directly rather than by "nothing changed": seed a row whose id IS
+	// divergent, and assert the next open leaves it alone. If the pass still
+	// ran, this row would be re-keyed.
+	seedIssue(t, ctx, conn2, "steady-src")
+	seedDependency(t, ctx, conn2, "steady-random-id", "steady-src", nil, nil, strptr("external:e1"))
+	commitSeed(t, ctx, conn2, "test: a divergent row written after the repair pass")
+
+	if _, err := schema.MigrateUp(ctx, conn2); err != nil {
+		t.Fatalf("MigrateUp on the converged store: %v", err)
+	}
+	wantSteady := []depRow{
+		{id: want, issueID: source, dependsOnIssueID: target},
+		{id: "steady-random-id", issueID: "steady-src", dependsOnExternal: "external:e1"},
+	}
+	if got := readDeps(t, ctx, conn2); !sameDepRows(got, wantSteady) {
+		t.Fatalf("after the steady-state open dependencies = %v, want %v", got, wantSteady)
+	}
+}
+
+// TestEmbeddedDepRekeyMergesFreshDuplicateEdges is the class-1 victim: a
+// database with duplicate typed edges and pending migrations, i.e. any rig that
+// upgrades across the #4259 fix carrying an old wisp-to-issue conversion. The
+// re-key runs because migrations are pending, and must merge rather than abort.
+func TestEmbeddedDepRekeyMergesFreshDuplicateEdges(t *testing.T) {
+	requireEmbedded(t)
+	ctx := t.Context()
+
+	t.Run("dependencies, main cursor behind", func(t *testing.T) {
+		dataDir := seedMainSchemaAt(t, ctx, 53)
+		conn, closeConn := openPinnedConn(t, ctx, dataDir)
+
+		seedIssue(t, ctx, conn, "src")
+		seedIssue(t, ctx, conn, "tgt")
+		seedIssue(t, ctx, conn, "other")
+		// The duplicate pair, both still random, plus an unrelated edge that
+		// must survive the pass re-keyed and intact.
+		seedDependency(t, ctx, conn, "rand-a", "src", strptr("tgt"), nil, nil)
+		seedDependency(t, ctx, conn, "rand-b", "src", nil, nil, strptr("tgt"))
+		seedDependency(t, ctx, conn, "rand-c", "other", strptr("tgt"), nil, nil)
+		commitSeed(t, ctx, conn, "test: duplicate typed edges before the 54..latest jump")
+		closeConn()
+
+		conn2, closeConn2 := openPinnedConn(t, ctx, dataDir)
+		defer closeConn2()
+
+		if _, err := schema.MigrateUp(ctx, conn2); err != nil {
+			t.Fatalf("MigrateUp over duplicate typed edges: %v", err)
+		}
+		if v := currentMainVersion(t, ctx, conn2); v != schema.LatestVersion() {
+			t.Fatalf("main schema version = %d, want latest %d", v, schema.LatestVersion())
+		}
+
+		want := []depRow{
+			{id: depid.New("other", "tgt"), issueID: "other", dependsOnIssueID: "tgt"},
+			{id: depid.New("src", "tgt"), issueID: "src", dependsOnIssueID: "tgt"},
+		}
+		if got := readDeps(t, ctx, conn2); !sameDepRows(got, want) {
+			t.Fatalf("dependencies = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("wisp_dependencies", func(t *testing.T) {
+		// The clone-local twin of the same table. Its re-key never syncs, but it
+		// aborts the whole pass just as loudly, so it needs the same merge.
+		dataDir := seedMainSchemaAt(t, ctx, schema.LatestVersion())
+		conn, closeConn := openPinnedConn(t, ctx, dataDir)
+		if _, err := schema.MigrateUp(ctx, conn); err != nil {
+			t.Fatalf("MigrateUp on the seed store: %v", err)
+		}
+
+		seedWisp(t, ctx, conn, "w1")
+		seedIssue(t, ctx, conn, "wt")
+		seedWispDependency(t, ctx, conn, "rand-w-a", "w1", strptr("wt"), nil, nil)
+		seedWispDependency(t, ctx, conn, "rand-w-b", "w1", nil, nil, strptr("wt"))
+		commitSeed(t, ctx, conn, "test: duplicate typed wisp edges")
+
+		unrecordIgnoredVersion(t, ctx, conn, depRekeyMarkerVersion)
+		closeConn()
+
+		conn2, closeConn2 := openPinnedConn(t, ctx, dataDir)
+		defer closeConn2()
+
+		if _, err := schema.MigrateUp(ctx, conn2); err != nil {
+			t.Fatalf("MigrateUp over duplicate typed wisp edges: %v", err)
+		}
+		want := []depRow{{id: depid.New("w1", "wt"), issueID: "w1", dependsOnIssueID: "wt"}}
+		if got := readDepTable(t, ctx, conn2, "wisp_dependencies"); !sameDepRows(got, want) {
+			t.Fatalf("wisp_dependencies = %v, want %v", got, want)
+		}
+	})
+}
+
+// TestEmbeddedDepRekeyAbortLeavesMarkerUnrecorded pins the retry guarantee that
+// the marker's position in MigrateUp buys: a re-key that cannot converge fails
+// the pass BEFORE ignoredSource.migrate records 0026, so the database does not
+// claim it migrated and the next open tries again. This is the property whose
+// absence turned #5268 from a loud error into silent half-applied state.
+func TestEmbeddedDepRekeyAbortLeavesMarkerUnrecorded(t *testing.T) {
+	requireEmbedded(t)
+	ctx := t.Context()
+
+	dataDir := seedMainSchemaAt(t, ctx, schema.LatestVersion())
+	conn, closeConn := openPinnedConn(t, ctx, dataDir)
+	if _, err := schema.MigrateUp(ctx, conn); err != nil {
+		t.Fatalf("MigrateUp on the seed store: %v", err)
+	}
+
+	for _, id := range []string{"c1", "c2", "c3", "c4"} {
+		seedIssue(t, ctx, conn, id)
+	}
+	// c3 -> c4 is squatting on the id that c1 -> c2 must move to: a distinct
+	// edge, so the pass cannot merge them and must refuse instead of guessing.
+	squatted := depid.New("c1", "c2")
+	seedDependency(t, ctx, conn, "rand-c1", "c1", strptr("c2"), nil, nil)
+	seedDependency(t, ctx, conn, squatted, "c3", strptr("c4"), nil, nil)
+	commitSeed(t, ctx, conn, "test: a foreign row squatting a deterministic dependency id")
+
+	unrecordIgnoredVersion(t, ctx, conn, depRekeyMarkerVersion)
+	closeConn()
+
+	conn2, closeConn2 := openPinnedConn(t, ctx, dataDir)
+	_, err := schema.MigrateUp(ctx, conn2)
+	if err == nil {
+		t.Fatal("MigrateUp succeeded over a squatted deterministic id")
+	}
+	if !strings.Contains(err.Error(), "bd doctor") {
+		t.Errorf("error %q does not point at bd doctor", err)
+	}
+	if ignoredVersionRecorded(t, ctx, conn2, depRekeyMarkerVersion) {
+		t.Fatalf("ignored migration %d recorded despite the failed re-key", depRekeyMarkerVersion)
+	}
+	// Nothing was written: the plan is validated before the first statement.
+	before := readDeps(t, ctx, conn2)
+	if len(before) != 2 {
+		t.Fatalf("dependencies = %v, want the two seeded rows untouched", before)
+	}
+
+	// Repair the way `bd doctor` would -- give the squatter its own
+	// deterministic id -- and prove the retried pass converges.
+	mustExecConn(t, ctx, conn2, "UPDATE dependencies SET id = ? WHERE id = ?", depid.New("c3", "c4"), squatted)
+	commitSeed(t, ctx, conn2, "test: repair the squatted dependency id")
+	closeConn2()
+
+	conn3, closeConn3 := openPinnedConn(t, ctx, dataDir)
+	defer closeConn3()
+	if _, err := schema.MigrateUp(ctx, conn3); err != nil {
+		t.Fatalf("MigrateUp after the repair: %v", err)
+	}
+	want := []depRow{
+		{id: depid.New("c1", "c2"), issueID: "c1", dependsOnIssueID: "c2"},
+		{id: depid.New("c3", "c4"), issueID: "c3", dependsOnIssueID: "c4"},
+	}
+	if got := readDeps(t, ctx, conn3); !sameDepRows(got, want) {
+		t.Fatalf("dependencies = %v, want %v", got, want)
+	}
+	if !ignoredVersionRecorded(t, ctx, conn3, depRekeyMarkerVersion) {
+		t.Fatalf("ignored migration %d not recorded after the retried pass succeeded", depRekeyMarkerVersion)
+	}
+}
+
+// --- helpers ---
+
+type depRow struct {
+	id                string
+	issueID           string
+	dependsOnIssueID  string
+	dependsOnWispID   string
+	dependsOnExternal string
+}
+
+func seedDependency(t *testing.T, ctx context.Context, conn *sql.Conn, id, issueID string, issueTarget, wispTarget, externalTarget *string) {
+	t.Helper()
+	seedDepTable(t, ctx, conn, "dependencies", id, issueID, issueTarget, wispTarget, externalTarget)
+}
+
+func seedWispDependency(t *testing.T, ctx context.Context, conn *sql.Conn, id, issueID string, issueTarget, wispTarget, externalTarget *string) {
+	t.Helper()
+	seedDepTable(t, ctx, conn, "wisp_dependencies", id, issueID, issueTarget, wispTarget, externalTarget)
+}
+
+// seedDepTable inserts an edge with an explicit id, which is the whole point:
+// the affected rows predate the deterministic derivation, so they cannot be
+// created through AddDependency.
+func seedDepTable(t *testing.T, ctx context.Context, conn *sql.Conn, table, id, issueID string, issueTarget, wispTarget, externalTarget *string) {
+	t.Helper()
+	mustExecConn(t, ctx, conn, `
+INSERT INTO `+table+` (id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata)
+VALUES (?, ?, ?, ?, ?, 'blocks', NOW(), 'tester', JSON_OBJECT())`,
+		id, issueID, nullable(issueTarget), nullable(wispTarget), nullable(externalTarget))
+}
+
+func readDeps(t *testing.T, ctx context.Context, conn *sql.Conn) []depRow {
+	t.Helper()
+	return readDepTable(t, ctx, conn, "dependencies")
+}
+
+func readDepTable(t *testing.T, ctx context.Context, conn *sql.Conn, table string) []depRow {
+	t.Helper()
+	rows, err := conn.QueryContext(ctx, `
+SELECT id, issue_id,
+       COALESCE(depends_on_issue_id, ''),
+       COALESCE(depends_on_wisp_id, ''),
+       COALESCE(depends_on_external, '')
+FROM `+table+`
+ORDER BY issue_id, id`)
+	if err != nil {
+		t.Fatalf("read %s: %v", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []depRow
+	for rows.Next() {
+		var r depRow
+		if err := rows.Scan(&r.id, &r.issueID, &r.dependsOnIssueID, &r.dependsOnWispID, &r.dependsOnExternal); err != nil {
+			t.Fatalf("scan %s row: %v", table, err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate %s: %v", table, err)
+	}
+	return out
+}
+
+func sameDepRows(got, want []depRow) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// unrecordIgnoredVersion removes one ignored-series cursor row, reproducing the
+// state a clone is in before it has run the marker's pass. The cursor table is
+// dolt-ignored, so this needs no commit.
+func unrecordIgnoredVersion(t *testing.T, ctx context.Context, conn *sql.Conn, version int) {
+	t.Helper()
+	mustExecConn(t, ctx, conn, "DELETE FROM ignored_schema_migrations WHERE version = ?", version)
+}
+
+func ignoredVersionRecorded(t *testing.T, ctx context.Context, conn *sql.Conn, version int) bool {
+	t.Helper()
+	var n int
+	if err := conn.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM ignored_schema_migrations WHERE version = ?", version).Scan(&n); err != nil {
+		t.Fatalf("read ignored_schema_migrations: %v", err)
+	}
+	return n > 0
+}

--- a/internal/storage/embeddeddolt/migrate_events_flip_test.go
+++ b/internal/storage/embeddeddolt/migrate_events_flip_test.go
@@ -168,10 +168,10 @@ func mustDrain(t *testing.T, ctx context.Context, conn *sql.Conn, sqlText string
 	}
 }
 
-func scalarInt(t *testing.T, ctx context.Context, conn *sql.Conn, query string) int {
+func scalarInt(t *testing.T, ctx context.Context, conn *sql.Conn, query string, args ...any) int {
 	t.Helper()
 	var v int
-	if err := conn.QueryRowContext(ctx, query).Scan(&v); err != nil {
+	if err := conn.QueryRowContext(ctx, query, args...).Scan(&v); err != nil {
 		t.Fatalf("scalar %q: %v", query, err)
 	}
 	return v

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -449,6 +449,22 @@ func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {
 			}
 			return nil
 		}
+		var rekeyErr *schema.DependencyRekeyConflictError
+		if s.intent != openStrict && errors.As(err, &rekeyErr) {
+			// Same principle for the dependency re-key's refusal (#5268): it is
+			// a convergence repair, not a precondition for reading, and before
+			// that pass existed these clones opened fine. Bricking 'bd list' and
+			// 'bd show' on latent id corruption the user cannot even inspect
+			// without them would be a worse outcome than a stale primary key.
+			// Nothing is lost by continuing: the 0026 marker stays unrecorded,
+			// so the next open retries the repair.
+			fmt.Fprintf(os.Stderr,
+				"Warning: %v\n"+
+					"  Continuing without re-keying dependencies. Dependency ids stay as\n"+
+					"  they are until the conflict is resolved; run 'bd doctor' to inspect.\n",
+				rekeyErr)
+			return nil
+		}
 		return fmt.Errorf("embeddeddolt: migrate: %w", err)
 	}
 

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -761,6 +761,68 @@ func replaceDependencyTargetInTx(ctx context.Context, tx *sql.Tx, table, column,
 			return fmt.Errorf("insert replacement dependency target: %w", err)
 		}
 	}
+	return rekeyDependencyTargetInTx(ctx, tx, table, column, newID)
+}
+
+// rekeyDependencyTargetInTx re-derives the surrogate primary key of every row
+// whose typed target column already carries newID but whose id was derived from
+// the pre-rename target.
+//
+// The typed target columns carry ON UPDATE CASCADE foreign keys
+// (fk_dep_issue_target, fk_wisp_dep_issue_target), and updateIssueIDInTx renames
+// the issues row FIRST, so by the time replaceDependencyTargetInTx runs the
+// cascade has already moved depends_on_issue_id from oldID to newID. Its
+// `WHERE <column> = oldID` therefore matches nothing and the row keeps
+// id = depid.New(issue_id, oldID) — a stale primary key that re-forks across
+// clones (#4259) and, once a later rename hands oldID to a different issue,
+// leaves two rows contending for one deterministic id, which is the chain the
+// migration-time re-key then has to untangle (#5268).
+//
+// This is the target-side mirror of rekeyDependencySourceInTx, which already
+// matches both the pre- and post-cascade state on the source column. Only rows
+// whose id is actually stale are touched, so it is a no-op on a converged table
+// and on the rows the loop above just reinserted with the right id.
+func rekeyDependencyTargetInTx(ctx context.Context, tx *sql.Tx, table, column, newID string) error {
+	//nolint:gosec // table and column are hardcoded by callers.
+	queryRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external
+		FROM %s
+		WHERE %s = ?
+	`, table, column), newID)
+	if err != nil {
+		return fmt.Errorf("query renamed dependency targets in %s: %w", table, err)
+	}
+	type rekey struct{ oldRowID, newRowID string }
+	var rekeys []rekey
+	for queryRows.Next() {
+		var id, issueID string
+		var issueTarget, wispTarget, external sql.NullString
+		if err := queryRows.Scan(&id, &issueID, &issueTarget, &wispTarget, &external); err != nil {
+			_ = queryRows.Close()
+			return fmt.Errorf("scan renamed dependency target: %w", err)
+		}
+		// Resolve rather than assume newID: on a row that somehow holds several
+		// typed targets, the identity the unique keys and depid see is the first
+		// non-null in precedence order, which need not be the renamed column.
+		target, ok := resolveDependencyTarget(issueTarget, wispTarget, external)
+		if !ok {
+			continue // ck_dep_one_target guarantees one target; skip defensively
+		}
+		if want := depid.New(issueID, target); want != id {
+			rekeys = append(rekeys, rekey{oldRowID: id, newRowID: want})
+		}
+	}
+	_ = queryRows.Close()
+	if err := queryRows.Err(); err != nil {
+		return fmt.Errorf("iterate renamed dependency targets: %w", err)
+	}
+	for _, rk := range rekeys {
+		//nolint:gosec // table is hardcoded by callers.
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf("UPDATE %s SET id = ? WHERE id = ?", table),
+			rk.newRowID, rk.oldRowID); err != nil {
+			return fmt.Errorf("rekey dependency target id %s -> %s in %s: %w", rk.oldRowID, rk.newRowID, table, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/storage/issueops/dependencies_test.go
+++ b/internal/storage/issueops/dependencies_test.go
@@ -134,6 +134,12 @@ func TestReplaceDependencyTargetNormalizesTargetColumns(t *testing.T) {
 			mock.ExpectExec(regexp.QuoteMeta("INSERT INTO dependencies (id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id)")).
 				WithArgs(depid.New("source", "new-target"), "source", tt.wantIssue, tt.wantWisp, tt.wantExternal, "blocks", nil, "tester", "{}", "thread-1").
 				WillReturnResult(sqlmock.NewResult(0, 1))
+			// The post-cascade sweep: rows whose typed column already carries
+			// newID because fk_dep_*_target's ON UPDATE CASCADE beat the rewrite
+			// here get their stale id re-derived. Nothing stale in this fixture.
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external")).
+				WithArgs("new-target").
+				WillReturnRows(sqlmock.NewRows([]string{"id", "issue_id", "depends_on_issue_id", "depends_on_wisp_id", "depends_on_external"}))
 			mock.ExpectCommit()
 
 			tx, err := db.BeginTx(context.Background(), nil)
@@ -191,5 +197,65 @@ func TestCycleReachabilityQueryMultipleTablesTraversesUniqueNodes(t *testing.T) 
 	}
 	if !strings.Contains(query, DepTargetExpr) {
 		t.Fatalf("query does not resolve depends_on_id via DepTargetExpr:\n%s", query)
+	}
+}
+
+// TestReplaceDependencyTargetRekeysCascadedRows pins the half of a rename the
+// rewrite above cannot see. fk_dep_issue_target carries ON UPDATE CASCADE and
+// updateIssueIDInTx renames the issues row first, so depends_on_issue_id already
+// reads newID by the time replaceDependencyTargetInTx runs: its
+// `WHERE ... = oldID` matches nothing and the row keeps id = depid(issue, oldID).
+// That stale primary key re-forks across clones (#4259) and, once a later rename
+// hands oldID to another issue, becomes the migration-time re-key chain of
+// gastownhall/beads#5268.
+func TestReplaceDependencyTargetRekeysCascadedRows(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM dependencies a")).
+		WithArgs("new-target", "new-target", "new-target").
+		WillReturnRows(sqlmock.NewRows([]string{"found"}))
+	// The cascade already moved the row, so the oldID rewrite finds nothing.
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id")).
+		WithArgs("old-target", "old-target").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"issue_id", "depends_on_issue_id", "depends_on_wisp_id", "depends_on_external",
+			"type", "created_at", "created_by", "metadata", "thread_id",
+		}))
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM dependencies")).
+		WithArgs("old-target", "old-target").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	// The sweep finds the cascaded row: right target, id still derived from the
+	// pre-rename name.
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external")).
+		WithArgs("new-target").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "issue_id", "depends_on_issue_id", "depends_on_wisp_id", "depends_on_external"}).
+			AddRow(depid.New("source", "old-target"), "source", "new-target", nil, nil).
+			// An already-correct sibling must not be touched.
+			AddRow(depid.New("other", "new-target"), "other", "new-target", nil, nil))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE dependencies SET id = ? WHERE id = ?")).
+		WithArgs(depid.New("source", "new-target"), depid.New("source", "old-target")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	if err := replaceDependencyTargetInTx(context.Background(), tx, "dependencies", "depends_on_issue_id", "old-target", "new-target"); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("replaceDependencyTargetInTx: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }

--- a/internal/storage/schema/dep_id_backfill.go
+++ b/internal/storage/schema/dep_id_backfill.go
@@ -4,11 +4,46 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/storage/depid"
 )
+
+// depRekeyTables are the two edge tables the re-key covers, in execution order.
+var depRekeyTables = []string{"dependencies", "wisp_dependencies"}
+
+// depTargetColumns is the COALESCE order of the three typed target columns,
+// which is also the survivor priority for a duplicated edge: an issue ref beats
+// a wisp ref beats an external ref. Changing this order changes both the derived
+// target and which twin survives, so it is deliberately the same list for both.
+var depTargetColumns = []string{"depends_on_issue_id", "depends_on_wisp_id", "depends_on_external"}
+
+// depDeleteChunk is how many ids one DELETE ... WHERE id IN (...) carries,
+// matching issueops' deleteBatchSize. The victims of #5268 are precisely the
+// databases with thousands of divergent rows, and this pass runs at open.
+const depDeleteChunk = 50
+
+// DependencyRekeyConflictError reports an edge table the re-key cannot converge
+// without guessing: a row outside any duplicate group is squatting on an id
+// another row must move to, or a set of rows form a rotation with no free id to
+// move through. Both are corruption rather than the cross-column duplicate this
+// pass merges, so the pass refuses before writing anything.
+//
+// It is typed because a repair pass must not brick reads: embeddeddolt's
+// non-strict opens (read-only commands, working-set reconcile) tolerate it and
+// continue, the same way they tolerate DirtyTablesError. Nothing is lost by
+// continuing — the 0026 marker stays unrecorded, so the next open retries.
+type DependencyRekeyConflictError struct {
+	Table  string
+	Detail string
+}
+
+func (e *DependencyRekeyConflictError) Error() string {
+	return fmt.Sprintf("%s: %s; run `bd doctor` to inspect the table (gastownhall/beads#5268)",
+		e.Table, e.Detail)
+}
 
 // rekeyDependencyIDs rewrites the surrogate primary key of every dependencies
 // and wisp_dependencies row whose id does not already equal
@@ -37,110 +72,183 @@ import (
 // external before the target existed as an issue, then again as an issue ref.
 // Both rows derive the same id, so the old row-at-a-time rewrite aborted the
 // second UPDATE with "duplicate primary key given" partway through the table.
-// rekeyDependencyTable now merges those duplicates instead (see its doc), and
-// ignored migration 0026 is the completion marker that makes the pass run once
-// on every existing clone — including one already at the latest main version
-// that a pre-1.3.0 binary left half-rekeyed — and re-run on the next open if it
-// ever aborts again.
+// planDependencyRekey now merges those duplicates instead, and ignored migration
+// 0026 is the completion marker that makes the pass run once on every existing
+// clone — including one already at the latest main version that a pre-1.3.0
+// binary left half-rekeyed — and re-run on the next open if it ever aborts.
+//
+// BOTH tables are planned before EITHER is executed. Planning is read-only, so a
+// refusal on wisp_dependencies must not leave the synced dependencies table
+// already rewritten: those writes would sit uncommitted (the pass aborts before
+// MigrateUp's DOLT_COMMIT) and the recovery pass would then classify them as
+// pre-existing dirty and skip them again.
+//
+// dirtyBefore is MigrateUp's set of committable tables that were already dirty
+// when the pass started. Writing the re-key into one of them would entangle
+// migration output with uncommitted user data — the hazard changedDirtyTableSignatures
+// exists to catch — but that guard runs AFTER ignoredSource.migrate has durably
+// recorded the 0026 marker, so it would fail the open once and never retry,
+// leaving the heal to ride an unrelated user commit. Refusing here instead, at
+// plan time, keeps the contract: nothing written, marker unrecorded, retried on
+// the next open once the user commits or discards the working set.
+func rekeyDependencyIDs(ctx context.Context, db DBConn, dirtyBefore map[string]dirtyTableState) (bool, error) {
+	plans := make([]*depPlan, 0, len(depRekeyTables))
+	for _, table := range depRekeyTables {
+		plan, err := planDependencyTableRekey(ctx, db, table)
+		if err != nil {
+			return false, err
+		}
+		plans = append(plans, plan)
+	}
 
-func rekeyDependencyIDs(ctx context.Context, db DBConn) (bool, error) {
-	wroteDeps, err := rekeyDependencyTable(ctx, db, "dependencies")
-	if err != nil {
-		return wroteDeps, fmt.Errorf("dependencies: %w", err)
+	var blocked []string
+	for _, plan := range plans {
+		if _, dirty := dirtyBefore[plan.table]; dirty && plan.writes() {
+			blocked = append(blocked, plan.table)
+		}
 	}
-	wroteWisp, err := rekeyDependencyTable(ctx, db, "wisp_dependencies")
-	if err != nil {
-		return wroteDeps || wroteWisp, fmt.Errorf("wisp_dependencies: %w", err)
+	if len(blocked) > 0 {
+		return false, &DirtyTablesError{Tables: blocked}
 	}
-	return wroteDeps || wroteWisp, nil
+
+	wrote := false
+	for _, plan := range plans {
+		planWrote, err := plan.execute(ctx, db)
+		wrote = wrote || planWrote
+		if err != nil {
+			return wrote, err
+		}
+	}
+	return wrote, nil
 }
 
 // depRow is one scanned edge: its current primary key, the natural identity
-// depid keys on, and which typed column carried the target.
+// depid keys on, which typed column carried the target, and the type the merge
+// would discard if this row loses.
 type depRow struct {
-	id        string
-	issueID   string
-	target    string
-	hasTarget bool
-	priority  int // index into depTargetColumns; lower wins the merge
+	id          string
+	issueID     string
+	target      string
+	depType     string
+	targetCount int // non-null typed target columns; only 1 is a well-formed edge
+	priority    int // index into depTargetColumns; lower wins the merge
 }
 
-// depTargetColumns is the COALESCE order of the three typed target columns,
-// which is also the survivor priority for a duplicated edge: an issue ref beats
-// a wisp ref beats an external ref. Changing this order changes both the
-// derived target and which twin survives, so it is the same list for both.
-var depTargetColumns = []string{"depends_on_issue_id", "depends_on_wisp_id", "depends_on_external"}
+// mergeable reports whether the row has exactly one typed target, i.e. whether
+// its natural identity is unambiguous enough to group and re-key. Rows with none
+// (ck_dep_one_target should prevent them) and rows with several (reachable by
+// merging drifted schemas or hand-repair SQL) are both left exactly as they are,
+// for `bd doctor` to surface rather than for this to guess about. Guessing is
+// what would be destructive now that a group can delete rows: truncating a
+// multi-target row to its first non-null column could drop it as a "duplicate"
+// and silently destroy the edge its other column recorded.
+func (r depRow) mergeable() bool { return r.targetCount == 1 }
 
-// rekeyDependencyTable re-derives ids for one edge table. table must be a
-// hardcoded constant ("dependencies" or "wisp_dependencies").
+// describe renders the row for a diagnostic, without inventing a target the row
+// does not have.
+func (r depRow) describe() string {
+	switch r.targetCount {
+	case 0:
+		return fmt.Sprintf("row %s (issue %s, no dependency target)", r.id, r.issueID)
+	case 1:
+		return fmt.Sprintf("row %s (issue %s -> %s)", r.id, r.issueID, r.target)
+	default:
+		return fmt.Sprintf("row %s (issue %s, %d dependency targets)", r.id, r.issueID, r.targetCount)
+	}
+}
+
+type depRekey struct{ oldID, newID string }
+
+// depMerge records one duplicate collapse, for the log line that keeps the
+// dropped row auditable.
+type depMerge struct {
+	issueID, target string
+	survivor, loser depRow
+}
+
+// depPlan is the fully validated statement plan for one edge table. deletes and
+// updates are both in execution order, and executing them in that order is the
+// only ordering that converges (see planDependencyRekey).
+type depPlan struct {
+	table   string
+	deletes []string
+	updates []depRekey
+	merges  []depMerge
+}
+
+func (p *depPlan) writes() bool { return len(p.deletes)+len(p.updates) > 0 }
+
+// execute applies an already-validated plan. Every statement is a final-state
+// mutation, so a partially applied plan is benign: the rows it touched are
+// already correct, the rest are untouched, and the next pass finishes the job.
 //
-// Plan-then-execute, deliberately (#5268): the whole table is read and the full
-// statement plan validated before a single write, so the pass either applies a
-// coherent plan or writes nothing at all. Rows are grouped by their derived id;
-// a group with more than one member is the same logical edge recorded in two or
-// three typed columns, which is invalid state that the per-column unique keys
-// cannot catch. The merge keeps the highest-priority typed row (issue > wisp >
-// external, mirroring the COALESCE order) and deletes the rest — the loser's
-// type/audit columns go with it, since edge identity deliberately excludes them
-// and the resolution has to be a pure function of table content so two clones
-// converge byte-identically (#4259). Nothing references dependencies.id, so
-// dropping the row is referentially safe.
-//
-// DELETEs run before UPDATEs because a loser may currently hold exactly the id
-// the survivor is being moved to (that is what a half-rekeyed database looks
-// like), and updating first would manufacture the very duplicate-primary-key
-// abort this replaces.
-//
-// Every statement is a final-state mutation, so a partially applied pass is
-// benign: the rows it touched are already correct, the rest are untouched, and
-// a re-run finishes the job. A converged table plans nothing.
-func rekeyDependencyTable(ctx context.Context, db DBConn, table string) (bool, error) {
+// Deliberately not wrapped in a SQL transaction. DBConn is satisfied by pooled
+// handles as well as pinned connections (lock.go and embeddeddolt/store.go feed
+// it both), and BEGIN/COMMIT issued through ExecContext on a pooled handle can
+// land on different sessions — which would silently drop the guarantee it was
+// added for. Convergence, not atomicity, is what makes partial application safe
+// here; chunking the deletes is what keeps the cost down.
+func (p *depPlan) execute(ctx context.Context, db DBConn) (bool, error) {
+	for _, m := range p.merges {
+		log.Printf("schema: %s: merging duplicate edge %s -> %s: keeping row %s (type %q), dropping row %s (type %q)",
+			p.table, m.issueID, m.target, m.survivor.id, m.survivor.depType, m.loser.id, m.loser.depType)
+	}
+	for start := 0; start < len(p.deletes); start += depDeleteChunk {
+		end := start + depDeleteChunk
+		if end > len(p.deletes) {
+			end = len(p.deletes)
+		}
+		chunk := p.deletes[start:end]
+		args := make([]any, len(chunk))
+		for i, id := range chunk {
+			args[i] = id
+		}
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(chunk)), ",")
+		//nolint:gosec // G201: table is a hardcoded constant and the placeholders are generated, never user input.
+		if _, err := db.ExecContext(ctx,
+			fmt.Sprintf(`DELETE FROM %s WHERE id IN (%s)`, p.table, placeholders), args...); err != nil {
+			return true, fmt.Errorf("%s: drop duplicate edge rows: %w", p.table, err)
+		}
+	}
+	for _, u := range p.updates {
+		//nolint:gosec // G201: table is a hardcoded constant, never user input.
+		if _, err := db.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET id = ? WHERE id = ?`, p.table),
+			u.newID, u.oldID); err != nil {
+			return true, fmt.Errorf("%s: re-key id %s -> %s: %w", p.table, u.oldID, u.newID, err)
+		}
+	}
+	return p.writes(), nil
+}
+
+// planDependencyTableRekey scans one edge table and returns its validated plan.
+// It is read-only: nothing is written by planning, which is what lets both
+// tables be planned before either is executed. table must be a hardcoded
+// constant ("dependencies" or "wisp_dependencies").
+func planDependencyTableRekey(ctx context.Context, db DBConn, table string) (*depPlan, error) {
 	// Skip cleanly if the table or its id column isn't present (e.g. an older or
 	// partial schema where the surrogate key was never added): nothing to re-key.
 	hasID, err := columnExists(ctx, db, table, "id")
 	if err != nil {
-		return false, err
+		return nil, fmt.Errorf("%s: %w", table, err)
 	}
 	if !hasID {
-		return false, nil
+		return &depPlan{table: table}, nil
 	}
-
 	rows, err := scanDependencyRows(ctx, db, table)
 	if err != nil {
-		return false, err
+		return nil, fmt.Errorf("%s: %w", table, err)
 	}
-	deletes, updates, err := planDependencyRekey(table, rows)
-	if err != nil {
-		return false, err
-	}
-
-	for _, id := range deletes {
-		//nolint:gosec // G201: table is a hardcoded constant, never user input.
-		if _, err := db.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE id = ?`, table), id); err != nil {
-			return true, fmt.Errorf("drop duplicate edge row %s: %w", id, err)
-		}
-	}
-	for _, u := range updates {
-		//nolint:gosec // G201: table is a hardcoded constant, never user input.
-		if _, err := db.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET id = ? WHERE id = ?`, table),
-			u.newID, u.oldID); err != nil {
-			return true, fmt.Errorf("re-key id %s -> %s: %w", u.oldID, u.newID, err)
-		}
-	}
-	return len(deletes)+len(updates) > 0, nil
+	return planDependencyRekey(table, rows)
 }
 
 // scanDependencyRows reads every edge row with its typed target columns exposed
 // rather than COALESCEd away: the merge needs to know which column held the
 // target, not just the resolved value. Resolution order is unchanged — the first
-// non-null in depTargetColumns is exactly what the old COALESCE returned. Rows
-// with no target at all — ck_dep_one_target should prevent them — come back with
-// hasTarget false and are left alone by the planner, exactly as before, so
-// `bd doctor` surfaces them rather than this guessing.
+// non-null in depTargetColumns is exactly what the old COALESCE returned.
 func scanDependencyRows(ctx context.Context, db DBConn, table string) ([]depRow, error) {
 	//nolint:gosec // G201: table and the column list are hardcoded constants, never user input.
 	rows, err := db.QueryContext(ctx, fmt.Sprintf(
-		`SELECT id, issue_id, %s FROM %s`, strings.Join(depTargetColumns, ", "), table))
+		`SELECT id, issue_id, %s, type FROM %s`, strings.Join(depTargetColumns, ", "), table))
 	if err != nil {
 		return nil, err
 	}
@@ -149,19 +257,24 @@ func scanDependencyRows(ctx context.Context, db DBConn, table string) ([]depRow,
 	var out []depRow
 	for rows.Next() {
 		var id, issueID string
+		var depType sql.NullString
 		targets := make([]sql.NullString, len(depTargetColumns))
 		dest := []any{&id, &issueID}
 		for i := range targets {
 			dest = append(dest, &targets[i])
 		}
+		dest = append(dest, &depType)
 		if err := rows.Scan(dest...); err != nil {
 			return nil, err
 		}
-		row := depRow{id: id, issueID: issueID, priority: len(depTargetColumns)}
+		row := depRow{id: id, issueID: issueID, depType: depType.String, priority: len(depTargetColumns)}
 		for i, t := range targets {
-			if t.Valid {
-				row.target, row.hasTarget, row.priority = t.String, true, i
-				break
+			if !t.Valid {
+				continue
+			}
+			row.targetCount++
+			if row.targetCount == 1 {
+				row.target, row.priority = t.String, i
 			}
 		}
 		out = append(out, row)
@@ -172,22 +285,43 @@ func scanDependencyRows(ctx context.Context, db DBConn, table string) ([]depRow,
 	return out, nil
 }
 
-type depRekey struct{ oldID, newID string }
-
-// planDependencyRekey turns the scanned table into the ordered DELETE and
-// UPDATE plans, or an error if the table cannot be converged without guessing.
-// It is a pure function of the scanned rows: group keys and statements are
-// emitted in sorted order so two clones with the same data produce the same
-// plan (map iteration order must never leak into the result).
-func planDependencyRekey(table string, rows []depRow) (deletes []string, updates []depRekey, err error) {
+// planDependencyRekey turns the scanned table into an ordered, validated plan,
+// or a DependencyRekeyConflictError if the table cannot be converged without
+// guessing. It is a pure function of the scanned rows — group keys and
+// statements are emitted in sorted order, never map-iteration order — so two
+// clones with the same data produce the same plan and converge to byte-identical
+// tables (#4259).
+//
+// Rows are grouped by their derived id. A group with more than one member is the
+// same logical edge recorded in two or three typed columns, which is invalid
+// state the per-column unique keys cannot catch. The merge keeps the
+// highest-priority typed row (issue > wisp > external, mirroring the COALESCE
+// order) and deletes the rest; the loser's type and audit columns go with it,
+// since edge identity deliberately excludes them and the resolution has to be a
+// pure function of table content. Nothing references dependencies.id, so
+// dropping the row is referentially safe.
+//
+// Ordering has two rules, and both are load-bearing:
+//
+//   - DELETEs run before UPDATEs, because a loser may currently hold exactly the
+//     id its survivor is moving to (that is what a half-re-keyed database looks
+//     like), and updating first would manufacture the very duplicate-primary-key
+//     abort this replaces.
+//   - UPDATEs run in topological order. A row can legitimately hold the id
+//     another row needs while itself needing to move — `bd rename A B` followed
+//     by `bd rename C A` produces exactly that chain — so the occupant is moved
+//     out of the way first rather than refused. Each id is wanted by at most one
+//     row and each row vacates at most one id, so the graph is a set of simple
+//     chains and rotations: chains are walked from their free end, and only a
+//     true rotation (no free id to move through) is refused.
+func planDependencyRekey(table string, rows []depRow) (*depPlan, error) {
 	groups := make(map[string][]depRow)
 	byCurrentID := make(map[string]depRow, len(rows))
 	for _, r := range rows {
 		byCurrentID[r.id] = r
-		if !r.hasTarget {
-			// Malformed row with no target: not part of any edge group, but it
-			// still occupies a primary key, so it stays in byCurrentID for the
-			// collision check below.
+		if !r.mergeable() {
+			// Malformed row: not part of any edge group, but it still occupies a
+			// primary key, so it stays in byCurrentID for the squat check below.
 			continue
 		}
 		want := depid.New(r.issueID, r.target)
@@ -200,47 +334,119 @@ func planDependencyRekey(table string, rows []depRow) (deletes []string, updates
 	}
 	sort.Strings(wantIDs)
 
+	plan := &depPlan{table: table}
 	doomed := make(map[string]bool)
+	var candidates []depRekey
 	for _, want := range wantIDs {
 		group := groups[want]
-		// Highest-priority typed column survives. The id tiebreak is
-		// unreachable while the uk_dep_* unique keys hold (they forbid two rows
-		// with the same issue_id and the same typed target) but keeps the plan
-		// deterministic on a database that lost one.
+		// Highest-priority typed column survives. The id tiebreak is unreachable
+		// while the uk_dep_* unique keys hold (they forbid two rows with the same
+		// issue_id and the same typed target) but keeps the plan deterministic on
+		// a database that lost one.
 		sort.Slice(group, func(i, j int) bool {
 			if group[i].priority != group[j].priority {
 				return group[i].priority < group[j].priority
 			}
 			return group[i].id < group[j].id
 		})
+		survivor := group[0]
 		for _, loser := range group[1:] {
-			deletes = append(deletes, loser.id)
 			doomed[loser.id] = true
+			plan.merges = append(plan.merges, depMerge{
+				issueID: survivor.issueID, target: survivor.target,
+				survivor: survivor, loser: loser,
+			})
 		}
-		if survivor := group[0]; survivor.id != want {
-			updates = append(updates, depRekey{oldID: survivor.id, newID: want})
+		if survivor.id != want {
+			candidates = append(candidates, depRekey{oldID: survivor.id, newID: want})
 		}
 	}
 
-	// Validate the whole plan before returning it: an UPDATE whose target id is
-	// already held by a row that is not being deleted would abort mid-pass on
-	// the primary key. That is genuine corruption (a row keyed to some other
-	// edge's deterministic id), not a duplicate this can merge, so name both
-	// rows and refuse rather than guess.
-	for _, u := range updates {
-		occupant, held := byCurrentID[u.newID]
+	// doomed is the single source of truth for what is being deleted; the
+	// statement list is derived from it so the two can never disagree.
+	plan.deletes = make([]string, 0, len(doomed))
+	for id := range doomed {
+		plan.deletes = append(plan.deletes, id)
+	}
+	sort.Strings(plan.deletes)
+
+	ordered, err := orderDependencyRekeys(table, candidates, byCurrentID, doomed)
+	if err != nil {
+		return nil, err
+	}
+	plan.updates = ordered
+	return plan, nil
+}
+
+// orderDependencyRekeys sequences the re-key UPDATEs so each one runs only once
+// the id it is moving to is free, or refuses when no such sequence exists.
+//
+// candidates arrives sorted by newID, which is what makes the emitted order a
+// pure function of table content. Every id is wanted by at most one candidate
+// (group keys are unique) and every candidate vacates at most one id (its row's
+// current key is unique), so "must run before" is a graph of in- and out-degree
+// at most one: disjoint chains and rotations. Walking each chain from its free
+// end covers every reachable node; anything left over is a rotation.
+func orderDependencyRekeys(table string, candidates []depRekey, byCurrentID map[string]depRow, doomed map[string]bool) ([]depRekey, error) {
+	byOldID := make(map[string]int, len(candidates))
+	for i, c := range candidates {
+		byOldID[c.oldID] = i
+	}
+
+	const none = -1
+	blockedBy := make([]int, len(candidates))
+	unblocks := make([]int, len(candidates))
+	for i := range candidates {
+		blockedBy[i], unblocks[i] = none, none
+	}
+	for i, c := range candidates {
+		occupant, held := byCurrentID[c.newID]
 		if !held || doomed[occupant.id] {
-			continue
+			continue // the id is free, or a DELETE frees it first
 		}
-		return nil, nil, fmt.Errorf(
-			"%s: cannot re-key row %s (issue %s -> %s) to %s: that id is already held by row (issue %s -> %s), which is not a duplicate of it; run `bd doctor` to inspect the table",
-			table, u.oldID, byCurrentID[u.oldID].issueID, byCurrentID[u.oldID].target,
-			u.newID, occupant.issueID, occupant.target)
+		vacating, planned := byOldID[occupant.id]
+		if !planned {
+			// The occupant is staying exactly where it is, so the id will never
+			// be free. A converged row cannot land here — it would derive the
+			// same id and therefore be in the same group — so the occupant is a
+			// malformed row squatting on another edge's key: corruption, not a
+			// duplicate this can merge.
+			return nil, &DependencyRekeyConflictError{
+				Table: table,
+				Detail: fmt.Sprintf("cannot re-key %s to %s: that id is already held by %s, which is neither a duplicate of it nor moving",
+					byCurrentID[c.oldID].describe(), c.newID, occupant.describe()),
+			}
+		}
+		blockedBy[i] = vacating
+		unblocks[vacating] = i
 	}
 
-	sort.Strings(deletes)
-	sort.Slice(updates, func(i, j int) bool { return updates[i].newID < updates[j].newID })
-	return deletes, updates, nil
+	ordered := make([]depRekey, 0, len(candidates))
+	emitted := make([]bool, len(candidates))
+	for i := range candidates {
+		if blockedBy[i] != none {
+			continue // not the head of a chain
+		}
+		for j := i; j != none && !emitted[j]; j = unblocks[j] {
+			emitted[j] = true
+			ordered = append(ordered, candidates[j])
+		}
+	}
+	if len(ordered) != len(candidates) {
+		var stuck []string
+		for i, done := range emitted {
+			if !done {
+				stuck = append(stuck, byCurrentID[candidates[i].oldID].describe())
+			}
+		}
+		sort.Strings(stuck)
+		return nil, &DependencyRekeyConflictError{
+			Table: table,
+			Detail: "cannot re-key a cycle of rows that each hold the id another one needs, with no free id to move through: " +
+				strings.Join(stuck, "; "),
+		}
+	}
+	return ordered, nil
 }
 
 // columnExists reports whether table.column is present in the current schema.

--- a/internal/storage/schema/dep_id_backfill.go
+++ b/internal/storage/schema/dep_id_backfill.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/steveyegge/beads/internal/storage/depid"
 )
@@ -26,6 +28,21 @@ import (
 // pass is a cheap no-op. dependencies changes are staged and committed by
 // MigrateUp; wisp_dependencies is dolt-ignored, so its re-key stays clone-local
 // (it only escapes on promotion, which copies the id).
+//
+// gastownhall/beads#5268: depid keys on (issue_id, resolved target) and
+// deliberately not on which typed column holds the target, but the unique keys
+// are per-column (uk_dep_issue_target / uk_dep_wisp_target /
+// uk_dep_external_target), so a legal table can hold the same logical edge
+// twice — e.g. an April wisp→issue conversion that recorded the edge as
+// external before the target existed as an issue, then again as an issue ref.
+// Both rows derive the same id, so the old row-at-a-time rewrite aborted the
+// second UPDATE with "duplicate primary key given" partway through the table.
+// rekeyDependencyTable now merges those duplicates instead (see its doc), and
+// ignored migration 0026 is the completion marker that makes the pass run once
+// on every existing clone — including one already at the latest main version
+// that a pre-1.3.0 binary left half-rekeyed — and re-run on the next open if it
+// ever aborts again.
+
 func rekeyDependencyIDs(ctx context.Context, db DBConn) (bool, error) {
 	wroteDeps, err := rekeyDependencyTable(ctx, db, "dependencies")
 	if err != nil {
@@ -38,8 +55,45 @@ func rekeyDependencyIDs(ctx context.Context, db DBConn) (bool, error) {
 	return wroteDeps || wroteWisp, nil
 }
 
+// depRow is one scanned edge: its current primary key, the natural identity
+// depid keys on, and which typed column carried the target.
+type depRow struct {
+	id        string
+	issueID   string
+	target    string
+	hasTarget bool
+	priority  int // index into depTargetColumns; lower wins the merge
+}
+
+// depTargetColumns is the COALESCE order of the three typed target columns,
+// which is also the survivor priority for a duplicated edge: an issue ref beats
+// a wisp ref beats an external ref. Changing this order changes both the
+// derived target and which twin survives, so it is the same list for both.
+var depTargetColumns = []string{"depends_on_issue_id", "depends_on_wisp_id", "depends_on_external"}
+
 // rekeyDependencyTable re-derives ids for one edge table. table must be a
 // hardcoded constant ("dependencies" or "wisp_dependencies").
+//
+// Plan-then-execute, deliberately (#5268): the whole table is read and the full
+// statement plan validated before a single write, so the pass either applies a
+// coherent plan or writes nothing at all. Rows are grouped by their derived id;
+// a group with more than one member is the same logical edge recorded in two or
+// three typed columns, which is invalid state that the per-column unique keys
+// cannot catch. The merge keeps the highest-priority typed row (issue > wisp >
+// external, mirroring the COALESCE order) and deletes the rest — the loser's
+// type/audit columns go with it, since edge identity deliberately excludes them
+// and the resolution has to be a pure function of table content so two clones
+// converge byte-identically (#4259). Nothing references dependencies.id, so
+// dropping the row is referentially safe.
+//
+// DELETEs run before UPDATEs because a loser may currently hold exactly the id
+// the survivor is being moved to (that is what a half-rekeyed database looks
+// like), and updating first would manufacture the very duplicate-primary-key
+// abort this replaces.
+//
+// Every statement is a final-state mutation, so a partially applied pass is
+// benign: the rows it touched are already correct, the rest are untouched, and
+// a re-run finishes the job. A converged table plans nothing.
 func rekeyDependencyTable(ctx context.Context, db DBConn, table string) (bool, error) {
 	// Skip cleanly if the table or its id column isn't present (e.g. an older or
 	// partial schema where the surrogate key was never added): nothing to re-key.
@@ -51,46 +105,142 @@ func rekeyDependencyTable(ctx context.Context, db DBConn, table string) (bool, e
 		return false, nil
 	}
 
-	// The natural target is the single non-null of the three typed columns —
-	// exactly what depid keys on and what the uk_dep_* unique keys enforce.
-	//nolint:gosec // G201: table is a hardcoded constant, never user input.
-	rows, err := db.QueryContext(ctx, fmt.Sprintf(
-		`SELECT id, issue_id, COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) FROM %s`,
-		table))
+	rows, err := scanDependencyRows(ctx, db, table)
 	if err != nil {
 		return false, err
 	}
-	type rekey struct{ oldID, newID string }
-	var todo []rekey
-	for rows.Next() {
-		var id, issueID string
-		var target sql.NullString
-		if err := rows.Scan(&id, &issueID, &target); err != nil {
-			_ = rows.Close()
-			return false, err
-		}
-		if !target.Valid {
-			// Malformed row with no target (ck_dep_one_target should prevent this);
-			// leave it untouched for `bd doctor` to surface rather than guessing.
-			continue
-		}
-		if want := depid.New(issueID, target.String); want != id {
-			todo = append(todo, rekey{oldID: id, newID: want})
-		}
-	}
-	_ = rows.Close()
-	if err := rows.Err(); err != nil {
+	deletes, updates, err := planDependencyRekey(table, rows)
+	if err != nil {
 		return false, err
 	}
 
-	for _, r := range todo {
+	for _, id := range deletes {
 		//nolint:gosec // G201: table is a hardcoded constant, never user input.
-		if _, err := db.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET id = ? WHERE id = ?`, table),
-			r.newID, r.oldID); err != nil {
-			return true, fmt.Errorf("re-key id %s -> %s: %w", r.oldID, r.newID, err)
+		if _, err := db.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE id = ?`, table), id); err != nil {
+			return true, fmt.Errorf("drop duplicate edge row %s: %w", id, err)
 		}
 	}
-	return len(todo) > 0, nil
+	for _, u := range updates {
+		//nolint:gosec // G201: table is a hardcoded constant, never user input.
+		if _, err := db.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET id = ? WHERE id = ?`, table),
+			u.newID, u.oldID); err != nil {
+			return true, fmt.Errorf("re-key id %s -> %s: %w", u.oldID, u.newID, err)
+		}
+	}
+	return len(deletes)+len(updates) > 0, nil
+}
+
+// scanDependencyRows reads every edge row with its typed target columns exposed
+// rather than COALESCEd away: the merge needs to know which column held the
+// target, not just the resolved value. Resolution order is unchanged — the first
+// non-null in depTargetColumns is exactly what the old COALESCE returned. Rows
+// with no target at all — ck_dep_one_target should prevent them — come back with
+// hasTarget false and are left alone by the planner, exactly as before, so
+// `bd doctor` surfaces them rather than this guessing.
+func scanDependencyRows(ctx context.Context, db DBConn, table string) ([]depRow, error) {
+	//nolint:gosec // G201: table and the column list are hardcoded constants, never user input.
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(
+		`SELECT id, issue_id, %s FROM %s`, strings.Join(depTargetColumns, ", "), table))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []depRow
+	for rows.Next() {
+		var id, issueID string
+		targets := make([]sql.NullString, len(depTargetColumns))
+		dest := []any{&id, &issueID}
+		for i := range targets {
+			dest = append(dest, &targets[i])
+		}
+		if err := rows.Scan(dest...); err != nil {
+			return nil, err
+		}
+		row := depRow{id: id, issueID: issueID, priority: len(depTargetColumns)}
+		for i, t := range targets {
+			if t.Valid {
+				row.target, row.hasTarget, row.priority = t.String, true, i
+				break
+			}
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+type depRekey struct{ oldID, newID string }
+
+// planDependencyRekey turns the scanned table into the ordered DELETE and
+// UPDATE plans, or an error if the table cannot be converged without guessing.
+// It is a pure function of the scanned rows: group keys and statements are
+// emitted in sorted order so two clones with the same data produce the same
+// plan (map iteration order must never leak into the result).
+func planDependencyRekey(table string, rows []depRow) (deletes []string, updates []depRekey, err error) {
+	groups := make(map[string][]depRow)
+	byCurrentID := make(map[string]depRow, len(rows))
+	for _, r := range rows {
+		byCurrentID[r.id] = r
+		if !r.hasTarget {
+			// Malformed row with no target: not part of any edge group, but it
+			// still occupies a primary key, so it stays in byCurrentID for the
+			// collision check below.
+			continue
+		}
+		want := depid.New(r.issueID, r.target)
+		groups[want] = append(groups[want], r)
+	}
+
+	wantIDs := make([]string, 0, len(groups))
+	for want := range groups {
+		wantIDs = append(wantIDs, want)
+	}
+	sort.Strings(wantIDs)
+
+	doomed := make(map[string]bool)
+	for _, want := range wantIDs {
+		group := groups[want]
+		// Highest-priority typed column survives. The id tiebreak is
+		// unreachable while the uk_dep_* unique keys hold (they forbid two rows
+		// with the same issue_id and the same typed target) but keeps the plan
+		// deterministic on a database that lost one.
+		sort.Slice(group, func(i, j int) bool {
+			if group[i].priority != group[j].priority {
+				return group[i].priority < group[j].priority
+			}
+			return group[i].id < group[j].id
+		})
+		for _, loser := range group[1:] {
+			deletes = append(deletes, loser.id)
+			doomed[loser.id] = true
+		}
+		if survivor := group[0]; survivor.id != want {
+			updates = append(updates, depRekey{oldID: survivor.id, newID: want})
+		}
+	}
+
+	// Validate the whole plan before returning it: an UPDATE whose target id is
+	// already held by a row that is not being deleted would abort mid-pass on
+	// the primary key. That is genuine corruption (a row keyed to some other
+	// edge's deterministic id), not a duplicate this can merge, so name both
+	// rows and refuse rather than guess.
+	for _, u := range updates {
+		occupant, held := byCurrentID[u.newID]
+		if !held || doomed[occupant.id] {
+			continue
+		}
+		return nil, nil, fmt.Errorf(
+			"%s: cannot re-key row %s (issue %s -> %s) to %s: that id is already held by row (issue %s -> %s), which is not a duplicate of it; run `bd doctor` to inspect the table",
+			table, u.oldID, byCurrentID[u.oldID].issueID, byCurrentID[u.oldID].target,
+			u.newID, occupant.issueID, occupant.target)
+	}
+
+	sort.Strings(deletes)
+	sort.Slice(updates, func(i, j int) bool { return updates[i].newID < updates[j].newID })
+	return deletes, updates, nil
 }
 
 // columnExists reports whether table.column is present in the current schema.

--- a/internal/storage/schema/dep_id_backfill_test.go
+++ b/internal/storage/schema/dep_id_backfill_test.go
@@ -2,7 +2,11 @@ package schema
 
 import (
 	"context"
+	"database/sql/driver"
+	"errors"
+	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
@@ -11,331 +15,566 @@ import (
 )
 
 // The re-key scan reads the typed target columns rather than COALESCEing them,
-// because the duplicate-edge merge has to know which column held the target
-// (gastownhall/beads#5268).
-const depScanPattern = `SELECT id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external FROM dependencies`
+// because the duplicate-edge merge has to know which column held the target and
+// which type it would discard (gastownhall/beads#5268).
+const depScanPattern = `SELECT id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type FROM `
 
 func depScanRows() *sqlmock.Rows {
-	return sqlmock.NewRows([]string{"id", "issue_id", "depends_on_issue_id", "depends_on_wisp_id", "depends_on_external"})
+	return sqlmock.NewRows([]string{"id", "issue_id", "depends_on_issue_id", "depends_on_wisp_id", "depends_on_external", "type"})
 }
 
-// expectDepScan primes the id-column probe and the table scan. mock is in
+// expectDepScan primes the id-column probe (expectColumnExists, shared with
+// lock_test.go's under-lock statement sequence) and the table scan. mock is in
 // sqlmock's default ordered mode, so the Exec expectations each test adds after
 // this also pin the statement ORDER — which is load-bearing here: a DELETE that
-// runs after its UPDATE re-creates the duplicate-primary-key abort.
-func expectDepScan(mock sqlmock.Sqlmock, rows *sqlmock.Rows) {
-	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.COLUMNS`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	mock.ExpectQuery(regexp.QuoteMeta(depScanPattern)).WillReturnRows(rows)
+// runs after its UPDATE re-creates the duplicate-primary-key abort, and an
+// UPDATE that runs before the update vacating its target id does the same.
+func expectDepScan(mock sqlmock.Sqlmock, table string, rows *sqlmock.Rows) {
+	expectColumnExists(mock, true)
+	mock.ExpectQuery(regexp.QuoteMeta(depScanPattern + table)).WillReturnRows(rows)
 }
 
-func expectDepDelete(mock sqlmock.Sqlmock, id string) {
-	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM dependencies WHERE id = ?")).
-		WithArgs(id).
-		WillReturnResult(sqlmock.NewResult(0, 1))
+func expectDepDelete(mock sqlmock.Sqlmock, table string, ids ...string) {
+	args := make([]driver.Value, 0, len(ids))
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
+	mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf("DELETE FROM %s WHERE id IN (%s)", table, placeholders))).
+		WithArgs(args...).
+		WillReturnResult(sqlmock.NewResult(0, int64(len(ids))))
 }
 
-func expectDepUpdate(mock sqlmock.Sqlmock, newID, oldID string) {
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE dependencies SET id = ? WHERE id = ?")).
+func expectDepUpdate(mock sqlmock.Sqlmock, table, newID, oldID string) {
+	mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf("UPDATE %s SET id = ? WHERE id = ?", table))).
 		WithArgs(newID, oldID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 }
+
+// rekeyOneTable plans and executes a single table, the shape most of these tests
+// exercise. Production code always plans BOTH tables before executing either
+// (TestRekeyDependencyIDsPlansBothTablesBeforeWriting covers that).
+func rekeyOneTable(db DBConn, table string) (bool, error) {
+	plan, err := planDependencyTableRekey(context.Background(), db, table)
+	if err != nil {
+		return false, err
+	}
+	return plan.execute(context.Background(), db)
+}
+
+func newDepMock(t *testing.T) (DBConn, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() {
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("unmet sql expectations: %v", err)
+		}
+	})
+	return db, mock
+}
+
+// --- statement-shape tests -------------------------------------------------
 
 // TestRekeyDependencyTableRewritesOnlyDivergentRows verifies the backfill that
 // converges existing rows after the #4259 fix: it re-keys a row whose id is not
 // the deterministic value, and leaves an already-deterministic row untouched.
 func TestRekeyDependencyTableRewritesOnlyDivergentRows(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer db.Close()
+	db, mock := newDepMock(t)
 
-	// Two rows: one carrying a legacy random id, one already deterministic.
 	randomRow := "random-uuid-aaaa"
 	deterministicRow := depid.New("c", "d")
-	expectDepScan(mock, depScanRows().
-		AddRow(randomRow, "a", "b", nil, nil).
-		AddRow(deterministicRow, "c", "d", nil, nil))
+	expectDepScan(mock, "dependencies", depScanRows().
+		AddRow(randomRow, "a", "b", nil, nil, "blocks").
+		AddRow(deterministicRow, "c", "d", nil, nil, "blocks"))
+	expectDepUpdate(mock, "dependencies", depid.New("a", "b"), randomRow)
 
-	// Only the divergent row is re-keyed, to its deterministic value.
-	expectDepUpdate(mock, depid.New("a", "b"), randomRow)
-
-	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
+	wrote, err := rekeyOneTable(db, "dependencies")
 	if err != nil {
-		t.Fatalf("rekeyDependencyTable: %v", err)
+		t.Fatalf("rekey: %v", err)
 	}
 	if !wrote {
 		t.Error("expected wrote=true when a row was re-keyed")
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }
 
 // TestRekeyDependencyTableSkipsMissingTable verifies the backfill no-ops cleanly
 // when the table/id column is absent (older or partial schema).
 func TestRekeyDependencyTableSkipsMissingTable(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer db.Close()
+	db, mock := newDepMock(t)
+	expectColumnExists(mock, false)
 
-	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.COLUMNS`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-
-	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
+	wrote, err := rekeyOneTable(db, "dependencies")
 	if err != nil {
-		t.Fatalf("rekeyDependencyTable: %v", err)
+		t.Fatalf("rekey: %v", err)
 	}
 	if wrote {
 		t.Error("expected wrote=false when the id column is absent")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
-	}
 }
 
 // TestRekeyDependencyTableIdempotent verifies that when every row already carries
-// its deterministic id, no UPDATE is issued (so re-running is a cheap no-op).
+// its deterministic id, no statement is issued at all.
 func TestRekeyDependencyTableIdempotent(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer db.Close()
-
-	expectDepScan(mock, depScanRows().AddRow(depid.New("a", "b"), "a", "b", nil, nil))
+	db, mock := newDepMock(t)
+	expectDepScan(mock, "dependencies", depScanRows().
+		AddRow(depid.New("a", "b"), "a", "b", nil, nil, "blocks").
+		AddRow(depid.New("a", "external:e1"), "a", nil, nil, "external:e1", "related").
+		AddRow(depid.New("b", "w1"), "b", nil, "w1", nil, "blocks"))
 	// No ExpectExec: zero writes expected.
 
-	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
+	wrote, err := rekeyOneTable(db, "dependencies")
 	if err != nil {
-		t.Fatalf("rekeyDependencyTable: %v", err)
+		t.Fatalf("rekey: %v", err)
 	}
 	if wrote {
-		t.Error("expected wrote=false when all rows already deterministic")
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
+		t.Error("expected wrote=false on a converged table")
 	}
 }
 
-// TestRekeyDependencyTableMergesFreshDuplicatePair is the reported abort
-// (gastownhall/beads#5268) in its simplest form: the same logical edge recorded
-// once as an issue ref and once as an external ref, both still carrying random
-// ids. Both derive the same deterministic id, which is what made the old
-// row-at-a-time rewrite die on the second UPDATE. The external twin is dropped
-// and the issue row is re-keyed.
+// TestRekeyDependencyTableMergesFreshDuplicatePair is the reported abort in its
+// simplest form: the same logical edge recorded once as an issue ref and once as
+// an external ref, both still carrying random ids. Both derive the same
+// deterministic id, which is what made the old row-at-a-time rewrite die on the
+// second UPDATE.
 func TestRekeyDependencyTableMergesFreshDuplicatePair(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	db, mock := newDepMock(t)
+	expectDepScan(mock, "dependencies", depScanRows().
+		AddRow("random-issue-row", "hq-cv-vvnmq", "ops-w05", nil, nil, "blocks").
+		AddRow("random-external-row", "hq-cv-vvnmq", nil, nil, "ops-w05", "blocks"))
+	expectDepDelete(mock, "dependencies", "random-external-row")
+	expectDepUpdate(mock, "dependencies", depid.New("hq-cv-vvnmq", "ops-w05"), "random-issue-row")
+
+	wrote, err := rekeyOneTable(db, "dependencies")
 	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer db.Close()
-
-	want := depid.New("hq-cv-vvnmq", "ops-w05")
-	expectDepScan(mock, depScanRows().
-		AddRow("random-issue-row", "hq-cv-vvnmq", "ops-w05", nil, nil).
-		AddRow("random-external-row", "hq-cv-vvnmq", nil, nil, "ops-w05"))
-
-	expectDepDelete(mock, "random-external-row")
-	expectDepUpdate(mock, want, "random-issue-row")
-
-	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
-	if err != nil {
-		t.Fatalf("rekeyDependencyTable: %v", err)
+		t.Fatalf("rekey: %v", err)
 	}
 	if !wrote {
 		t.Error("expected wrote=true when a duplicate pair was merged")
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }
 
 // TestRekeyDependencyTableMergesHalfRekeyedPairLoserHoldsID covers the database
 // a pre-1.3.0 binary left half-re-keyed with the LOSER moved first: the external
-// twin already sits on the deterministic id and the surviving issue row does
-// not. The twin still loses — the survivor rule is the typed column, not who got
+// twin already sits on the deterministic id and the surviving issue row does not.
+// The twin still loses — the survivor rule is the typed column, not who got
 // there first — so the DELETE has to run before the UPDATE that reclaims the id.
 func TestRekeyDependencyTableMergesHalfRekeyedPairLoserHoldsID(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer db.Close()
-
+	db, mock := newDepMock(t)
 	want := depid.New("a", "t")
-	expectDepScan(mock, depScanRows().
-		AddRow("random-issue-row", "a", "t", nil, nil).
-		AddRow(want, "a", nil, nil, "t"))
+	expectDepScan(mock, "dependencies", depScanRows().
+		AddRow("random-issue-row", "a", "t", nil, nil, "blocks").
+		AddRow(want, "a", nil, nil, "t", "blocks"))
+	expectDepDelete(mock, "dependencies", want)
+	expectDepUpdate(mock, "dependencies", want, "random-issue-row")
 
-	expectDepDelete(mock, want)
-	expectDepUpdate(mock, want, "random-issue-row")
-
-	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
-	if err != nil {
-		t.Fatalf("rekeyDependencyTable: %v", err)
-	}
-	if !wrote {
-		t.Error("expected wrote=true when a half-re-keyed pair was merged")
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
-	}
-}
-
-// TestRekeyDependencyTableMergesHalfRekeyedPairSurvivorHoldsID is the other
-// half-re-keyed orientation: the surviving issue row already holds the
-// deterministic id, so only the duplicate needs dropping and no UPDATE is
-// planned at all.
-func TestRekeyDependencyTableMergesHalfRekeyedPairSurvivorHoldsID(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer db.Close()
-
-	expectDepScan(mock, depScanRows().
-		AddRow(depid.New("a", "t"), "a", "t", nil, nil).
-		AddRow("random-external-row", "a", nil, nil, "t"))
-
-	expectDepDelete(mock, "random-external-row")
-
-	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
-	if err != nil {
-		t.Fatalf("rekeyDependencyTable: %v", err)
-	}
-	if !wrote {
-		t.Error("expected wrote=true when a duplicate row was dropped")
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
+	if _, err := rekeyOneTable(db, "dependencies"); err != nil {
+		t.Fatalf("rekey: %v", err)
 	}
 }
 
 // TestRekeyDependencyTableMergesTripleDuplicate exercises the full survivor
-// priority: the same target recorded in all three typed columns collapses to the
-// issue ref, with the wisp and external rows dropped.
+// priority and the delete chunking: the same target in all three typed columns
+// collapses to the issue ref with both losers dropped in ONE statement.
 func TestRekeyDependencyTableMergesTripleDuplicate(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer db.Close()
+	db, mock := newDepMock(t)
+	expectDepScan(mock, "dependencies", depScanRows().
+		AddRow("row-issue", "a", "t", nil, nil, "blocks").
+		AddRow("row-wisp", "a", nil, "t", nil, "blocks").
+		AddRow("row-external", "a", nil, nil, "t", "blocks"))
+	expectDepDelete(mock, "dependencies", "row-external", "row-wisp")
+	expectDepUpdate(mock, "dependencies", depid.New("a", "t"), "row-issue")
 
-	expectDepScan(mock, depScanRows().
-		AddRow("row-issue", "a", "t", nil, nil).
-		AddRow("row-wisp", "a", nil, "t", nil).
-		AddRow("row-external", "a", nil, nil, "t"))
-
-	// DELETEs are emitted in sorted id order, so "row-external" precedes
-	// "row-wisp"; both precede the survivor's UPDATE.
-	expectDepDelete(mock, "row-external")
-	expectDepDelete(mock, "row-wisp")
-	expectDepUpdate(mock, depid.New("a", "t"), "row-issue")
-
-	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
-	if err != nil {
-		t.Fatalf("rekeyDependencyTable: %v", err)
-	}
-	if !wrote {
-		t.Error("expected wrote=true when a triple duplicate was merged")
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
+	if _, err := rekeyOneTable(db, "dependencies"); err != nil {
+		t.Fatalf("rekey: %v", err)
 	}
 }
 
-// TestRekeyDependencyTableRefusesForeignIDCollision pins the corruption guard:
-// when a row that is NOT a duplicate already occupies an id the plan wants to
-// move another row onto, the pass names both rows and writes nothing. Merging
-// them would silently discard a distinct edge, and re-keying into the collision
-// is exactly the abort this change exists to remove.
-func TestRekeyDependencyTableRefusesForeignIDCollision(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+// TestRekeyDependencyTableChunksDeletes pins that a large merge does not issue
+// one working-set flush per row: the victims of #5268 are exactly the databases
+// with thousands of divergent rows, and this pass runs at open.
+func TestRekeyDependencyTableChunksDeletes(t *testing.T) {
+	db, mock := newDepMock(t)
+
+	rows := depScanRows()
+	var losers []string
+	for i := 0; i < depDeleteChunk+5; i++ {
+		issue := fmt.Sprintf("i%03d", i)
+		// Each pair is one logical edge duplicated across two typed columns, so
+		// each contributes exactly one loser and one already-correct survivor.
+		rows.AddRow(depid.New(issue, "t"), issue, "t", nil, nil, "blocks")
+		loser := fmt.Sprintf("loser-%03d", i)
+		rows.AddRow(loser, issue, nil, nil, "t", "blocks")
+		losers = append(losers, loser)
 	}
-	defer db.Close()
+	expectDepScan(mock, "dependencies", rows)
+	slices.Sort(losers)
+	expectDepDelete(mock, "dependencies", losers[:depDeleteChunk]...)
+	expectDepDelete(mock, "dependencies", losers[depDeleteChunk:]...)
 
-	// The id "a -> t" wants is squatted on by the edge "b -> u", which is a
-	// different logical edge, so it is not a duplicate that can be merged.
-	squatted := depid.New("a", "t")
-	expectDepScan(mock, depScanRows().
-		AddRow("random-row", "a", "t", nil, nil).
-		AddRow(squatted, "b", "u", nil, nil))
-	// No ExpectExec at all: validation runs before the first write.
+	if _, err := rekeyOneTable(db, "dependencies"); err != nil {
+		t.Fatalf("rekey: %v", err)
+	}
+}
 
-	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
+// TestRekeyDependencyTableRefusalWithPendingDeletesWritesNothing is the
+// all-or-nothing contract at its only interesting point: a table that holds BOTH
+// a mergeable duplicate (so the plan has deletes) and an unresolvable squat. A
+// pass that validated after deleting would drop rows and then abort.
+func TestRekeyDependencyTableRefusalWithPendingDeletesWritesNothing(t *testing.T) {
+	db, mock := newDepMock(t)
+	expectDepScan(mock, "dependencies", depScanRows().
+		// A mergeable duplicate pair: contributes a DELETE and an UPDATE.
+		AddRow("dup-issue", "a", "t", nil, nil, "blocks").
+		AddRow("dup-external", "a", nil, nil, "t", "blocks").
+		// A malformed row squatting on the id that b -> u must move to.
+		AddRow("rand-b", "b", "u", nil, nil, "blocks").
+		AddRow(depid.New("b", "u"), "squatter", nil, nil, nil, "blocks"))
+	// No ExpectExec at all: validation runs before the first statement.
+
+	wrote, err := rekeyOneTable(db, "dependencies")
 	if err == nil {
-		t.Fatal("expected an error when a foreign row squats a planned id")
+		t.Fatal("expected a refusal when a malformed row squats a planned id")
 	}
 	if wrote {
 		t.Error("expected wrote=false when the plan was rejected before any write")
 	}
-	for _, want := range []string{"random-row", squatted, "bd doctor"} {
+}
+
+// TestRekeyDependencyIDsPlansBothTablesBeforeWriting pins the cross-table
+// contract: a refusal on wisp_dependencies must not leave the synced
+// dependencies table already rewritten, because those writes would sit
+// uncommitted (the pass aborts before MigrateUp's DOLT_COMMIT) and the recovery
+// pass would classify them as pre-existing dirty and skip them again.
+func TestRekeyDependencyIDsPlansBothTablesBeforeWriting(t *testing.T) {
+	db, mock := newDepMock(t)
+	expectDepScan(mock, "dependencies", depScanRows().
+		AddRow("random-row", "a", "t", nil, nil, "blocks"))
+	expectDepScan(mock, "wisp_dependencies", depScanRows().
+		AddRow("rand-b", "b", "u", nil, nil, "blocks").
+		AddRow(depid.New("b", "u"), "squatter", nil, nil, nil, "blocks"))
+	// No ExpectExec: the dependencies plan is valid but must not execute.
+
+	wrote, err := rekeyDependencyIDs(context.Background(), db, nil)
+	if err == nil {
+		t.Fatal("expected the wisp_dependencies refusal to abort the pass")
+	}
+	if wrote {
+		t.Error("expected wrote=false: no table may be written when either plan is refused")
+	}
+	var conflict *DependencyRekeyConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("error %v is not a *DependencyRekeyConflictError", err)
+	}
+	if conflict.Table != "wisp_dependencies" {
+		t.Errorf("conflict.Table = %q, want wisp_dependencies", conflict.Table)
+	}
+}
+
+// TestRekeyDependencyIDsRefusesToWriteIntoDirtyTable covers the marker-vs-guard
+// hazard: MigrateUp's changed-signature guard runs AFTER ignoredSource.migrate
+// has durably recorded the 0026 marker, so a re-key that wrote into a
+// pre-existing dirty table would fail the open once and never retry, leaving the
+// heal to ride an unrelated user commit. Refusing at plan time keeps the pass
+// write-free and retryable, and DirtyTablesError is the type whose documented
+// recovery (bd dolt commit) already covers it.
+func TestRekeyDependencyIDsRefusesToWriteIntoDirtyTable(t *testing.T) {
+	db, mock := newDepMock(t)
+	expectDepScan(mock, "dependencies", depScanRows().
+		AddRow("random-row", "a", "t", nil, nil, "blocks"))
+	expectDepScan(mock, "wisp_dependencies", depScanRows())
+	// No ExpectExec: the plan is valid but must not execute.
+
+	dirty := map[string]dirtyTableState{"dependencies": {}}
+	wrote, err := rekeyDependencyIDs(context.Background(), db, dirty)
+	if err == nil {
+		t.Fatal("expected a refusal when the re-key would write into a dirty table")
+	}
+	if wrote {
+		t.Error("expected wrote=false")
+	}
+	var dirtyErr *DirtyTablesError
+	if !errors.As(err, &dirtyErr) {
+		t.Fatalf("error %v is not a *DirtyTablesError", err)
+	}
+	if !slices.Equal(dirtyErr.Tables, []string{"dependencies"}) {
+		t.Errorf("dirtyErr.Tables = %v, want [dependencies]", dirtyErr.Tables)
+	}
+}
+
+// TestRekeyDependencyIDsIgnoresDirtyTableWithNothingToDo keeps the refusal
+// scoped to passes that actually write: a converged clone whose dependencies
+// table happens to be dirty must still open.
+func TestRekeyDependencyIDsIgnoresDirtyTableWithNothingToDo(t *testing.T) {
+	db, mock := newDepMock(t)
+	expectDepScan(mock, "dependencies", depScanRows().
+		AddRow(depid.New("a", "t"), "a", "t", nil, nil, "blocks"))
+	expectDepScan(mock, "wisp_dependencies", depScanRows())
+
+	wrote, err := rekeyDependencyIDs(context.Background(), db, map[string]dirtyTableState{"dependencies": {}})
+	if err != nil {
+		t.Fatalf("rekeyDependencyIDs: %v", err)
+	}
+	if wrote {
+		t.Error("expected wrote=false")
+	}
+}
+
+// --- planner tests ---------------------------------------------------------
+
+func depIssueRow(id, issueID, target string) depRow {
+	return depRow{id: id, issueID: issueID, target: target, depType: "blocks", targetCount: 1, priority: 0}
+}
+
+func depWispRow(id, issueID, target string) depRow {
+	return depRow{id: id, issueID: issueID, target: target, depType: "blocks", targetCount: 1, priority: 1}
+}
+
+func depExternalRow(id, issueID, target string) depRow {
+	return depRow{id: id, issueID: issueID, target: target, depType: "blocks", targetCount: 1, priority: 2}
+}
+
+func mustPlan(t *testing.T, rows []depRow) *depPlan {
+	t.Helper()
+	plan, err := planDependencyRekey("dependencies", rows)
+	if err != nil {
+		t.Fatalf("planDependencyRekey: %v", err)
+	}
+	return plan
+}
+
+func planUpdatePairs(plan *depPlan) [][2]string {
+	out := make([][2]string, 0, len(plan.updates))
+	for _, u := range plan.updates {
+		out = append(out, [2]string{u.oldID, u.newID})
+	}
+	return out
+}
+
+// TestPlanDependencyRekeyOrdersRenameChain is the workflow the refusal used to
+// brick, reproduced at the planner: `bd rename A B` leaves the edge's id derived
+// from A while its target column already reads B (the FK cascade beat the
+// rewrite), and a later `bd rename C A` puts a second row on the id the first one
+// needs. Neither row is corrupt and the state is mechanically convergible —
+// vacate the first, then move the second.
+func TestPlanDependencyRekeyOrdersRenameChain(t *testing.T) {
+	staleAfterFirstRename := depid.New("src", "A")
+	rows := []depRow{
+		// Renamed A -> B: id still derived from A, target column already B.
+		depIssueRow(staleAfterFirstRename, "src", "B"),
+		// Renamed C -> A: id still derived from C, target column already A.
+		depIssueRow(depid.New("src", "C"), "src", "A"),
+	}
+	plan := mustPlan(t, rows)
+
+	if len(plan.deletes) != 0 {
+		t.Errorf("deletes = %v, want none: neither row is a duplicate", plan.deletes)
+	}
+	want := [][2]string{
+		{staleAfterFirstRename, depid.New("src", "B")},
+		{depid.New("src", "C"), depid.New("src", "A")},
+	}
+	if got := planUpdatePairs(plan); !slices.Equal(got, want) {
+		t.Fatalf("updates = %v, want %v (the occupant must vacate first)", got, want)
+	}
+}
+
+// TestPlanDependencyRekeyOrdersLongerChain keeps the ordering honest beyond the
+// two-row case: a three-link chain must come out head-first, not in the sorted
+// order the candidates were built in.
+func TestPlanDependencyRekeyOrdersLongerChain(t *testing.T) {
+	// c holds b's wanted id, b holds a's wanted id, a's wanted id is free.
+	idA, idB, idC := depid.New("s", "a"), depid.New("s", "b"), depid.New("s", "c")
+	rows := []depRow{
+		depIssueRow(idC, "s", "b"), // wants idB, currently holds idC
+		depIssueRow(idB, "s", "a"), // wants idA, currently holds idB
+		depIssueRow("free-random", "s", "c"),
+	}
+	plan := mustPlan(t, rows)
+
+	want := [][2]string{
+		{idB, idA},           // idA is free
+		{idC, idB},           // now idB is free
+		{"free-random", idC}, // now idC is free
+	}
+	if got := planUpdatePairs(plan); !slices.Equal(got, want) {
+		t.Fatalf("updates = %v, want %v", got, want)
+	}
+}
+
+// TestPlanDependencyRekeyRefusesCycle is the one ordering that has no solution
+// without a temporary id: two rows each holding exactly the id the other needs.
+func TestPlanDependencyRekeyRefusesCycle(t *testing.T) {
+	idA, idB := depid.New("s", "a"), depid.New("s", "b")
+	rows := []depRow{
+		depIssueRow(idA, "s", "b"),
+		depIssueRow(idB, "s", "a"),
+	}
+	_, err := planDependencyRekey("dependencies", rows)
+	if err == nil {
+		t.Fatal("expected a refusal for a rotation with no free id")
+	}
+	var conflict *DependencyRekeyConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("error %v is not a *DependencyRekeyConflictError", err)
+	}
+	for _, want := range []string{"cycle", idA, idB, "bd doctor"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error %q does not mention %q", err, want)
 		}
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
+}
+
+// TestPlanDependencyRekeyRefusesMalformedSquatter pins the one refusal that
+// survives the chain ordering. A converged row can never squat another edge's id
+// (it would derive the same id and join that group), so the only squatters left
+// are malformed rows — and the diagnostic must say so rather than render a
+// dangling "issue x -> ".
+func TestPlanDependencyRekeyRefusesMalformedSquatter(t *testing.T) {
+	squatted := depid.New("a", "t")
+	rows := []depRow{
+		depIssueRow("random-row", "a", "t"),
+		{id: squatted, issueID: "orphan", depType: "blocks", targetCount: 0, priority: 3},
+	}
+	_, err := planDependencyRekey("dependencies", rows)
+	if err == nil {
+		t.Fatal("expected a refusal when a malformed row squats a planned id")
+	}
+	for _, want := range []string{"random-row", squatted, "no dependency target", "bd doctor"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "dependencies: dependencies:") {
+		t.Errorf("error %q double-stamps the table name", err)
+	}
+	if strings.Contains(err.Error(), "-> )") {
+		t.Errorf("error %q renders a dangling target arrow", err)
 	}
 }
 
-// TestRekeyDependencyTableIdempotentAfterMerge is the steady state a merged
-// table lands in: one row per edge, each already deterministic. A re-run plans
-// nothing, which is what makes ignored migration 0026's forced pass free on an
-// already-converged clone.
-func TestRekeyDependencyTableIdempotentAfterMerge(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+// TestPlanDependencyRekeyLeavesMalformedRows keeps the "surface, don't guess"
+// contract symmetric. A row with no target was always skipped; a row with
+// SEVERAL non-null targets (reachable by merging drifted schemas or hand-repair
+// SQL) must be skipped too, because truncating it to its first non-null column
+// could now group it as a duplicate and DELETE it, silently destroying the edge
+// its other column recorded.
+func TestPlanDependencyRekeyLeavesMalformedRows(t *testing.T) {
+	rows := []depRow{
+		{id: "no-target", issueID: "a", depType: "blocks", targetCount: 0, priority: 3},
+		{id: "multi-target", issueID: "a", target: "t", depType: "blocks", targetCount: 2, priority: 0},
+		// A well-formed row on the same (issue, first-non-null target) as the
+		// multi-target row. Without the carve-out the multi-target row joins this
+		// group and loses on priority, and its second target is destroyed.
+		depIssueRow(depid.New("a", "t"), "a", "t"),
 	}
-	defer db.Close()
+	plan := mustPlan(t, rows)
 
-	expectDepScan(mock, depScanRows().
-		AddRow(depid.New("a", "t"), "a", "t", nil, nil).
-		AddRow(depid.New("a", "external:e1"), "a", nil, nil, "external:e1").
-		AddRow(depid.New("b", "w1"), "b", nil, "w1", nil))
-	// No ExpectExec: zero writes expected.
-
-	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
-	if err != nil {
-		t.Fatalf("rekeyDependencyTable: %v", err)
+	if len(plan.deletes) != 0 {
+		t.Errorf("deletes = %v, want none", plan.deletes)
 	}
-	if wrote {
-		t.Error("expected wrote=false on a converged table")
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
+	if len(plan.updates) != 0 {
+		t.Errorf("updates = %v, want none", planUpdatePairs(plan))
 	}
 }
 
-// TestRekeyDependencyTableLeavesTargetlessRows keeps the pre-existing contract
-// for a row with no target at all (ck_dep_one_target should make it
-// unreachable): it is not re-keyed, not deleted, and not guessed about — it is
-// left for `bd doctor` to surface.
-func TestRekeyDependencyTableLeavesTargetlessRows(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer db.Close()
+// TestPlanDependencyRekeyRecordsMergedLosers pins the audit trail for the one
+// thing the merge destroys. The twins can legitimately carry different types —
+// each insert wrote its own caller's — and type drives readiness, so a dropped
+// row has to be nameable after the fact.
+func TestPlanDependencyRekeyRecordsMergedLosers(t *testing.T) {
+	survivor := depIssueRow("issue-row", "a", "t")
+	survivor.depType = "related"
+	loser := depExternalRow("external-row", "a", "t")
+	loser.depType = "blocks"
+	plan := mustPlan(t, []depRow{survivor, loser})
 
-	expectDepScan(mock, depScanRows().AddRow("orphan-row", "a", nil, nil, nil))
-	// No ExpectExec: zero writes expected.
+	if len(plan.merges) != 1 {
+		t.Fatalf("merges = %v, want exactly one", plan.merges)
+	}
+	m := plan.merges[0]
+	if m.survivor.id != "issue-row" || m.survivor.depType != "related" {
+		t.Errorf("survivor = %+v, want the issue-ref row keeping its own type", m.survivor)
+	}
+	if m.loser.id != "external-row" || m.loser.depType != "blocks" {
+		t.Errorf("loser = %+v, want the external row with its dropped type", m.loser)
+	}
+	if m.issueID != "a" || m.target != "t" {
+		t.Errorf("merge edge = %s -> %s, want a -> t", m.issueID, m.target)
+	}
+}
 
-	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
-	if err != nil {
-		t.Fatalf("rekeyDependencyTable: %v", err)
+// TestPlanDependencyRekeySurvivorPriority states the merge rule directly, across
+// every pairing, so a reordering of depTargetColumns cannot silently change
+// which row survives.
+func TestPlanDependencyRekeySurvivorPriority(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		rows         []depRow
+		wantSurvivor string
+		wantDeletes  []string
+	}{
+		{
+			name:         "issue beats wisp",
+			rows:         []depRow{depWispRow("w", "a", "t"), depIssueRow("i", "a", "t")},
+			wantSurvivor: "i",
+			wantDeletes:  []string{"w"},
+		},
+		{
+			name:         "issue beats external",
+			rows:         []depRow{depExternalRow("e", "a", "t"), depIssueRow("i", "a", "t")},
+			wantSurvivor: "i",
+			wantDeletes:  []string{"e"},
+		},
+		{
+			name:         "wisp beats external",
+			rows:         []depRow{depExternalRow("e", "a", "t"), depWispRow("w", "a", "t")},
+			wantSurvivor: "w",
+			wantDeletes:  []string{"e"},
+		},
+		{
+			name:         "issue beats both",
+			rows:         []depRow{depExternalRow("e", "a", "t"), depWispRow("w", "a", "t"), depIssueRow("i", "a", "t")},
+			wantSurvivor: "i",
+			wantDeletes:  []string{"e", "w"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := mustPlan(t, tc.rows)
+			if !slices.Equal(plan.deletes, tc.wantDeletes) {
+				t.Errorf("deletes = %v, want %v", plan.deletes, tc.wantDeletes)
+			}
+			want := [][2]string{{tc.wantSurvivor, depid.New("a", "t")}}
+			if got := planUpdatePairs(plan); !slices.Equal(got, want) {
+				t.Errorf("updates = %v, want %v", got, want)
+			}
+		})
 	}
-	if wrote {
-		t.Error("expected wrote=false when the only row has no target")
+}
+
+// TestPlanDependencyRekeyIsOrderIndependent is the #4259 contract: the plan must
+// be a pure function of table CONTENT, never of scan order, or two clones diverge.
+func TestPlanDependencyRekeyIsOrderIndependent(t *testing.T) {
+	rows := []depRow{
+		depIssueRow("r1", "a", "t"),
+		depExternalRow("r2", "a", "t"),
+		depWispRow("r3", "b", "w1"),
+		depIssueRow(depid.New("c", "d"), "c", "d"),
+		depIssueRow(depid.New("s", "a"), "s", "b"),
+		depIssueRow(depid.New("s", "c"), "s", "a"),
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
+	want := mustPlan(t, rows)
+	reversed := slices.Clone(rows)
+	slices.Reverse(reversed)
+	got := mustPlan(t, reversed)
+
+	if !slices.Equal(got.deletes, want.deletes) {
+		t.Errorf("deletes = %v, want %v", got.deletes, want.deletes)
+	}
+	if !slices.Equal(planUpdatePairs(got), planUpdatePairs(want)) {
+		t.Errorf("updates = %v, want %v", planUpdatePairs(got), planUpdatePairs(want))
 	}
 }

--- a/internal/storage/schema/dep_id_backfill_test.go
+++ b/internal/storage/schema/dep_id_backfill_test.go
@@ -3,11 +3,43 @@ package schema
 import (
 	"context"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/steveyegge/beads/internal/storage/depid"
 )
+
+// The re-key scan reads the typed target columns rather than COALESCEing them,
+// because the duplicate-edge merge has to know which column held the target
+// (gastownhall/beads#5268).
+const depScanPattern = `SELECT id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external FROM dependencies`
+
+func depScanRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"id", "issue_id", "depends_on_issue_id", "depends_on_wisp_id", "depends_on_external"})
+}
+
+// expectDepScan primes the id-column probe and the table scan. mock is in
+// sqlmock's default ordered mode, so the Exec expectations each test adds after
+// this also pin the statement ORDER — which is load-bearing here: a DELETE that
+// runs after its UPDATE re-creates the duplicate-primary-key abort.
+func expectDepScan(mock sqlmock.Sqlmock, rows *sqlmock.Rows) {
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.COLUMNS`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery(regexp.QuoteMeta(depScanPattern)).WillReturnRows(rows)
+}
+
+func expectDepDelete(mock sqlmock.Sqlmock, id string) {
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM dependencies WHERE id = ?")).
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+func expectDepUpdate(mock sqlmock.Sqlmock, newID, oldID string) {
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE dependencies SET id = ? WHERE id = ?")).
+		WithArgs(newID, oldID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+}
 
 // TestRekeyDependencyTableRewritesOnlyDivergentRows verifies the backfill that
 // converges existing rows after the #4259 fix: it re-keys a row whose id is not
@@ -19,22 +51,15 @@ func TestRekeyDependencyTableRewritesOnlyDivergentRows(t *testing.T) {
 	}
 	defer db.Close()
 
-	// id column present.
-	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.COLUMNS`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-
 	// Two rows: one carrying a legacy random id, one already deterministic.
 	randomRow := "random-uuid-aaaa"
 	deterministicRow := depid.New("c", "d")
-	mock.ExpectQuery(`SELECT id, issue_id, COALESCE\(.*\) FROM dependencies`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "issue_id", "target"}).
-			AddRow(randomRow, "a", "b").
-			AddRow(deterministicRow, "c", "d"))
+	expectDepScan(mock, depScanRows().
+		AddRow(randomRow, "a", "b", nil, nil).
+		AddRow(deterministicRow, "c", "d", nil, nil))
 
 	// Only the divergent row is re-keyed, to its deterministic value.
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE dependencies SET id = ? WHERE id = ?")).
-		WithArgs(depid.New("a", "b"), randomRow).
-		WillReturnResult(sqlmock.NewResult(0, 1))
+	expectDepUpdate(mock, depid.New("a", "b"), randomRow)
 
 	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
 	if err != nil {
@@ -81,12 +106,8 @@ func TestRekeyDependencyTableIdempotent(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.COLUMNS`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	mock.ExpectQuery(`SELECT id, issue_id, COALESCE\(.*\) FROM dependencies`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "issue_id", "target"}).
-			AddRow(depid.New("a", "b"), "a", "b"))
-	// No ExpectExec: zero UPDATEs expected.
+	expectDepScan(mock, depScanRows().AddRow(depid.New("a", "b"), "a", "b", nil, nil))
+	// No ExpectExec: zero writes expected.
 
 	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
 	if err != nil {
@@ -94,6 +115,225 @@ func TestRekeyDependencyTableIdempotent(t *testing.T) {
 	}
 	if wrote {
 		t.Error("expected wrote=false when all rows already deterministic")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// TestRekeyDependencyTableMergesFreshDuplicatePair is the reported abort
+// (gastownhall/beads#5268) in its simplest form: the same logical edge recorded
+// once as an issue ref and once as an external ref, both still carrying random
+// ids. Both derive the same deterministic id, which is what made the old
+// row-at-a-time rewrite die on the second UPDATE. The external twin is dropped
+// and the issue row is re-keyed.
+func TestRekeyDependencyTableMergesFreshDuplicatePair(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	want := depid.New("hq-cv-vvnmq", "ops-w05")
+	expectDepScan(mock, depScanRows().
+		AddRow("random-issue-row", "hq-cv-vvnmq", "ops-w05", nil, nil).
+		AddRow("random-external-row", "hq-cv-vvnmq", nil, nil, "ops-w05"))
+
+	expectDepDelete(mock, "random-external-row")
+	expectDepUpdate(mock, want, "random-issue-row")
+
+	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
+	if err != nil {
+		t.Fatalf("rekeyDependencyTable: %v", err)
+	}
+	if !wrote {
+		t.Error("expected wrote=true when a duplicate pair was merged")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// TestRekeyDependencyTableMergesHalfRekeyedPairLoserHoldsID covers the database
+// a pre-1.3.0 binary left half-re-keyed with the LOSER moved first: the external
+// twin already sits on the deterministic id and the surviving issue row does
+// not. The twin still loses — the survivor rule is the typed column, not who got
+// there first — so the DELETE has to run before the UPDATE that reclaims the id.
+func TestRekeyDependencyTableMergesHalfRekeyedPairLoserHoldsID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	want := depid.New("a", "t")
+	expectDepScan(mock, depScanRows().
+		AddRow("random-issue-row", "a", "t", nil, nil).
+		AddRow(want, "a", nil, nil, "t"))
+
+	expectDepDelete(mock, want)
+	expectDepUpdate(mock, want, "random-issue-row")
+
+	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
+	if err != nil {
+		t.Fatalf("rekeyDependencyTable: %v", err)
+	}
+	if !wrote {
+		t.Error("expected wrote=true when a half-re-keyed pair was merged")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// TestRekeyDependencyTableMergesHalfRekeyedPairSurvivorHoldsID is the other
+// half-re-keyed orientation: the surviving issue row already holds the
+// deterministic id, so only the duplicate needs dropping and no UPDATE is
+// planned at all.
+func TestRekeyDependencyTableMergesHalfRekeyedPairSurvivorHoldsID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	expectDepScan(mock, depScanRows().
+		AddRow(depid.New("a", "t"), "a", "t", nil, nil).
+		AddRow("random-external-row", "a", nil, nil, "t"))
+
+	expectDepDelete(mock, "random-external-row")
+
+	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
+	if err != nil {
+		t.Fatalf("rekeyDependencyTable: %v", err)
+	}
+	if !wrote {
+		t.Error("expected wrote=true when a duplicate row was dropped")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// TestRekeyDependencyTableMergesTripleDuplicate exercises the full survivor
+// priority: the same target recorded in all three typed columns collapses to the
+// issue ref, with the wisp and external rows dropped.
+func TestRekeyDependencyTableMergesTripleDuplicate(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	expectDepScan(mock, depScanRows().
+		AddRow("row-issue", "a", "t", nil, nil).
+		AddRow("row-wisp", "a", nil, "t", nil).
+		AddRow("row-external", "a", nil, nil, "t"))
+
+	// DELETEs are emitted in sorted id order, so "row-external" precedes
+	// "row-wisp"; both precede the survivor's UPDATE.
+	expectDepDelete(mock, "row-external")
+	expectDepDelete(mock, "row-wisp")
+	expectDepUpdate(mock, depid.New("a", "t"), "row-issue")
+
+	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
+	if err != nil {
+		t.Fatalf("rekeyDependencyTable: %v", err)
+	}
+	if !wrote {
+		t.Error("expected wrote=true when a triple duplicate was merged")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// TestRekeyDependencyTableRefusesForeignIDCollision pins the corruption guard:
+// when a row that is NOT a duplicate already occupies an id the plan wants to
+// move another row onto, the pass names both rows and writes nothing. Merging
+// them would silently discard a distinct edge, and re-keying into the collision
+// is exactly the abort this change exists to remove.
+func TestRekeyDependencyTableRefusesForeignIDCollision(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// The id "a -> t" wants is squatted on by the edge "b -> u", which is a
+	// different logical edge, so it is not a duplicate that can be merged.
+	squatted := depid.New("a", "t")
+	expectDepScan(mock, depScanRows().
+		AddRow("random-row", "a", "t", nil, nil).
+		AddRow(squatted, "b", "u", nil, nil))
+	// No ExpectExec at all: validation runs before the first write.
+
+	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
+	if err == nil {
+		t.Fatal("expected an error when a foreign row squats a planned id")
+	}
+	if wrote {
+		t.Error("expected wrote=false when the plan was rejected before any write")
+	}
+	for _, want := range []string{"random-row", squatted, "bd doctor"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// TestRekeyDependencyTableIdempotentAfterMerge is the steady state a merged
+// table lands in: one row per edge, each already deterministic. A re-run plans
+// nothing, which is what makes ignored migration 0026's forced pass free on an
+// already-converged clone.
+func TestRekeyDependencyTableIdempotentAfterMerge(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	expectDepScan(mock, depScanRows().
+		AddRow(depid.New("a", "t"), "a", "t", nil, nil).
+		AddRow(depid.New("a", "external:e1"), "a", nil, nil, "external:e1").
+		AddRow(depid.New("b", "w1"), "b", nil, "w1", nil))
+	// No ExpectExec: zero writes expected.
+
+	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
+	if err != nil {
+		t.Fatalf("rekeyDependencyTable: %v", err)
+	}
+	if wrote {
+		t.Error("expected wrote=false on a converged table")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// TestRekeyDependencyTableLeavesTargetlessRows keeps the pre-existing contract
+// for a row with no target at all (ck_dep_one_target should make it
+// unreachable): it is not re-keyed, not deleted, and not guessed about — it is
+// left for `bd doctor` to surface.
+func TestRekeyDependencyTableLeavesTargetlessRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	expectDepScan(mock, depScanRows().AddRow("orphan-row", "a", nil, nil, nil))
+	// No ExpectExec: zero writes expected.
+
+	wrote, err := rekeyDependencyTable(context.Background(), db, "dependencies")
+	if err != nil {
+		t.Fatalf("rekeyDependencyTable: %v", err)
+	}
+	if wrote {
+		t.Error("expected wrote=false when the only row has no target")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)

--- a/internal/storage/schema/migrations/ignored/0026_dep_rekey_dedup_marker.up.sql
+++ b/internal/storage/schema/migrations/ignored/0026_dep_rekey_dedup_marker.up.sql
@@ -1,0 +1,36 @@
+-- Ignored migration 0026: clone-local marker that forces one dependency-id
+-- re-key pass with the duplicate-edge merge (gastownhall/beads#5268).
+--
+-- rekeyDependencyIDs (internal/storage/schema/dep_id_backfill.go) converges the
+-- per-clone-random dependency ids that migration 0043's DEFAULT (UUID()) minted,
+-- the data half of the #4259 fix. Until 1.3.0 it rewrote ids one row at a time
+-- with no awareness of the ids already in the table, so a database holding the
+-- same logical edge in two typed target columns -- legal, because depid keys on
+-- (issue_id, resolved target) while uk_dep_issue_target / uk_dep_wisp_target /
+-- uk_dep_external_target are per-column -- aborted mid-table with "duplicate
+-- primary key given". The numbered migrations and their cursor rows commit
+-- per-step, before the re-key tail runs, so the abort left the main cursor
+-- durably at latest with only part of the table re-keyed: migrationWorkNeeded
+-- then reported no work and the re-key never ran again.
+--
+-- While this version is still pending, migrationWorkNeeded returns true, so
+-- every existing clone runs exactly one more MigrateUp pass and the fixed
+-- (merge-aware) re-key heals it, including the clones that a pre-1.3.0 binary
+-- left half-re-keyed at the latest main version. The pass is cheap on a
+-- converged database: the re-key scan finds nothing to change and writes
+-- nothing, which is why this marker needs none of the shipped-main-version
+-- gating the aux-row-id passes carry (ignored 0009 / 0018) -- the dependency
+-- re-key already ran on every migration pass before this change.
+--
+-- Recording the marker AFTER the re-key step is the other half of the fix:
+-- ignoredSource.migrate runs later in MigrateUp than rekeyDependencyIDs, so a
+-- re-key that fails for any reason leaves this version unrecorded and the pass
+-- is retried on the next open instead of a database claiming it migrated.
+--
+-- The cursor table is dolt-ignored, so the marker is clone-local by
+-- construction: every clone performs its own convergence pass, which is safe
+-- precisely because the derivation and the duplicate-merge rule are both
+-- deterministic functions of table content.
+--
+-- The marker itself changes nothing.
+SELECT 1;

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -667,6 +667,13 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	// migrated clones converge to byte-identical, merge-safe dependencies. Runs
 	// here, after the schema migrations (0050 has asserted the canonical schema),
 	// and only on a pass where migration work was needed.
+	//
+	// #5268: ignored migration 0026 is what makes "migration work was needed"
+	// true one more time on every existing clone, so the now merge-aware re-key
+	// reaches the databases a pre-1.3.0 binary left half-re-keyed at the latest
+	// main version. It is also why this call sits ABOVE ignoredSource.migrate:
+	// the marker records only if the re-key returned, so an aborted re-key is
+	// retried on the next open instead of the database claiming it migrated.
 	rekeyed, err := rekeyDependencyIDs(ctx, db)
 	if err != nil {
 		return applied, fmt.Errorf("rekey dependency ids: %w", err)

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -674,8 +674,22 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	// main version. It is also why this call sits ABOVE ignoredSource.migrate:
 	// the marker records only if the re-key returned, so an aborted re-key is
 	// retried on the next open instead of the database claiming it migrated.
-	rekeyed, err := rekeyDependencyIDs(ctx, db)
+	//
+	// dirtyBefore goes in because that same ordering means the changed-signature
+	// guard below runs AFTER the marker is durably recorded: a re-key that wrote
+	// into a pre-existing dirty table would fail the pass once and then never
+	// retry. The re-key refuses at plan time instead, before any write.
+	rekeyed, err := rekeyDependencyIDs(ctx, db, dirtyBefore)
 	if err != nil {
+		// The two refusals the re-key raises deliberately carry their own
+		// user-facing recovery text and are matched with errors.As by the
+		// callers that must stay open (embeddeddolt's non-strict intents), so
+		// they travel unwrapped rather than under a mechanical prefix.
+		var dirtyErr *DirtyTablesError
+		var conflictErr *DependencyRekeyConflictError
+		if errors.As(err, &dirtyErr) || errors.As(err, &conflictErr) {
+			return applied, err
+		}
 		return applied, fmt.Errorf("rekey dependency ids: %w", err)
 	}
 	backfilled = backfilled || rekeyed


### PR DESCRIPTION
Fixes #5268.

> **Revision 2** — rewritten after an adversarial review posted 15 inline findings, two of them reproduced live against the first cut. The planner now *orders* convergible states instead of refusing them, the rename path that mints them is fixed at the source, and the refusals that remain can no longer brick an open. Per-finding disposition is in a follow-up comment.

## Root cause

Three defects compound into silent half-applied state.

**1. The re-key cannot represent a duplicate typed edge.** `depid.New` keys on `(issue_id, resolved target)` and deliberately *not* on which typed column holds the target, but the unique keys are per column (`uk_dep_issue_target` / `uk_dep_wisp_target` / `uk_dep_external_target`). A database can therefore legally hold the same logical edge twice — the reporter's data has 9 such pairs in 5,336 rows, from an April wisp→issue conversion that recorded the edge as `depends_on_external` while the target did not yet exist as an issue, then again as `depends_on_issue_id`. Both rows derive the same UUIDv5, so `rekeyDependencyTable`'s row-at-a-time `UPDATE ... SET id = ?` succeeded on the first and died on the second with `Error 1062: duplicate primary key given`.

**2. The commit cursor is already permanent when that happens.** `runMigrations` with `commitEachStep` (the #4566 contract) commits each numbered migration *and its `schema_migrations` cursor row* atomically before the re-key tail runs. So the abort leaves the main cursor durably at latest with only part of the table re-keyed (1,710 of 5,336 rows for the reporter), and the debris uncommitted in the working set. On retry `migrationWorkNeeded` sees both cursors at latest and returns false: the open succeeds and the re-key never runs again. The dependency re-key had no completion marker of its own — unlike the aux-table re-key, whose marker machinery (ignored 0009/0018) was built for exactly this hazard class.

**3. Renames mint stale keys, and the review found it.** `fk_dep_issue_target` carries `ON UPDATE CASCADE` and `updateIssueIDInTx` renames the `issues` row *first*, so `depends_on_issue_id` already reads the new name by the time `replaceDependencyTargetInTx` looks for the old one. Its `WHERE ... = oldID` matches nothing and the row keeps `id = depid(issue_id, oldID)`. Rename a second issue *into* the freed name and two well-formed rows contend for one deterministic id. This is not corruption and it is reachable from `bd rename` alone — the review reproduced it live.

## The fix

### Convergent, merge-aware, order-aware re-key

`planDependencyRekey` is plan-then-execute over a full table scan:

1. **Group** every row by its derived id. A group larger than one *is* a duplicated logical edge; the survivor is the highest-priority typed column (`depends_on_issue_id` > `depends_on_wisp_id` > `depends_on_external`, mirroring the COALESCE order and the reporter's own manual repair), losers are deleted.
2. **Order** the DELETEs before the UPDATEs (a half-re-keyed twin may sit on exactly the id its survivor is moving to) and the UPDATEs **topologically**. A row can legitimately hold the id another row needs while itself needing to move — defect 3 above produces exactly that chain — so the occupant is *vacated first* rather than refused. Every id is wanted by at most one row and every row vacates at most one id, so "must run before" is a graph of in- and out-degree ≤ 1: disjoint chains and rotations. Chains are walked from their free end; only a true rotation is refused.
3. **Refuse**, before any write, in the two cases that genuinely cannot converge: a rotation, and a malformed row squatting on another edge's key. Note that a *well-formed* row can no longer be a squatter — a converged row derives the same id and therefore joins that group — so this refusal now means what it says.
4. **Leave malformed rows alone.** Zero-target rows were always skipped; rows with *several* non-null targets now are too. Truncating one to its first non-null column could group it as a duplicate and delete it, silently destroying the edge its other column recorded — a new hazard the merge introduced.

Both tables are **planned before either is executed**: a `wisp_dependencies` refusal used to abort the pass after `dependencies` had already been rewritten, leaving those writes uncommitted, and the recovery pass would then classify them as pre-existing dirty and skip them again.

Properties: **idempotent**, **convergent under partial application** (every statement is a final-state mutation), and **deterministic across clones** — sorted group keys, sorted candidates, and an emission order that is a pure function of table content, so two clones converge to byte-identical tables and the #4259 merge-safety property holds.

### Renames stop minting the chain

`replaceDependencyTargetInTx` now sweeps the rows whose typed target column already carries `newID` and re-derives any stale id — the target-side mirror of `rekeyDependencySourceInTx`, which has always matched both the pre- and post-cascade state on the source side. Only stale rows are touched, so it is a no-op on a converged table.

### Retry-until-converged marker, and the guard it races

New clone-local marker `migrations/ignored/0026_dep_rekey_dedup_marker.up.sql` (`SELECT 1;` plus doc comment, the shape of aux markers 0009/0018). While it is pending, `migrationWorkNeeded` is true, so every existing clone runs one more pass and the fixed re-key heals it — including clones already at main-latest. `ignoredSource.migrate` runs *after* `rekeyDependencyIDs`, so an aborted re-key leaves 0026 unrecorded and retries on the next open.

That same ordering means `changedDirtyTableSignatures` runs *after* the marker is durably recorded. A re-key that wrote into a pre-existing dirty `dependencies` would therefore fail the open once and then never retry, leaving the heal applied-but-uncommitted to ride an unrelated user commit — the exact entanglement the guard exists to prevent. So the re-key now **refuses at plan time** when it would write into a dirty table, as a `*DirtyTablesError`: nothing written, marker unrecorded, and the type whose documented recovery (`bd dolt commit`) already covers it. This supersedes the design's "accepted two-pass behavior"; no aux-style sentinel is needed.

### Read-availability: typed refusal, tolerated on non-strict opens

**Decision: type the error and extend the leniency.** `OpenForReadOnlyCommand` is a writable open that runs `MigrateUp`, and embeddeddolt's open path only tolerated `*schema.DirtyTablesError` — so a clone in the refusal state failed *every* embedded open, `bd list` and `bd show` included, forever (marker unrecorded ⇒ never stops). Before this pass existed, those clones opened fine.

`*schema.DependencyRekeyConflictError` is now tolerated on both non-strict intents, warning and continuing. The justification: the re-key is a *convergence repair*, not a precondition for reading; bricking the commands a user needs to diagnose the problem is strictly worse than a stale primary key; and nothing is lost by continuing, because the marker stays unrecorded and the next strict open retries. `openStrict` still fails loudly, so `bd migrate` and ordinary writes surface it.

### Cost

Deletes are chunked 50 at a time (`issueops/delete.go`'s `deleteBatchSize` pattern) rather than one autocommit working-set flush per row — the victims are precisely the databases with thousands of divergent rows, and this pass runs at open. Deliberately **not** wrapped in a SQL transaction: `DBConn` is satisfied by pooled handles as well as pinned connections (`lock.go` and `embeddeddolt/store.go` feed it both), and `BEGIN`/`COMMIT` through `ExecContext` on a pooled handle can land on different sessions, silently dropping the guarantee it was added for. Convergence, not atomicity, is what makes partial application safe here.

### Auditability of the merge

Every merged loser is logged with the edge, both row ids, and **both types** — twins can legitimately carry different types, and `type` drives readiness, so a dropped row must be nameable after the fact. Taking the "strongest" type instead is a follow-up, not this PR: the schema package cannot reach `issueops`' blocking-type taxonomy without an import cycle, and refusing on type disagreement would hard-fail exactly the victims the pass exists to heal.

## Victim taxonomy coverage

| Class | State | Repaired |
|---|---|---|
| 1 | Fresh migrator with duplicate edges | Yes — the merge-aware re-key never aborts |
| 2a | Half-re-keyed, main cursor still behind | Yes — pending migrations run the pass, which collapses the pairs |
| 2b | Half-re-keyed **and** main cursor already at latest | Yes — via the 0026 marker's forced clone-local pass |
| 3 | Any *future* re-key abort at main-latest | Yes — unrecorded marker ⇒ retried on next open |
| 4 | Stale keys from `bd rename` (chain state) | Yes — ordered, plus the rename path no longer mints them |
| 5 | Uncommitted dirty `dependencies` | Refused write-free with the documented `bd dolt commit` recovery, then converges |

## Test plan

**Unit — `internal/storage/schema/dep_id_backfill_test.go`, 18 tests** (11 sqlmock statement-shape + 7 pure-planner). Statement shape: the fresh duplicate pair, the half-re-keyed orientation, the triple duplicate, **delete chunking** (55 losers ⇒ exactly two DELETEs), **a refusal on a table that also has pending deletes** (zero Execs — the all-or-nothing path's only interesting point), **cross-table planning** (a wisp refusal writes nothing to `dependencies`), and **the dirty-table refusal** (plus its converse: a dirty table with nothing to do still opens). Planner: the rename chain, a three-link chain, a rotation refusal, the malformed squatter (asserting no doubled table prefix and no dangling `-> `), malformed rows left alone, merged-loser records with both types, survivor priority across all four pairings, and **order-independence** (same rows reversed ⇒ identical plan).

**Unit — `internal/storage/issueops/dependencies_test.go`.** The post-cascade sweep, with an already-correct sibling that must not be touched.

**Integration — real Dolt, `internal/storage/embeddeddolt/migrate_dep_rekey_dedup_test.go`, 7 tests.** The bug *is* Dolt's primary-key enforcement, so a statement-echo mock cannot reproduce it.

- *Half-re-keyed victim repair* (load-bearing): the reporter's shape on a store at main-latest. Asserts the marker forces the pass, the table converges, 0026 records, and the *next* open short-circuits — proved positively by seeding a divergent row afterwards and asserting it is left alone.
- *Fresh duplicates in one pass*: `dependencies` across a real v53→latest jump, and `wisp_dependencies` on the marker-forced pass.
- *Rename chain converges* — the review's live repro, at the migration.
- *Renames keep ids deterministic* — through `issueops.UpdateIssueIDInTx`, so the real FK cascade fires; both target-side and source-side renames.
- *Dirty `dependencies` refuses write-free* — `DirtyTablesError`, rows compared by value, marker unrecorded, then converges after `bd dolt commit`.
- *Rotation aborts with the marker unrecorded* — nothing written (compared by value, not by row count), **and `OpenForReadOnlyCommand` still succeeds**, then converges once the rotation is broken.
- *Marker-version guard* — fails with an actionable message if a later ignored migration would silently stop the fixtures from forcing the pass.

**Prove-it** — each new fix verified to fail without it:

| Reverted | Failure |
|---|---|
| the merge (original `rekeyDependencyTable`) | all 3 original E2Es fail with `Error 1062: duplicate primary key given` |
| the rename sweep | dep row keeps `depid(src, "old-target")` instead of `depid(src, "new-target")` |
| the chain ordering | `MigrateUp over a re-key chain: ... that id is already held by row ...` |

**Regression sweep — all green**

| Check | Result |
|---|---|
| `go build ./...`, `go vet ./...` | pass |
| `golangci-lint` (pre-commit, every commit) | 0 issues |
| `scripts/check-migration-hygiene.sh` | OK |
| `go test ./internal/storage/schema/...` | ok |
| `go test ./internal/storage/issueops/...` | ok |
| `BEADS_TEST_EMBEDDED_DOLT=1 go test ./internal/storage/embeddeddolt/...` | ok |
| `go test ./internal/storage/dolt/... -run 'Dependen\|BackfillID\|Rename'` | ok |
| `TestInsertBackfillIDPathsAgree` | PASS |

All with `CGO_ENABLED=1 -tags=gms_pure_go`. The ignored-latest bump to 26 caused no fixture fallout — every affected test already reads `LatestIgnoredVersion()` dynamically.

## Proposed changelog line

`CHANGELOG.md` is deliberately untouched here (release-branch policy); the line for the release notes:

> Fixed: `bd migrate` no longer aborts with a duplicate-primary-key error when the same dependency edge exists in two typed target columns; duplicate edges are now merged deterministically (issue-ref wins over wisp/external), renaming an issue no longer leaves its dependency rows on a stale primary key, and databases left half-rekeyed by earlier binaries are detected and repaired on the next migration pass (#5268).

## Follow-ups — documented, deliberately not fixed here

Each was raised by the review and is a pre-existing defect in a neighbouring path, not something this change introduces or can safely absorb into a release PR.

1. **`migration_repairs.go:499` — the pre-0053 backfill is duplicate-blind.** For the #4690 drifted shape, `backfillDependenciesID` assigns `depid.New(issue, target)` per row with no grouping, so an issue-ref + external-ref twin both receive the same id (no PK yet, both UPDATEs succeed) and `ensureDependenciesIDPrimaryKey`'s `ADD PRIMARY KEY (id)` then aborts *inside `mainSource.migrate`* — before the merge-aware re-key can run. That population's every open fails at 0053. Needs the same group-aware merge, or a temporary unique key that defers to the re-key.
2. **`cmd/bd/doctor/fix/dep_keys.go` — the escape hatch this PR's error text points at is thin.** `ScanDependencyKeys` has no duplicate-edge or squatted-id category, and `repairDependencyKeys` is still the pre-#5268 row-at-a-time UPDATE: order-dependent on a squat, and non-converging on a duplicate typed edge. `planDependencyRekey` is a pure function and should be ported into the doctor fix, with a scan category naming the collision.
3. **`create.go:946` / `promote.go:76` can still mint duplicates.** Batch-create's `ON DUPLICATE KEY UPDATE` and promotion's `INSERT IGNORE` are keyed only on the deterministic PK plus the per-column unique keys, without the cross-typed-column existence check the single-add path has (`depTargetEquals`). A random-id row merged from a not-yet-rekeyed peer plus a later batch-create of the same edge in a different column mints a fresh duplicate post-0026. The invariant needs enforcing at the insert paths.
4. **`mergesettle.go:628` — merge DELETEs of synced loser rows.** `dependencyConflictsAreAuditOnly` returns false as soon as one side of a conflict is a deletion, so a lineage where clone A's forced pass deletes a loser while lagging clone B touches that row drops the whole `dependencies` table to manual conflict resolution on the next pull. Either teach the settle path that deleting a row whose `(issue, resolved target)` survives under the deterministic id is audit-only, or document the operator impact.
5. **Type disagreement on merge.** Logging every dropped loser (this PR) is the audit floor; taking the strongest type, or refusing when twins disagree, needs the blocking-type taxonomy that lives in `issueops` — an import cycle from `schema` — and probably a doctor category rather than a silent rewrite.
6. **Streaming fast path.** The planner materializes the whole table to group it. Fine at the sizes involved (the reporter's worst case is 5,336 rows), but a streaming pre-pass that skips the map entirely when nothing is divergent would keep it flat for very large rigs.
7. **`bd doctor` check** surfacing cross-column duplicate edges and non-deterministic dependency ids (carried over from the original design's out-of-scope list).

The original design's second follow-up — aux-style in-progress sentinels to exempt the dep tables from the changed-signature guard — is **dropped**, not deferred: the plan-time `DirtyTablesError` refusal makes it unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
