### PR TITLE
fix(schema): clamp ignored-cursor sentinel replay to floor 11 — stop restamping wisp updated_at on upgrade (#5366 follow-up)

### DIFF
--- a/internal/storage/schema/cursor_reality_test.go
+++ b/internal/storage/schema/cursor_reality_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"regexp"
 	"strings"
@@ -44,41 +45,60 @@ func stubSentinelColumns(t *testing.T, present map[string]bool, probeErr error) 
 	return &probed
 }
 
-// TestCursorContradictedBySchema is the gh 5033 / gh 4356 regression: the
-// cursor is a claim about the schema, and a claim the schema contradicts must
-// not be believed. Before this, a database whose clone-local wisp tables were
-// absent but whose (also clone-local) cursor rows survived reported at-latest,
+// allSentinelTables is the "everything the table sentinels ask for is present"
+// shape, so column-sentinel cases can say so without repeating the list.
+func allSentinelTables() map[string]bool {
+	present := make(map[string]bool, len(ignoredSource.sentinelTables))
+	for _, table := range ignoredSource.sentinelTables {
+		present[table] = true
+	}
+	return present
+}
+
+// TestCursorRealityFloor is the gh 5033 / gh 4356 regression: the cursor is a
+// claim about the schema, and a claim the schema contradicts must not be
+// believed. Before this, a database whose clone-local wisp tables were absent
+// but whose (also clone-local) cursor rows survived reported at-latest,
 // migrationWorkNeeded() short-circuited, the ignored series never re-ran, and
 // the damage surfaced much later as "table not found: wisp_dependencies".
