### PR TITLE
fix(create): wire --storage-class through the proxied, markdown, and graph input paths

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -197,32 +197,9 @@ var createCmd = &cobra.Command{
 			return HandleError("--ephemeral and --no-history are mutually exclusive")
 		}
 		storageClassFlag, _ := cmd.Flags().GetString("storage-class")
-		storageClass, err := resolveStorageClass(storageClassFlag, types.IssueType(issueType).Normalize())
+		storageClass, wisp, err := resolveCreateStorageClass(storageClassFlag, types.IssueType(issueType), wisp, noHistory)
 		if err != nil {
 			return HandleError("%v", err)
-		}
-		// --storage-class ephemeral is the spelled-out spelling of --ephemeral
-		// (Protocol v0.1 C1.4: the wisp plane is today's ephemeral-class
-		// implementation). It routes to the wisp path exactly like the flag;
-		// the --no-history mutual exclusion above still applies.
-		if storageClass == types.StorageClassEphemeral {
-			if noHistory {
-				return HandleError("--storage-class ephemeral and --no-history are mutually exclusive")
-			}
-			wisp = true
-			storageClass = "" // wisp-plane rows derive ephemeral class (C1.2); no marker cell needed
-		}
-		// Reconcile the requested durable class with the effective wisp plane
-		// (flag > config, Protocol v0.1 §C1.3): an explicit --storage-class
-		// contradicts --ephemeral/--no-history and is rejected, so the durable
-		// intent is preserved rather than silently collapsed into an
-		// effective-ephemeral record; a per-type config default yields to the
-		// explicit flag. versioned normalizes to the unset marker only after the
-		// check (C2.4).
-		var storageClassConflict bool
-		storageClass, storageClassConflict = reconcileStorageClassPlane(storageClass, storageClassFlag != "", wisp || noHistory)
-		if storageClassConflict {
-			return HandleError("--storage-class %s conflicts with --ephemeral/--no-history: wisp-plane records are storage class ephemeral", storageClass)
 		}
 		molTypeStr, _ := cmd.Flags().GetString("mol-type")
 		var molType types.MolType
@@ -757,6 +734,49 @@ func reconcileStorageClassPlane(class types.StorageClass, explicit, wispPlane bo
 		class = "" // config default yields to the explicit wisp-plane flag
 	}
 	return class.Normalize(), false
