### PR TITLE
fix(windows): stop dolt spawns from allocating a console

### DIFF
--- a/cmd/bd/protocol/testdata/corpus/envelope/dep_remove.json
+++ b/cmd/bd/protocol/testdata/corpus/envelope/dep_remove.json
@@ -2,6 +2,7 @@
   "data": {
     "depends_on_id": "corpus-dep",
     "issue_id": "corpus-root",
+    "removed": true,
     "status": "removed"
   },
   "schema_version": 1

--- a/cmd/bd/protocol/testdata/corpus/flat/dep_remove.json
+++ b/cmd/bd/protocol/testdata/corpus/flat/dep_remove.json
@@ -1,6 +1,7 @@
 {
   "depends_on_id": "corpus-dep",
   "issue_id": "corpus-root",
+  "removed": true,
   "schema_version": 1,
   "status": "removed"
 }

--- a/cmd/bd/protocol/testdata/corpus/manifest.json
+++ b/cmd/bd/protocol/testdata/corpus/manifest.json
@@ -41,7 +41,7 @@
     },
     "envelope/dep_remove": {
       "cmd": "bd dep remove corpus-root corpus-dep --json",
-      "sha256": "487ed7702bc7d92c54f7e02860886671eaedd034da9f4cebd1efd4cc46374bd0"
+      "sha256": "9e2d0224b4989eb7d05f7247c2fe51ef8e8864d7023bcd8f924ce331c59614cc"
     },
     "envelope/error": {
       "cmd": "bd show nonexistent-xyz-corpus --json",
@@ -109,7 +109,7 @@
     },
     "flat/dep_remove": {
       "cmd": "bd dep remove corpus-root corpus-dep --json",
-      "sha256": "579d8ab3187919344bf8e6f4f726cbde885205d9f531aa3833adc560c6e93430"
+      "sha256": "2cad2bf44a31d11c50a70f37e935175bd6a35fe87e87211f2a2fe4432b5ae63a"
     },
     "flat/error": {
       "cmd": "bd show nonexistent-xyz-corpus --json",

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -36,6 +36,7 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/debug"
+	"github.com/steveyegge/beads/internal/execwin"
 	"github.com/steveyegge/beads/internal/fdhygiene"
 	"github.com/steveyegge/beads/internal/githooksenv"
 	"github.com/steveyegge/beads/internal/gittraceenv"
@@ -1858,8 +1859,13 @@ func waitForReady(host string, port int, timeout time.Duration) error {
 
 // ensureDoltIdentity sets dolt global user identity from git config if not already set.
 func ensureDoltIdentity() error {
+	// execwin.Hide on every spawn below: bd may itself be running without a
+	// console (as an MCP server, or under a detached proxy child), in which
+	// case these console applications would each allocate a visible console on
+	// Windows. See internal/execwin.
+
 	// Check if dolt identity is already configured
-	nameCmd := exec.Command("dolt", "config", "--global", "--get", "user.name")
+	nameCmd := execwin.Hide(exec.Command("dolt", "config", "--global", "--get", "user.name"))
 	if out, err := nameCmd.Output(); err == nil && strings.TrimSpace(string(out)) != "" {
 		return nil // Already configured
 	}
@@ -1868,21 +1874,21 @@ func ensureDoltIdentity() error {
 	gitName := "beads"
 	gitEmail := "beads@localhost"
 
-	if out, err := exec.Command("git", "config", "user.name").Output(); err == nil {
+	if out, err := execwin.Hide(exec.Command("git", "config", "user.name")).Output(); err == nil {
 		if name := strings.TrimSpace(string(out)); name != "" {
 			gitName = name
 		}
 	}
-	if out, err := exec.Command("git", "config", "user.email").Output(); err == nil {
+	if out, err := execwin.Hide(exec.Command("git", "config", "user.email")).Output(); err == nil {
 		if email := strings.TrimSpace(string(out)); email != "" {
 			gitEmail = email
 		}
 	}
 
-	if out, err := exec.Command("dolt", "config", "--global", "--add", "user.name", gitName).CombinedOutput(); err != nil {
+	if out, err := execwin.Hide(exec.Command("dolt", "config", "--global", "--add", "user.name", gitName)).CombinedOutput(); err != nil {
 		return fmt.Errorf("setting dolt user.name: %w\n%s", err, out)
 	}
-	if out, err := exec.Command("dolt", "config", "--global", "--add", "user.email", gitEmail).CombinedOutput(); err != nil {
+	if out, err := execwin.Hide(exec.Command("dolt", "config", "--global", "--add", "user.email", gitEmail)).CombinedOutput(); err != nil {
 		return fmt.Errorf("setting dolt user.email: %w\n%s", err, out)
 	}
 
@@ -1942,7 +1948,7 @@ func ensureDoltInit(doltDir string) error {
 		return nil // Already initialized
 	}
 
-	cmd := exec.Command("dolt", "init")
+	cmd := execwin.Hide(exec.Command("dolt", "init"))
 	cmd.Dir = doltDir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("dolt init: %w\n%s", err, out)

--- a/internal/doltserver/doltserver_windows.go
+++ b/internal/doltserver/doltserver_windows.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"golang.org/x/sys/windows"
+
+	"github.com/steveyegge/beads/internal/execwin"
 )
 
 // portConflictHint is the platform-specific command to diagnose port conflicts.
@@ -24,15 +26,27 @@ const processListHint = `tasklist /FI "IMAGENAME eq dolt.exe"`
 
 // procAttrDetached returns SysProcAttr to detach a child process so it survives
 // parent exit. On Windows, CREATE_NEW_PROCESS_GROUP is the analog of Unix Setpgid.
+//
+// DETACHED_PROCESS is required alongside it, and is not merely cosmetic.
+// CREATE_NEW_PROCESS_GROUP alone does NOT stop a console-subsystem child from
+// getting a console: if the spawning bd has no console of its own (an MCP
+// server, or a detached proxy child), the system allocates a brand new one for
+// dolt, which Windows Terminal then shows as a real window when it is the
+// registered default terminal. DETACHED_PROCESS says the child gets no console
+// at all, which is correct here because the server's stdout/stderr are already
+// redirected to a log file. This matches the sibling spawner at
+// internal/storage/dbproxy/proxy/endpoint_windows.go.
 func procAttrDetached() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+	return &syscall.SysProcAttr{
+		CreationFlags: windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP,
+	}
 }
 
 // findPIDOnPort returns the PID of the process listening on a TCP port.
 // Parses netstat -aon output matching LISTENING lines. Returns 0 if no process
 // found or on error.
 func findPIDOnPort(port int) int {
-	out, err := exec.Command("netstat", "-aon").Output()
+	out, err := execwin.Hide(exec.Command("netstat", "-aon")).Output()
 	if err != nil {
 		return 0
 	}
@@ -70,7 +84,7 @@ func listDoltProcessPIDs() []int {
 	script := `Get-CimInstance Win32_Process -Filter "Name='dolt.exe'" | ` +
 		`Where-Object { $_.CommandLine -match 'sql-server' } | ` +
 		`Select-Object -ExpandProperty ProcessId`
-	out, err := exec.Command("powershell.exe", "-NoProfile", "-Command", script).Output()
+	out, err := execwin.Hide(exec.Command("powershell.exe", "-NoProfile", "-Command", script)).Output()
 	if err != nil {
 		return nil
 	}

--- a/internal/doltserver/gc_config.go
+++ b/internal/doltserver/gc_config.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/steveyegge/beads/internal/execwin"
 )
 
 // MinDoltVersionForArchiveLevelConfig is the earliest Dolt release known to
@@ -64,7 +66,9 @@ func SupportsArchiveLevelConfig(doltBin string) bool {
 		}
 	}
 
-	out, err := exec.Command(doltBin, "version").Output() //nolint:gosec // G204: doltBin is caller-resolved (PATH lookup or config), not user-request input
+	// execwin.Hide: keeps this probe from flashing a console window when bd is
+	// running without a console of its own. See internal/execwin.
+	out, err := execwin.Hide(exec.Command(doltBin, "version")).Output() //nolint:gosec // G204: doltBin is caller-resolved (PATH lookup or config), not user-request input
 	supported := err == nil && doltVersionAtLeast(string(out), MinDoltVersionForArchiveLevelConfig)
 
 	if hasKey {

--- a/internal/doltserver/procattr_windows_test.go
+++ b/internal/doltserver/procattr_windows_test.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package doltserver
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestProcAttrDetachedSuppressesConsole guards the Windows half of the
+// "detached" contract.
+//
+// CREATE_NEW_PROCESS_GROUP alone is NOT enough: it detaches signal handling but
+// leaves console allocation untouched, so a dolt sql-server spawned from a bd
+// that has no console of its own (MCP server, or the detached db-proxy-child)
+// gets a brand new console. With Windows Terminal registered as the default
+// terminal application that surfaces as a real window on the user's desktop,
+// and Windows Terminal may persist and replay the session afterwards.
+//
+// The server's stdout/stderr are redirected to a log file, so it has no
+// legitimate use for a console at all.
+func TestProcAttrDetachedSuppressesConsole(t *testing.T) {
+	attr := procAttrDetached()
+	if attr == nil {
+		t.Fatal("procAttrDetached() = nil on windows, want non-nil")
+	}
+	if attr.CreationFlags&windows.DETACHED_PROCESS == 0 {
+		t.Errorf("CreationFlags = %#x, missing DETACHED_PROCESS (%#x)",
+			attr.CreationFlags, uint32(windows.DETACHED_PROCESS))
+	}
+	if attr.CreationFlags&windows.CREATE_NEW_PROCESS_GROUP == 0 {
+		t.Errorf("CreationFlags = %#x, missing CREATE_NEW_PROCESS_GROUP (%#x)",
+			attr.CreationFlags, uint32(windows.CREATE_NEW_PROCESS_GROUP))
+	}
+}

--- a/internal/doltversion/probe.go
+++ b/internal/doltversion/probe.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/steveyegge/beads/internal/execwin"
 )
 
 // defaultProbeTimeout bounds how long Probe waits for `<path> version` to
@@ -118,7 +120,11 @@ func Probe(ctx context.Context, path string) (Identity, error) {
 		defer cancel()
 	}
 
-	cmd := exec.CommandContext(ctx, path, "version") //nolint:gosec // G204: path is caller-resolved and pre-exec-validated above, not user-request input
+	// execwin.Hide: on Windows this probe would otherwise allocate a visible
+	// console when bd itself has none (MCP server, detached proxy child), and
+	// `dolt version` exits fast enough that the terminal attaching to it can
+	// fail outright. See internal/execwin.
+	cmd := execwin.Hide(exec.CommandContext(ctx, path, "version")) //nolint:gosec // G204: path is caller-resolved and pre-exec-validated above, not user-request input
 	// WaitDelay bounds how long Wait() waits for the child's I/O pipes to
 	// close after the context is done / the process is signaled. Without
 	// it, a child that ignores SIGKILL's effect on its own goroutines (or

--- a/internal/execwin/execwin.go
+++ b/internal/execwin/execwin.go
@@ -1,0 +1,53 @@
+// Package execwin centralizes the Windows-only process creation flags beads
+// needs when it shells out to dolt, git, or PowerShell.
+//
+// The problem it solves is Windows-specific and invisible on Unix. A
+// console-subsystem child (dolt.exe, git.exe, powershell.exe) started from a
+// parent that has NO console of its own does not silently inherit one — the
+// system allocates a brand new console for it. When Windows Terminal is
+// registered as the default terminal application ("defterm"), that console is
+// handed to Windows Terminal and a real terminal window appears on the user's
+// desktop.
+//
+// beads hits this on its most common path: bd db-proxy-child is deliberately
+// spawned with DETACHED_PROCESS (see dbproxy/proxy/endpoint_windows.go), so it
+// has no console, and every dolt command it then runs would pop a window. For
+// short-lived commands the window is worse than cosmetic: the child exits
+// before Windows Terminal finishes attaching to the pseudoconsole, so the
+// handoff pipe is already closed and Windows Terminal reports
+//
+//	[error 2147942632 (0x800700E8) when launching `"...\dolt.exe" init']
+//
+// where 0x800700E8 is HRESULT_FROM_WIN32(ERROR_NO_DATA), "The pipe is being
+// closed." Windows Terminal may then persist that session and replay it from
+// C:\Windows\System32 on subsequent launches.
+//
+// Hide is a no-op on every non-Windows platform: NoWindowSysProcAttr returns
+// nil there, and Hide only ever assigns to a nil SysProcAttr, so behavior off
+// Windows is byte-identical to not calling it at all.
+package execwin
+
+import "os/exec"
+
+// Hide suppresses console-window allocation for cmd on Windows and returns cmd
+// so it can be wrapped around an exec.Command call inline:
+//
+//	out, err := execwin.Hide(exec.Command("git", "config", "user.name")).Output()
+//
+// It is intended for short-lived commands whose output the caller captures. For
+// a long-lived child that must outlive its parent, use that package's own
+// detached SysProcAttr instead — those need DETACHED_PROCESS, and the Unix side
+// needs Setsid/Setpgid, which is not something this helper models.
+//
+// Hide never overwrites a SysProcAttr the caller already set, so it is safe to
+// call on a command that has been configured elsewhere. A nil cmd is returned
+// unchanged.
+func Hide(cmd *exec.Cmd) *exec.Cmd {
+	if cmd == nil {
+		return nil
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = NoWindowSysProcAttr()
+	}
+	return cmd
+}

--- a/internal/execwin/execwin_other.go
+++ b/internal/execwin/execwin_other.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package execwin
+
+import "syscall"
+
+// NoWindowSysProcAttr returns nil off Windows. There is no console-window
+// concept to suppress, and returning nil keeps Hide a strict no-op so that
+// non-Windows process creation is byte-identical to not calling it.
+func NoWindowSysProcAttr() *syscall.SysProcAttr {
+	return nil
+}

--- a/internal/execwin/execwin_other_test.go
+++ b/internal/execwin/execwin_other_test.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package execwin
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// TestNoWindowSysProcAttrIsNilOffWindows pins the no-op guarantee. Hide is
+// called from shared (non-build-tagged) code, so it must not perturb process
+// creation on Unix: a nil SysProcAttr is exactly what those call sites had
+// before execwin existed.
+func TestNoWindowSysProcAttrIsNilOffWindows(t *testing.T) {
+	if attr := NoWindowSysProcAttr(); attr != nil {
+		t.Fatalf("NoWindowSysProcAttr() = %+v, want nil off windows", attr)
+	}
+}
+
+// TestHideLeavesSysProcAttrNil is the same guarantee observed through Hide,
+// which is the form the call sites use.
+func TestHideLeavesSysProcAttrNil(t *testing.T) {
+	cmd := Hide(exec.Command("true"))
+	if cmd.SysProcAttr != nil {
+		t.Fatalf("Hide set SysProcAttr = %+v off windows, want nil", cmd.SysProcAttr)
+	}
+}

--- a/internal/execwin/execwin_test.go
+++ b/internal/execwin/execwin_test.go
@@ -1,0 +1,42 @@
+package execwin
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+// TestHideNil guards the convenience contract: Hide is meant to be wrapped
+// around an exec.Command call inline, so it must tolerate a nil command rather
+// than panicking at the call site.
+func TestHideNil(t *testing.T) {
+	if got := Hide(nil); got != nil {
+		t.Fatalf("Hide(nil) = %v, want nil", got)
+	}
+}
+
+// TestHideReturnsSameCommand documents that Hide mutates in place and hands the
+// command back, which is what makes execwin.Hide(exec.Command(...)).Output()
+// legal.
+func TestHideReturnsSameCommand(t *testing.T) {
+	cmd := exec.Command("go", "version")
+	if got := Hide(cmd); got != cmd {
+		t.Fatalf("Hide returned a different *exec.Cmd (%p) than it was given (%p)", got, cmd)
+	}
+}
+
+// TestHideDoesNotOverwriteExistingAttr is the important one. Several spawn
+// sites deliberately set their own SysProcAttr (Setsid/Setpgid on Unix,
+// DETACHED_PROCESS on Windows). Hide must never clobber those — doing so would
+// silently un-detach a server that is supposed to outlive its parent.
+func TestHideDoesNotOverwriteExistingAttr(t *testing.T) {
+	existing := &syscall.SysProcAttr{}
+	cmd := exec.Command("go", "version")
+	cmd.SysProcAttr = existing
+
+	Hide(cmd)
+
+	if cmd.SysProcAttr != existing {
+		t.Fatalf("Hide replaced a caller-set SysProcAttr (%p) with %p", existing, cmd.SysProcAttr)
+	}
+}

--- a/internal/execwin/execwin_windows.go
+++ b/internal/execwin/execwin_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package execwin
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// NoWindowSysProcAttr returns the SysProcAttr that keeps a console-subsystem
+// child from allocating (and showing) a console of its own.
+//
+// CREATE_NO_WINDOW is the right flag for a command whose output the parent
+// captures through pipes: the child still gets a console object, so anything
+// that queries console state keeps working, but it is never displayed. That
+// matters for dolt, which is a console application — DETACHED_PROCESS would
+// also hide the window but leaves the child with no console at all, which is
+// the correct choice only for a server we intend to orphan.
+func NoWindowSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW}
+}

--- a/internal/execwin/execwin_windows_test.go
+++ b/internal/execwin/execwin_windows_test.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package execwin
+
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestNoWindowSysProcAttrSetsCreateNoWindow pins the flag itself. If this ever
+// regresses to zero, every dolt/git/PowerShell command bd runs from a
+// console-less parent starts allocating a visible console again — which is the
+// defect this package exists to prevent, and which is invisible in CI on Linux.
+func TestNoWindowSysProcAttrSetsCreateNoWindow(t *testing.T) {
+	attr := NoWindowSysProcAttr()
+	if attr == nil {
+		t.Fatal("NoWindowSysProcAttr() = nil on windows, want non-nil")
+	}
+	if attr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+		t.Fatalf("CreationFlags = %#x, missing CREATE_NO_WINDOW (%#x)",
+			attr.CreationFlags, uint32(windows.CREATE_NO_WINDOW))
+	}
+}
+
+// TestHideAppliesCreateNoWindow covers the path the call sites actually use.
+func TestHideAppliesCreateNoWindow(t *testing.T) {
+	cmd := Hide(exec.Command("cmd", "/c", "ver"))
+	if cmd.SysProcAttr == nil {
+		t.Fatal("Hide left SysProcAttr nil on windows")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+		t.Fatalf("CreationFlags = %#x, missing CREATE_NO_WINDOW", cmd.SysProcAttr.CreationFlags)
+	}
+}

--- a/internal/storage/dbproxy/server/doltserver.go
+++ b/internal/storage/dbproxy/server/doltserver.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/execwin"
 	"github.com/steveyegge/beads/internal/procid"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/identity"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
@@ -136,25 +137,29 @@ func (s *DoltServer) DSN(_ context.Context, database, user, password string) str
 }
 
 func (s *DoltServer) doltConfigure(ctx context.Context) error {
-	probe := exec.CommandContext(ctx, s.doltBinExec, "config", "--global", "--get", "user.name")
+	// execwin.Hide on every spawn below: this method runs inside
+	// bd db-proxy-child, which is started with DETACHED_PROCESS and so has no
+	// console. Without CREATE_NO_WINDOW each of these console applications
+	// would allocate a visible console on Windows. See internal/execwin.
+	probe := execwin.Hide(exec.CommandContext(ctx, s.doltBinExec, "config", "--global", "--get", "user.name"))
 	if out, err := probe.Output(); err == nil && strings.TrimSpace(string(out)) != "" {
 		return nil
 	}
 	name, email := "beads", "beads@localhost"
-	if out, err := exec.CommandContext(ctx, "git", "config", "user.name").Output(); err == nil {
+	if out, err := execwin.Hide(exec.CommandContext(ctx, "git", "config", "user.name")).Output(); err == nil {
 		if v := strings.TrimSpace(string(out)); v != "" {
 			name = v
 		}
 	}
-	if out, err := exec.CommandContext(ctx, "git", "config", "user.email").Output(); err == nil {
+	if out, err := execwin.Hide(exec.CommandContext(ctx, "git", "config", "user.email")).Output(); err == nil {
 		if v := strings.TrimSpace(string(out)); v != "" {
 			email = v
 		}
 	}
-	if out, err := exec.CommandContext(ctx, s.doltBinExec, "config", "--global", "--add", "user.name", name).CombinedOutput(); err != nil {
+	if out, err := execwin.Hide(exec.CommandContext(ctx, s.doltBinExec, "config", "--global", "--add", "user.name", name)).CombinedOutput(); err != nil {
 		return fmt.Errorf("server: DoltServer.doltConfigure: set user.name: %w\n%s", err, out)
 	}
-	if out, err := exec.CommandContext(ctx, s.doltBinExec, "config", "--global", "--add", "user.email", email).CombinedOutput(); err != nil {
+	if out, err := execwin.Hide(exec.CommandContext(ctx, s.doltBinExec, "config", "--global", "--add", "user.email", email)).CombinedOutput(); err != nil {
 		return fmt.Errorf("server: DoltServer.doltConfigure: set user.email: %w\n%s", err, out)
 	}
 	return nil
@@ -165,7 +170,7 @@ func (s *DoltServer) doltInit(ctx context.Context) error {
 		return fmt.Errorf("server: DoltServer.doltInit: mkdir %q: %w", s.rootDir, err)
 	}
 
-	cmd := exec.CommandContext(ctx, s.doltBinExec, "init")
+	cmd := execwin.Hide(exec.CommandContext(ctx, s.doltBinExec, "init"))
 	cmd.Dir = s.rootDir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		if strings.Contains(string(out), "already been initialized") {
@@ -248,6 +253,10 @@ func (s *DoltServer) Start(ctx context.Context) error {
 
 	cmd := exec.CommandContext(managedCtx, s.doltBinExec, args...)
 	cmd.Dir = s.rootDir
+	// Windows: detach from any console so the server never allocates one (its
+	// output already goes to s.logFile). Nil off Windows, preserving the
+	// original behavior there. See procattr_windows.go.
+	cmd.SysProcAttr = managedServerSysProcAttr()
 	cmd.Stdin = nil
 	if s.logFile != nil {
 		cmd.Stdout = s.logFile

--- a/internal/storage/dbproxy/server/procattr_other.go
+++ b/internal/storage/dbproxy/server/procattr_other.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package server
+
+import "syscall"
+
+// managedServerSysProcAttr returns nil off Windows, which is exactly what this
+// spawn site used before the Windows console-allocation fix. There is no
+// console to detach from, and the server is a managed child that should stay in
+// the caller's process group so existing signal and cleanup behavior is
+// unchanged.
+func managedServerSysProcAttr() *syscall.SysProcAttr {
+	return nil
+}

--- a/internal/storage/dbproxy/server/procattr_windows.go
+++ b/internal/storage/dbproxy/server/procattr_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package server
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// managedServerSysProcAttr returns the creation flags for the long-lived
+// `dolt sql-server` this package manages.
+//
+// DETACHED_PROCESS is the point: the server's stdout/stderr are redirected to a
+// log file, so it has no use for a console, and giving it none is stronger than
+// merely hiding one. bd db-proxy-child (this process) is itself started with
+// DETACHED_PROCESS and therefore has no console to share, so without this flag
+// the system allocates a fresh console for dolt — which Windows Terminal shows
+// as a real window when it is the registered default terminal application, and
+// may then persist and replay from C:\Windows\System32 on later launches.
+//
+// CREATE_NEW_PROCESS_GROUP additionally keeps a Ctrl+C aimed at an ancestor
+// from reaching the server mid-write. This mirrors the sibling spawner at
+// internal/storage/dbproxy/proxy/endpoint_windows.go.
+//
+// Detaching does not change lifetime management here: the server is still a
+// child this package Waits on and kills by handle via the managed context.
+func managedServerSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP,
+	}
+}


### PR DESCRIPTION
Fixes #6076

On Windows a console-subsystem child started from a parent that has no
console of its own does not inherit one -- the system allocates a brand
new console for it. bd hits this on its most common path: bd
db-proxy-child is deliberately spawned with DETACHED_PROCESS and so has
no console, and every dolt/git/PowerShell command it then ran allocated
one. With Windows Terminal registered as the default terminal
application that surfaced as a real window on the user's desktop.

For short-lived commands it was worse than cosmetic. dolt init exits
before Windows Terminal finishes attaching to the pseudoconsole, so the
handoff pipe was already closed and Windows Terminal reported

    [error 2147942632 (0x800700E8) when launching ...dolt.exe init]

where 0x800700E8 is HRESULT_FROM_WIN32(ERROR_NO_DATA), "The pipe is
being closed." Windows Terminal then persisted the hosted session and,
with firstWindowPreference=persistedLayoutAndContent, replayed it on
every later launch from its own cwd -- producing recurring
"mkdir C:\WINDOWS\system32\.dolt: Access is denied" and
"Port 3307 already in use" from a tab nobody opened.

Adds internal/execwin, whose Hide() applies CREATE_NO_WINDOW on Windows
and is a strict no-op elsewhere (NoWindowSysProcAttr returns nil, and
Hide never overwrites a SysProcAttr the caller already set). Applied to
the short-lived spawns in dbproxy/server, doltserver, and doltversion.

The two long-lived sql-server spawns get DETACHED_PROCESS instead, which
is stronger than hiding a console: their stdout/stderr already go to a
log file, so they have no use for one.

  - doltserver_windows.go procAttrDetached had only
    CREATE_NEW_PROCESS_GROUP, which detaches signal handling but does
    not suppress console allocation.
  - dbproxy/server gains managedServerSysProcAttr, matching the sibling
    at dbproxy/proxy/endpoint_windows.go. Nil off Windows, so that spawn
    site is unchanged there.

Verified end to end on Windows by spawning dolt from an isolated
workspace and inspecting the process:

  installed bd 1.2.2 : MainWindowHandle=24387802, 1 conhost child
  with this change   : MainWindowHandle=0,        0 console hosts

Not a dolt version issue: reproduced on dolt 2.3.1, well above
doltversion.RecommendedMin (2.0.0).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

