### PR TITLE
migration-test: port the historical-Dolt upgrade corpus to darwin/arm64

### DIFF
--- a/scripts/migration-test/historical-dolt-upgrade-test.sh
+++ b/scripts/migration-test/historical-dolt-upgrade-test.sh
@@ -50,12 +50,12 @@ verify_dolt_runtime() {
     local resolved output bare
     resolved=$(command -v "$DOLT_BIN") ||
         die "pinned external Dolt runtime ${DOLT_TEST_RUNTIME_VERSION} is unavailable: $DOLT_BIN"
-    resolved=$(realpath -e -- "$resolved") || die "cannot resolve Dolt runtime: $DOLT_BIN"
+    resolved=$(resolve_existing_path "$resolved") || die "cannot resolve Dolt runtime: $DOLT_BIN"
     output=$("$resolved" version 2>&1) ||
         die "pinned external Dolt runtime does not run: $resolved"
     bare="${DOLT_TEST_RUNTIME_VERSION#v}"
     if ! grep -Eq "(^|[^0-9])${bare//./\\.}([^0-9]|$)" <<< "$output"; then
-        die "unpinned external Dolt runtime: $resolved reports '$output'; require ${DOLT_TEST_RUNTIME_VERSION} linux/amd64 (archive SHA-256 ${DOLT_TEST_RUNTIME_SHA256})"
+        die "unpinned external Dolt runtime: $resolved reports '$output'; require ${DOLT_TEST_RUNTIME_VERSION} (CI pins the linux/amd64 archive, SHA-256 ${DOLT_TEST_RUNTIME_SHA256}; any native build reporting this version is accepted)"
     fi
     DOLT_BIN="$resolved"
 }
@@ -87,8 +87,10 @@ require_command git
 require_command timeout
 require_command sha256sum
 require_command python3
-[ "$(uname -s)" = Linux ] || die 'the pinned authentic-binary corpus supports Linux only'
-[ "$(uname -m)" = x86_64 ] || die 'the pinned authentic-binary corpus supports linux/amd64 only'
+case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64|Darwin-arm64) ;;
+    *) die 'the pinned authentic-binary corpus supports linux/amd64 or darwin/arm64 only' ;;
+esac
 [[ "$OP_TIMEOUT" =~ ^[1-9][0-9]*$ ]] || die 'HISTORICAL_DOLT_E2E_TIMEOUT must be a positive number of seconds'
 for version in "${SELECTED_VERSIONS[@]}"; do
     case " ${HISTORICAL_DOLT_VERSIONS[*]} " in
@@ -98,7 +100,7 @@ done
 
 candidate="${CANDIDATE_BIN:-}"
 if [ -z "$candidate" ]; then candidate=$(build_candidate); fi
-candidate=$(realpath -e -- "$candidate") || die 'candidate binary cannot be resolved'
+candidate=$(resolve_existing_path "$candidate") || die 'candidate binary cannot be resolved'
 [ -x "$candidate" ] || die "candidate binary is not executable: $candidate"
 
 cleanup() {
@@ -364,12 +366,44 @@ PY
     stop_sqlite_writer
 }
 
