### PR TITLE
ci: add messgo and mutago PR gates

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -756,6 +756,61 @@ jobs:
           BD_LINT_NEW_FROM_MERGE_BASE: origin/main
         run: make ci-pr-lint
 
+  messgo:
+    name: Messgo (production Go)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CGO_ENABLED: "0"
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          # The script compares the complete production files in the PR with
+          # the merge base; shallow history cannot resolve that base.
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+
+      - name: Check messgo rulesets
+        env:
+          MESSGO_DIFF_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+        run: ./scripts/ci/messgo.sh
+
+  mutago:
+    name: Mutago (changed production Go)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CGO_ENABLED: "0"
+    # Mutation analysis is deliberately bounded: a pathological package must
+    # fail with a useful timeout rather than consume an unbounded runner.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+
+      - name: Check covered mutation score
+        env:
+          MUTAGO_DIFF_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          # Two workers keep mutation analysis within the runner's resource
+          # budget; callers can override this for a local diagnostic run.
+          MUTAGO_WORKERS: '2'
+        run: ./scripts/ci/mutago.sh
+
   # Focused job for the hexagonal storage layer (internal/storage/domain/* and
   # internal/storage/uow). These packages back the proxied-server init path and
   # also live behind the existing ./... matrix, but TestDomainDB requires the
@@ -1309,6 +1364,8 @@ jobs:
       - pr-policy-wrapper
       - pr-core-wrapper
       - pr-lint-wrapper
+      - messgo
+      - mutago
       - test-domain-uow
       - contract-corpus
       - fmt-check
@@ -1339,6 +1396,8 @@ jobs:
             PR_POLICY_WRAPPER
             PR_CORE_WRAPPER
             PR_LINT_WRAPPER
+            MESSGO
+            MUTAGO
             TEST_DOMAIN_UOW
             CONTRACT_CORPUS
             FMT_CHECK
@@ -1361,6 +1420,8 @@ jobs:
           PR_POLICY_WRAPPER: ${{ needs.pr-policy-wrapper.result }}
           PR_CORE_WRAPPER: ${{ needs.pr-core-wrapper.result }}
           PR_LINT_WRAPPER: ${{ needs.pr-lint-wrapper.result }}
+          MESSGO: ${{ needs.messgo.result }}
+          MUTAGO: ${{ needs.mutago.result }}
           TEST_DOMAIN_UOW: ${{ needs.test-domain-uow.result }}
           CONTRACT_CORPUS: ${{ needs.contract-corpus.result }}
           FMT_CHECK: ${{ needs.fmt-check.result }}