+}
+
+// resolveCreateStorageClass is the ONE create-time storage-class decision every
+// `bd create` CLI door makes: parse the flag (or fall back to the per-type
+// storage-class.<type> config default), route the ephemeral spelling to the wisp
+// plane, and reject a durable class that contradicts the plane. Every door goes
+// through it so the direct, proxied, and --file routes cannot answer differently;
+// graphApplyNodeStorageClass is the per-node mirror, which additionally honors a
+// node's own pointer overrides.
+//
+// flagValue is the raw --storage-class spelling ("" when unset). wisp/noHistory
+// are the plane flags as the caller read them; the returned wisp is the plane
+// AFTER the ephemeral spelling has been folded in (Protocol v0.1 C1.4). The
+// returned class is already normalized (C2.4), so it can go straight onto the
+// issue.
+func resolveCreateStorageClass(flagValue string, issueType types.IssueType, wisp, noHistory bool) (types.StorageClass, bool, error) {
+	class, err := resolveStorageClass(flagValue, issueType.Normalize())
+	if err != nil {
+		return "", wisp, err
+	}
+	// --storage-class ephemeral is the spelled-out spelling of --ephemeral
+	// (Protocol v0.1 C1.4: the wisp plane is today's ephemeral-class
+	// implementation). It routes to the wisp path exactly like the flag; the
+	// --ephemeral/--no-history mutual exclusion still applies.
+	if class == types.StorageClassEphemeral {
+		if noHistory {
+			return "", wisp, errors.New("--storage-class ephemeral and --no-history are mutually exclusive")
+		}
+		wisp = true
+		class = "" // wisp-plane rows derive ephemeral class (C1.2); no marker cell needed
+	}
+	// Reconcile the requested durable class with the effective wisp plane
+	// (flag > config, Protocol v0.1 §C1.3): an explicit --storage-class
+	// contradicts --ephemeral/--no-history and is rejected, so the durable
+	// intent is preserved rather than silently collapsed into an
+	// effective-ephemeral record; a per-type config default yields to the
+	// explicit flag. versioned normalizes to the unset marker only after the
+	// check (C2.4).
+	class, conflict := reconcileStorageClassPlane(class, flagValue != "", wisp || noHistory)
+	if conflict {
+		return "", wisp, fmt.Errorf("--storage-class %s conflicts with --ephemeral/--no-history: wisp-plane records are storage class ephemeral", class)
+	}
+	return class, wisp, nil
 }
 
 func buildCreateIssue(params createIssueParams) *types.Issue {

--- a/cmd/bd/create_input.go
+++ b/cmd/bd/create_input.go
@@ -46,6 +46,8 @@ type createInput struct {
 	validate           bool
 	ephemeral          bool
 	noHistory          bool
+	storageClass       types.StorageClass
+	storageClassFlag   string
 	molType            types.MolType
 	wispType           types.WispType
 	eventCategory      string
@@ -180,6 +182,21 @@ func gatherCreateInput(cmd *cobra.Command, args []string) (createInput, error) {
 	in.priority = priority
 
 	in.issueType, _ = cmd.Flags().GetString("type")
+
+	// The raw flag rides along for the --file batch, which resolves the class
+	// per template (the per-type config default needs a type to key on, and only
+	// a template has one). --graph rejects the flag outright, so the only route
+	// that resolves it here is the single-issue create, on both transports.
+	in.storageClassFlag, _ = cmd.Flags().GetString("storage-class")
+	if in.markdownFile == "" && in.graphFile == "" {
+		class, wisp, err := resolveCreateStorageClass(in.storageClassFlag, types.IssueType(in.issueType), in.ephemeral, in.noHistory)
+		if err != nil {
+			return in, HandleError("%v", err)
+		}
+		in.storageClass = class
+		in.ephemeral = wisp
+	}
+
 	in.status, _ = cmd.Flags().GetString("status")
 	in.assignee, _ = cmd.Flags().GetString("assignee")
 	in.externalRef, _ = cmd.Flags().GetString("external-ref")
@@ -333,6 +350,12 @@ func rejectSingleIssueFlagsForGraph(cmd *cobra.Command) error {
 	}
 	if cmd.Flags().Changed("mol-type") {
 		return HandleError("--mol-type is not valid with --graph (set mol_type per node in the plan instead)")
+	}
+	// Same shape as --mol-type: a plan-wide class would duplicate the per-node
+	// storage_class field (plus its per-type config default) that graph-apply
+	// already honors, so the flag is refused rather than accepted and ignored.
+	if cmd.Flags().Changed("storage-class") {
+		return HandleError("--storage-class is not valid with --graph (set storage_class per node in the plan instead)")
 	}
 	return nil
 }

--- a/cmd/bd/create_proxied_server.go
+++ b/cmd/bd/create_proxied_server.go
@@ -226,6 +226,7 @@ func buildCreateIssueFromInput(in createInput) *types.Issue {
 		EstimatedMinutes:   in.estimatedMinutes,
 		Ephemeral:          in.ephemeral,
 		NoHistory:          in.noHistory,
+		StorageClass:       in.storageClass,
 		CreatedBy:          in.createdBy,
 		Owner:              in.owner,
 		MolType:            in.molType,

--- a/cmd/bd/markdown.go
+++ b/cmd/bd/markdown.go
@@ -368,6 +368,15 @@ func buildMarkdownBatchRequest(templates []*IssueTemplate, in createInput) (issu
 		if err != nil {
 			return issueops.CreateBatchRequest{}, HandleError("%v", err)
 		}
+		// Resolved per template, not once for the file: the plan-wide flag
+		// applies to every item, but the per-type storage-class.<type> default
+		// keys on the template's own type, and the ephemeral spelling moves that
+		// item to the wisp plane. A conflict refuses the whole file here, before
+		// any transaction opens.
+		storageClass, ephemeral, err := resolveCreateStorageClass(in.storageClassFlag, template.IssueType, in.ephemeral, in.noHistory)
+		if err != nil {
+			return issueops.CreateBatchRequest{}, HandleError("template %q: %v", template.Title, err)
+		}
 		items = append(items, issueops.BatchCreateItem{
 			Issue: &types.Issue{
 				Title:              template.Title,
@@ -379,8 +388,9 @@ func buildMarkdownBatchRequest(templates []*IssueTemplate, in createInput) (issu
 				IssueType:          template.IssueType,
 				Assignee:           template.Assignee,
 				Labels:             template.Labels,
-				Ephemeral:          in.ephemeral,
+				Ephemeral:          ephemeral,
 				NoHistory:          in.noHistory,
+				StorageClass:       storageClass,
 				MolType:            in.molType,
 				CreatedBy:          in.createdBy,
 				Owner:              in.owner,

--- a/cmd/bd/storage_class_embedded_test.go
+++ b/cmd/bd/storage_class_embedded_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,6 +40,28 @@ func TestEmbeddedCreateStorageClass(t *testing.T) {
 			t.Fatalf("query storage_class: %v", err)
 		}
 		return got
+	}
+
+	// The batch doors mint their own ids, so the DB assertions look rows up by
+	// the title the markdown file gave them. An absent row is "" rather than a
+	// failure: which PLANE a row landed on is the thing under test.
+	issueIDByTitle := func(t *testing.T, beadsDir, prefix, table, title string) string {
+		t.Helper()
+		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), filepath.Join(beadsDir, "embeddeddolt"), prefix, "main")
+		if err != nil {
+			t.Fatalf("OpenSQL: %v", err)
+		}
+		defer cleanup()
+		var id string
+		//nolint:gosec // G202: table is a test-local literal, never caller input
+		err = db.QueryRowContext(t.Context(), "SELECT id FROM "+table+" WHERE title = ?", title).Scan(&id)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ""
+		}
+		if err != nil {
+			t.Fatalf("query %s by title: %v", table, err)
+		}
+		return id
 	}
 
 	t.Run("explicit_unversioned", func(t *testing.T) {
@@ -183,6 +206,118 @@ func TestEmbeddedCreateStorageClass(t *testing.T) {
 		}
 		if cell.Valid && cell.String == string(types.StorageClassUnversioned) {
 			t.Errorf("config-derived unversioned leaked to the no-history wisp row: %q", cell.String)
+		}
+	})
+
+	// `bd create --file` used to accept --storage-class and the per-type config
+	// default and honor neither. buildMarkdownBatchRequest is the ONE projection
+	// both transports use, so these subtests cover the direct half of that fix
+	// and TestStorageClassProxiedServer covers the other.
+	t.Run("markdown_batch", func(t *testing.T) {
+		batch := `## Batch one
+
+### Description
+First.
+
+## Batch two
+
+### Description
+Second.
+`
+		t.Run("explicit_unversioned_on_every_row", func(t *testing.T) {
+			dir, beadsDir, _ := bdInit(t, bd, "--prefix", "sm")
+			plan := writeMarkdownPlan(t, dir, "batch.md", batch)
+			if out, err := bdRunWithFlockRetry(t, bd, dir, "create", "--file", plan, "--storage-class", "unversioned"); err != nil {
+				t.Fatalf("create --file: %v\n%s", err, out)
+			}
+			for _, title := range []string{"Batch one", "Batch two"} {
+				id := issueIDByTitle(t, beadsDir, "sm", "issues", title)
+				if cell := storageClassCell(t, beadsDir, "sm", id); !cell.Valid || cell.String != "unversioned" {
+					t.Errorf("%s (%s): DB cell = %+v, want 'unversioned'", title, id, cell)
+				}
+			}
+		})
+
+		// The per-type default resolves per TEMPLATE, because that is where the
+		// type lives — a file-wide resolution would key on nothing.
+		t.Run("per_type_config_default", func(t *testing.T) {
+			dir, beadsDir, _ := bdInit(t, bd, "--prefix", "sn")
+			if out, err := bdRunWithFlockRetry(t, bd, dir, "config", "set", "storage-class.task", "unversioned"); err != nil {
+				t.Fatalf("config set: %v\n%s", err, out)
+			}
+			// Templates default to type task; the bug template must be untouched.
+			plan := writeMarkdownPlan(t, dir, "batch.md", batch+`
+## Batch bug
+
+### Type
+bug
+
+### Description
+Third.
+`)
+			if out, err := bdRunWithFlockRetry(t, bd, dir, "create", "--file", plan); err != nil {
+				t.Fatalf("create --file: %v\n%s", err, out)
+			}
+			for _, title := range []string{"Batch one", "Batch two"} {
+				id := issueIDByTitle(t, beadsDir, "sn", "issues", title)
+				if cell := storageClassCell(t, beadsDir, "sn", id); !cell.Valid || cell.String != "unversioned" {
+					t.Errorf("%s (%s): DB cell = %+v, want the storage-class.task default", title, id, cell)
+				}
+			}
+			bugID := issueIDByTitle(t, beadsDir, "sn", "issues", "Batch bug")
+			if cell := storageClassCell(t, beadsDir, "sn", bugID); cell.Valid {
+				t.Errorf("Batch bug (%s): DB cell = %q, want NULL (the task default must not spill)", bugID, cell.String)
+			}
+		})
+
+		// C1.4 through the batch door: the spelled-out class moves every row to
+		// the wisp plane, exactly as --ephemeral does.
+		t.Run("ephemeral_spelling_routes_to_wisp_plane", func(t *testing.T) {
+			dir, beadsDir, _ := bdInit(t, bd, "--prefix", "sp")
+			plan := writeMarkdownPlan(t, dir, "batch.md", batch)
+			if out, err := bdRunWithFlockRetry(t, bd, dir, "create", "--file", plan, "--storage-class", "ephemeral"); err != nil {
+				t.Fatalf("create --file: %v\n%s", err, out)
+			}
+			for _, title := range []string{"Batch one", "Batch two"} {
+				id := issueIDByTitle(t, beadsDir, "sp", "wisps", title)
+				if id == "" {
+					t.Errorf("%s should live in wisps", title)
+				}
+			}
+		})
+
+		t.Run("durable_class_with_ephemeral_is_rejected", func(t *testing.T) {
+			dir, beadsDir, _ := bdInit(t, bd, "--prefix", "sq")
+			plan := writeMarkdownPlan(t, dir, "batch.md", batch)
+			out, err := bdRunWithFlockRetry(t, bd, dir, "create", "--file", plan, "--ephemeral", "--storage-class", "versioned")
+			if err == nil {
+				t.Fatalf("durable class with --ephemeral should be refused, got:\n%s", out)
+			}
+			if !strings.Contains(string(out), "conflicts with --ephemeral/--no-history") {
+				t.Errorf("expected the wisp-plane conflict error, got:\n%s", out)
+			}
+			// The whole file is refused before the transaction opens.
+			if id := issueIDByTitle(t, beadsDir, "sq", "issues", "Batch one"); id != "" {
+				t.Errorf("a refused --file left %s behind", id)
+			}
+		})
+	})
+
+	// A plan-wide --storage-class has no meaning next to the per-node
+	// storage_class field that already works, so --graph refuses it the way it
+	// refuses --mol-type rather than accepting and ignoring it.
+	t.Run("graph_rejects_plan_wide_storage_class", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "sh")
+		planPath := filepath.Join(dir, "plan.json")
+		if err := os.WriteFile(planPath, []byte(`{"nodes":[{"key":"a","title":"Graph node","description":"n"}]}`), 0o600); err != nil {
+			t.Fatalf("write graph plan: %v", err)
+		}
+		out, err := bdRunWithFlockRetry(t, bd, dir, "create", "--graph", planPath, "--storage-class", "unversioned")
+		if err == nil {
+			t.Fatalf("--graph with a plan-wide --storage-class should be refused, got:\n%s", out)
+		}
+		if !strings.Contains(string(out), "set storage_class per node in the plan instead") {
+			t.Errorf("error should point at the per-node field, got:\n%s", out)
 		}
 	})
 

--- a/cmd/bd/storage_class_proxied_integration_test.go
+++ b/cmd/bd/storage_class_proxied_integration_test.go
@@ -1,0 +1,341 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// The proxied-server mirror of TestEmbeddedCreateStorageClass. This is the
+// transport the field report was filed against and the one Enterprise builds
+// run: every `--storage-class` value was accepted and dropped, so an
+// `ephemeral` request minted a DURABLE row and the durable-class-on-wisp-plane
+// conflict the direct door rejects was silently collapsed.
+//
+// Every assertion reads the raw cell out of the server's own tables, because
+// the JSON the command prints is the request's own struct on some routes and
+// would agree with itself either way.
+//
+// CI note: this shard is gated on BEADS_TEST_PROXIED_SERVER=1 and runs mostly
+// only on push-to-main, so it is meant to be run locally alongside any change
+// to the create input path.
+func TestStorageClassProxiedServer(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	// storageClassCell pins the at-rest form (NULL vs literal) on whichever
+	// plane the row was supposed to land on.
+	storageClassCell := func(t *testing.T, db *sql.DB, table, id string) sql.NullString {
+		t.Helper()
+		var got sql.NullString
+		//nolint:gosec // G202: table is a test-local literal, never caller input
+		if err := db.QueryRowContext(context.Background(), "SELECT storage_class FROM "+table+" WHERE id = ?", id).Scan(&got); err != nil {
+			t.Fatalf("query %s.storage_class for %s: %v", table, id, err)
+		}
+		return got
+	}
+
+	// Batch doors mint their own ids, so their rows are found by title. An
+	// absent row is "" rather than a failure: the PLANE is what is under test.
+	idByTitle := func(t *testing.T, db *sql.DB, table, title string) string {
+		t.Helper()
+		var id string
+		//nolint:gosec // G202: table is a test-local literal, never caller input
+		err := db.QueryRowContext(context.Background(), "SELECT id FROM "+table+" WHERE title = ?", title).Scan(&id)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ""
+		}
+		if err != nil {
+			t.Fatalf("query %s by title %q: %v", table, title, err)
+		}
+		return id
+	}
+
+	setStorageClassConfig := func(t *testing.T, p proxiedProject, key, value string) {
+		t.Helper()
+		if out, err := bdProxiedRun(t, bd, p.dir, "config", "set", key, value); err != nil {
+			t.Fatalf("config set %s: %v\n%s", key, err, out)
+		}
+	}
+
+	// THE FIELD REPORT: `--storage-class unversioned` on this door left the cell
+	// NULL, so the class could never be read back — and `bd update` has no
+	// storage-class surface, which makes a create-time drop unrepairable.
+	t.Run("explicit_unversioned_persists", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pu")
+		issue := bdProxiedCreate(t, bd, p.dir, "Unversioned bead", "-d", "x", "--storage-class", "unversioned")
+		if issue.StorageClass != types.StorageClassUnversioned {
+			t.Errorf("JSON storage_class = %q, want unversioned", issue.StorageClass)
+		}
+		db := openProxiedDB(t, p)
+		if cell := storageClassCell(t, db, "issues", issue.ID); !cell.Valid || cell.String != "unversioned" {
+			t.Errorf("DB cell = %+v, want 'unversioned'", cell)
+		}
+	})
+
+	t.Run("default_and_explicit_versioned_stay_null", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pv")
+		db := openProxiedDB(t, p)
+
+		plain := bdProxiedCreate(t, bd, p.dir, "Plain bead", "-d", "x")
+		if cell := storageClassCell(t, db, "issues", plain.ID); cell.Valid {
+			t.Errorf("plain create: DB cell = %q, want NULL", cell.String)
+		}
+		// C2.4: the explicit versioned spelling normalizes to the same NULL, so
+		// a NULL cell here is correct rather than the bug.
+		explicit := bdProxiedCreate(t, bd, p.dir, "Versioned bead", "-d", "x", "--storage-class", "versioned")
+		if cell := storageClassCell(t, db, "issues", explicit.ID); cell.Valid {
+			t.Errorf("explicit versioned: DB cell = %q, want NULL", cell.String)
+		}
+	})
+
+	// WORSE THAN A NO-OP before the fix: this minted a durable versioned row for
+	// a request that asked for ephemeral.
+	t.Run("ephemeral_spelling_routes_to_wisp_plane", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pe")
+		issue := bdProxiedCreate(t, bd, p.dir, "Ephemeral bead", "-d", "x", "--storage-class", "ephemeral")
+		if !issue.Ephemeral {
+			t.Errorf("--storage-class ephemeral should set the ephemeral flag")
+		}
+		db := openProxiedDB(t, p)
+		var count int
+		if err := db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM issues WHERE id = ?", issue.ID).Scan(&count); err != nil {
+			t.Fatalf("query issues: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("an ephemeral request minted a DURABLE row %s", issue.ID)
+		}
+		var ephemeral int
+		if err := db.QueryRowContext(context.Background(), "SELECT ephemeral FROM wisps WHERE id = ?", issue.ID).Scan(&ephemeral); err != nil {
+			t.Fatalf("query wisps: %v", err)
+		}
+		if ephemeral != 1 {
+			t.Errorf("wisps.ephemeral = %d, want 1", ephemeral)
+		}
+		if cell := storageClassCell(t, db, "wisps", issue.ID); cell.Valid {
+			t.Errorf("wisp row cell = %q, want NULL (wisp-plane rows derive their class)", cell.String)
+		}
+	})
+
+	// Finding A of #5164, unfixed on this route until now: the direct door
+	// rejects the contradiction, this one silently made the row a wisp.
+	t.Run("durable_class_with_wisp_plane_is_rejected", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pf")
+		db := openProxiedDB(t, p)
+		for _, planeFlag := range []string{"--ephemeral", "--no-history"} {
+			out := bdProxiedCreateFail(t, bd, p.dir, "Conflicting "+planeFlag, "-d", "x", planeFlag, "--storage-class", "versioned")
+			// Byte-identical to the direct door's message.
+			if !strings.Contains(out, "conflicts with --ephemeral/--no-history") {
+				t.Errorf("%s: expected the wisp-plane conflict error, got:\n%s", planeFlag, out)
+			}
+			if id := idByTitle(t, db, "wisps", "Conflicting "+planeFlag); id != "" {
+				t.Errorf("%s: a refused create left wisp %s behind", planeFlag, id)
+			}
+			if id := idByTitle(t, db, "issues", "Conflicting "+planeFlag); id != "" {
+				t.Errorf("%s: a refused create left issue %s behind", planeFlag, id)
+			}
+		}
+		out := bdProxiedCreateFail(t, bd, p.dir, "Doubly ephemeral", "-d", "x", "--no-history", "--storage-class", "ephemeral")
+		if !strings.Contains(out, "--storage-class ephemeral and --no-history are mutually exclusive") {
+			t.Errorf("expected the ephemeral/no-history exclusion, got:\n%s", out)
+		}
+	})
+
+	// Release-audit finding #48: the per-type default was resolved only by the
+	// direct door, so the same config.yaml produced different rows depending on
+	// which transport the workspace was initialized with.
+	t.Run("per_type_config_default", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pc")
+		setStorageClassConfig(t, p, "storage-class.task", "unversioned")
+		db := openProxiedDB(t, p)
+
+		byDefault := bdProxiedCreate(t, bd, p.dir, "Defaulted bead", "-d", "x", "-t", "task")
+		if cell := storageClassCell(t, db, "issues", byDefault.ID); !cell.Valid || cell.String != "unversioned" {
+			t.Errorf("config default: DB cell = %+v, want 'unversioned'", cell)
+		}
+		// Flag over config (C1.3), and versioned normalizes back to NULL.
+		forced := bdProxiedCreate(t, bd, p.dir, "Forced versioned", "-d", "x", "-t", "task", "--storage-class", "versioned")
+		if cell := storageClassCell(t, db, "issues", forced.ID); cell.Valid {
+			t.Errorf("explicit versioned over config default: DB cell = %q, want NULL", cell.String)
+		}
+		// Other types are untouched by the task default.
+		bug := bdProxiedCreate(t, bd, p.dir, "A bug", "-d", "x", "-t", "bug")
+		if cell := storageClassCell(t, db, "issues", bug.ID); cell.Valid {
+			t.Errorf("other type: DB cell = %q, want NULL", cell.String)
+		}
+		// A config-derived durable class is not a caller contradiction, so it
+		// YIELDS to the explicit plane instead of blocking the create.
+		yielded := bdProxiedCreate(t, bd, p.dir, "Ephemeral over config", "-d", "x", "-t", "task", "--ephemeral")
+		if !yielded.Ephemeral {
+			t.Errorf("--ephemeral over config default should set the ephemeral flag")
+		}
+		if cell := storageClassCell(t, db, "wisps", yielded.ID); cell.Valid {
+			t.Errorf("config-derived unversioned leaked to the wisp row: %q", cell.String)
+		}
+	})
+
+	// buildMarkdownBatchRequest is ONE projection shared by both transports, so
+	// this is the proxied half of the same fix the embedded suite covers.
+	t.Run("markdown_batch", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pm")
+		db := openProxiedDB(t, p)
+		writeBatch := func(t *testing.T, name, body string) string {
+			t.Helper()
+			path := filepath.Join(p.dir, name)
+			if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+				t.Fatalf("write markdown plan: %v", err)
+			}
+			return path
+		}
+
+		unversioned := writeBatch(t, "unversioned.md", `## Proxied batch one
+
+### Description
+First.
+
+## Proxied batch two
+
+### Description
+Second.
+`)
+		if out, err := bdProxiedRun(t, bd, p.dir, "create", "--file", unversioned, "--storage-class", "unversioned"); err != nil {
+			t.Fatalf("create --file: %v\n%s", err, out)
+		}
+		for _, title := range []string{"Proxied batch one", "Proxied batch two"} {
+			id := idByTitle(t, db, "issues", title)
+			if id == "" {
+				t.Fatalf("%s was not created", title)
+			}
+			if cell := storageClassCell(t, db, "issues", id); !cell.Valid || cell.String != "unversioned" {
+				t.Errorf("%s (%s): DB cell = %+v, want 'unversioned'", title, id, cell)
+			}
+		}
+
+		ephemeral := writeBatch(t, "ephemeral.md", `## Proxied batch wisp
+
+### Description
+Third.
+`)
+		if out, err := bdProxiedRun(t, bd, p.dir, "create", "--file", ephemeral, "--storage-class", "ephemeral"); err != nil {
+			t.Fatalf("create --file --storage-class ephemeral: %v\n%s", err, out)
+		}
+		if id := idByTitle(t, db, "wisps", "Proxied batch wisp"); id == "" {
+			t.Error("--file --storage-class ephemeral should land its rows in wisps")
+		}
+
+		conflicting := writeBatch(t, "conflict.md", `## Proxied batch refused
+
+### Description
+Fourth.
+`)
+		out, err := bdProxiedRun(t, bd, p.dir, "create", "--file", conflicting, "--ephemeral", "--storage-class", "versioned")
+		if err == nil {
+			t.Fatalf("durable class with --ephemeral should be refused, got:\n%s", out)
+		}
+		if !strings.Contains(string(out), "conflicts with --ephemeral/--no-history") {
+			t.Errorf("expected the wisp-plane conflict error, got:\n%s", out)
+		}
+		if id := idByTitle(t, db, "issues", "Proxied batch refused"); id != "" {
+			t.Errorf("a refused --file left %s behind", id)
+		}
+	})
+
+	t.Run("markdown_batch_per_type_config_default", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pb")
+		setStorageClassConfig(t, p, "storage-class.task", "unversioned")
+		db := openProxiedDB(t, p)
+
+		path := filepath.Join(p.dir, "defaults.md")
+		if err := os.WriteFile(path, []byte(`## Proxied default task
+
+### Description
+Task body.
+
+## Proxied default bug
+
+### Type
+bug
+
+### Description
+Bug body.
+`), 0o600); err != nil {
+			t.Fatalf("write markdown plan: %v", err)
+		}
+		if out, err := bdProxiedRun(t, bd, p.dir, "create", "--file", path); err != nil {
+			t.Fatalf("create --file: %v\n%s", err, out)
+		}
+		taskID := idByTitle(t, db, "issues", "Proxied default task")
+		if cell := storageClassCell(t, db, "issues", taskID); !cell.Valid || cell.String != "unversioned" {
+			t.Errorf("task template: DB cell = %+v, want the storage-class.task default", cell)
+		}
+		bugID := idByTitle(t, db, "issues", "Proxied default bug")
+		if cell := storageClassCell(t, db, "issues", bugID); cell.Valid {
+			t.Errorf("bug template: DB cell = %q, want NULL (the task default must not spill)", cell.String)
+		}
+	})
+
+	t.Run("graph_rejects_plan_wide_storage_class", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pg")
+		path := filepath.Join(p.dir, "plan.json")
+		if err := os.WriteFile(path, []byte(`{"nodes":[{"key":"a","title":"Proxied graph node","description":"n"}]}`), 0o600); err != nil {
+			t.Fatalf("write graph plan: %v", err)
+		}
+		out := bdProxiedCreateFail(t, bd, p.dir, "--graph", path, "--storage-class", "unversioned")
+		if !strings.Contains(out, "set storage_class per node in the plan instead") {
+			t.Errorf("error should point at the per-node field, got:\n%s", out)
+		}
+		// The per-node field is the mechanism that works, on this transport too.
+		perNode := filepath.Join(p.dir, "per-node.json")
+		if err := os.WriteFile(perNode, []byte(`{"nodes":[{"key":"a","title":"Proxied per-node","description":"n","storage_class":"unversioned"}]}`), 0o600); err != nil {
+			t.Fatalf("write graph plan: %v", err)
+		}
+		if out, err := bdProxiedRun(t, bd, p.dir, "create", "--graph", perNode); err != nil {
+			t.Fatalf("create --graph with a per-node class: %v\n%s", err, out)
+		}
+		db := openProxiedDB(t, p)
+		id := idByTitle(t, db, "issues", "Proxied per-node")
+		if cell := storageClassCell(t, db, "issues", id); !cell.Valid || cell.String != "unversioned" {
+			t.Errorf("per-node class: DB cell = %+v, want 'unversioned'", cell)
+		}
+	})
+
+	// The dry-run preview builds the same issue the real create does, so it
+	// inherits the fix — and a preview that showed a class the create would not
+	// write would be worse than none.
+	t.Run("dry_run_preview_shows_the_resolved_class", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pd")
+		setStorageClassConfig(t, p, "storage-class.bug", "unversioned")
+
+		preview := bdProxiedCreate(t, bd, p.dir, "Previewed bead", "-d", "x", "--dry-run", "--storage-class", "unversioned")
+		if preview.StorageClass != types.StorageClassUnversioned {
+			t.Errorf("dry-run preview storage_class = %q, want unversioned", preview.StorageClass)
+		}
+		fromConfig := bdProxiedCreate(t, bd, p.dir, "Previewed default", "-d", "x", "-t", "bug", "--dry-run")
+		if fromConfig.StorageClass != types.StorageClassUnversioned {
+			t.Errorf("dry-run preview of the config default = %q, want unversioned", fromConfig.StorageClass)
+		}
+		wisp := bdProxiedCreate(t, bd, p.dir, "Previewed wisp", "-d", "x", "--dry-run", "--storage-class", "ephemeral")
+		if !wisp.Ephemeral || wisp.StorageClass != "" {
+			t.Errorf("dry-run preview of the ephemeral spelling: ephemeral=%v class=%q", wisp.Ephemeral, wisp.StorageClass)
+		}
+	})
+}

