### PR TITLE
fix(doctor): doctor respects --readonly and the migration freeze — no more --fix bypass, diagnosis no longer auto-migrates (#6028)

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -212,6 +212,9 @@ Examples:
 		if err != nil {
 			return HandleError("failed to resolve path: %v", err)
 		}
+		if err := checkDoctorMutationGate(absPath); err != nil {
+			return err
+		}
 		if err := validateDoctorWorkspaceBackend(absPath); isLegacyUpgradeRefusal(err) {
 			return printLegacyUpgradeDiagnostic(err)
 		} else if err != nil {
@@ -352,6 +355,57 @@ func init() {
 	doctorCmd.Flags().BoolVar(&doctorServer, "server", false, "Run Dolt server mode health checks (connectivity, version, schema)")
 	doctorCmd.Flags().StringVar(&doctorMigration, "migration", "", "Run legacy Dolt-server migration diagnostics: 'pre' or 'post'")
 	doctorCmd.Flags().BoolVar(&doctorAgent, "agent", false, "Agent-facing diagnostic mode: rich context for AI agents (ZFC-compliant)")
+}
+
+// doctorMutationOp returns the operation label for a doctor invocation that
+// will mutate the workspace, or "" when this run is diagnosis-only. --fix and
+// --clean are the complete trigger set: every mutating doctor surface
+// (applyFixes, applyFixesInteractive, applyValidateFixes, the pollution and
+// artifacts cleaners) is reached only through one of those two flags.
+func doctorMutationOp() string {
+	switch {
+	case doctorFix:
+		return "doctor --fix"
+	case doctorClean:
+		return "doctor --clean"
+	}
+	return ""
+}
+
+// checkDoctorMutationGate is doctor's stand-in for the CheckReadonly call every
+// other write command makes at the top of its RunE (#6028). Doctor never made
+// that call, and its skipStoreAnnotation opt-out also skips the root
+// PersistentPreRunE's freeze gate, so both `--readonly` and an active
+// MIGRATION-FREEZE were bypassed structurally rather than deliberately.
+//
+// One call, once, at the flag-level flip point — not per fixer: there are 40+
+// fixers and any check sprinkled among them rots the moment one is added. It
+// runs before every mode dispatch (including the embedded-mode gate), so a
+// refused run never half-executes and never needs a store to refuse.
+//
+// There is deliberately no doctor-side override. A migration freeze is exactly
+// when a shared store has mixed-version clients and `bd doctor --fix` is the
+// mid-incident reflex command; the operator clears the freeze first.
+func checkDoctorMutationGate(absPath string) error {
+	op := doctorMutationOp()
+	if op == "" {
+		return nil
+	}
+	if readonlyMode {
+		// Wording matches CheckReadonly (errors.go) exactly; doctor returns the
+		// error rather than calling that void helper so its deferred metrics
+		// CloseEventAndAdd still runs.
+		fmt.Fprintf(os.Stderr, "Error: operation '%s' is not allowed in read-only mode\n", op)
+		return &exitError{Code: 1}
+	}
+	// Doctor is the one write-capable command that takes a target path, so the
+	// freeze has to be looked up against that target as well as against the
+	// directory bd was launched in: `bd doctor /frozen/repo --fix` from an
+	// unfrozen cwd would otherwise walk the wrong tree entirely. ...ErrorFor
+	// covers both (FindFrom(absPath) alone would miss a freeze in the caller's
+	// own cwd), and doctorCmd already sets SilenceErrors/SilenceUsage
+	// statically, so the cobra-silencing gate variant buys nothing here.
+	return migrationFreezeErrorFor(op, absPath)
 }
 
 func shouldSkipDoctorNetworkChecks() bool {
@@ -528,18 +582,32 @@ func runDiagnostics(path string) doctorResult {
 	// Since doctor skips PersistentPreRun DB init (via skipStoreAnnotation),
 	// trackBdVersion() and autoMigrateOnVersionBump() haven't run yet.
 	//
-	// Scope version tracking to the doctor target. Without this, `bd doctor <path>`
-	// can accidentally touch the caller's current repo .beads state.
-	origBeadsDir, hadBeadsDir := os.LookupEnv("BEADS_DIR")
-	_ = os.Setenv("BEADS_DIR", beadsDir)
-	trackBdVersion()
-	if hadBeadsDir {
-		_ = os.Setenv("BEADS_DIR", origBeadsDir)
-	} else {
-		_ = os.Unsetenv("BEADS_DIR")
-	}
+	// #6028: skipping that hook also skipped its guards on these exact two
+	// calls — main.go runs them only when policy.runMaintenance is set and the
+	// workspace is not frozen for maintenance. Doctor replicates the calls, so
+	// it must replicate the guard, or plain `bd doctor` (no --fix needed)
+	// rewrites .beads/.local_version and silently applies a schema migration to
+	// a read-only or mid-freeze store: precisely the torn-upgrade write the
+	// freeze exists to prevent. Under either gate doctor now *reports* the
+	// version/migration mismatch in the checks below instead of healing it.
+	//
+	// The probe takes beadsDir for the same reason the mutation gate takes
+	// absPath: these writes land in the doctor target, so a freeze on that tree
+	// must stop them even when bd was launched somewhere unfrozen.
+	if !readonlyMode && !migrationFreezeActiveFor(beadsDir) {
+		// Scope version tracking to the doctor target. Without this, `bd doctor <path>`
+		// can accidentally touch the caller's current repo .beads state.
+		origBeadsDir, hadBeadsDir := os.LookupEnv("BEADS_DIR")
+		_ = os.Setenv("BEADS_DIR", beadsDir)
+		trackBdVersion()
+		if hadBeadsDir {
+			_ = os.Setenv("BEADS_DIR", origBeadsDir)
+		} else {
+			_ = os.Unsetenv("BEADS_DIR")
+		}
 
-	autoMigrateOnVersionBump(beadsDir)
+		autoMigrateOnVersionBump(beadsDir)
+	}
 
 	// Check 1b: Dolt format compatibility (GH#2137)
 	// Must run before opening the database — old noms formats cause server panics.

--- a/cmd/bd/doctor_mutation_gate_test.go
+++ b/cmd/bd/doctor_mutation_gate_test.go
@@ -1,0 +1,226 @@
+// Tests for doctor's mutation gate (#6028): `bd doctor --fix` / `--clean` must
+// refuse to run under strict --readonly, exactly like the ~120 write commands
+// that call CheckReadonly at the top of their RunE. Doctor never made that call
+// — it opts out of the root PersistentPreRunE store init via
+// skipStoreAnnotation, which also opted it out of that hook's gates — so both
+// --readonly and an active MIGRATION-FREEZE were bypassed structurally.
+//
+// The freeze half of the same gate lives in migration_freeze_gate_test.go,
+// beside the rest of the freeze suite; both halves share the helpers below and
+// the hermetic subprocess harness declared there.
+//
+// This file MUST NOT carry a cgo build tag: it drives a bd binary built with
+// the gms_pure_go tag via subprocess, and asserts only on files and output.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// doctorMutationSurface is one class of doctor invocation that mutates the
+// workspace. Section 2 of the #6028 design enumerates the complete set: every
+// mutating path is reached through --fix or --clean and nothing else, so these
+// five rows cover the whole write surface, including fixers added later.
+type doctorMutationSurface struct {
+	name string
+	args []string
+	// op is the operation label the gate reports, derived from which flag made
+	// the run mutating (--fix wins when both are set).
+	op string
+}
+
+func doctorMutationSurfaces() []doctorMutationSurface {
+	return []doctorMutationSurface{
+		{name: "fix", args: []string{"doctor", "--fix", "--yes"}, op: "doctor --fix"},
+		{name: "fix-interactive", args: []string{"doctor", "--fix", "-i"}, op: "doctor --fix"},
+		{name: "validate-fix", args: []string{"doctor", "--check=validate", "--fix", "--yes"}, op: "doctor --fix"},
+		{name: "pollution-clean", args: []string{"doctor", "--check=pollution", "--clean", "--yes"}, op: "doctor --clean"},
+		{name: "artifacts-clean", args: []string{"doctor", "--check=artifacts", "--clean", "--yes"}, op: "doctor --clean"},
+	}
+}
+
+// doctorWorkspaceFingerprint captures the two workspace files a refused doctor
+// run is most likely to have touched: .local_version (trackBdVersion's target)
+// and metadata.json (the Metadata Config / Database fixers' target).
+func doctorWorkspaceFingerprint(t *testing.T, dir string) map[string][]byte {
+	t.Helper()
+	fingerprint := make(map[string][]byte)
+	for _, name := range []string{localVersionFile, "metadata.json"} {
+		path := filepath.Join(dir, ".beads", name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				t.Fatalf("fingerprinting %s: %v", path, err)
+			}
+			continue
+		}
+		fingerprint[name] = data
+	}
+	return fingerprint
+}
+
+// assertDoctorWorkspaceUnchanged proves the refusal happened before any
+// mutation, not merely that the refusal message was printed.
+func assertDoctorWorkspaceUnchanged(t *testing.T, dir string, before map[string][]byte) {
+	t.Helper()
+	after := doctorWorkspaceFingerprint(t, dir)
+	if len(after) != len(before) {
+		t.Errorf("workspace file set changed across a refused doctor run: had %d tracked files, now %d", len(before), len(after))
+	}
+	for name, want := range before {
+		got, ok := after[name]
+		if !ok {
+			t.Errorf(".beads/%s was deleted by a refused doctor run", name)
+			continue
+		}
+		if string(got) != string(want) {
+			t.Errorf(".beads/%s was rewritten by a refused doctor run:\nbefore:\n%s\nafter:\n%s", name, want, got)
+		}
+	}
+}
+
+// assertDoctorRefusalIsClean checks the shared shape of every gate refusal:
+// nothing on stdout, and none of the output a fix or clean run would produce.
+func assertDoctorRefusalIsClean(t *testing.T, stdout string) {
+	t.Helper()
+	if strings.TrimSpace(stdout) != "" {
+		t.Errorf("stdout should be empty when doctor is refused, got:\n%s", stdout)
+	}
+	for _, marker := range []string{"Applying fixes", "Deleting", "Verifying fixes"} {
+		if strings.Contains(stdout, marker) {
+			t.Errorf("refused doctor run produced %q on stdout — it started mutating before refusing:\n%s", marker, stdout)
+		}
+	}
+}
+
+// TestDoctorMutationBlockedInReadonlyMode is the readonly half of the gate.
+// One workspace serves every row: a refused run must leave it untouched, so a
+// row that leaks a mutation is caught by the next row's fingerprint too.
+func TestDoctorMutationBlockedInReadonlyMode(t *testing.T) {
+	bd, dir := setupMigrationFreezeWorkspace(t)
+	before := doctorWorkspaceFingerprint(t, dir)
+
+	for _, tt := range doctorMutationSurfaces() {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append(append([]string{}, tt.args...), "--readonly")
+			stdout, stderr, code := runBDMigrationFreeze(t, bd, dir, args...)
+
+			if code != 1 {
+				t.Fatalf("exit code = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+			}
+			want := "operation '" + tt.op + "' is not allowed in read-only mode"
+			if !strings.Contains(stderr, want) {
+				t.Errorf("stderr missing %q:\n%s", want, stderr)
+			}
+			assertDoctorRefusalIsClean(t, stdout)
+			assertDoctorWorkspaceUnchanged(t, dir, before)
+		})
+	}
+}
+
+// TestDoctorDiagnosisWorksInReadonlyMode pins the other half of the contract:
+// the gate keys on --fix/--clean alone, so every diagnosis mode still runs
+// under --readonly. Diagnosing a sandboxed workspace is the whole point.
+func TestDoctorDiagnosisWorksInReadonlyMode(t *testing.T) {
+	bd, dir := setupMigrationFreezeWorkspace(t)
+
+	for _, args := range [][]string{
+		{"doctor"},
+		{"doctor", "--dry-run"},
+		{"doctor", "--check=pollution"},
+		{"doctor", "--check=artifacts"},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			stdout, stderr, _ := runBDMigrationFreeze(t, bd, dir, append(args, "--readonly")...)
+			if strings.Contains(stderr, "not allowed in read-only mode") {
+				t.Errorf("bd %v was refused under --readonly but mutates nothing:\nstderr:\n%s\nstdout:\n%s", args, stderr, stdout)
+			}
+		})
+	}
+}
+
+// TestDoctorMaintenanceSkippedInReadonlyMode is the readonly twin of
+// TestDoctorMaintenanceSkippedDuringMigrationFreeze — see that test for why
+// plain `bd doctor` had hidden writes at all, and for the shared-server setup.
+func TestDoctorMaintenanceSkippedInReadonlyMode(t *testing.T) {
+	bd, dir := setupMigrationFreezeWorkspace(t)
+	seedStaleLocalVersion(t, dir)
+
+	stdout, stderr, _ := runBDMigrationFreezeWithEnv(t, bd, dir, doctorMaintenanceEnv(), "doctor", "--readonly")
+
+	assertDoctorReportedStaleVersionWithoutHealing(t, dir, stdout, stderr)
+	if strings.Contains(stderr, "not allowed in read-only mode") {
+		t.Errorf("plain 'bd doctor --readonly' must diagnose, not refuse:\nstderr:\n%s", stderr)
+	}
+}
+
+// TestDoctorMutationNotBlockedWithoutGates is the regression-safety control:
+// with no freeze sentinel and no --readonly, the gate must be invisible. The
+// fix outcome itself is not this test's business — only that neither refusal
+// fires and neither exit path is the gate's.
+func TestDoctorMutationNotBlockedWithoutGates(t *testing.T) {
+	bd, dir := setupMigrationFreezeWorkspace(t)
+
+	for _, tt := range doctorMutationSurfaces() {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr, code := runBDMigrationFreeze(t, bd, dir, tt.args...)
+			if code == ExitMigrationFrozen || strings.Contains(stderr, "frozen for migration") {
+				t.Errorf("bd %v hit the freeze gate with no marker present (exit %d):\nstderr:\n%s", tt.args, code, stderr)
+			}
+			if strings.Contains(stderr, "not allowed in read-only mode") {
+				t.Errorf("bd %v hit the readonly gate without --readonly (exit %d):\nstderr:\n%s", tt.args, code, stderr)
+			}
+			_ = stdout
+		})
+	}
+}
+
+// TestDoctorMaintenanceStillRunsWithoutGates is the companion control for the
+// diagnosis-path change: unfrozen and not read-only, plain `bd doctor` must
+// still reconcile a stale .local_version exactly as it did before #6028.
+func TestDoctorMaintenanceStillRunsWithoutGates(t *testing.T) {
+	bd, dir := setupMigrationFreezeWorkspace(t)
+	seedStaleLocalVersion(t, dir)
+
+	stdout, stderr, _ := runBDMigrationFreezeWithEnv(t, bd, dir, doctorMaintenanceEnv(), "doctor")
+
+	if !strings.Contains(stderr, "auto-migrate:") {
+		t.Errorf("expected autoMigrateOnVersionBump to run (an 'auto-migrate:' debug line) with no gate active, got none:\nstderr:\n%s", stderr)
+	}
+	got := readWorkspaceLocalVersion(t, dir)
+	if got == staleLocalVersion {
+		t.Errorf("%s = %q — trackBdVersion did not run with no gate active; the #6028 skip is too broad:\nstdout:\n%s",
+			localVersionFile, got, stdout)
+	}
+}
+
+// TestDoctorReadonlyWinsOverMigrationFreeze pins the branch order inside the
+// gate: --readonly is checked first, so a workspace that is both frozen and
+// sandboxed reports the readonly refusal. This mirrors CheckReadonly, which
+// also answers readonly before delegating to the freeze check. Either refusal
+// stops the run, but they carry different exit codes — 1 vs ExitMigrationFrozen
+// — so which one wins is observable, and the precedence has to be deliberate.
+func TestDoctorReadonlyWinsOverMigrationFreeze(t *testing.T) {
+	bd, dir := setupMigrationFreezeWorkspace(t)
+	writeFreezeMarker(t, dir, "migrator", "dolt v2 migration")
+	before := doctorWorkspaceFingerprint(t, dir)
+
+	stdout, stderr, code := runBDFrozen(t, bd, dir, "doctor", "--fix", "--yes", "--readonly")
+
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (not %d — readonly is answered before the freeze)\nstdout:\n%s\nstderr:\n%s",
+			code, ExitMigrationFrozen, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "operation 'doctor --fix' is not allowed in read-only mode") {
+		t.Errorf("stderr missing the readonly refusal (readonly must be checked before the freeze):\n%s", stderr)
+	}
+	if strings.Contains(stderr, "frozen for migration") {
+		t.Errorf("stderr carries the freeze refusal too; the gate should report exactly one reason:\n%s", stderr)
+	}
+	assertDoctorRefusalIsClean(t, stdout)
+	assertDoctorWorkspaceUnchanged(t, dir, before)
+}