-func TestCursorContradictedBySchema(t *testing.T) {
+//
+// A missing sentinel COLUMN is a weaker contradiction than a missing sentinel
+// table: it floors the cursor at the sentinel's replayFloor instead of zeroing
+// it, so the migrations that ran long before the column existed are not
+// replayed. See TestCurrentVersionClampsToSentinelFloor for what that buys.
+func TestCursorRealityFloor(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tc := range []struct {
-		name    string
-		present map[string]bool
-		columns map[string]bool
-		want    bool
+		name        string
+		present     map[string]bool
+		columns     map[string]bool
+		wantFloor   int
+		wantLimited bool
 	}{
 		{
-			name:    "no wisp tables at all",
-			present: map[string]bool{},
-			columns: map[string]bool{},
-			want:    true,
+			name:        "no wisp tables at all",
+			present:     map[string]bool{},
+			columns:     map[string]bool{},
+			wantFloor:   0,
+			wantLimited: true,
 		},
 		{
 			// Partial materialization must count as contradicted; checking
 			// only the first sentinel would miss exactly gh 5033's shape,
 			// where wisp_dependencies is the missing one.
-			name:    "wisps present, wisp_dependencies absent",
-			present: map[string]bool{"wisps": true},
-			columns: map[string]bool{},
-			want:    true,
+			name:        "wisps present, wisp_dependencies absent",
+			present:     map[string]bool{"wisps": true},
+			columns:     map[string]bool{},
+			wantFloor:   0,
+			wantLimited: true,
 		},
 		{
-			name:    "wisp_dependencies present, wisps absent",
-			present: map[string]bool{"wisp_dependencies": true},
-			columns: map[string]bool{},
-			want:    true,
+			name:        "wisp_dependencies present, wisps absent",
+			present:     map[string]bool{"wisp_dependencies": true},
+			columns:     map[string]bool{},
+			wantFloor:   0,
+			wantLimited: true,
 		},
 		// These two cases document the two real-world shapes the stub seam
 		// collapses: an absent leases table and a present-but-column-less leases
@@ -86,68 +106,200 @@ func TestCursorContradictedBySchema(t *testing.T) {
 		// (columns["leases.granted_node"] == false), because the real
 		// schemaColumnExists COUNT(*) is 0 for a missing table and a missing
 		// column alike. They deliberately exercise the same branch — the naming
-		// records intent, not a distinct seam path.
+		// records intent, not a distinct seam path. Both floor at 11, which is
+		// what lets the replay heal both (0012 re-creates leases, 0016 adds the
+		// column) without reaching back to 0007.
 		{
-			name:    "leases table absent",
-			present: map[string]bool{"wisps": true, "wisp_dependencies": true},
-			columns: map[string]bool{},
-			want:    true,
+			name:        "leases table absent",
+			present:     allSentinelTables(),
+			columns:     map[string]bool{},
+			wantFloor:   11,
+			wantLimited: true,
 		},
 		{
-			name:    "leases granted_node absent",
-			present: map[string]bool{"wisps": true, "wisp_dependencies": true},
-			columns: map[string]bool{},
-			want:    true,
+			name:        "leases granted_node absent",
+			present:     allSentinelTables(),
+			columns:     map[string]bool{},
+			wantFloor:   11,
+			wantLimited: true,
 		},
 		{
-			name:    "schema corroborates the cursor",
-			present: map[string]bool{"wisps": true, "wisp_dependencies": true},
-			columns: map[string]bool{"leases.granted_node": true},
-			want:    false,
+			// A missing sentinel table outranks any column floor, and says so
+			// without paying for the column probe at all.
+			name:        "wisp tables and leases column both absent",
+			present:     map[string]bool{},
+			columns:     map[string]bool{},
+			wantFloor:   0,
+			wantLimited: true,
+		},
+		{
+			name:        "schema corroborates the cursor",
+			present:     allSentinelTables(),
+			columns:     map[string]bool{"leases.granted_node": true},
+			wantFloor:   0,
+			wantLimited: false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			stubSentinelTables(t, tc.present, nil)
 			stubSentinelColumns(t, tc.columns, nil)
-			got, err := ignoredSource.cursorContradictedBySchema(ctx, nil)
+			floor, limited, err := ignoredSource.cursorRealityFloor(ctx, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if got != tc.want {
-				t.Errorf("cursorContradictedBySchema = %v, want %v", got, tc.want)
+			if limited != tc.wantLimited {
+				t.Errorf("cursorRealityFloor limited = %v, want %v", limited, tc.wantLimited)
+			}
+			if limited && floor != tc.wantFloor {
+				t.Errorf("cursorRealityFloor floor = %d, want %d", floor, tc.wantFloor)
 			}
 		})
 	}
 }
 
-// A probe failure must not be laundered into "contradicted" — that would
-// re-run the whole series on a database whose state could not be read.
+// mockIgnoredCursorRead stands up a database that answers exactly the two
+// queries currentVersion issues for the ignored series before it consults the
+// sentinels: the cursor-table existence probe and the MAX(version) read.
+func mockIgnoredCursorRead(t *testing.T, raw int) *sql.DB {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	expectCursorProbe(mock, "ignored_schema_migrations", true)
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", raw)
+	t.Cleanup(func() {
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("unmet cursor-read expectations: %v", err)
+		}
+		db.Close()
+	})
+	return db
+}
+
+// TestCurrentVersionClampsToSentinelFloor is the wisp-restamp regression
+// (#5981 harm class, #5366 follow-up). Every released tree — v1.1.0, v1.1.2,
+// v1.2.x — tops the ignored series at 0011 and has no leases table, so the
+// leases.granted_node sentinel reads absent on the very first open by a 1.3.0
+// binary. Zeroing the cursor there replays 0001–0025, and ignored/0007's
+// unguarded `UPDATE wisps SET is_blocked = 0` re-fires wisps.updated_at's
+// ON UPDATE CURRENT_TIMESTAMP across a plane with no history to restore from.
+// The cursor must be believed up to the floor instead, so only the genuinely
+// pending tail applies.
+func TestCurrentVersionClampsToSentinelFloor(t *testing.T) {
+	ctx := context.Background()
+	latest := LatestIgnoredVersion()
+
+	for _, tc := range []struct {
+		name    string
+		raw     int
+		present map[string]bool
+		columns map[string]bool
+		want    int
+	}{
+		{
+			// THE regression: the release lineage. Believed 11 ⇒ pending set is
+			// 0012–0025, which is the correct pending set for these stores.
+			name:    "release lineage upgrade, cursor 11, leases absent",
+			raw:     11,
+			present: allSentinelTables(),
+			columns: map[string]bool{},
+			want:    11,
+		},
+		{
+			// The ga-usd3k ordinal collision: leases exists, the column does
+			// not. Clamped to 11, so 0012–0015 re-run guarded/idempotent and
+			// 0016 heals — without 0007.
+			name:    "ordinal collision, cursor 17, column absent",
+			raw:     17,
+			present: allSentinelTables(),
+			columns: map[string]bool{},
+			want:    11,
+		},
+		{
+			name:    "at-latest cursor, column absent",
+			raw:     latest,
+			present: allSentinelTables(),
+			columns: map[string]bool{},
+			want:    11,
+		},
+		{
+			// A cursor already below the floor is believed as read: the floor
+			// is a ceiling on belief, never a promotion.
+			name:    "cursor below the floor is untouched",
+			raw:     8,
+			present: allSentinelTables(),
+			columns: map[string]bool{},
+			want:    8,
+		},
+		{
+			// gh 5033 is bit-for-bit unchanged: table sentinels floor at 0, so
+			// the whole series still replays for the shape it was written for.
+			name:    "wisp tables absent, at-latest cursor",
+			raw:     latest,
+			present: map[string]bool{},
+			columns: map[string]bool{},
+			want:    0,
+		},
+		{
+			name:    "wisp tables and leases column both absent",
+			raw:     latest,
+			present: map[string]bool{},
+			columns: map[string]bool{},
+			want:    0,
+		},
+		{
+			name:    "fully corroborated cursor is believed as read",
+			raw:     latest,
+			present: allSentinelTables(),
+			columns: map[string]bool{"leases.granted_node": true},
+			want:    latest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stubSentinelTables(t, tc.present, nil)
+			stubSentinelColumns(t, tc.columns, nil)
+			db := mockIgnoredCursorRead(t, tc.raw)
+
+			got, err := ignoredSource.currentVersion(ctx, db)
+			if err != nil {
+				t.Fatalf("currentVersion: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("currentVersion = %d, want %d (raw cursor %d)", got, tc.want, tc.raw)
+			}
+		})
+	}
+}
+
+// A probe failure must not be laundered into a contradiction — that would
+// re-run the series on a database whose state could not be read.
 func TestCursorProbeErrorIsNotTreatedAsContradicted(t *testing.T) {
 	boom := errors.New("information_schema unavailable")
 	stubSentinelTables(t, nil, boom)
 
-	got, err := ignoredSource.cursorContradictedBySchema(context.Background(), nil)
+	_, limited, err := ignoredSource.cursorRealityFloor(context.Background(), nil)
 	if !errors.Is(err, boom) {
 		t.Errorf("probe error was swallowed: err = %v", err)
 	}
-	if got {
+	if limited {
 		t.Error("an unreadable probe reported the cursor as contradicted")
 	}
 }
 
 // The main series is deliberately unguarded: its tables are not clone-local,
 // so it cannot reach the contradicted state, and probing would add queries to
-// every store open for nothing. cursorContradictedBySchema must be a no-op for
-// it — including never probing.
+// every store open for nothing. cursorRealityFloor must be a no-op for it —
+// including never probing.
 func TestMainSourceIsNotProbed(t *testing.T) {
 	probed := stubSentinelTables(t, map[string]bool{}, nil)
 	columnProbed := stubSentinelColumns(t, map[string]bool{}, nil)
 
-	got, err := mainSource.cursorContradictedBySchema(context.Background(), nil)
+	_, limited, err := mainSource.cursorRealityFloor(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got {
+	if limited {
 		t.Error("mainSource reported contradicted; it has no sentinels and must never be")
 	}
 	if len(*probed) != 0 {
@@ -192,39 +344,95 @@ func TestSentinelTablesAreCreatedByTheSeries(t *testing.T) {
 }
 
 // TestSentinelColumnsAreCreatedByTheSeries is the column-sentinel analogue of
-// TestSentinelTablesAreCreatedByTheSeries: a sentinel column this series does
-// not add could never be repaired by re-running it, so an otherwise at-latest
-// cursor would be rejected on every open — turning a silent wrong answer into a
-// permanent re-migration loop in the field. Enforce the creating side in CI.
+// TestSentinelTablesAreCreatedByTheSeries, plus the floor-honesty check the
+// replay clamp depends on. Two things have to hold for every sentinel column:
+//
+//   - The series must ADD the column, and must CREATE the table carrying it.
+//     A sentinel the series cannot repair would be rejected on every open —
+//     a permanent re-migration loop in the field.
+//   - Both of those files must sit strictly ABOVE the sentinel's replayFloor,
+//     or the clamped replay would skip the very migrations that heal it. That
+//     is what makes floor 11 correct today (0012 creates leases, 0016 adds
+//     granted_node) and what makes a future renumbering of either file fail
+//     here instead of stranding users.
+//
+// Versions are parsed per file rather than matched against the concatenated
+// series precisely so the floor can be checked, not just the existence.
 func TestSentinelColumnsAreCreatedByTheSeries(t *testing.T) {
-	entries, err := ignoredSource.files.ReadDir(ignoredSource.dir)
-	if err != nil {
-		t.Fatalf("read %s: %v", ignoredSource.dir, err)
-	}
-	var all strings.Builder
-	for _, e := range entries {
-		blob, err := ignoredSource.files.ReadFile(ignoredSource.dir + "/" + e.Name())
-		if err != nil {
-			t.Fatalf("read %s: %v", e.Name(), err)
-		}
-		all.Write(blob)
-	}
-	body := all.String()
-
 	if len(ignoredSource.sentinelColumns) == 0 {
 		t.Fatal("ignoredSource has no sentinel columns; the granted_node guard is inert")
 	}
+
+	bodies := make(map[int]string)
+	for _, mf := range ignoredSource.list() {
+		blob, err := ignoredSource.files.ReadFile(ignoredSource.dir + "/" + mf.name)
+		if err != nil {
+			t.Fatalf("read %s: %v", mf.name, err)
+		}
+		bodies[mf.version] = string(blob)
+	}
+
+	// findVersion returns the lowest migration version whose body matches,
+	// or 0 when nothing does.
+	findVersion := func(re *regexp.Regexp) int {
+		found := 0
+		for version, body := range bodies {
+			if !re.MatchString(body) {
+				continue
+			}
+			if found == 0 || version < found {
+				found = version
+			}
+		}
+		return found
+	}
+
+	// The floor exists to exclude ignored/0007's unguarded recompute, whose
+	// bare `UPDATE wisps SET is_blocked = 0` re-fires wisps.updated_at's
+	// ON UPDATE CURRENT_TIMESTAMP. Its guarded successor 0015 writes
+	// `is_blocked = 0, updated_at = updated_at` and deliberately does not
+	// match. Pinning the file rather than a bare literal keeps the floor
+	// honest if the pair is ever renumbered.
+	unguarded := findVersion(regexp.MustCompile(`(?i)UPDATE\s+wisps\s+SET\s+is_blocked\s*=\s*0\s*;`))
+	if unguarded == 0 {
+		t.Fatal("the unguarded `UPDATE wisps SET is_blocked = 0` the replay floor exists to exclude is gone; re-derive the floor")
+	}
+
 	for _, sc := range ignoredSource.sentinelColumns {
 		// ignored/0016 adds the column with a guarded, idempotent
 		// `ALTER TABLE <table> ADD COLUMN <column>`, which is also why
-		// re-running the series repairs rather than clobbers. Bind the table so
-		// a sentinel naming a column the series only adds to some other table
+		// re-running it repairs rather than clobbers. Bind the table so a
+		// sentinel naming a column the series only adds to some other table
 		// (or never adds at all) fails here rather than in the field.
-		re := regexp.MustCompile(`(?i)ALTER TABLE\s+` + regexp.QuoteMeta(sc.table) +
-			`\s+ADD COLUMN\s+` + regexp.QuoteMeta(sc.column))
-		if !re.MatchString(body) {
+		adder := findVersion(regexp.MustCompile(`(?i)ALTER TABLE\s+` + regexp.QuoteMeta(sc.table) +
+			`\s+ADD COLUMN\s+` + regexp.QuoteMeta(sc.column)))
+		if adder == 0 {
 			t.Errorf("sentinel column %s.%s is never added by the %s series; re-running it could not repair that column",
 				sc.table, sc.column, ignoredSource.dir)
+			continue
+		}
+		// ignored/0012 builds the carrier table as __temp__<name> and renames
+		// it into place only when <name> is absent. The single COLUMNS probe
+		// cannot tell "table missing" from "column missing", so the replay has
+		// to be able to heal both.
+		creator := findVersion(regexp.MustCompile(regexp.QuoteMeta("__temp__" + sc.table)))
+		if creator == 0 {
+			t.Errorf("carrier table %s for sentinel column %s.%s is never created by the %s series",
+				sc.table, sc.table, sc.column, ignoredSource.dir)
+			continue
+		}
+
+		if adder <= sc.replayFloor {
+			t.Errorf("sentinel column %s.%s is added by ignored/%04d, at or below its replayFloor %d; the clamped replay would skip the migration that heals it",
+				sc.table, sc.column, adder, sc.replayFloor)
+		}
+		if creator <= sc.replayFloor {
+			t.Errorf("carrier table %s is created by ignored/%04d, at or below sentinel %s.%s's replayFloor %d; a store missing the table entirely would never be repaired",
+				sc.table, creator, sc.table, sc.column, sc.replayFloor)
+		}
+		if sc.replayFloor < unguarded {
+			t.Errorf("sentinel %s.%s replayFloor %d does not exclude ignored/%04d, whose unguarded UPDATE restamps wisps.updated_at",
+				sc.table, sc.column, sc.replayFloor, unguarded)
 		}
 	}
 }
@@ -346,5 +554,102 @@ func TestMigrateAppliesUnderContradictedCursor(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// TestMigrateStartsAboveTheFloorUnderColumnContradiction is the applier-side
+// half of the clamp, and the sibling of TestMigrateAppliesUnderContradictedCursor
+// (which keeps covering the table-sentinel shape). Deciding the believed cursor
+// correctly is worthless if the applier then starts the replay somewhere else:
+// the harm this fix exists to stop is executed BY the applier, when it re-runs
+// ignored/0007.
+//
+// The mock walks migrate() to the first statement it applies and fails it
+// distinctively. Attribution to 0012 — not 0001 — is the proof: the applier
+// skipped 0001–0011 (0007 among them) and resumed at the leases creator, which
+// is exactly the pending set a clamped cursor of 11 describes.
+func TestMigrateStartsAboveTheFloorUnderColumnContradiction(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// migrate() preamble: cursor-table bootstrap, content_hash presence check.
+	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS ignored_schema_migrations")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta("SHOW COLUMNS FROM ignored_schema_migrations LIKE 'content_hash'")).
+		WillReturnRows(sqlmock.NewRows([]string{"Field", "Type", "Null", "Key", "Default", "Extra"}).
+			AddRow("content_hash", "char(64)", "YES", "", nil, ""))
+
+	// The guarded read: cursor claims at-latest, both table sentinels
+	// corroborate it, and only the leases column does not.
+	expectCursorProbe(mock, "ignored_schema_migrations", true)
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
+	for range ignoredSource.sentinelTables {
+		mock.ExpectQuery(regexp.QuoteMeta("FROM INFORMATION_SCHEMA.TABLES")).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	}
+	mock.ExpectQuery(regexp.QuoteMeta("FROM INFORMATION_SCHEMA.COLUMNS")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	boom := errors.New("stop here: the applier resumed above the floor")
+	mock.ExpectExec(".*").WillReturnError(boom)
+
+	_, _, err = ignoredSource.migrate(context.Background(), db, 0)
+	if err == nil {
+		t.Fatal("migrate returned nil with a column-contradicted at-latest cursor; the heal for ignored 0012/0016 never ran")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("migrate failed for another reason before applying: %v", err)
+	}
+	if !strings.Contains(err.Error(), "0012") {
+		t.Errorf("replay did not resume at the leases creator: %v", err)
+	}
+	if strings.Contains(err.Error(), "0001_") {
+		t.Errorf("replay reached back into the pre-floor range; ignored/0007 would restamp wisps.updated_at: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// TestPendingVersionsUnderFloorDoNotReArmAuxMarkers guards the collateral the
+// clamp also fixes. rekeyAuxRowIDsAllPasses gates each convergence pass on its
+// marker version appearing in ignoredSource.pendingVersions, which reads the
+// same guarded cursor. Zeroing put marker 9 back in the pending set on every
+// release-lineage upgrade, spuriously re-running the pass-1 aux row-id rewrite
+// over the synced events/comments/snapshots planes — a convergent no-op by
+// design, but wasted work and needless churn risk. The clamp makes the marker
+// gate see the true pending set.
+func TestPendingVersionsUnderFloorDoNotReArmAuxMarkers(t *testing.T) {
+	stubSentinelTables(t, allSentinelTables(), nil)
+	stubSentinelColumns(t, map[string]bool{}, nil)
+	db := mockIgnoredCursorRead(t, 11)
+
+	pending, err := ignoredSource.pendingVersions(context.Background(), db)
+	if err != nil {
+		t.Fatalf("pendingVersions: %v", err)
+	}
+
+	pendingSet := make(map[int]bool, len(pending))
+	for _, v := range pending {
+		pendingSet[v] = true
+	}
+
+	for _, pass := range auxRekeyPasses {
+		// Marker 9 is below the floor and must stay applied; marker 18 is
+		// genuinely pending on a cursor-11 store and must stay armed.
+		want := pass.markerVersion > 11
+		if pendingSet[pass.markerVersion] != want {
+			t.Errorf("aux rekey marker %d pending = %v, want %v (cursor 11 clamped at floor 11)",
+				pass.markerVersion, pendingSet[pass.markerVersion], want)
+		}
+	}
+	if !pendingSet[12] {
+		t.Error("ignored/0012 is not pending on a cursor-11 store; the leases heal would never run")
+	}
+	if pendingSet[7] {
+		t.Error("ignored/0007 is pending on a cursor-11 store; its unguarded UPDATE would restamp wisps.updated_at")
 	}
 }

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -228,7 +228,7 @@ type migrationSource struct {
 	// sentinelTables are tables this series is responsible for creating. A
 	// non-zero cursor is only believed while they all exist: the cursor is a
 	// claim about the schema, and a claim contradicted by the schema is worth
-	// less than no claim at all. See cursorContradictedBySchema.
+	// less than no claim at all. See cursorRealityFloor.
 	//
 	// INVARIANT: no future migration in this series may DROP or RENAME a
 	// sentinel. Older binaries in the field check their own sentinel list
@@ -238,13 +238,16 @@ type migrationSource struct {
 	// the dropping side is this comment.
 	sentinelTables []string
 	// sentinelColumns are clone-local columns whose absence contradicts an
-	// otherwise at-latest cursor just as strongly as an absent sentinel table.
+	// otherwise at-latest cursor. Unlike a missing sentinel table, a missing
+	// column disbelieves the cursor only back to the column's replayFloor: it
+	// says nothing about the migrations that ran long before the column
+	// existed, and replaying those is not free (see schemaSentinelColumn).
 	//
 	// INVARIANT: no future migration in this series may DROP or RENAME a
 	// sentinel column (or the table carrying it). Older binaries in the field
 	// check their own sentinel list against the live schema, so removing one
 	// would make every healthy newer database read as "contradicted" to them
-	// and re-run their whole series. TestSentinelColumnsAreCreatedByTheSeries
+	// and replay the series from their floor. TestSentinelColumnsAreCreatedByTheSeries
 	// enforces the creating side only; the dropping side is this comment.
 	sentinelColumns []schemaSentinelColumn
 }
@@ -252,6 +255,30 @@ type migrationSource struct {
 type schemaSentinelColumn struct {
 	table  string
 	column string
+	// replayFloor is the highest cursor value this sentinel's absence still
+	// leaves believable. When the column is missing, currentVersion returns
+	// min(cursor, replayFloor) rather than 0, so only migrations above the
+	// floor replay. Two constraints fix it:
+	//
+	//   (i)  Every migration at or below the floor must stay OUT of the replay.
+	//        The column's absence is no evidence at all about migrations that
+	//        predate it, and replaying them is destructive: ignored/0007's
+	//        unguarded `UPDATE wisps SET is_blocked = 0` re-fires the
+	//        ON UPDATE CURRENT_TIMESTAMP on wisps.updated_at, silently
+	//        restamping every wisp on a plane with no history to restore from
+	//        (#5981 harm class). ignored/0015 is the guarded successor and is
+	//        genuinely pending on those stores, so the recompute still happens
+	//        — just without the timestamp damage.
+	//   (ii) The migration that creates the column AND the migration that
+	//        creates the table carrying it must both be ABOVE the floor, so the
+	//        replay can still heal both shapes the single INFORMATION_SCHEMA
+	//        COUNT(*) probe collapses: table absent entirely, and table present
+	//        but column-less. A floor above the table's creator would strand
+	//        the table-absent shape in a permanent re-migration loop.
+	//
+	// TestSentinelColumnsAreCreatedByTheSeries pins the floor to those two
+	// files, so a future renumbering breaks CI rather than users.
+	replayFloor int
 }
 
 var (
@@ -270,8 +297,20 @@ var (
 		// is caught by whichever is absent.
 		sentinelTables: []string{"wisps", "wisp_dependencies"},
 		// A historical ignored-v16 ordinal collision can leave the local
-		// leases table present but without the column frozen 0016 adds.
-		sentinelColumns: []schemaSentinelColumn{{table: "leases", column: "granted_node"}},
+		// leases table present but without the column frozen 0016 adds; a
+		// database materialized out of band can be missing the leases table
+		// altogether. The single COLUMNS probe reads both shapes as absent and
+		// the replay heals both: 0012 re-creates the table, 0016 adds the
+		// column.
+		//
+		// The floor of 11 is what keeps that heal from also being a data loss.
+		// Every released tree (v1.1.0, v1.1.2, v1.2.x) tops the ignored series
+		// at 0011 and has no leases table, so on the first open by a binary
+		// carrying this sentinel the probe fails and — unclamped — the whole
+		// 0001–0025 series replays, dragging in ignored/0007 and restamping
+		// wisps.updated_at across the plane. Believing the cursor up to 11
+		// applies exactly the pending tail 0012–0025 instead.
+		sentinelColumns: []schemaSentinelColumn{{table: "leases", column: "granted_node", replayFloor: 11}},
 	}
 )
 
@@ -1243,47 +1282,65 @@ func (m migrationSource) currentVersion(ctx context.Context, db DBConn) (int, er
 	// no wisps tables. atLatest() then short-circuits migrationWorkNeeded()
 	// and the series never re-runs, surfacing much later and much further away
 	// as "table not found: wisp_dependencies" on `bd close`.
-	contradicted, cerr := m.cursorContradictedBySchema(ctx, db)
-	if cerr != nil {
-		return 0, cerr
+	//
+	// A contradicted cursor is disbelieved only back to the floor of whatever
+	// sentinel is missing, not all the way to zero: the absence of a sentinel
+	// is evidence about the migration that creates it and everything after,
+	// and nothing at all about what ran before. Zeroing anyway replays the
+	// whole series, which is not a no-op (see schemaSentinelColumn.replayFloor).
+	floor, limited, ferr := m.cursorRealityFloor(ctx, db)
+	if ferr != nil {
+		return 0, ferr
 	}
-	if contradicted {
-		return 0, nil
+	if limited && floor < current {
+		current = floor
 	}
 	return current, nil
 }
 
-// cursorContradictedBySchema reports whether this series' cursor claims work
-// that the schema does not corroborate.
+// cursorRealityFloor reports how much of this series' cursor the live schema
+// corroborates. limited is false when nothing is missing (believe the cursor as
+// read); otherwise floor is the highest version still believable — 0 for a
+// missing sentinel table, and the sentinel's replayFloor for a missing sentinel
+// column.
 //
-// Returning "cursor is 0" rather than an error is deliberate: the series is
-// written to be re-runnable against a database that already has some of it.
+// Clamping rather than erroring is deliberate: the series is written to be
+// re-runnable against a database that already has some of it.
 // migrations/ignored/0001 builds each table as __temp__<name> and then
 // `RENAME TABLE __temp__x TO x` only when x does not already exist, DROPping
 // the temp otherwise; later migrations gate their ALTERs on
-// INFORMATION_SCHEMA lookups. So re-running the series repairs the missing
-// tables and leaves existing data untouched — which is why this can heal
+// INFORMATION_SCHEMA lookups. So re-running that range repairs the missing
+// objects and leaves existing data untouched — which is why this can heal
 // rather than merely diagnose.
-func (m migrationSource) cursorContradictedBySchema(ctx context.Context, db DBConn) (bool, error) {
+//
+// Sentinel tables are probed first and short-circuit the whole check: they
+// floor at 0, so no column probe could lower the answer, and skipping it keeps
+// this cheap on the path every store open takes.
+func (m migrationSource) cursorRealityFloor(ctx context.Context, db DBConn) (int, bool, error) {
 	for _, table := range m.sentinelTables {
 		present, err := sentinelTableExists(ctx, db, table)
 		if err != nil {
-			return false, fmt.Errorf("checking %s sentinel table %s: %w", m.cursorTable, table, err)
+			return 0, false, fmt.Errorf("checking %s sentinel table %s: %w", m.cursorTable, table, err)
 		}
 		if !present {
-			return true, nil
+			return 0, true, nil
 		}
 	}
+	floor, limited := 0, false
 	for _, column := range m.sentinelColumns {
 		present, err := sentinelColumnExists(ctx, db, column.table, column.column)
 		if err != nil {
-			return false, fmt.Errorf("checking %s sentinel column %s.%s: %w", m.cursorTable, column.table, column.column, err)
+			return 0, false, fmt.Errorf("checking %s sentinel column %s.%s: %w", m.cursorTable, column.table, column.column, err)
 		}
-		if !present {
-			return true, nil
+		if present {
+			continue
 		}
+		if !limited || column.replayFloor < floor {
+			floor = column.replayFloor
+		}
+		limited = true
 	}
-	return false, nil
+	return floor, limited, nil
 }
 
 // sentinelTableExists is a function variable for the same reason

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -643,7 +643,7 @@ func TestEnsureWispIsBlockedForRecomputeNoopsWhenWispsAbsent(t *testing.T) {
 	// with a table-not-found error if wisps is genuinely missing when they
 	// run. The no-op is safe here only because it is never reached with
 	// wisps absent in a real pass: ignored/0001 (or the cursor-reality
-	// repair, cursorContradictedBySchema, when the cursor and schema
+	// repair, cursorRealityFloor, when the cursor and schema
 	// disagree) always materializes wisps before the pass advances this far.
 	// This test exercises the repair function in isolation and is not a
 	// claim that 0007/0015 tolerate a missing wisps table.


### PR DESCRIPTION
Ship blocker for the 1.3.0 cut. A missing ignored-series sentinel currently zeroes the migration cursor, which replays the whole `ignored/0001–0025` series on every upgrade from a released tree — and that replay silently restamps `wisps.updated_at` across the plane.

## Mechanism

1. #5366 (`2043fb25d`, 2026-08-25) added `sentinelColumns: {leases.granted_node}` to `ignoredSource`.
2. `currentVersion()` returns **0** on **any** missing sentinel, table or column. `migrate()` reads the cursor through `currentVersion` by design (the gh 5033 applier contract), so a zeroed cursor makes `runMigrations` replay from `minVersion=0`.
3. `ignored/0016_add_lease_granted_node` is the only creator of that column. Every released tree — v1.1.0, v1.1.2, v1.2.x — tops the ignored series at **0011** and has no `leases` table at all. So on the first open by a 1.3.0 binary the probe finds no `granted_node`, the cursor is disbelieved, and **0001–0025 replays** instead of the correct pending set 0012–0025.
4. The replay drags in `ignored/0007_recompute_wisp_is_blocked`, whose first statement is an unguarded `UPDATE wisps SET is_blocked = 0;`. `wisps.updated_at` carries `ON UPDATE CURRENT_TIMESTAMP` (`ignored/0001` L18), so every wisp the replay toggles gets its timestamp rewritten to migration time.
5. The wisps table is `dolt_ignore`d — clone-local, no committed history. There is no cursor-rollback and no `AS OF` to recover from. That is the #5981 harm class.

`ignored/0015` is the guarded successor that added the `updated_at = updated_at` self-assign precisely for this hazard. It is *genuinely* pending on a cursor-11 store and runs correctly. Only the **spurious** 0007 replay does damage. Census of the spurious range 0001–0011: 0007 is the only migration whose UPDATE touches a table with an `ON UPDATE` timestamp column.

**No released binary carries this bug.** v1.2.2 has no `sentinelColumns` at all; the field only exists on `main` / `release/1.3.0` since 2026-08-25. This has to land before the cut or it ships in the first release that has it. (The #5366 one-shot repair binary already ran against the five affected city stores; that population is healed and out of scope.)

## The fix: clamp, don't zero

A missing sentinel object should disbelieve the cursor only back to the migration that **creates** that object — not back to zero. `schemaSentinelColumn` gains a `replayFloor`, and `currentVersion` returns `min(cursor, floor)` when the sentinel is missing.

Floor **11** is exact; both constraints meet there:

- **Must be ≥ 11** so 0001–0011, destructive 0007 included, never replay on a store whose cursor legitimately claims them. This is the fix.
- **Must be ≤ 11** so the replay still reaches `ignored/0012` (the `__temp__leases` + conditional-RENAME creator) as well as 0016. The single `INFORMATION_SCHEMA.COLUMNS` `COUNT(*)` probe returns 0 for a missing **table** and a missing **column** alike, so the heal has to cover both shapes. A floor of 15 would strand the table-absent shape in a permanent re-migration loop (0016 no-ops without `leases`); 11 heals both, preserving #5366's full healing power.

Table sentinels (`wisps`, `wisp_dependencies`, created by 0001) keep floor 0 — gh 5033 / gh 4356 behavior is bit-for-bit unchanged, including the cheap short-circuit that skips the column probe entirely when a table is missing.

| store shape | raw cursor | today (HEAD) | with fix |
|---|---|---|---|
| v1.1.0/v1.1.2/v1.2.x upgrade (no leases) | 11 | replay 1–25 → **0007 restamps** | believed 11 → apply 12–25 |
| ga-usd3k ordinal collision (leases present, column absent) | 17+ | replay 1–25 → 0007 restamps again | clamp 11 → replay 12–25 (0012–0015 guarded no-ops, 0016 heals) |
| out-of-band clone, cursor at-latest, leases table gone | 25 | replay 1–25 | clamp 11 → replay 12–25, 0012 re-creates leases |
| gh 5033 (wisp tables gone) | any | replay 1–25 | replay 1–25 (**unchanged**) |
| healthy store | any | believed | believed |

**Safety:** the replay set under the fix is a strict subset of today's (12–25 ⊂ 1–25) in every contradicted shape, so no new replay-idempotence obligations are created — 0012–0025's guarded re-run is already shipped behavior under #5366. The clamp is read-side only: cursor rows are never deleted or rewritten (recording stays `INSERT IGNORE`), so there is no interaction with other binaries' `MAX(version)` reads, and the sentinel itself is not removed — the "older binaries check their own sentinel list" INVARIANT still holds.

**Collateral also fixed:** `aux_row_id_backfill.go` gates both aux-rekey passes on their marker versions (9 and 18) appearing in `ignoredSource.pendingVersions()`, which reads the same guarded cursor. Under the contradiction, marker 9 became spuriously "pending" on every release-lineage upgrade, re-running the pass-1 aux row-id rewrite over the synced events/comments/snapshots planes — a convergent no-op by design, but wasted work and needless churn. In-flight #6045 adds a third such marker with the same gating; the un-clamped sentinel would spuriously re-arm that too. Clamping makes the marker gate see the true pending set.

## Why not just guard `ignored/0007`?

Adding the `updated_at = updated_at` self-assign to 0007 (the way 0015 does) was considered and rejected on three independent blockers:

1. **Frozen.** `scripts/check-migration-hygiene.sh` Check C hard-fails any modification to a migration file that exists on the base branch, explicitly including `ignored/*.sql`. Content hashes are recorded at apply time. Carving an exception is a governance change out of proportion to this fix.
2. **A superseding migration cannot help.** A new `ignored/0027` would run *after* 0007's replay already restamped, and the wisp plane has no history to restore from. Dead end by construction.
3. **A `preMigrationRepair` cannot express it.** The repair registry has pre-hooks only. Making 0007 timestamp-safe from a pre-hook means temporarily ALTERing `ON UPDATE CURRENT_TIMESTAMP` off `wisps.updated_at` with no post-hook to restore it — a crash in that window permanently changes live-plane column semantics. Worse than the disease.

It also treats one symptom: the spurious full replay itself (marker re-arming) would remain, and any future unguarded ignored migration would re-open the same wound.

**Accepted residual:** the **v1.0.1 lineage** has no ignored cursor at all, so it runs 0007 for the *first* time over a populated plane and legitimately restamps the wisps whose `is_blocked` it computes. That is a genuine first-run data migration on a pre-split-plane lineage, not a replay defect. The corpus already scopes its tolerance to exactly that lane (`is_wisp_plane_split_source`); only closed-row stability is guaranteed there.

## Test plan

All in `internal/storage/schema/cursor_reality_test.go`:

- **`TestCurrentVersionClampsToSentinelFloor`** — THE regression. Table-driven over `currentVersion` with a mocked cursor read: cursor 11 + column absent → **believed 11** (the release lineage); cursor 17 → 11 (collision heal); at-latest → 11; cursor 8 → 8 (the floor is a ceiling on belief, never a promotion); wisp tables absent → 0 (gh 5033 unchanged); corroborated → raw cursor.
- **`TestCursorRealityFloor`** — the probe itself, now returning `(floor, limited)`; keeps every gh 5033 / gh 4356 case and adds the table-outranks-column case.
- **`TestMigrateStartsAboveTheFloorUnderColumnContradiction`** — applier-side proof. Walks `migrate()` to the first statement it applies and fails it distinctively; error attribution must contain `0012` and must **not** reach `0001`. The harm is executed *by* the applier, so deciding the cursor correctly is not enough.
- **`TestPendingVersionsUnderFloorDoNotReArmAuxMarkers`** — marker 9 excluded, marker 18 still armed, 0012 pending, 0007 not.
- **`TestSentinelColumnsAreCreatedByTheSeries`** tightened into a floor-honesty test: parses versions per file and asserts the column adder (0016), the carrier-table creator (`__temp__leases`, 0012), and the unguarded `UPDATE wisps SET is_blocked = 0;` (0007) all sit on the correct side of the floor. A future renumbering breaks this test rather than users. 0015's guarded `is_blocked = 0, updated_at = updated_at` deliberately does not match.
- Untouched and still green: `TestMigrationWorkNeededWhenLeaseGrantedNodeAbsent` (the #5366 contract — at-latest cursor + missing column ⇒ clamp 11 < latest ⇒ work needed, probe count and order identical), `TestCursorProbeErrorIsNotTreatedAsContradicted`, `TestMainSourceIsNotProbed`, `TestMigrateAppliesUnderContradictedCursor`, `TestMigrationWorkNeededWhenWispTablesAbsent`.

Results:

- `go build ./...` — clean
- `go vet ./...` — clean
- `golangci-lint run ./internal/storage/schema/...` — 0 issues
- `./scripts/test.sh ./internal/storage/schema/...` — **ok** (58.3s uncached)
- `./scripts/test.sh ./internal/storage/embeddeddolt/...` — **ok** (78.3s)
- `./scripts/check-migration-hygiene.sh` — **Migration hygiene OK** (proves no frozen file was touched)
- **Negative control:** setting `replayFloor` back to 0 fails 4 of the new tests, including every case of `TestCurrentVersionClampsToSentinelFloor` and the applier test. The tests detect the bug they were written for.

## Corpus coordination (#6049)

The upgrade corpus on `test/1.3.0-wisp-plane-upgrade-corpus` currently tolerates this restamp behind a `TODO(wisp-restamp)` marker in `verify_no_restamp`. Those scripts live on that unmerged branch and are **not** touched here.

Once this PR and #6049 both merge, the corpus tolerance flips to the strict assertion: for split sources (`is_wisp_plane_split_source` — the v1.1.0/v1.1.2/v1.2.2 lanes) the wisps projection (`id, status, updated_at`) must be byte-identical before and after (`cmp -s`), with a revert-the-fix negative control proving the gate detects what it was tightened for. The v1.0.1 lane keeps its existing tolerance (the accepted residual above), and the closed-rows gate stays on for all lanes. That tightening will be dispatched separately.

## Proposed changelog line

Not editing `CHANGELOG.md` in this PR:

```
fix(schema): believe a v1.1.x/v1.2.x ignored-migration cursor when leases.granted_node is merely not yet migrated, so upgrades apply only the pending ignored tail instead of replaying ignored/0007 and silently restamping wisps.updated_at (#5981 class, #5366 follow-up)
```

## Scope notes

- No migration file added, edited, or renumbered; no ordinal taken (0026 belongs to in-flight #6045, which touches `MigrateUp` and `dep_id_backfill.go` — no overlap with the regions here).
- One stale comment naming the old `cursorContradictedBySchema` survives in `ignored/0023_repair_events_journal_shape.up.sql:23`. That file is frozen, so it is deliberately left alone; the comment's substance (sentinels test EXISTENCE) is still accurate.
- Stores already damaged by a pre-fix dev binary are unrecoverable — no history on the ignored plane, nothing to repair forward.
- Cross-refs: #5981 (harm class), #5366 (the sentinel this follows up), #6045 (ordinal coordination), #6049 (verification vehicle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