--- a/cmd/bd/storage_class_pure_test.go
+++ b/cmd/bd/storage_class_pure_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -95,5 +96,159 @@ func TestReconcileStorageClassPlane(t *testing.T) {
 					tt.class, tt.explicit, tt.wispPlane, gotClass, gotConf, tt.wantClass, tt.wantConf)
 			}
 		})
+	}
+}
+
+// resolveCreateStorageClass is the ONE create-time decision every CLI door
+// makes, so its table is the contract the direct, proxied and --file routes all
+// answer from. Each case names the class the caller asked for, the plane flags
+// it asked for, and what the record must end up as.
+func TestResolveCreateStorageClass(t *testing.T) {
+	tests := []struct {
+		name      string
+		flag      string
+		issueType types.IssueType
+		wisp      bool
+		noHistory bool
+		wantClass types.StorageClass
+		wantWisp  bool
+		wantErr   string
+	}{
+		{name: "no flag is unset", issueType: types.TypeTask},
+		{name: "explicit unversioned persists", flag: "unversioned", issueType: types.TypeTask, wantClass: types.StorageClassUnversioned},
+		// C2.4: versioned is the default and serializes as the unset marker, so
+		// the durable row carries no cell.
+		{name: "explicit versioned normalizes to unset", flag: "versioned", issueType: types.TypeTask},
+		// C1.4: the spelled-out ephemeral class IS --ephemeral, and a wisp-plane
+		// row derives its class (C1.2) rather than carrying a marker.
+		{name: "explicit ephemeral routes to the wisp plane", flag: "ephemeral", issueType: types.TypeTask, wantWisp: true},
+		{name: "ephemeral flag alone leaves the class unset", issueType: types.TypeTask, wisp: true, wantWisp: true},
+		{name: "no-history alone leaves the class unset", issueType: types.TypeTask, noHistory: true},
+		// An explicit durable class on a wisp plane is a contradiction the caller
+		// spelled out, so it is refused rather than silently collapsed.
+		{name: "explicit versioned with --ephemeral conflicts", flag: "versioned", issueType: types.TypeTask, wisp: true, wantWisp: true, wantErr: "conflicts with --ephemeral/--no-history"},
+		{name: "explicit unversioned with --ephemeral conflicts", flag: "unversioned", issueType: types.TypeTask, wisp: true, wantWisp: true, wantErr: "conflicts with --ephemeral/--no-history"},
+		{name: "explicit unversioned with --no-history conflicts", flag: "unversioned", issueType: types.TypeTask, noHistory: true, wantErr: "conflicts with --ephemeral/--no-history"},
+		{name: "explicit ephemeral with --no-history conflicts", flag: "ephemeral", issueType: types.TypeTask, noHistory: true, wantErr: "--storage-class ephemeral and --no-history are mutually exclusive"},
+		{name: "unparseable flag is a usage error", flag: "permanent", issueType: types.TypeTask, wantErr: "versioned, unversioned, or ephemeral"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotClass, gotWisp, err := resolveCreateStorageClass(tt.flag, tt.issueType, tt.wisp, tt.noHistory)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("resolveCreateStorageClass(%q, wisp=%v, noHistory=%v) error = %v, want one containing %q",
+						tt.flag, tt.wisp, tt.noHistory, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveCreateStorageClass(%q, wisp=%v, noHistory=%v): %v", tt.flag, tt.wisp, tt.noHistory, err)
+			}
+			if gotClass != tt.wantClass || gotWisp != tt.wantWisp {
+				t.Errorf("resolveCreateStorageClass(%q, wisp=%v, noHistory=%v) = (%q, %v), want (%q, %v)",
+					tt.flag, tt.wisp, tt.noHistory, gotClass, gotWisp, tt.wantClass, tt.wantWisp)
+			}
+		})
+	}
+}
+
+// The per-type storage-class.<type> default is the half of the contract the
+// proxied and --file doors used to skip entirely, and it is keyed on the
+// NORMALIZED type, so an alias must find the canonical key.
+func TestResolveCreateStorageClassConfigDefault(t *testing.T) {
+	initConfigForTest(t)
+	config.Set("storage-class.task", "unversioned")
+	config.Set("storage-class.feature", "unversioned")
+
+	class, wisp, err := resolveCreateStorageClass("", types.TypeTask, false, false)
+	if err != nil || class != types.StorageClassUnversioned || wisp {
+		t.Errorf("config default: got (%q, %v, %v), want (unversioned, false, nil)", class, wisp, err)
+	}
+	// Aliases normalize before the lookup, so --type feat finds
+	// storage-class.feature (the only spelling `bd config set` accepts).
+	class, _, err = resolveCreateStorageClass("", types.IssueType("feat"), false, false)
+	if err != nil || class != types.StorageClassUnversioned {
+		t.Errorf("alias type: got (%q, %v), want unversioned", class, err)
+	}
+	// Another type is untouched.
+	class, _, err = resolveCreateStorageClass("", types.TypeBug, false, false)
+	if err != nil || class != "" {
+		t.Errorf("unconfigured type: got (%q, %v), want unset", class, err)
+	}
+	// Flag over config (C1.3).
+	class, _, err = resolveCreateStorageClass("versioned", types.TypeTask, false, false)
+	if err != nil || class != "" {
+		t.Errorf("explicit versioned over config default: got (%q, %v), want unset", class, err)
+	}
+	// A config-derived durable class is not a caller contradiction, so it YIELDS
+	// to the explicit plane rather than blocking the create.
+	class, wisp, err = resolveCreateStorageClass("", types.TypeTask, true, false)
+	if err != nil || class != "" || !wisp {
+		t.Errorf("config default under --ephemeral: got (%q, %v, %v), want ('', true, nil)", class, wisp, err)
+	}
+}
+
+// The proxied single create's whole bug was that the class never reached
+// createInput, so the two links in that chain get their own pins.
+func TestGatherCreateInputCarriesStorageClass(t *testing.T) {
+	initConfigForTest(t)
+
+	in, err := gatherCreateInput(newCreateFlagsCommand(t, "--storage-class", "unversioned"), []string{"Unversioned"})
+	if err != nil {
+		t.Fatalf("gatherCreateInput: %v", err)
+	}
+	if in.storageClass != types.StorageClassUnversioned || in.storageClassFlag != "unversioned" || in.ephemeral {
+		t.Errorf("unversioned: storageClass=%q flag=%q ephemeral=%v", in.storageClass, in.storageClassFlag, in.ephemeral)
+	}
+	if issue := buildCreateIssueFromInput(in); issue.StorageClass != types.StorageClassUnversioned {
+		t.Errorf("buildCreateIssueFromInput dropped the class: got %q", issue.StorageClass)
+	}
+
+	// C1.4 on the proxied door: the spelled-out class flips the input to the
+	// wisp plane, which is what routes the create away from the durable table.
+	in, err = gatherCreateInput(newCreateFlagsCommand(t, "--storage-class", "ephemeral"), []string{"Ephemeral"})
+	if err != nil {
+		t.Fatalf("gatherCreateInput ephemeral: %v", err)
+	}
+	if !in.ephemeral || in.storageClass != "" {
+		t.Errorf("ephemeral spelling: ephemeral=%v storageClass=%q, want true/unset", in.ephemeral, in.storageClass)
+	}
+	if issue := buildCreateIssueFromInput(in); !issue.Ephemeral || issue.StorageClass != "" {
+		t.Errorf("buildCreateIssueFromInput: ephemeral=%v class=%q", issue.Ephemeral, issue.StorageClass)
+	}
+
+	if _, err := gatherCreateInput(newCreateFlagsCommand(t, "--ephemeral", "--storage-class", "versioned"), []string{"Conflict"}); err == nil {
+		t.Error("--ephemeral with an explicit durable class should be refused before any transaction")
+	}
+
+	// --file keeps the RAW flag for per-template resolution and resolves nothing
+	// here: the per-type default needs a type, and only a template has one.
+	in, err = gatherCreateInput(newCreateFlagsCommand(t, "--file", "plan.md", "--storage-class", "unversioned"), nil)
+	if err != nil {
+		t.Fatalf("gatherCreateInput --file: %v", err)
+	}
+	if in.storageClassFlag != "unversioned" || in.storageClass != "" {
+		t.Errorf("--file: flag=%q resolved=%q, want the raw flag and no premature resolution", in.storageClassFlag, in.storageClass)
+	}
+}
+
+// --graph refuses a plan-wide --storage-class the way it already refuses
+// --mol-type: the per-node storage_class field (plus its per-type config
+// default) is the mechanism that works, and a second plan-wide one would only
+// raise precedence questions. Both transports route through this check.
+// (HandleError writes the text to stderr and returns a bare exit code, so the
+// wording is pinned by the subprocess suites that capture it.)
+func TestRejectSingleIssueFlagsForGraphRefusesStorageClass(t *testing.T) {
+	if err := rejectSingleIssueFlagsForGraph(newCreateFlagsCommand(t, "--graph", "plan.json", "--storage-class", "unversioned")); err == nil {
+		t.Fatal("--graph with a plan-wide --storage-class should be refused")
+	}
+	if err := rejectSingleIssueFlagsForGraph(newCreateFlagsCommand(t, "--graph", "plan.json")); err != nil {
+		t.Errorf("--graph without the flag should pass: %v", err)
+	}
+	// --file still HONORS the flag, so it must not be caught by the graph
+	// rejection's shared single-issue list.
+	if err := rejectSingleIssueFlagsForMarkdown(newCreateFlagsCommand(t, "--file", "plan.md", "--storage-class", "unversioned")); err != nil {
+		t.Errorf("--file with --storage-class should be accepted: %v", err)
 	}
 }

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -1456,6 +1456,13 @@ paths:
         `await_id`.
 
 