--- a/cmd/bd/errors.go
+++ b/cmd/bd/errors.go
@@ -308,7 +308,16 @@ func migrationFreezeErrorFor(operation string, extraRoots ...string) error {
 // paths that keep running while frozen but must not apply version tracking or
 // schema auto-migration.
 func migrationFreezeActive() bool {
-	return migration.Find(freezeSearchRoots()...).Frozen()
+	return migrationFreezeActiveFor()
+}
+
+// migrationFreezeActiveFor is migrationFreezeActive against extra roots — the
+// probe half of the migrationFreezeErrorFor pair, for a diagnosis path handed a
+// workspace that is not the one bd was launched in. `bd doctor /frozen/repo`
+// skips its own maintenance writes on the strength of this, so it has to look
+// at the tree it is about to write to and not just at the caller's cwd.
+func migrationFreezeActiveFor(extraRoots ...string) bool {
+	return migration.Find(freezeRootsWith(extraRoots)...).Frozen()
 }
 
 func freezeRootsWith(extraRoots []string) []string {

--- a/cmd/bd/migration_freeze_gate_test.go
+++ b/cmd/bd/migration_freeze_gate_test.go
@@ -851,6 +851,220 @@ func TestAutoMigrateSkippedDuringMigrationFreeze(t *testing.T) {
 	}
 }
 
+// TestDoctorMutationBlockedDuringMigrationFreeze covers the freeze half of
+// doctor's mutation gate (#6028). Doctor was the one write-capable command the
+// dc-6jaq gate above never reached: it carries skipStoreAnnotation, so the root
+// PersistentPreRunE returns before its freeze check ever runs, and doctor's own
+// RunE never called CheckReadonly. Its fixers then opened stores directly — two
+// of them by shelling out to a child bd — and mutated straight through an
+// active freeze.
+//
+// One row per writing surface class. The gate fires before doctor's
+// embedded-mode gate, so these refusals need no Dolt server, and the
+// interactive row proves the refusal precedes any prompt (stdin is closed; a
+// hang here is the failure).
+func TestDoctorMutationBlockedDuringMigrationFreeze(t *testing.T) {
+	bd, dir := setupMigrationFreezeWorkspace(t)
+	marker := writeFreezeMarker(t, dir, "migrator", "dolt v2 migration")
+	before := doctorWorkspaceFingerprint(t, dir)
+
+	for _, tt := range doctorMutationSurfaces() {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr, code := runBDFrozen(t, bd, dir, tt.args...)
+
+			if code != ExitMigrationFrozen {
+				t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, ExitMigrationFrozen, stdout, stderr)
+			}
+			for _, want := range []string{
+				"workspace is frozen for migration",
+				"bd " + tt.op + " is blocked by the freeze marker at " + marker,
+				"To resume writes, remove that file.",
+			} {
+				if !strings.Contains(stderr, want) {
+					t.Errorf("stderr missing %q:\n%s", want, stderr)
+				}
+			}
+			assertVendorNeutral(t, stderr)
+			assertDoctorRefusalIsClean(t, stdout)
+			assertDoctorWorkspaceUnchanged(t, dir, before)
+		})
+	}
+}
+
+// TestDoctorPathArgBlockedByTargetFreeze covers the reason doctor's gate takes
+// the resolved target path: doctor is the only write-capable command that
+// operates on a directory named on the command line, so keying the lookup on
+// the caller's cwd alone would let `bd doctor /frozen/repo --fix` walk an
+// entirely unrelated tree and mutate straight through the marker.
+func TestDoctorPathArgBlockedByTargetFreeze(t *testing.T) {
+	target := t.TempDir()
+	bd := setupMigrationFreezeWorkspaceIn(t, target)
+	marker := writeFreezeMarker(t, target, "migrator", "dolt v2 migration")
+	before := doctorWorkspaceFingerprint(t, target)
+
+	// cwd is an unrelated, unfrozen workspace; only the target is frozen.
+	outside := t.TempDir()
+	setupMigrationFreezeWorkspaceIn(t, outside)
+
+	stdout, stderr, code := runBDFrozen(t, bd, outside, "doctor", target, "--fix", "--yes")
+
+	if code != ExitMigrationFrozen {
+		t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, ExitMigrationFrozen, stdout, stderr)
+	}
+	if !strings.Contains(stderr, marker) {
+		t.Errorf("refusal should name the target's own marker %q:\n%s", marker, stderr)
+	}
+	assertVendorNeutral(t, stderr)
+	assertDoctorRefusalIsClean(t, stdout)
+	assertDoctorWorkspaceUnchanged(t, target, before)
+}
+
+// TestDoctorPathArgMaintenanceSkippedByTargetFreeze is the diagnosis-side twin:
+// plain `bd doctor <path>` writes .local_version into the *target*, so the skip
+// probe has to key on the target too, not merely on where bd was launched.
+func TestDoctorPathArgMaintenanceSkippedByTargetFreeze(t *testing.T) {
+	target := t.TempDir()
+	bd := setupMigrationFreezeWorkspaceIn(t, target)
+	seedStaleLocalVersion(t, target)
+	writeFreezeMarker(t, target, "migrator", "dolt v2 migration")
+
+	outside := t.TempDir()
+	setupMigrationFreezeWorkspaceIn(t, outside)
+
+	_, stderr, _ := runBDMigrationFreezeWithEnv(t, bd, outside,
+		append(freezeWalkEnv(), doctorMaintenanceEnv()...), "doctor", target)
+
+	if got := readWorkspaceLocalVersion(t, target); got != staleLocalVersion {
+		t.Errorf("%s in the frozen target = %q, want unchanged %q — the maintenance probe keyed on cwd, not on the target",
+			localVersionFile, got, staleLocalVersion)
+	}
+	if strings.Contains(stderr, "auto-migrate:") {
+		t.Errorf("autoMigrateOnVersionBump ran against a frozen target:\n%s", stderr)
+	}
+}
+
+// TestDoctorDiagnosisWorksDuringMigrationFreeze is the constraint that shapes
+// the whole gate: a freeze is exactly when an operator needs to diagnose, so
+// every non-mutating doctor mode must keep running. The gate keys on
+// --fix/--clean and nothing else.
+func TestDoctorDiagnosisWorksDuringMigrationFreeze(t *testing.T) {
+	bd, dir := setupMigrationFreezeWorkspace(t)
+	writeFreezeMarker(t, dir, "migrator", "dolt v2 migration")
+
+	for _, args := range [][]string{
+		{"doctor"},
+		{"doctor", "--check=pollution"},
+		{"doctor", "--check=artifacts"},
+		{"doctor", "--check=conventions"},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			stdout, stderr, code := runBDFrozen(t, bd, dir, args...)
+			if code == ExitMigrationFrozen || strings.Contains(stderr, "frozen for migration") {
+				t.Errorf("bd %v was refused during a freeze but mutates nothing (exit %d):\nstderr:\n%s\nstdout:\n%s",
+					args, code, stderr, stdout)
+			}
+		})
+	}
+}
+
+// TestDoctorDryRunWorksDuringMigrationFreeze pins the dry-run boundary: plain
+// --dry-run only previews and stays available, while --fix --dry-run is
+// refused (the gate reads the mutating flag, not the preview flag — the same
+// posture the freeze gate takes on every other command's --dry-run).
+func TestDoctorDryRunWorksDuringMigrationFreeze(t *testing.T) {
+	bd, dir := setupMigrationFreezeWorkspace(t)
+	writeFreezeMarker(t, dir, "migrator", "dolt v2 migration")
+
+	stdout, stderr, code := runBDFrozen(t, bd, dir, "doctor", "--dry-run")
+	if code == ExitMigrationFrozen || strings.Contains(stderr, "frozen for migration") {
+		t.Errorf("'bd doctor --dry-run' previews only and must not be refused (exit %d):\nstderr:\n%s\nstdout:\n%s", code, stderr, stdout)
+	}
+
+	stdout, stderr, code = runBDFrozen(t, bd, dir, "doctor", "--fix", "--dry-run")
+	if code != ExitMigrationFrozen || !strings.Contains(stderr, "workspace is frozen for migration") {
+		t.Errorf("'bd doctor --fix --dry-run' must be refused (exit %d, want %d):\nstderr:\n%s\nstdout:\n%s",
+			code, ExitMigrationFrozen, stderr, stdout)
+	}
+}
+
+// staleLocalVersion is an implausibly old recorded version: it forces
+// trackBdVersion to see a version "bump" so the maintenance work under test
+// actually does something observable instead of short-circuiting.
+const staleLocalVersion = "0.0.1"
+
+func seedStaleLocalVersion(t *testing.T, dir string) {
+	t.Helper()
+	path := filepath.Join(dir, ".beads", localVersionFile)
+	if err := os.WriteFile(path, []byte(staleLocalVersion+"\n"), 0644); err != nil {
+		t.Fatalf("writing stale %s: %v", localVersionFile, err)
+	}
+}
+
+// readWorkspaceLocalVersion reads .beads/.local_version out of a test
+// workspace (the production readLocalVersion takes the file path directly).
+func readWorkspaceLocalVersion(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, ".beads", localVersionFile))
+	if err != nil {
+		t.Fatalf("reading %s: %v", localVersionFile, err)
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// doctorMaintenanceEnv puts doctor on its full diagnosis path. runDiagnostics —
+// where the maintenance calls under test live — sits behind doctor's
+// embedded-mode gate, so the workspace has to look server-backed;
+// BEADS_DOLT_SHARED_SERVER is enough, and no server needs to answer, because
+// the maintenance block runs before doctor opens its shared store. BD_DEBUG
+// surfaces autoMigrateOnVersionBump's own "auto-migrate:" logging, so the
+// absence of that line is direct evidence the function was never entered.
+func doctorMaintenanceEnv() []string {
+	return []string{"BEADS_DOLT_SHARED_SERVER=1", "BD_DEBUG=1"}
+}
+
+// assertDoctorReportedStaleVersionWithoutHealing is the #6028 diagnosis
+// contract in one place: doctor reports the version mismatch as a finding and
+// leaves the store alone.
+func assertDoctorReportedStaleVersionWithoutHealing(t *testing.T, dir, stdout, stderr string) {
+	t.Helper()
+	if got := readWorkspaceLocalVersion(t, dir); got != staleLocalVersion {
+		t.Errorf("%s = %q, want unchanged %q — doctor's diagnosis rewrote it through an active gate",
+			localVersionFile, got, staleLocalVersion)
+	}
+	if strings.Contains(stderr, "auto-migrate:") {
+		t.Errorf("autoMigrateOnVersionBump ran its store-opening body during a gated 'bd doctor' "+
+			"(found an 'auto-migrate:' debug line) — diagnosis must not apply schema migrations:\n%s", stderr)
+	}
+	if !strings.Contains(stdout, "Version Tracking") || !strings.Contains(stdout, staleLocalVersion) {
+		t.Errorf("doctor should still REPORT the stale version %q as a finding, not silently skip it:\n%s",
+			staleLocalVersion, stdout)
+	}
+}
+
+// TestDoctorMaintenanceSkippedDuringMigrationFreeze is the regression test for
+// the sharpest half of #6028: plain `bd doctor` — no --fix, no --clean — wrote
+// to a frozen store. runDiagnostics re-implements PersistentPreRunE's two
+// maintenance side effects (trackBdVersion, autoMigrateOnVersionBump) because
+// doctor skips that hook, but it inherited none of the hook's guards, so it
+// rewrote .beads/.local_version and could auto-apply a schema migration
+// mid-freeze — the exact torn-upgrade write the freeze exists to prevent.
+//
+// This is the doctor-side twin of TestAutoMigrateSkippedDuringMigrationFreeze
+// above, which pins the same two calls on the PersistentPreRunE path.
+func TestDoctorMaintenanceSkippedDuringMigrationFreeze(t *testing.T) {
+	bd, dir := setupMigrationFreezeWorkspace(t)
+	seedStaleLocalVersion(t, dir)
+	writeFreezeMarker(t, dir, "migrator", "dolt v2 migration")
+
+	stdout, stderr, code := runBDMigrationFreezeWithEnv(t, bd, dir,
+		append(freezeWalkEnv(), doctorMaintenanceEnv()...), "doctor")
+
+	assertDoctorReportedStaleVersionWithoutHealing(t, dir, stdout, stderr)
+	if code == ExitMigrationFrozen || strings.Contains(stderr, "frozen for migration") {
+		t.Errorf("plain 'bd doctor' must diagnose during a freeze, not refuse (exit %d):\nstderr:\n%s", code, stderr)
+	}
+}
+
 // TestAutoMigrateStillRunsWithoutFreeze is the companion regression-safety
 // check for the ask-#2 fix: without a freeze marker, the new early gate in
 // PersistentPreRunE must not interfere with autoMigrateOnVersionBump's normal


### PR DESCRIPTION
Fixes #6028.

`bd doctor --fix` mutated a workspace that strict `--readonly` and an active migration freeze had both declared off-limits. Worse than filed: plain `bd doctor`, with no `--fix` at all, also wrote to a frozen store.

## Bypass anatomy

There is no "skip the gate" for doctor anywhere. The bypass is structural, and it is two independent misses:

1. **Doctor opts out of the root store gate entirely.** `doctorCmd` carries `Annotations: {skipStoreAnnotation: "1"}`, so the root `PersistentPreRunE` resolves that via `commandOptsOutOfStore` and returns early — before the freeze gate, before the `frozenForMaintenance` skip that protects `trackBdVersion` / `autoMigrateOnVersionBump`, and before the read-only store-open policy.
2. **Doctor's RunE never called `CheckReadonly`.** That per-command chokepoint (which also folds in the freeze check) is called by ~120 write commands at the top of their RunE; `grep -n CheckReadonly cmd/bd/doctor*.go` returned zero hits. Doctor's fixers instead open stores directly (`fix.openBeadMutatingStore`, `openBeadMutatingStoreCreating`, `ensureDirectMode`), and two of them shell out to a child `bd` (`bd init --force` in the Database Integrity fixer, the hook rewrite in the Git Hooks fixer). A child process would independently trip the freeze — but `--readonly` is a per-invocation flag that does **not** propagate to children, so a parent-level guard is mandatory regardless.

#6043 closes the same skip-store hole for `bd init` and `bd bootstrap`; doctor is the third command in that class, and its gate has to live in doctor because doctor's whole store lifecycle is deliberately self-managed. Confirmed empirically: with this PR's `doctor.go` reverted to `release/1.3.0` (which now contains #6043), all eight doctor gate tests fail.

### The finding that isn't in the issue: plain `bd doctor` writes

`runDiagnostics` re-implements the two maintenance side effects doctor skipped along with `PersistentPreRunE` — `trackBdVersion()` (writes `.beads/.local_version`) and `autoMigrateOnVersionBump()` (opens a **writable** store and applies schema migrations) — and inherited none of that hook's guards. `main.go` runs the identical two calls only when `policy.runMaintenance && !frozenForMaintenance`.

Reproduced before this change: freeze a server-mode workspace, seed a stale `.beads/.local_version`, run plain `bd doctor`. Exit 0, no refusal — and `.local_version` silently rewritten `0.0.1` -> `1.2.2`, with `autoMigrateOnVersionBump`'s `auto-migrate:` debug line proving it entered its store-opening body. That is precisely the torn-upgrade write a migration freeze exists to prevent, reachable without ever typing `--fix`.

## The fix: two chokepoints, both keyed on the target

**G1 — `checkDoctorMutationGate(absPath)`**, one call early in doctor's RunE, triggered iff `doctorFix || doctorClean`. That is the complete trigger set: every mutating doctor surface (`applyFixes`, `applyFixesInteractive`, `applyValidateFixes`, the pollution cleaner, the artifacts cleaner, and all 40+ fixers behind them) is reached only through one of those two flags. Under `--readonly` it prints the standard `operation '%s' is not allowed in read-only mode` and exits 1; otherwise `migrationFreezeErrorFor(op, absPath)` refuses with `ExitMigrationFrozen`.

- One call at the flag-level flip point, **not per fixer** — 40+ sites would rot the moment one is added, which is exactly how `bd q` was missed by the original readonly work.
- Placed **before** the embedded-mode gate, so a refused run never half-executes, produces one unambiguous exit code, and needs no Dolt server to refuse.
- **No doctor-side override.** A migration freeze is exactly when a shared store has mixed-version clients, and `bd doctor --fix` is the mid-incident reflex command; an override would be the torn-upgrade button. The operator clears the marker first, and the refusal names its path.
- No tiering of "harmless" filesystem fixers. A partial run ("fixed 6, refused 9") is the one thing an operator mid-incident cannot afford.
- Consequence, deliberate: `bd doctor --fix --dry-run` now refuses under either gate (the gate reads the mutating flag, not the preview flag). Plain `bd doctor --dry-run` is untouched; it never mutates.

**G2 — the `runDiagnostics` maintenance block** is now wrapped in `!readonlyMode && !migrationFreezeActiveFor(beadsDir)`, mirroring `main.go`'s guard on the identical two calls. Under either gate doctor now **reports** the version/migration mismatch as a finding (`Version Tracking: Last recorded version is very old: 0.0.1 (current: 1.2.2)`) instead of silently healing it.

**Both take the target path**, because doctor is the one write-capable command that operates on a directory named on the command line. `migrationFreezeErrorFor(op, absPath)` is #6043's recommended entry point here — it covers the caller's own cwd *and* the named target, where `FindFrom(absPath)` alone would miss a freeze in the cwd. `doctorCmd` already sets `SilenceErrors`/`SilenceUsage` statically, so the cobra-silencing `...GateFor` variant buys nothing.

The one addition to `errors.go` is `migrationFreezeActiveFor(extraRoots...)`, the probe half of the existing `migrationFreezeErrorFor` pair — three lines, same naming convention. Without it G2 would still key on cwd, so `bd doctor /frozen/repo` from an unfrozen shell would keep rewriting the frozen target's `.local_version`: the identical bug G1 closes, one function down.

Every diagnosis mode still runs under both gates — plain `bd doctor`, `--dry-run`, `--agent`, `--json`, `--output`, `--check=*` without `--fix`/`--clean`, `--check-health`, `--deep`, `--server`, `--migration`, `--perf`. Diagnosing a frozen or sandboxed workspace is the point of the issue's last paragraph.

## Merge order

Resolved: **#6043 has merged into `release/1.3.0`**, so this PR is rebased straight onto the release branch and stands alone again. History is one commit; the #6043-era commits it was briefly stacked on are gone.

Its interface arrived exactly as promised, which is why the diff here is small:

- The local `migrationFreezeError` shim this PR originally carried was dropped outright — #6043's extraction supersedes it, so nothing competes in `cmd/bd/errors.go` (verified byte-identical across the squash).
- `doctor.go` compiled against #6043's helpers with no repairs; everything here is an upgrade on top of them.
- Freeze refusals exit `ExitMigrationFrozen` (14), name the marker path, and pass `assertVendorNeutral`.
- D7 (`bd doctor <path> --fix`) is **closed**, not deferred — on both the gate and the probe.

One thing to know when reading `cmd/bd/errors.go`: `migrationFreezeActiveFor` belongs to **this** PR, not to #6043. It was written while this branch was stacked, so it never existed on #6043's branch and was not part of that squash.

## Test plan

14 tests, all subprocess-driven through #6043's hermetic freeze harness. Marker-on-disk tests use `runBDFrozen` / `freezeWalkEnv()`, since the base env now pins `BD_MIGRATION_FREEZE_FILE` package-wide in `TestMain` and a test that forgets this sees no marker at all. Every one of the eight gate tests was confirmed to **fail** against `release/1.3.0` with this PR's `doctor.go` reverted, then pass with it.

`cmd/bd/migration_freeze_gate_test.go` (freeze half):

- `TestDoctorMutationBlockedDuringMigrationFreeze` — table-driven, one row per writing surface class: `--fix --yes`, `--fix -i`, `--check=validate --fix`, `--check=pollution --clean`, `--check=artifacts --clean`. Each asserts `ExitMigrationFrozen`, the neutral refusal naming the operation and the marker's own path, `assertVendorNeutral`, empty stdout with no `Applying fixes` / `Deleting` / `Verifying fixes`, and a byte-comparison that `.beads/.local_version` and `.beads/metadata.json` are untouched. The interactive row also proves the refusal precedes any prompt (stdin closed; a hang is the failure).
- `TestDoctorPathArgBlockedByTargetFreeze` — marker in the target, cwd an unrelated unfrozen workspace: refused, naming the target's marker. This is the D7 case.
- `TestDoctorPathArgMaintenanceSkippedByTargetFreeze` — the diagnosis-side twin: plain `bd doctor <frozen-path>` from an unfrozen cwd leaves the target's `.local_version` alone.
- `TestDoctorDiagnosisWorksDuringMigrationFreeze`, `TestDoctorDryRunWorksDuringMigrationFreeze` — the non-mutating modes are not refused; the dry-run test pins both sides of the boundary.
- `TestDoctorMaintenanceSkippedDuringMigrationFreeze` — the G2 regression test, doctor-side twin of `TestAutoMigrateSkippedDuringMigrationFreeze`. Stale `.local_version` byte-identical, no `auto-migrate:` debug line, and doctor's output still **reports** the stale version.

`cmd/bd/doctor_mutation_gate_test.go` (readonly half plus controls):

- `TestDoctorMutationBlockedInReadonlyMode` — the same five-row table with `--readonly` and no marker: exit 1, per-row operation label, workspace unchanged.
- `TestDoctorDiagnosisWorksInReadonlyMode`, `TestDoctorMaintenanceSkippedInReadonlyMode` — readonly twins.
- `TestDoctorMutationNotBlockedWithoutGates`, `TestDoctorMaintenanceStillRunsWithoutGates` — regression-safety controls: with neither gate active, no refusal fires and `.local_version` reconciliation still happens exactly as before.
- `TestDoctorReadonlyWinsOverMigrationFreeze` — pins the branch order (readonly is answered first, exit 1 rather than 14), so the precedence is deliberate rather than incidental.

Reaching `runDiagnostics` needs doctor off its embedded-mode path, so the maintenance tests set `BEADS_DOLT_SHARED_SERVER=1`; no server has to answer, because the maintenance block runs before doctor opens its shared store. `BD_DEBUG=1` surfaces `autoMigrateOnVersionBump`'s own logging, so the absence of that line is direct evidence the function was never entered.

Gates run locally: `go build ./...`, `go build -tags gms_pure_go ./...`, `CGO_ENABLED=0 go build ./...`, `go vet ./...`, `golangci-lint run ./cmd/bd/...` (0 issues), and the full `./scripts/test.sh ./cmd/bd/` shard.

## Proposed changelog line (not edited in this PR)

- **`bd doctor` now honors strict `--readonly` and the migration freeze** (#6028). `bd doctor --fix` / `--clean` refuse to mutate under either gate — the freeze refusal exits 14 and names the marker, and there is no doctor-side override — and plain `bd doctor` diagnosis no longer rewrites `.local_version` or auto-applies schema migrations while a freeze is active or `--readonly` is set; it reports the pending migration instead. Both gates key on the directory doctor was pointed at, not just the one it was launched in. Diagnosis itself keeps working under a freeze.

## Follow-ups worth their own issues (not done here)

- Stale help text: `doctor.go` advertises `--fix --force` and `--fix --source=jsonl`, neither of which is a registered flag.
- `--check=validate --fix --dry-run` mutates when no gate is active — `applyValidateFixes` never consults `doctorDryRun`. Now refused under a gate; the unfrozen wart remains.
- Post-merge cleanup: a shared `readonlyError(op) error` (the readonly message is duplicated in doctor on purpose, to keep this PR off `CheckReadonly`'s hunk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

