### PR TITLE
docs(gates): document multi-rig/proxied gate limitations for 1.3.0 (#5861)

### DIFF
--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -423,6 +423,39 @@ don't know", not "this is definitely broken". A genuinely missing or
 broken `dolt` binary (not found, not executable, or the probe itself
 fails/times out) is a hard error, not a warning.
 
+### Proxied-server mode: closing a bead gate fails with "no local store available"
+
+```
+gate condition not satisfied: bead gate "bd-a1b2": no local store available (use --force to override)
+```
+
+`bd close` on a bead gate refuses this way in proxied-server mode even when
+the awaited bead is closed. Proxied-server commands run against a shared
+`dolt sql-server` and never open a local store, so the close path has
+nothing to read the awaited bead's status from.
+
+`bd gate check` does evaluate bead gates in proxied-server mode, and closes
+the ones whose target has closed:
+
+```bash
+bd gate check --type=bead      # closes bead gates whose awaited bead is closed
+bd close <gate-id> --force     # or close without verifying the condition
+```
+
+Tracked in [#5861](https://github.com/gastownhall/beads/issues/5861).
+
+### Prefix routing: "proxy server store needs to be uow provider"
+
+A lookup routed through the orchestrator's `routes.jsonl` prefix routes
+fails with this error when the rig that owns the prefix is itself running in
+proxied-server mode — routed reads cannot open a proxied-server rig. In an
+all-proxied shared-server topology that applies to every routed target, so
+cross-rig bead gates and a plain `bd show <routed-id>` both dead-end here.
+
+Run the command from the owning rig's own workspace instead, where the ID
+resolves locally rather than through a route. Tracked in
+[#5861](https://github.com/gastownhall/beads/issues/5861).
+
 ## Sync Issues
 
 ### Changes not syncing

--- a/docs/workflows/gates.md
+++ b/docs/workflows/gates.md
@@ -17,8 +17,8 @@ closes. Gates close in one of two ways:
 
 - **Manually** — `bd gate resolve <gate-id>` (human gates always close this
   way).
-- **Via `bd gate check`** — evaluates open timer and GitHub gates against
-  the real world and closes the ones whose condition is met.
+- **Via `bd gate check`** — evaluates open timer, GitHub, and bead gates
+  against the real world and closes the ones whose condition is met.
 
 ```bash
 bd gate list                 # open gates
@@ -37,7 +37,7 @@ bd gate resolve <gate-id>    # close a gate manually
 | `timer` | a duration after gate creation | `bd gate check` once the timeout elapses |
 | `gh:run` | a GitHub Actions workflow to complete successfully | `bd gate check` (uses `gh run view`) |
 | `gh:pr` | a pull request to merge | `bd gate check` (uses `gh pr view`) |
-| `bead` | a bead in another rig to close | cannot be checked because multi-rig routing was removed; resolve these gates manually |
+| `bead` | a bead to close — a plain ID names a bead in this rig, the cross-rig form is `<rig>:<bead-id>` | `bd gate check` for plain local IDs; cross-rig values cannot be checked — resolve those manually |
 
 Timeouts use Go duration syntax: `30m`, `1h`, `24h` (there is no `d` unit —
 write `24h`, not `1d`).
@@ -50,6 +50,26 @@ blocks; `human`/`timer`/`bead` gates do not, since `metadata.repo` is
 unrelated, ordinary metadata for those types. `bd gate check` rejects
 malformed repository values instead of falling back to the current
 repository.
+
+### Known limitations: multi-rig and proxied-server topologies
+
+Bead gates and prefix routing (`routes.jsonl`) do not work in every
+topology. Three limitations to expect, all tracked in
+[#5861](https://github.com/gastownhall/beads/issues/5861):
+
+- **Cross-rig bead gates never resolve on their own.** A `<rig>:<bead-id>`
+  await value reports `cannot be checked (multi-rig routing removed)` and
+  stays pending regardless of the awaited bead's status. Close it with
+  `bd gate resolve`.
+- **`bd close` cannot verify a bead gate in the experimental proxied-server
+  mode.** Proxied-server commands never open a local store, so closing the
+  gate refuses with `no local store available` even when the awaited bead is
+  closed. Run `bd gate check`, which evaluates bead gates in proxied-server
+  mode and closes the satisfied ones, or `bd close --force`.
+- **Prefix routing cannot open a proxied-server target rig.** A routed
+  lookup into a rig that is itself in proxied-server mode fails with
+  `proxy server store needs to be uow provider`, so an all-proxied
+  shared-server topology cannot resolve routed targets at all.
 
 ## Gates in formulas
 


### PR DESCRIPTION
## Summary

Docs-only. Documents the multi-rig / proxied-server gate limitations for
1.3.0 instead of fixing them, and corrects a stale claim in the gate-types
table. **No code or behavior changes.**

`#5861` stays open — this PR is `Refs`, not `Fixes`.

## Why documentation and not a fix

1.3.0 does not ship or advertise multi-rig proxied-server operation:

- Every proxied-server flag is tagged `[EXPERIMENTAL]` in the CLI reference,
  and `docs/architecture/dolt.md` documents only *embedded* and *server*
  modes as topologies — proxied-server appears solely in flag dumps and
  "not supported in proxied-server mode" caveats.
- Multi-rig is documented as a **server-mode** use case
  (`docs/architecture/dolt.md`: "Switch to server mode when you need …
  Orchestrator multi-rig setups"). The combination multi-rig + proxied is
  advertised nowhere.
- `routes.jsonl` has no user-facing setup docs at all; its only mention is
  the `bd doctor --orchestrator` flag text.
- Both failures are **pre-existing**, not 1.3 regressions, and neither has an
  advertised surface to defend. `release/1.3.0` carries no docs delta and
  `CHANGELOG.md [Unreleased]` has no multi-rig/proxied/routing feature line.

The real fix for the routed-read half is structural (see sizing below), and
the close-time half alone would ship an untested-at-release-scale change into
an experimental mode days before cut. Documenting the limitation
verbatim-searchably is the honest 1.3 answer.

## What changed

**`docs/workflows/gates.md`**

- Gate-types table: the `bead` row claimed bead gates "cannot be checked
  because multi-rig routing was removed". That has been wrong since local
  bead-gate evaluation was restored — `checkBeadGate` only refuses the
  cross-rig `<rig>:<bead-id>` form; a plain local ID is evaluated and closed
  by `bd gate check`. Row rewritten to say exactly that.
- The "how a gate closes" bullet now lists bead gates alongside timer and
  GitHub gates, so the page no longer contradicts itself.
- New `### Known limitations: multi-rig and proxied-server topologies`
  subsection at the end of "Gate types", three bullets, each quoting the
  verbatim error string so the text is greppable and searchable on the site:
  `cannot be checked (multi-rig routing removed)`,
  `no local store available`,
  `proxy server store needs to be uow provider`.

**`docs/reference/troubleshooting.md`** — two new entries under "Dolt Server
Issues", next to the existing proxied-server entry:

- `### Proxied-server mode: closing a bead gate fails with "no local store available"`
  — shows the full error, explains that proxied-server commands never open a
  local store, and gives the two workarounds that work today
  (`bd gate check`, which *does* evaluate and close bead gates in proxied
  mode via the proxied fresh-read getter, or `bd close --force`).
- `### Prefix routing: "proxy server store needs to be uow provider"` — the
  routed target rig is itself proxied-server; routed reads cannot open one,
  so an all-proxied shared-server topology dead-ends on every routed target
  (cross-rig bead gates *and* a plain `bd show <routed-id>`).

Both link #5861.

## Proposed release-notes line

> Known limitation: multi-rig prefix routing (`routes.jsonl`) is not
> supported with proxied-server rigs — cross-rig bead gates stay pending,
> `bd close` of a bead gate in proxied-server mode requires `bd gate check`
> or `--force`, and routed lookups cannot open proxied-server targets
> (#5861).

No `CHANGELOG.md` edit in this PR; the line above is for the release notes.

## Interaction with #5859

#5859 ("evaluate cross-rig bead gates via prefix routes", fixes #5857) is
open against `main`, carries no docs changes, and is not on
`release/1.3.0` — #5861 was filed from its review.

If #5859 merges and is picked into 1.3 after all, only **bullet 1** of the
limitations subsection and the gate-types `bead` row go partially stale:
cross-rig gates would start working in *direct/server* topologies but still
not in proxied ones — which is exactly what #5861 is about. Bullets 2 and 3
hold either way. The text was written so that contingency is a one-bullet
reword, not a rewrite.

## Deferred: the `gate check` help-text polish

The design flagged an optional fourth change — `cmd/bd/gate.go:600` and
`:622` oversell (`bead — Check cross-rig bead gates`) and should read as
local-bead phrasing — with the generated `docs/cli-reference/gate.md`
regenerated at its source. **Deferred, because the regeneration is not
mechanical on this branch:** `docs/cli-docs.pin` is `v1.2.2`, and
`scripts/resolve-docs-bd.sh` builds bd *from that tag*, ignoring the current
checkout. A `gate.go` edit here would therefore produce no change in the
committed generated docs until the pin is bumped at release time, and forcing
it (`BD_DOCS_IGNORE_PIN=1`) would splice a whole v1.2.2→main regeneration
diff into a docs PR. It is accuracy polish, not release-required — best done
in the same change as the next pin bump.

## Not changed here (follow-ups)

- `docs/core-concepts/dependencies.md` gate-types table still says the `bead`
  row is auto-resolved by "Remote bead status checked", which has the same
  staleness as the row fixed here. Left alone to keep this PR inside the
  agreed scope; worth a follow-up.

## Shape of the real fix (next cycle, not for 1.3)

- **(a) close-time getter — small (~10 lines + test).** In
  `checkGateSatisfaction` (`cmd/bd/close.go:571`), when proxied-server mode
  is active and the global store is nil, pass `proxiedFreshReadGetter{}`
  instead of `store` — it already satisfies `issueGetter`, and it is what
  `bd gate check` already uses in proxied mode. Test alongside
  `cmd/bd/close_gate_test.go`. Candidate early-next-cycle fix, or a late-1.3
  cherry if the release manager wants the local-gate half closed.
- **(b) routed reads of proxied targets — structural.** Resolve the live TODO
  in `cmd/bd/store_factory.go` (~line 270) with a read-only storage adapter
  over a UOW provider for the target database (proxied topologies share one
  sql-server, `resolveViaPrefixRoutingWithAccess` already computes the target
  DB, and proxied mode already supports a database override), or teach
  `RoutedResult` to carry a provider. Needs design review on store
  lifecycle/cleanup in `routed.go`. Depends on #5859 for the gate-visible
  payoff; also unblocks plain routed `bd show` in all-proxied topologies.

## Verification

All green on this branch:

| Gate | Result |
|---|---|
| `go test ./test/docsync` | ok |
| `./scripts/generate-cli-docs.sh --check` | PASS: generated CLI docs are fresh |
| `./scripts/check-cli-docs-drift.sh` | PASS: generated CLI docs are fresh |
| `./scripts/check-doc-flags.sh` | PASSED (only pre-existing unrelated warnings) |
| `./scripts/check-doc-freshness.sh` | PASSED |
| `./mint.sh broken-links` | success, no broken links found |

No Go files touched, so no build/test impact.

Refs #5861

🤖 Generated with [Claude Code](https://claude.com/claude-code)