+        The per-type `storage-class.<type>` keys in `config.yaml` are CLI-door
+        policy that `bd create` resolves before it calls the role, so they do not
+        reach any create on this surface — this operation, `issues:batchCreate`
+        and `issues:batchApply` all mint the unset (versioned) class no matter
+        what those keys say on the server's machine.
+
+
         `comments` and an inline `dependencies` list on the issue itself — the
         role refuses both, because edges belong to the request's own
         `dependencies` member where their direction can be stated.


### PR DESCRIPTION
Field report 5: `bd create --storage-class` is accepted and ignored.

Investigated at `71377f276` (release/1.3.0 tip). The direct/embedded CLI door was already fixed in-window by #5149 and #5164 — but the value dies at the **CLI-input layer** on every other route, so the reported no-op still reproduced verbatim on the transport the report was filed against.

## Verdict

| route | before | after |
|---|---|---|
| embedded single create | **correct** (fixed in-window by #5149 / #5164) | unchanged (pure refactor) |
| **proxied single create** | `--storage-class` accepted, `storage_class` NULL — **the field report, verbatim** | class persisted |
| proxied `--storage-class ephemeral` | mints a **DURABLE versioned row** for a request that asked for ephemeral | routes to `wisps`, `ephemeral=1` |
| proxied `--ephemeral --storage-class versioned` | conflict **silently collapsed** into a wisp (Finding A of #5164, unfixed on this route) | rejected, same message as the direct door |
| proxied `storage-class.<type>` config default | skipped (release-audit unverified finding #48) | honored |
| `--file` markdown batch, **both** transports | flag and config default accepted-and-ignored | honored per template |
| `--graph` plan-wide `--storage-class`, both transports | accepted-and-ignored | **rejected**, pointing at the per-node field |
| HTTP `POST /v0/beads/issues`, `issues:batchCreate`, `issues:batchApply` | honest — `storage_class` is not a create member and unknown members are refused by name (400) | **wire unchanged**; one spec sentence documents the config-default divergence |

`bd update` has no storage-class surface, so a class dropped at create time cannot be repaired afterwards — which is what raised the severity of the silent drop.

Version forensics, since the report named 1.1.0: `--storage-class` does not exist in any v1.1.x tag (the feature commit `b0c2286bf` is contained in v1.2.0/v1.2.1 only; v1.2.2 is the recovery re-tag of the v1.1.2 tree). A stock 1.1.0 binary would have said "unknown flag", so the reporting build was almost certainly running **proxied-server mode**, where the symptom still reproduced bit-for-bit at HEAD.

## Drop points

All routes converge on `buildCreateIssue` → `types.Issue.StorageClass` → `issueops/helpers.go:154`. The storage layer was fine; the value died before reaching it.

| # | drop point | what was lost |
|---|---|---|
| 1 | `cmd/bd/create_input.go` — `createInput` had no storage-class member and `gatherCreateInput` never read the flag | the class itself |
| 2 | `cmd/bd/create_proxied_server.go:213` — `buildCreateIssueFromInput` built `createIssueParams` without `StorageClass`, and the route never called `resolveStorageClass`/`reconcileStorageClassPlane` | persistence, the ephemeral→wisp translation, the plane-conflict rejection, and the config default |
| 3 | `cmd/bd/markdown.go` `buildMarkdownBatchRequest` — set `Ephemeral`/`NoHistory`/`MolType` per item but no `StorageClass`, and resolved no config default | `--file` on both transports |
| 4 | `cmd/bd/create_input.go` `rejectSingleIssueFlagsForGraph` — no `storage-class` arm, so the flag passed the `--graph` rejection and was then ignored | plan-wide `--graph` flag |

## The fix

One resolver; every CLI door goes through it; the door that can't honor the flag rejects it loudly.

1. **`resolveCreateStorageClass` extracted** from `create.go`'s RunE (parse → per-type config fallback → ephemeral spelling routes to the wisp plane → `--no-history` exclusivity → plane reconciliation). The direct route now calls it: pure refactor, identical behavior and error strings, with the existing embedded suite as the regression net.
2. **`createInput` carries the resolved class** (plus the raw flag, for the batch doors' per-item type resolution) and may flip `ephemeral`, so the proxied single create gets persistence, `ephemeral`→wisp routing, the conflict rejection and the config default in one wire-up. The dry-run preview inherits it for free.
3. **`buildMarkdownBatchRequest` resolves per template.** One shared projection, so `--file` is fixed on both transports at once: the plan-wide flag applies to every item, the per-type default keys on each template's own type, `ephemeral` moves that item to the wisp plane, and a conflict refuses the whole file before any transaction opens.
4. **`--graph` refuses a plan-wide `--storage-class`**, exactly the shape `--mol-type` already has ("set `storage_class` per node in the plan instead"). Wiring it as a plan-wide default would duplicate the per-node + config mechanism that already works on both transports and invite precedence questions.
5. **No HTTP wire change.** The deliberate exclusion of caller-set `storage_class` is a ratified surface and stays. Audit #48 is closed honestly with one prose sentence in `openapi.v0.yaml`: the per-type config defaults are CLI-door policy, and role-backed creates mint the unset (versioned) class.

### Follow-up (main, not this branch): role-level config defaults

Server-side resolution of `storage-class.<type>` is **not safe to bolt on today**. After C2.4 normalization, an explicit `--storage-class versioned` arrives at the role indistinguishable from "unset", so a role-side default would silently override an explicit user choice. The follow-up has to first decide where `""` stops meaning both things — e.g. stop normalizing at the doors and let `helpers.go:154`'s existing `Normalize()`-on-persist be the single normalization point. Doing it in 1.3.0 would also change the ratified `issueops.Lifecycle.Create` contract and every HTTP door's observable behavior, which belongs in the canonical-API governance flow rather than a release-branch bug fix.

## Repro, before and after

Same script, same 10 commands, two binaries; assertions read the raw cells out of the server's own tables.

```sh
bd init --proxied-server --quiet --prefix px --non-interactive --skip-agents --skip-hooks
bd create unv        -d x --storage-class unversioned
bd create eph        -d x --storage-class ephemeral
bd create ver        -d x --storage-class versioned
bd create conflict   -d x --ephemeral --storage-class versioned
bd create --file batchU.md --storage-class unversioned     # 2 templates
bd create --file batchE.md --storage-class ephemeral       # 1 template
bd create --graph plan.json --storage-class unversioned    # 1 node
bd config set storage-class.task unversioned
bd create cfg-single -d x -t task
bd create --file batchC.md                                 # config default only
bd create cfg-yields -d x -t task --ephemeral              # default must yield
bd sql "SELECT id, title, IFNULL(storage_class,'NULL'), ephemeral FROM issues"
bd sql "SELECT id, title, IFNULL(storage_class,'NULL'), ephemeral FROM wisps"
```

**BEFORE** (`71377f276`) — every command accepted, every class dropped:

```
create --storage-class unversioned                   -> accepted
create --storage-class ephemeral                     -> accepted
create --storage-class versioned                     -> accepted
create --ephemeral --storage-class versioned         -> accepted
create --file batchU.md --storage-class unversioned  -> accepted
create --file batchE.md --storage-class ephemeral    -> accepted
create --graph plan.json --storage-class unversioned -> accepted
create -t task            (config default)           -> accepted
create --file batchC.md   (config default)           -> accepted
create -t task --ephemeral (default must yield)      -> accepted

-- issues (durable plane) --
id     | title          | storage_class | ephemeral
-------+----------------+---------------+----------
px-idv | cfg-single     | NULL          | 0
px-ga4 | eph            | NULL          | 0          <- ephemeral request, DURABLE row
px-hmc | file-cfg       | NULL          | 0
px-yjh | file-eph       | NULL          | 0          <- ephemeral request, DURABLE row
px-270 | file-unv-1     | NULL          | 0
px-0n6 | file-unv-2     | NULL          | 0
px-xp4 | graph-planwide | NULL          | 0
px-1u6 | unv            | NULL          | 0          <- THE FIELD REPORT
px-14f | ver            | NULL          | 0
(9 rows)

-- wisps (ephemeral plane) --
px-wisp-3bd | cfg-yields | NULL | 1
px-wisp-uty | conflict   | NULL | 1                  <- conflict silently collapsed
(2 rows)
```

**AFTER** (this branch):

```
create --storage-class unversioned                   -> accepted
create --storage-class ephemeral                     -> accepted
create --storage-class versioned                     -> accepted
create --ephemeral --storage-class versioned         -> REJECTED: Error: --storage-class versioned conflicts with
                                                        --ephemeral/--no-history: wisp-plane records are storage class ephemeral
create --file batchU.md --storage-class unversioned  -> accepted
create --file batchE.md --storage-class ephemeral    -> accepted
create --graph plan.json --storage-class unversioned -> REJECTED: Error: --storage-class is not valid with --graph
                                                        (set storage_class per node in the plan instead)
create -t task            (config default)           -> accepted
create --file batchC.md   (config default)           -> accepted
create -t task --ephemeral (default must yield)      -> accepted

-- issues (durable plane) --
id     | title      | storage_class | ephemeral
-------+------------+---------------+----------
px-gw2 | cfg-single | unversioned   | 0          <- config default honored
px-2jg | file-cfg   | unversioned   | 0          <- config default honored on --file
px-iqz | file-unv-1 | unversioned   | 0
px-m2q | file-unv-2 | unversioned   | 0
px-g4a | unv        | unversioned   | 0          <- the field report, fixed
px-6ol | ver        | NULL          | 0          <- correct by design (C2.4)
(6 rows)

-- wisps (ephemeral plane) --
px-wisp-ais | cfg-yields | NULL | 1              <- config default yields to the explicit plane
px-wisp-kvo | eph        | NULL | 1              <- ephemeral request, wisp row
px-wisp-d88 | file-eph   | NULL | 1
(3 rows)
```

Note `versioned` → NULL is **correct by design**, not a residual bug: `versioned` is the default and serializes as the unset marker (`types.StorageClass.Normalize`, C2.4); `EffectiveStorageClass()` resolves NULL → versioned, wisp-plane → ephemeral. Only `unversioned`/`ephemeral` were being dropped.

## Test plan

Every invariant is asserted **at the DB**, per class value, per path — the JSON alone agrees with itself on the routes that echo the request struct.

- `unversioned` → `storage_class = 'unversioned'`, `ephemeral = 0`
- `versioned` / no flag → cell NULL, `ephemeral = 0`
- `ephemeral` → row in `wisps`, `ephemeral = 1`, cell NULL
- durable class + `--ephemeral`/`--no-history` → rejected, nothing written on either plane

**New:** `cmd/bd/storage_class_proxied_integration_test.go` (`BEADS_TEST_PROXIED_SERVER=1`, `newSharedProxiedProject` harness) — 9 subtests covering the four invariants plus the config default, its yield to an explicit plane, `--file` on all four outcomes, `--file` + per-type default, the `--graph` rejection alongside the per-node field that works, and the dry-run preview showing the resolved class.

**Extended:** `storage_class_embedded_test.go` (four `--file` subtests + the `--graph` rejection); `storage_class_pure_test.go` (`resolveCreateStorageClass` table across three classes × plane flags × both conflict arms, the alias-normalized config key, and pins on `gatherCreateInput` → `buildCreateIssueFromInput` carrying the class).

Results — all local, `CGO_ENABLED=1 -tags=gms_pure_go`:

| suite | result |
|---|---|
| `BEADS_TEST_PROXIED_SERVER=1 go test ./cmd/bd -run StorageClassProxiedServer` | **PASS** 9/9, 47.3s |
| `BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd -run TestEmbeddedCreateStorageClass` | **PASS** 14/14, 97.3s |
| `./scripts/test.sh ./cmd/bd` (full package) | **PASS**, 371.3s |
| `go test ./internal/httpapi/...` | **PASS** |
| `go build ./... && go vet ./...` | clean |
| `golangci-lint` (pre-commit, all three commits) | 0 issues |

The proxied shard is gated and mostly runs only on push-to-main, so **it was run locally** — its green above is not something PR CI will re-prove.

## Proposed CHANGELOG line

Not added here (no `CHANGELOG.md` edit in this PR):

> `fix(create): --storage-class is honored on the proxied-server and --file routes and rejected as a plan-wide --graph flag; it was silently ignored there`

## Not in scope

No schema change, no storage-layer change, no `bd update` surface, no HTTP wire change, no `CHANGELOG.md` edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