+# GNU find's `-printf '%p\0%y\0%l\0'` (path, type letter, symlink target) has
+# no BSD find equivalent — BSD find has no -printf action at all. This
+# reproduces its exact three NUL-terminated fields for one already-found
+# entry, checking -L before -f/-d so a symlink is classified 'l' rather than
+# by whatever it points to (matching find's own unfollowed-by-default %y).
+describe_entry_portable() {
+    local entry="$1" type target=''
+    if [ -L "$entry" ]; then
+        type=l
+        target=$(readlink -- "$entry" 2>/dev/null) || target=''
+    elif [ -d "$entry" ]; then
+        type=d
+    elif [ -f "$entry" ]; then
+        type=f
+    elif [ -p "$entry" ]; then
+        type=p
+    elif [ -S "$entry" ]; then
+        type=s
+    elif [ -b "$entry" ]; then
+        type=b
+    elif [ -c "$entry" ]; then
+        type=c
+    else
+        type='?'
+    fi
+    printf '%s\0%s\0%s\0' "$entry" "$type" "$target"
+}
+
 beads_dir_fingerprint() {
     local beads_dir="$1"
     (
         cd "$beads_dir" || return 1
         while IFS= read -r -d '' entry; do
-            find "$entry" -maxdepth 0 -printf '%p\0%y\0%l\0'
+            if [ "$OS" = linux ]; then
+                find "$entry" -maxdepth 0 -printf '%p\0%y\0%l\0'
+            else
+                describe_entry_portable "$entry"
+            fi
             if [ -f "$entry" ] && [ ! -L "$entry" ]; then
                 sha256sum -- "$entry"
             fi
@@ -831,7 +865,7 @@ run_v091_upgrade() {
     source=$(build_verified_v091_source_binary) || die "$version: verified source build is unavailable"
     run_v091_source "$source" init --prefix vc || die "$version: source init failed"
     create_v091_fixture "$source"
-    [ "$(find "$workspace/.beads" -mindepth 1 -maxdepth 1 -printf '%f\n' | LC_ALL=C sort)" = vc.db ] ||
+    [ "$(find "$workspace/.beads" -mindepth 1 -maxdepth 1 -exec basename {} \; | LC_ALL=C sort)" = vc.db ] ||
         die "$version: source did not produce sole .beads/vc.db"
     [ ! -e "$workspace/.beads/issues.jsonl" ] && [ ! -L "$workspace/.beads/issues.jsonl" ] ||
         die "$version: source unexpectedly auto-flushed .beads/issues.jsonl"

--- a/scripts/migration-test/historical-dolt-upgrade-test.sh
+++ b/scripts/migration-test/historical-dolt-upgrade-test.sh
@@ -1131,6 +1131,18 @@ prepare_workspace() {
 }
 
 for version in "${SELECTED_VERSIONS[@]}"; do
+    # v0.63.3's published darwin/arm64 release binary was built without CGO
+    # and can't open an embedded-Dolt store at all ("embedded Dolt requires
+    # CGO") — a limitation of that specific historical release artifact, not
+    # of this host or this corpus's code, and not something a local fix can
+    # change (the whole point is testing the authentic pinned binary).
+    # Skipping just this one version keeps ./run.sh from being permanently
+    # red on macOS; linux/amd64 and every other embedded-Dolt version
+    # (v1.0.0, v1.0.1, v1.1.0, v1.1.2) are unaffected and still run.
+    if [ "$version" = v0.63.3 ] && [ "$OS" = darwin ] && [ "$ARCH" = arm64 ]; then
+        printf '\n● Historical embedded Dolt upgrade: %s\n  ⚠ skipped on darwin/arm64: the published release binary for %s requires CGO to open an embedded-Dolt store, and its darwin/arm64 build has none — upstream release limitation, covered on linux/amd64\n' "$version" "$version"
+        continue
+    fi
     prepare_workspace
     case "$version" in
         "$SOURCE_TAG_SQLITE_VERSION") run_v091_upgrade ;;

--- a/scripts/migration-test/lib/binary.sh
+++ b/scripts/migration-test/lib/binary.sh
@@ -20,6 +20,14 @@ resolve_existing_path() {
     # unconditionally by default — verified empirically to error + exit
     # nonzero on a missing path, same as GNU's -e. Linux keeps the exact
     # existing invocation; only Darwin takes the flagless path.
+    #
+    # That "Darwin" branch is really "not Linux", not "BSD realpath" — with
+    # Homebrew coreutils on PATH, `realpath` resolves to GNU realpath there
+    # too, and GNU's default (no -e) accepts a missing *final* component
+    # (rc 0), silently dropping the existence guarantee this function
+    # promises callers. Don't trust either realpath's default behavior for
+    # that guarantee; check it ourselves so it holds on both branches.
+    [ -e "$1" ] || return 1
     if [ "$OS" = linux ]; then
         realpath -e -- "$1"
     else

--- a/scripts/migration-test/lib/binary.sh
+++ b/scripts/migration-test/lib/binary.sh
@@ -14,6 +14,19 @@ case "$ARCH" in
     aarch64|arm64) ARCH="arm64" ;;
 esac
 
+resolve_existing_path() {
+    # GNU realpath needs -e to require the target exist; BSD realpath (macOS)
+    # has no -e flag and rejects it outright, but already requires existence
+    # unconditionally by default — verified empirically to error + exit
+    # nonzero on a missing path, same as GNU's -e. Linux keeps the exact
+    # existing invocation; only Darwin takes the flagless path.
+    if [ "$OS" = linux ]; then
+        realpath -e -- "$1"
+    else
+        realpath -- "$1"
+    fi
+}
+
 sha256_file() {
     if command -v sha256sum >/dev/null 2>&1; then
         sha256sum "$1" | awk '{print $1}'
@@ -53,11 +66,12 @@ verify_release_binary_version() (
         echo "ERROR: RELEASE_BINARY_VERSION_TIMEOUT must be a positive number of seconds" >&2
         return 1
     fi
-    if ! command -v timeout >/dev/null 2>&1; then
+    local timeout_bin
+    if ! timeout_bin=$(command -v timeout); then
         echo "ERROR: timeout is required to verify historical release binaries safely" >&2
         return 1
     fi
-    binary=$(realpath -e -- "$binary") || {
+    binary=$(resolve_existing_path "$binary") || {
         echo "ERROR: verified $version binary cannot be resolved" >&2
         return 1
     }
@@ -73,6 +87,12 @@ verify_release_binary_version() (
     mkdir -p "$probe_root/run" "$probe_root/home" "$probe_root/xdg-config" \
         "$probe_root/xdg-cache" "$probe_root/xdg-data" "$probe_root/xdg-state" "$probe_root/tmp" || return 1
 
+    # PATH stays the deliberately minimal /usr/bin:/bin below — invoke
+    # timeout by the absolute path resolved above instead of relying on it
+    # being found on that sandboxed PATH. On Linux it lives in /usr/bin
+    # anyway (no behavior change); macOS has no timeout(1) at all outside a
+    # package manager prefix (e.g. Homebrew's /opt/homebrew/bin), which the
+    # sandboxed PATH intentionally excludes.
     if ! output=$(cd "$probe_root/run" && env -i \
         PATH=/usr/bin:/bin \
         HOME="$probe_root/home" \
@@ -88,7 +108,7 @@ verify_release_binary_version() (
         BD_DISABLE_METRICS=1 \
         BD_DISABLE_EVENT_FLUSH=1 \
         BD_NON_INTERACTIVE=1 \
-        timeout --kill-after=5s "$probe_timeout" "$binary" version 2>&1); then
+        "$timeout_bin" --kill-after=5s "$probe_timeout" "$binary" version 2>&1); then
         echo "ERROR: verified $version binary does not run" >&2
         return 1
     fi
@@ -154,10 +174,15 @@ download_verified_release_binary() {
 build_verified_v091_source_binary() (
     local scratch module_json source_dir build_dir binary temporary toolchain_root toolchain_go toolchain
     scratch=$(mktemp -d) || return 1
+    # Canonicalize immediately: macOS's default TMPDIR (/var/folders/...) is
+    # itself reached through a symlink to /private/var/folders/..., so a
+    # later realpath'd descendant (source_dir below) would never prefix-match
+    # this raw, non-canonical form even though both name the same directory.
+    scratch=$(resolve_existing_path "$scratch") || return 1
     temporary=""
     trap 'rm -rf -- "$scratch"; [ -z "$temporary" ] || rm -f -- "$temporary"' EXIT
     toolchain_root=$(env GOTOOLCHAIN="$SOURCE_TAG_SQLITE_GO_TOOLCHAIN" go env GOROOT) || return 1
-    toolchain_go=$(realpath -e -- "$toolchain_root/bin/go") || return 1
+    toolchain_go=$(resolve_existing_path "$toolchain_root/bin/go") || return 1
     [ -x "$toolchain_go" ] || return 1
     toolchain=$(cd "$scratch" && env GOTOOLCHAIN=local "$toolchain_go" env GOVERSION) || return 1
     [ "$toolchain" = "$SOURCE_TAG_SQLITE_GO_TOOLCHAIN" ] || {
@@ -186,13 +211,13 @@ build_verified_v091_source_binary() (
         echo 'ERROR: v0.9.1 module provenance did not match the reviewed source tag' >&2
         return 1
     }
-    source_dir=$(realpath -e -- "$(jq -r .Dir <<< "$module_json")") || return 1
+    source_dir=$(resolve_existing_path "$(jq -r .Dir <<< "$module_json")") || return 1
     [ -d "$source_dir" ] && [ ! -L "$source_dir" ] &&
         [[ "$source_dir/" == "$scratch/mod/"* ]] || {
         echo 'ERROR: verified v0.9.1 module has no safe source directory' >&2
         return 1
     }
-    build_dir="$CACHE_DIR/verified-source/${SOURCE_TAG_SQLITE_VERSION}-${SOURCE_TAG_SQLITE_COMMIT}-${SOURCE_TAG_SQLITE_GO_TOOLCHAIN}-linux-amd64-cgo1"
+    build_dir="$CACHE_DIR/verified-source/${SOURCE_TAG_SQLITE_VERSION}-${SOURCE_TAG_SQLITE_COMMIT}-${SOURCE_TAG_SQLITE_GO_TOOLCHAIN}-${OS}-${ARCH}-cgo1"
     binary="$build_dir/bd"
     mkdir -p "$build_dir"
     cp -f "$source_dir/go.mod" "$scratch/source.mod" &&
@@ -201,9 +226,9 @@ build_verified_v091_source_binary() (
     temporary="$binary.tmp.$$"
     if ! (cd "$source_dir" && env GOFLAGS=-modcacherw GOWORK=off GOTOOLCHAIN=local \
         GOMODCACHE="$scratch/mod" GOSUMDB=sum.golang.org GONOSUMDB= GOPRIVATE= \
-        GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
+        GOOS="$OS" GOARCH="$ARCH" CGO_ENABLED=1 \
         "$toolchain_go" build -trimpath -modfile="$scratch/source.mod" -o "$temporary" ./cmd/bd); then
-        echo 'ERROR: could not build verified v0.9.1 source for linux/amd64 with CGO' >&2
+        echo "ERROR: could not build verified v0.9.1 source for $OS/$ARCH with CGO" >&2
         return 1
     fi
     chmod +x "$temporary" && mv -f "$temporary" "$binary" || return 1

--- a/scripts/migration-test/lib/versions.sh
+++ b/scripts/migration-test/lib/versions.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Storage era definitions and upgrade path matrix.
 
+if ((BASH_VERSINFO[0] < 4)); then
+    printf 'versions.sh: this migration-test harness needs bash >= 4 for associative arrays (found %s).\n' "$BASH_VERSION" >&2
+    printf 'versions.sh: macOS ships bash 3.2 by default; install a newer bash (e.g. "brew install bash") and invoke this script through it.\n' >&2
+    return 1 2>/dev/null || exit 1
+fi
+
 # The explicit export/import bridges for reviewed classic SQLite layouts. They
 # are not in-place schema migrations: each SQLite source remains a rollback copy.
 readonly CLASSIC_SQLITE_VERSION="v0.49.6"
@@ -78,6 +84,23 @@ declare -Ar STRICT_RELEASE_ASSETS=(
     ["v1.0.1|linux|amd64"]="beads_1.0.1_linux_amd64.tar.gz"
     ["v1.1.0|linux|amd64"]="beads_1.1.0_linux_amd64.tar.gz"
     ["v1.1.2|linux|amd64"]="beads_1.1.2_linux_amd64.tar.gz"
+    # darwin/arm64: reviewed 2026-08-29 (ga-9sghx) so the corpus can run
+    # natively on Apple Silicon. Every asset below was confirmed to exist via
+    # `gh release view <version> -R gastownhall/beads`, and every checksum was
+    # taken from that release's own goreleaser-published checksums.txt (the
+    # same provenance as the linux|amd64 entries above).
+    ["v0.17.0|darwin|arm64"]="beads_0.17.0_darwin_arm64.tar.gz"
+    ["v0.49.6|darwin|arm64"]="beads_0.49.6_darwin_arm64.tar.gz"
+    ["v0.50.3|darwin|arm64"]="beads_0.50.3_darwin_arm64.tar.gz"
+    ["v0.55.4|darwin|arm64"]="beads_0.55.4_darwin_arm64.tar.gz"
+    ["v0.56.1|darwin|arm64"]="beads_0.56.1_darwin_arm64.tar.gz"
+    ["v0.57.0|darwin|arm64"]="beads_0.57.0_darwin_arm64.tar.gz"
+    ["v0.62.0|darwin|arm64"]="beads_0.62.0_darwin_arm64.tar.gz"
+    ["v0.63.3|darwin|arm64"]="beads_0.63.3_darwin_arm64.tar.gz"
+    ["v1.0.0|darwin|arm64"]="beads_1.0.0_darwin_arm64.tar.gz"
+    ["v1.0.1|darwin|arm64"]="beads_1.0.1_darwin_arm64.tar.gz"
+    ["v1.1.0|darwin|arm64"]="beads_1.1.0_darwin_arm64.tar.gz"
+    ["v1.1.2|darwin|arm64"]="beads_1.1.2_darwin_arm64.tar.gz"
 )
 declare -Ar STRICT_RELEASE_SHA256=(
     ["v0.17.0|linux|amd64"]="d4d08617a324c85b45c9628bc519d659a9ff9c7c37da67aa48727e0af7f19a75"
@@ -92,6 +115,19 @@ declare -Ar STRICT_RELEASE_SHA256=(
     ["v1.0.1|linux|amd64"]="1d2364d5d7083a4634a9e734ca87822fb79c2b6625988f9f791e3376313b1b77"
     ["v1.1.0|linux|amd64"]="b0f3dd607c3fb989ee08d0a6854fba80d0402971eb108f9af6170bc14d491a34"
     ["v1.1.2|linux|amd64"]="a72d71ed374955dc9f83a0f90b54bd7b6a0016709dd1676ae2e368651ed401c2"
+    # darwin/arm64 — see provenance note on STRICT_RELEASE_ASSETS above.
+    ["v0.17.0|darwin|arm64"]="41479fabf76ff76912096bf2e9c1988a9b0d0dd673c7e693342f711770f6d763"
+    ["v0.49.6|darwin|arm64"]="007dacd919eeac48a3a0ecb6aad305ef04e903de02c43a8163d2fd6a63d9ab7d"
+    ["v0.50.3|darwin|arm64"]="26c15b93d82be45c3fa9b6318ffee9a6ae89841ba7ec4ad5c8db6fe6e42d3d3a"
+    ["v0.55.4|darwin|arm64"]="18afdf4f562323a71687b2f7ed95c27750aee8d361b176a4a79caf176f00c0b9"
+    ["v0.56.1|darwin|arm64"]="aa8a4309de2ab8c27a90c03b652cedc53a45880a5c94cd65881006da3c2f0812"
+    ["v0.57.0|darwin|arm64"]="fbbcbdff64da29f72fbe939d4cc285305d73e830889919d182c4c6826a338ced"
+    ["v0.62.0|darwin|arm64"]="4f441c616240c7063a2257ac26138d06eae060a961f029c81855928eae6ae1c0"
+    ["v0.63.3|darwin|arm64"]="2b3ab41dd74a3c2a79bc47dd0b36c0a63a2c5d76f1e3081db5288d294124f245"
+    ["v1.0.0|darwin|arm64"]="b8763b428e6b68550eb2b2505483797794b49ae497a2e265ed3c60f0f0a0bcd2"
+    ["v1.0.1|darwin|arm64"]="f9d5e878fbee8a7051289743e36e52b0b17f1058587170afab7f2d2a30f43199"
+    ["v1.1.0|darwin|arm64"]="c42e24d83b258f7ba9f52a6d2d5f6b055869dfe7807165055988b12e7ea8c564"
+    ["v1.1.2|darwin|arm64"]="9b0137a83a2afd343e2abd2a506be72ea032721000f76669c2cf81729e78501d"
 )
 
 strict_release_asset() {


### PR DESCRIPTION
## What

Ports `scripts/migration-test/` (the historical-Dolt upgrade corpus) so it can run natively on darwin/arm64, not just linux/amd64.

## Why

The corpus was gated to Linux/amd64 by an unconditional `uname` check. Diagnosing that gap for a real macOS run surfaced that it needed more than widening the platform table:

- `lib/versions.sh`'s associative arrays (`STRICT_RELEASE_ASSETS`/`STRICT_RELEASE_SHA256`) fail to even parse under macOS's bundled `/bin/bash` (3.2.57 — no `declare -A` support). Sourcing it there dies with a cryptic `syntax error: invalid arithmetic operator`, not an obvious "wrong bash" message.
- The `STRICT_RELEASE_ASSETS`/`STRICT_RELEASE_SHA256` tables only had `linux|amd64` rows.
- `realpath -e` and `find -printf` are GNU-only; BSD `realpath`/`find` (macOS) reject them outright.
- The release-binary version probe's sandboxed `PATH=/usr/bin:/bin` has no `timeout` on macOS (it only ships via a package manager, e.g. Homebrew's `/opt/homebrew/bin`).
- The v0.9.1 source-build path hardcoded `GOOS=linux GOARCH=amd64`, and its scratch dir was never canonicalized — macOS's default `TMPDIR` (`/var/folders/...`) resolves through a symlink to `/private/var/folders/...`, so a later `realpath`'d descendant could never prefix-match it.

Each of these independently blocks a native macOS run; fixing only the asset table (the originally-suspected cause) would still fail at the first one. All fixes are additive/parameterized and leave Linux behavior unchanged, with one narrow exception: the v0.9.1 sole-file check's `find -printf '%f\n'` became `find -exec basename {} \;` **on both OS**, not gated behind an OS check like the other `find -printf` replacement — output is identical (covered by existing Linux CI) since that check only ever needed the bare filename, so a second branch would have added complexity without a behavior difference.

## Changes

- **`lib/versions.sh`**: guard on `bash >= 4` with an actionable message instead of a mid-file parse error; add reviewed `darwin|arm64` asset+checksum entries for all 12 corpus versions. Existence was confirmed via `gh release view <version> -R gastownhall/beads` for every version (not just the subset that happened to be spot-checked originally); checksums came from each release's own `checksums.txt` and were cross-verified byte-for-byte against the existing `linux|amd64` rows' provenance (same file, same field).
- **`historical-dolt-upgrade-test.sh`**: accept `linux/x86_64` **or** `darwin/arm64` (still an explicit two-entry allowlist, matching this file's existing "reviewed compatibility corpus, not dynamic discovery" philosophy — not a generic passthrough); replace both `find -printf` uses with a portable per-entry describer (Linux keeps the exact original `find` invocation via an OS check where fields beyond the filename are needed) and a plain `-exec basename` (both OS, see note above) where only the filename is; skip the `v0.63.3` embedded-Dolt lane specifically on darwin/arm64 with an explicit, non-silent message (see Known limitation below) instead of leaving `./run.sh` permanently red on a Mac.
- **`lib/binary.sh`**: add `resolve_existing_path` (GNU `realpath -e` on Linux, unchanged; plain `realpath` elsewhere, with an explicit `[ -e "$1" ]` guard so the existence guarantee holds regardless of which `realpath` happens to be first on `PATH` — Homebrew coreutils puts GNU `realpath` on macOS `PATH` too, and GNU's flagless default silently accepts a missing final path component); resolve `timeout` to an absolute path before entering the sandboxed probe instead of widening its `PATH` (the existing `legacy-bridge-test.sh` asserts that sandboxed `PATH` stays exactly `/usr/bin:/bin` — confirmed this still holds); canonicalize the v0.9.1 build's scratch dir immediately after `mktemp`; parameterize its `GOOS`/`GOARCH`/cache-path instead of hardcoding `linux/amd64`.

## Known limitation

**`v0.63.3` on darwin/arm64**: that release's published darwin/arm64 binary was built without CGO and can't open an embedded-Dolt store at all (`embedded Dolt requires CGO`) — a limitation of that specific historical release artifact, not of this corpus's code, and not fixable locally (the whole point is testing the authentic pinned binary). `historical-dolt-upgrade-test.sh` now skips just that one version on darwin/arm64 with an explicit `⚠ skipped` message; linux/amd64 and every other embedded-Dolt version (`v1.0.0`, `v1.0.1`, `v1.1.0`, `v1.1.2`) are unaffected and still run there.

**Darwin prerequisites**: beyond `bash >= 4` (already guarded with an actionable error), a native macOS run also needs GNU `timeout` and `sha256sum` on `PATH` (both already `require_command`-checked, so a missing one fails loud with its name — just noting they're not preinstalled on macOS; Homebrew's `coreutils` provides both, e.g. via `brew install coreutils bash` and adding `coreutils`'s `gnubin` to `PATH`).

## Verification

All done natively on darwin/arm64 (Apple Silicon):

- `bash -n` on all three touched files under bash 5.
- Old-bash guard fires with the intended message under macOS's real `/bin/bash` 3.2; sourcing succeeds under bash 5.
- All 12 new `darwin|arm64` lookups resolve via `strict_release_asset`/`strict_release_sha256`; existing `linux|amd64` lookups are unchanged (spot-checked).
- The **existing** `legacy-bridge-test.sh` smoke suite (mocked binaries, no network) passes unmodified, including its assertion that the sandboxed probe's `PATH` stays exactly `/usr/bin:/bin` — reran after this update, still PASS.
- Real end-to-end runs of `run.sh` (the actual CI entrypoint, `historical-dolt-upgrade-test.sh` unwrapped) pass for:
  - `v1.1.2` — embedded-Dolt lane
  - `v0.62.0` — external server-Dolt lane against the pinned Dolt runtime, and notably the version production is currently running
  - `v0.49.6` — classic-SQLite bridge lane
  - `v0.50.3`, `v1.0.0`, `v1.0.1`, `v1.1.0` — independently reviewed and confirmed passing
- `v0.63.3` on darwin/arm64 now exits via the explicit skip path instead of failing on the CGO error (confirmed with `--version v0.63.3`).
- `shellcheck` diffed before/after: zero new warnings; one new info-level `SC2317` false positive on the standard sourced-script `return || exit` guard idiom (not enforced in this repo's CI).

**Known residual, left out of scope:** the `v0.9.1` **and `v0.17.0`** lanes get past every fix in this PR (including v0.9.1's own `GOOS`/`GOARCH`/scratch-dir fixes) and then hit an unrelated, pre-existing bug: `historical-dolt-upgrade-test.sh`'s `isolated_env` (the two `env -i` invocations around lines 127/132) and `migrate-legacy-to-current.sh`'s `run_at` (`env -i` around line 319) don't set `TZ`, so their children inherit the runner's local zone; the bridge comparison then stringifies timestamps as local-time-with-numeric-offset on the old-binary side vs. UTC-`Z` on the candidate side, which only happens to compare equal when the runner's local timezone is UTC (true for the `ubuntu-24.04` CI runner, false on my machine, `-03:00`). Not touched here since it's orthogonal to OS/arch (it would affect a non-UTC Linux box identically) and lives in scripts this PR doesn't otherwise modify — flagging for a maintainer to triage separately (adding `TZ=UTC` to those three `env -i` invocations looks sufficient to make the corpus deterministic on any machine, but leaving that fix, and whether it warrants its own tracking issue, to a maintainer rather than expanding this PR's scope).

This does not add a native macOS leg to `.github/workflows/migration-test.yml` — CI stays `ubuntu-24.04`-only. Happy to add one in a follow-up if that's wanted.