--- a/scripts/ci/messgo.sh
+++ b/scripts/ci/messgo.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# messgo is intentionally scoped to production Go in the change.  The
+# repository's baseline contains legacy findings, so a whole-tree required
+# check would make unrelated changes impossible to merge.  A file touched by
+# this change is scanned in full; tests are excluded by design.
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../.." && pwd)"
+cd "$repo_root"
+
+# Keep the tool's Go subprocesses on the repository's pure-Go build path.
+# shellcheck disable=SC1091
+source ./.buildflags
+
+diff_base="${MESSGO_DIFF_BASE:-}"
+if [[ -n "$diff_base" ]]; then
+  if ! git rev-parse --verify --quiet "$diff_base^{commit}" >/dev/null; then
+    printf 'messgo: merge-base %q is not available locally\n' "$diff_base" >&2
+    exit 1
+  fi
+  changed_files="$(git diff --name-only "$diff_base"...HEAD -- '*.go')"
+else
+  changed_files="$(git ls-files -- '*.go')"
+fi
+
+paths=()
+while IFS= read -r path; do
+  [[ -n "$path" ]] || continue
+  [[ "$path" != *_test.go ]] || continue
+  [[ -f "$path" ]] || continue
+  paths+=("$path")
+done <<<"$changed_files"
+
+if ((${#paths[@]} == 0)); then
+  echo 'messgo: no production Go files in scope; skipping'
+  exit 0
+fi
+
+path_list=""
+for path in "${paths[@]}"; do
+  path_list+="${path_list:+,}$path"
+done
+
+if [[ -n "${MESSGO_BIN:-}" ]]; then
+  messgo=("$MESSGO_BIN")
+elif command -v messgo >/dev/null 2>&1; then
+  messgo=("$(command -v messgo)")
+else
+  messgo=(go run github.com/quality-gates/messgo/cmd/messgo@v0.2.2)
+fi
+
+printf 'messgo: scanning %d production Go file(s)\n' "${#paths[@]}"
+"${messgo[@]}" "$path_list" github 'unusedcode,design,codesize' --ignore-tests

--- a/scripts/ci/mutago.sh
+++ b/scripts/ci/mutago.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# mutago measures only changed production lines.  This keeps the required
+# covered-MSI gate focused on the code a change actually owns while retaining
+# full test coverage and per-test mutation attribution for those lines.
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../.." && pwd)"
+cd "$repo_root"
+
+# shellcheck disable=SC1091
+source ./.buildflags
+
+diff_base="${MUTAGO_DIFF_BASE:-}"
+if [[ -z "$diff_base" && -n "${GITHUB_BASE_REF:-}" ]]; then
+  diff_base="origin/$GITHUB_BASE_REF"
+fi
+if [[ -z "$diff_base" ]] && git rev-parse --verify --quiet "origin/main^{commit}" >/dev/null; then
+  diff_base=origin/main
+fi
+if [[ -z "$diff_base" ]]; then
+  diff_base="$(git merge-base HEAD origin/main 2>/dev/null || true)"
+fi
+if [[ -z "$diff_base" ]] || ! git rev-parse --verify --quiet "$diff_base^{commit}" >/dev/null; then
+  printf 'mutago: unable to resolve a merge-base (set MUTAGO_DIFF_BASE)\n' >&2
+  exit 1
+fi
+
+changed_files="$(git diff --name-only "$diff_base"...HEAD -- '*.go')"
+paths=()
+while IFS= read -r path; do
+  [[ -n "$path" ]] || continue
+  [[ "$path" != *_test.go ]] || continue
+  [[ -f "$path" ]] || continue
+  paths+=("$path")
+done <<<"$changed_files"
+
+if ((${#paths[@]} == 0)); then
+  echo 'mutago: no changed production Go files; skipping'
+  exit 0
+fi
+
+if [[ -n "${MUTAGO_BIN:-}" ]]; then
+  mutago=("$MUTAGO_BIN")
+elif command -v mutago >/dev/null 2>&1; then
+  mutago=("$(command -v mutago)")
+else
+  mutago=(go run github.com/quality-gates/mutago/v2/cmd/mutago@v2.9.1)
+fi
+
+printf 'mutago: scanning %d changed production Go file(s) against %s\n' "${#paths[@]}" "$diff_base"
+"${mutago[@]}" \
+  --coverage \
+  --per-test \
+  --git-diff-lines \
+  --git-diff-base="$diff_base" \
+  --min-covered-msi=80 \
+  --ignore-msi-with-no-mutations \
+  --quiet \
+  --no-diffs \
+  --workers="${MUTAGO_WORKERS:-2}" \
+  --test-flags=-tags=gms_pure_go \
+  "${paths[@]}"

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -61,6 +61,64 @@ func TestPRCIGateRequiresPolicyAndLintWrappers(t *testing.T) {
 	}
 }
 
+func TestPRCIGateRequiresMessgoAndMutago(t *testing.T) {
+	workflow := readCIWorkflow(t, "pr.yml")
+	gate := workflow.job(t, "ci-gate")
+	gateEnv := gate.step(t, "Evaluate CI gate").Env
+
+	for _, jobName := range []string{"messgo", "mutago"} {
+		job := workflow.job(t, jobName)
+		if job.RunsOn != "ubuntu-latest" {
+			t.Errorf("%s runs-on = %q, want ubuntu-latest", jobName, job.RunsOn)
+		}
+		if job.Env["CGO_ENABLED"] != "0" {
+			t.Errorf("%s CGO_ENABLED = %q, want 0", jobName, job.Env["CGO_ENABLED"])
+		}
+		checkout := job.Steps[0]
+		if actionFamily(checkout.Uses) != "actions/checkout" || checkout.With["fetch-depth"] != "0" {
+			t.Errorf("%s checkout = uses %q with %v, want full history checkout", jobName, checkout.Uses, checkout.With)
+		}
+		setupGo := job.step(t, "Set up Go")
+		if setupGo.Uses != setupGoActionFamily+"@"+setupGoSHA || setupGo.With["go-version-file"] != "go.mod" || setupGo.With["cache"] != "false" {
+			t.Errorf("%s setup-go = uses %q with %v", jobName, setupGo.Uses, setupGo.With)
+		}
+	}
+
+	messgo := workflow.job(t, "messgo")
+	messgoStep := messgo.step(t, "Check messgo rulesets")
+	if messgoStep.Run != "./scripts/ci/messgo.sh" {
+		t.Errorf("messgo command = %q", messgoStep.Run)
+	}
+	if messgoStep.Env["MESSGO_DIFF_BASE"] != "${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}" {
+		t.Errorf("messgo base env = %q", messgoStep.Env["MESSGO_DIFF_BASE"])
+	}
+
+	mutago := workflow.job(t, "mutago")
+	if mutago.TimeoutMinutes != 60 {
+		t.Errorf("mutago timeout = %d, want 60 minutes", mutago.TimeoutMinutes)
+	}
+	mutagoStep := mutago.step(t, "Check covered mutation score")
+	if mutagoStep.Run != "./scripts/ci/mutago.sh" {
+		t.Errorf("mutago command = %q", mutagoStep.Run)
+	}
+	if mutagoStep.Env["MUTAGO_DIFF_BASE"] != "${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}" {
+		t.Errorf("mutago base env = %q", mutagoStep.Env["MUTAGO_DIFF_BASE"])
+	}
+
+	for jobName, gateKey := range map[string]string{"messgo": "MESSGO", "mutago": "MUTAGO"} {
+		if !contains(gate.Needs, jobName) {
+			t.Errorf("ci-gate needs %q: %v", jobName, gate.Needs)
+		}
+		wantEnv := "${{ needs." + jobName + ".result }}"
+		if got := gateEnv[gateKey]; got != wantEnv {
+			t.Errorf("ci-gate env %s = %q, want %q", gateKey, got, wantEnv)
+		}
+		if !contains(strings.Fields(gateEnv["CI_GATE_REQUIRED"]), gateKey) {
+			t.Errorf("ci-gate required set omits %s", gateKey)
+		}
+	}
+}
+
 func TestPRWorkflowExercisesWindowsBenchmarkEnvScrubbing(t *testing.T) {
 	workflow := readCIWorkflow(t, "pr.yml")
 	job := workflow.job(t, "pr-preflight-platforms")


### PR DESCRIPTION
## What

Add required PR jobs for pinned messgo rulesets (`unusedcode,design,codesize`) and mutago covered-MSI (minimum 80%) on changed production Go. Both jobs use full-history checkout, pure-Go build flags, bounded mutation workers, and feed the existing `ci-gate` aggregation.

## Why

Make the requested static-design and mutation-quality checks reproducible in CI without making legacy whole-tree findings block unrelated changes.

## Verification

- `scripts/dev-docker.sh go test ./scripts`
- `scripts/dev-docker.sh bash scripts/check-build-tags.sh`
- `shellcheck scripts/ci/messgo.sh scripts/ci/mutago.sh`
- `bash -n scripts/ci/messgo.sh scripts/ci/mutago.sh`
- `git diff --check`
- Local no-production-diff smoke run for both scripts

The large pre-existing worktree refactor is intentionally not part of this CI commit.