### PR TITLE
test(cmd): fix jsonOutput global leak breaking noticeSharedMigrateRefusal subtests in full-package runs

### DIFF
--- a/cmd/bd/conflicts_conclude_integration_test.go
+++ b/cmd/bd/conflicts_conclude_integration_test.go
@@ -138,13 +138,18 @@ func runConcludeCommand(t *testing.T, commandStore storage.DoltStorage, asJSON b
 	defer func() { os.Stdout, os.Stderr = oldStdout, oldStderr }()
 	store, rootCtx, jsonOutput = commandStore, context.Background(), asJSON
 	conflictsConclude = true
+	// Deferred, like the stdio restore above it: RunE below can panic or
+	// t.Fatal, and a plain statement after the call would then leave jsonOutput
+	// set to asJSON — which callers pass as true — for the rest of the package.
+	defer func() {
+		store, rootCtx, jsonOutput = oldStore, oldRootCtx, oldJSON
+		conflictsConclude = oldConclude
+	}()
 
 	commandErr := conflictsResolveCmd.RunE(conflictsResolveCmd, nil)
 
 	_ = wOut.Close()
 	_ = wErr.Close()
-	store, rootCtx, jsonOutput = oldStore, oldRootCtx, oldJSON
-	conflictsConclude = oldConclude
 
 	var stdout, stderr bytes.Buffer
 	_, _ = stdout.ReadFrom(rOut)

--- a/cmd/bd/notion_test.go
+++ b/cmd/bd/notion_test.go
@@ -160,7 +160,7 @@ func TestGetNotionConfigPrefersStoreOverEnv(t *testing.T) {
 
 func TestRunNotionStatusJSONWithMissingConfig(t *testing.T) {
 	saveAndRestoreGlobals(t)
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	store = nil
 	dbPath = ""
 	t.Setenv("NOTION_TOKEN", "")
@@ -383,7 +383,7 @@ func TestRunNotionStatusUsesHTTPClient(t *testing.T) {
 	newNotionStatusClient = func(token string) *notion.Client {
 		return notion.NewClient(token).WithBaseURL(server.URL)
 	}
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	store = nil
 	dbPath = ""
 	t.Setenv("NOTION_TOKEN", "env-token")

--- a/cmd/bd/shared_migrate_consent_test.go
+++ b/cmd/bd/shared_migrate_consent_test.go
@@ -65,6 +65,14 @@ func TestIsSchemaMigrateVerbScope(t *testing.T) {
 // returns one error type for several decisions whose correct actions differ,
 // and the migrate verb does not unlock the remote-backed ones at all.
 func TestNoticeSharedMigrateRefusalPerDecision(t *testing.T) {
+	// The notice self-suppresses under --json, so if jsonOutput arrives here
+	// already true, every case below reads as "the notice printed nothing" —
+	// which is exactly how a leak from an earlier test in the package
+	// presents, and is how this test failed in full-package runs while passing
+	// under a narrow -run. Pin it, so a failure here can only ever be about
+	// this code.
+	pinJSONOutput(t, false)
+
 	for _, tt := range []struct {
 		decision string
 		want     string
@@ -100,9 +108,7 @@ func TestNoticeSharedMigrateRefusalPerDecision(t *testing.T) {
 	// --json puts a machine-readable gate block on this same stream a moment
 	// later; prose prepended to it makes the documented contract unparseable.
 	t.Run("suppressed in json mode", func(t *testing.T) {
-		orig := jsonOutput
-		jsonOutput = true
-		defer func() { jsonOutput = orig }()
+		pinJSONOutput(t, true)
 		out := captureNoticeStderr(t, func() {
 			noticeSharedMigrateRefusal(&schema.RemoteMigrateGateError{
 				CurrentVersion: 65, LatestVersion: 66, Pending: 1,

--- a/cmd/bd/version_test.go
+++ b/cmd/bd/version_test.go
@@ -51,7 +51,7 @@ func TestVersionCommand(t *testing.T) {
 			t.Fatalf("Failed to create pipe: %v", err)
 		}
 		os.Stdout = w
-		jsonOutput = true
+		pinJSONOutput(t, true)
 
 		// Run version command
 		if err := versionCmd.RunE(versionCmd, []string{}); err != nil {
@@ -83,8 +83,6 @@ func TestVersionCommand(t *testing.T) {
 		}
 	})
 
-	// Restore default
-	jsonOutput = false
 }
 
 func TestResolveCommitHash(t *testing.T) {
@@ -158,7 +156,7 @@ func TestVersionOutputWithCommitAndBranch(t *testing.T) {
 			t.Fatalf("Failed to create pipe: %v", err)
 		}
 		os.Stdout = w
-		jsonOutput = false
+		pinJSONOutput(t, false)
 
 		if err := versionCmd.RunE(versionCmd, []string{}); err != nil {
 			t.Fatalf("versionCmd.RunE: %v", err)
@@ -187,7 +185,7 @@ func TestVersionOutputWithCommitAndBranch(t *testing.T) {
 			t.Fatalf("Failed to create pipe: %v", err)
 		}
 		os.Stdout = w
-		jsonOutput = true
+		pinJSONOutput(t, true)
 
 		if err := versionCmd.RunE(versionCmd, []string{}); err != nil {
 			t.Fatalf("versionCmd.RunE: %v", err)


### PR DESCRIPTION
Pre-tag RC hygiene. `TestNoticeSharedMigrateRefusalPerDecision` (added by #6048) is red on `release/1.3.0` itself in any full `cmd/bd` package run, while passing under a narrow `-run`. Two more tests were failing for the same reason.

## Diagnosis

The test covers `noticeSharedMigrateRefusal`, the one-shot version-bump notice, which **self-suppresses under `--json`** so it cannot corrupt the gate's JSON block on the same stream. Every one of the six failing subtests observed an *empty* notice — so the failure was never about the notice logic. The `jsonOutput` package global was already `true` when the test started, left behind by an earlier test in the binary.

Three tests set `jsonOutput` and never put it back:

| Test | File |
|---|---|
| `TestRunNotionStatusJSONWithMissingConfig` | `notion_test.go` |
| `TestRunNotionStatusUsesHTTPClient` | `notion_test.go` |
| `TestVersionOutputWithCommitAndBranch` | `version_test.go` |

Two of them do call `saveAndRestoreGlobals(t)` — which does **not** cover `jsonOutput`, despite that helper's doc comment promising callers "All globals saved atomically (can't forget one)". The notion tests are the ones that reach `TestNoticeSharedMigrateRefusalPerDecision`, since Go runs a package's tests in file order and `notion_test.go` sorts before `shared_migrate_consent_test.go`. `version_test.go` sorts after, so its leak lands on whatever runs later.

This is the same class as the `commandDidWriteTipMetadata` leak #6043 caught.

## Fix

Both sides, as asked.

**The leakers** now use `pinJSONOutput(t, …)` — the helper this package *already has* for exactly this, in `ready_input_test.go:126`. Its doc comment had diagnosed this bug class before it bit:

> `jsonOutput` is not per-test state: several cmd/bd tests set it and never restore it (`saveAndRestoreGlobals`, which a number of them use, does not cover it), so a test that reads it instead of setting it passes under a narrow `-run` and fails in a full-package run depending on what ran first.

**The victim** pins the global itself (`pinJSONOutput(t, false)`) at the top of the test, so a future leak cannot silently turn it green-when-narrow and red-when-full again. Verified independently: with the leaker still leaking, the pin alone makes the test pass.

Two adjacent instances of the same defect, fixed while here:

- `TestVersionCommand` "restored" by assigning the literal `false` rather than the saved value — correct only by coincidence of the default.
- `runConcludeCommand` (`conflicts_conclude_integration_test.go`) restored `store, rootCtx, jsonOutput` with a plain statement *after* a `RunE` that can panic, while the `os.Stdout`/`os.Stderr` restore directly above it was already deferred. Now deferred too.

I deliberately did **not** add `jsonOutput` to `saveAndRestoreGlobals`. It is the tempting root-cause fix, but it changes restore behavior for every one of that helper's callers, which is more blast radius than an RC branch wants. `pinJSONOutput` is the convention the package chose, and it is opt-in per test. Extending `saveAndRestoreGlobals` is worth doing on `main` after the tag — I'd suggest an issue for it.

## Proof — baseline diff

Full `./scripts/test.sh ./cmd/bd/` (~23 min), run twice on this machine: once on this branch, once on a pristine checkout of the release tip `3e06ee692`.

| | Failures |
|---|---|
| Pristine `release/1.3.0` | 25 |
| This branch | 22 |

```
FIXED (red on baseline, green here):
  TestNoticeSharedMigrateRefusalPerDecision
  TestPourMissingVarHintUnchanged
  TestWispMissingVarHintUnchanged

NEW (introduced by this change):
  (none)
```

The two extra repairs were unlooked-for and confirm the diagnosis: both assert on a `--var` hint's *text* form, and on baseline both received the JSON form instead — the same leaked global, a different victim.

The 22 remaining failures are byte-identical on both sides: the `TestInit*` group, `TestDoltRemoteAddPersistsSyncRemoteToSharedWorktreeConfig`, `TestConfigValidateReadOnlyIsHermetic`, the doctor max-rows pair and others — pre-existing environment failures on this box (leaked temp dirs failing `workspacegate`, and a legacy-workspace guard), untouched by this change.

Also green: `go build ./...`, `go vet ./...`, `gofmt`, golangci-lint (0 issues), and `CGO_ENABLED=0 go test -tags gms_pure_go -c ./cmd/bd`.

## Credit

Diagnosis credit to #6056's agent, which isolated this to a global leak rather than a defect in the notice by diffing a full-package run against a pristine `git archive` of the release tip — seven identical FAIL lines on both sides is what ruled out the notice code and pointed at test ordering. This PR follows the same method to prove the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
