### PR TITLE
fix(version): recognize brew --HEAD version stamps — never route HEAD witnesses into pre-v56 recovery (#5625 carry, #5603)

### DIFF
--- a/cmd/bd/doctor/version.go
+++ b/cmd/bd/doctor/version.go
@@ -16,6 +16,17 @@ var latestGitHubReleaseFetcher = fetchLatestGitHubRelease
 // CheckCLIVersion checks if the CLI version is up to date.
 // Takes cliVersion parameter since it can't access the Version variable from main package.
 func CheckCLIVersion(cliVersion string) DoctorCheck {
+	// A Homebrew --HEAD build carries no orderable version — CompareVersions
+	// would read it as 0.0.0 and warn "update available" forever, and the
+	// suggested upgrade would actually move the user off HEAD.
+	if IsBrewHeadVersion(cliVersion) {
+		return DoctorCheck{
+			Name:    "CLI Version",
+			Status:  StatusOK,
+			Message: fmt.Sprintf("%s (Homebrew --HEAD build; release comparison skipped)", cliVersion),
+		}
+	}
+
 	latestVersion, err := latestGitHubReleaseFetcher()
 	if err != nil {
 		// Network error or API issue - don't fail, just warn
@@ -151,6 +162,20 @@ func CheckMetadataVersionTracking(path string, currentVersion string) DoctorChec
 		}
 	}
 
+	trackingActive := DoctorCheck{
+		Name:    "Version Tracking",
+		Status:  StatusOK,
+		Message: fmt.Sprintf("Version tracking active (last: %s, current: %s)", lastVersion, currentVersion),
+	}
+
+	// A Homebrew --HEAD stamp carries no ordering, so the staleness heuristic
+	// below cannot apply — but it is a healthy marker, not a malformed one.
+	// Warning about it would be permanent: the offered fix rewrites the same
+	// stamp back.
+	if IsBrewHeadVersion(lastVersion) {
+		return trackingActive
+	}
+
 	// Validate that version is a valid semver-like string
 	if !IsValidSemver(lastVersion) {
 		return DoctorCheck{
@@ -171,11 +196,7 @@ func CheckMetadataVersionTracking(path string, currentVersion string) DoctorChec
 
 		// Guard against short version strings (e.g., "5" → [5] has no [1])
 		if len(currentParts) < 2 || len(lastParts) < 2 {
-			return DoctorCheck{
-				Name:    "Version Tracking",
-				Status:  StatusOK,
-				Message: fmt.Sprintf("Version tracking active (last: %s, current: %s)", lastVersion, currentVersion),
-			}
+			return trackingActive
 		}
 
 		// Simple heuristic: warn if minor version is 10+ behind or major version differs by 1+
@@ -193,11 +214,7 @@ func CheckMetadataVersionTracking(path string, currentVersion string) DoctorChec
 		}
 
 		// Version is behind but not too old - this is normal after upgrade
-		return DoctorCheck{
-			Name:    "Version Tracking",
-			Status:  StatusOK,
-			Message: fmt.Sprintf("Version tracking active (last: %s, current: %s)", lastVersion, currentVersion),
-		}
+		return trackingActive
 	}
 
 	// Version is current or ahead

--- a/cmd/bd/doctor/version.go
+++ b/cmd/bd/doctor/version.go
@@ -289,6 +289,49 @@ func CompareVersions(v1, v2 string) int {
 	return 0
 }
 
+// IsBrewHeadVersion recognizes the version Homebrew stamps into --HEAD
+// installs of the core beads formula: HEAD-<shortsha>, a bare HEAD when the
+// head spec resolves no commit, and either shape carrying Homebrew's
+// _<revision> suffix. Such a stamp is a healthy current-era version marker,
+// not a malformed one — the binary rewrites it identically on every run, so
+// nothing the user does can "fix" it into semver.
+//
+// This is the canonical definition; every consumer of a version stamp that
+// needs to tell a --HEAD build apart from a release delegates here so the
+// ends cannot drift.
+func IsBrewHeadVersion(version string) bool {
+	rest, ok := strings.CutPrefix(version, "HEAD")
+	if !ok {
+		return false
+	}
+	// Homebrew's pkg_version appends _<revision> once the formula carries a
+	// revision, so a revision bump must not read as malformed. The revision is
+	// an unsigned decimal; a digits-only check keeps Atoi's tolerance of
+	// signed forms ("+1", "-0") from admitting shapes brew never emits.
+	if cut := strings.IndexByte(rest, '_'); cut >= 0 {
+		revision := rest[cut+1:]
+		if revision == "" || strings.Trim(revision, "0123456789") != "" {
+			return false
+		}
+		rest = rest[:cut]
+	}
+	// Homebrew leaves the version as a bare "HEAD" whenever the head spec
+	// cannot resolve a commit.
+	if rest == "" {
+		return true
+	}
+	sha, ok := strings.CutPrefix(rest, "-")
+	if !ok {
+		return false
+	}
+	// Bound the tail to a plausible git abbreviation so that arbitrary hex
+	// cannot stand in for a commit; git never abbreviates below 7 characters.
+	if len(sha) < 7 || len(sha) > 40 {
+		return false
+	}
+	return strings.Trim(sha, "0123456789abcdefABCDEF") == ""
+}
+
 // IsValidSemver checks if a version string is valid semver-like format (X.Y.Z)
 func IsValidSemver(version string) bool {
 	if version == "" {

--- a/cmd/bd/doctor/version_test.go
+++ b/cmd/bd/doctor/version_test.go
@@ -69,6 +69,41 @@ func TestIsValidSemver(t *testing.T) {
 	}
 }
 
+func TestIsBrewHeadVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{name: "short sha", version: "HEAD-f925f3f", want: true},
+		{name: "full sha", version: "HEAD-" + strings.Repeat("a", 40), want: true},
+		{name: "uppercase sha", version: "HEAD-F925F3F", want: true},
+		{name: "bare HEAD", version: "HEAD", want: true},
+		{name: "revision suffix", version: "HEAD-f925f3f_1", want: true},
+		{name: "bare HEAD with revision suffix", version: "HEAD_2", want: true},
+		{name: "empty sha", version: "HEAD-"},
+		{name: "non-hex sha", version: "HEAD-zzzzzzz"},
+		{name: "sha below git abbreviation floor", version: "HEAD-abc"},
+		{name: "sha beyond object id length", version: "HEAD-" + strings.Repeat("a", 41)},
+		{name: "dirty suffix", version: "HEAD-f925f3f-dirty"},
+		{name: "non-numeric revision", version: "HEAD-f925f3f_x"},
+		{name: "signed revision", version: "HEAD-f925f3f_+1"},
+		{name: "negative zero revision", version: "HEAD_-0"},
+		{name: "empty revision", version: "HEAD-f925f3f_"},
+		{name: "unrelated prefix", version: "HEADLESS-f925f3f"},
+		{name: "semver", version: "1.1.2"},
+		{name: "empty", version: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsBrewHeadVersion(tt.version); got != tt.want {
+				t.Fatalf("IsBrewHeadVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUpgradeCommandForPath(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/bd/doctor/version_test.go
+++ b/cmd/bd/doctor/version_test.go
@@ -154,6 +154,39 @@ func TestCheckCLIVersionUsesFetcher(t *testing.T) {
 	}
 }
 
+// TestCheckCLIVersionBrewHeadBuild verifies that a --HEAD build is not told to
+// run `brew upgrade beads`. CompareVersions reads the stamp as 0.0.0, so every
+// release looks newer forever, and taking the advice would move the user off
+// HEAD entirely.
+func TestCheckCLIVersionBrewHeadBuild(t *testing.T) {
+	orig := latestGitHubReleaseFetcher
+	fetched := false
+	latestGitHubReleaseFetcher = func() (string, error) {
+		fetched = true
+		return "1.3.0", nil
+	}
+	t.Cleanup(func() { latestGitHubReleaseFetcher = orig })
+
+	for _, stamp := range []string{"HEAD-f925f3f", "HEAD", "HEAD-f925f3f_1"} {
+		t.Run(stamp, func(t *testing.T) {
+			check := CheckCLIVersion(stamp)
+			if check.Status != StatusOK {
+				t.Fatalf("Status = %q, want %q (message: %q)", check.Status, StatusOK, check.Message)
+			}
+			if check.Fix != "" {
+				t.Fatalf("Fix = %q, want no upgrade advice for a --HEAD build", check.Fix)
+			}
+			if !strings.Contains(check.Message, stamp) {
+				t.Fatalf("Message = %q, want it to name the stamp", check.Message)
+			}
+		})
+	}
+
+	if fetched {
+		t.Error("CheckCLIVersion fetched the latest release for a --HEAD build; there is nothing to compare against")
+	}
+}
+
 func TestParseVersionParts(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -223,6 +256,34 @@ func TestCheckMetadataVersionTracking_EmptyFile(t *testing.T) {
 	}
 	if check.Message != ".local_version file is empty" {
 		t.Errorf("Message = %q, want %q", check.Message, ".local_version file is empty")
+	}
+}
+
+// TestCheckMetadataVersionTracking_BrewHeadStamp verifies that the version
+// stamp a Homebrew --HEAD install writes is reported as healthy rather than
+// permanently warning as an invalid format the user cannot fix: the offered
+// fix, running any bd command, writes the same stamp straight back.
+func TestCheckMetadataVersionTracking_BrewHeadStamp(t *testing.T) {
+	for _, stamp := range []string{"HEAD-f925f3f", "HEAD", "HEAD-f925f3f_1"} {
+		t.Run(stamp, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			beadsDir := filepath.Join(tmpDir, ".beads")
+			if err := os.MkdirAll(beadsDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(beadsDir, ".local_version"), []byte(stamp+"\n"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			check := CheckMetadataVersionTracking(tmpDir, "HEAD-aaaaaaa")
+
+			if check.Status != StatusOK {
+				t.Errorf("Status = %q, want %q (message: %q)", check.Status, StatusOK, check.Message)
+			}
+			if check.Fix != "" {
+				t.Errorf("Fix = %q, want no fix advice for a --HEAD stamp", check.Fix)
+			}
+		})
 	}
 }
 

--- a/cmd/bd/upgrade.go
+++ b/cmd/bd/upgrade.go
@@ -58,7 +58,7 @@ Examples:
 		}
 
 		if versionUpgradeDetected {
-			fmt.Printf("✨ bd upgraded from v%s to v%s\n", previousVersion, Version)
+			fmt.Printf("✨ bd upgraded from %s to %s\n", displayVersion(previousVersion), displayVersion(Version))
 			newVersions := getVersionsSince(previousVersion)
 			if len(newVersions) > 0 {
 				fmt.Printf("   %d version%s with changes available\n",
@@ -68,9 +68,9 @@ Examples:
 				fmt.Println("Run 'bd upgrade review' to see what changed")
 			}
 		} else if previousVersion == "" {
-			fmt.Printf("bd version: v%s (first run or version tracking just enabled)\n", Version)
+			fmt.Printf("bd version: %s (first run or version tracking just enabled)\n", displayVersion(Version))
 		} else {
-			fmt.Printf("bd version: v%s (no upgrade detected)\n", Version)
+			fmt.Printf("bd version: %s (no upgrade detected)\n", displayVersion(Version))
 		}
 		return nil
 	},
@@ -109,7 +109,7 @@ Examples:
 		}
 
 		if !versionUpgradeDetected {
-			fmt.Printf("You're already on v%s (no upgrade detected)\n", Version)
+			fmt.Printf("You're already on %s (no upgrade detected)\n", displayVersion(Version))
 			fmt.Println("Run 'bd info --whats-new' to see recent changes")
 			return nil
 		}
@@ -124,12 +124,12 @@ Examples:
 			})
 		}
 
-		fmt.Printf("\n🔄 Upgraded from v%s to v%s\n", lastVersion, Version)
+		fmt.Printf("\n🔄 Upgraded from %s to %s\n", displayVersion(lastVersion), displayVersion(Version))
 		fmt.Println(strings.Repeat("=", 60))
 		fmt.Println()
 
 		if len(newVersions) == 0 {
-			fmt.Printf("v%s is newer than v%s but not in changelog\n", Version, lastVersion)
+			fmt.Printf("%s is newer than %s but not in changelog\n", displayVersion(Version), displayVersion(lastVersion))
 			fmt.Println("Run 'bd info --whats-new' to see recent documented changes")
 			return nil
 		}
@@ -211,11 +211,11 @@ Examples:
 		}
 
 		if lastSeenVersion == Version {
-			fmt.Printf("✓ Already on v%s\n", Version)
+			fmt.Printf("✓ Already on %s\n", displayVersion(Version))
 		} else if lastSeenVersion == "" {
-			fmt.Printf("✓ Acknowledged bd v%s\n", Version)
+			fmt.Printf("✓ Acknowledged bd %s\n", displayVersion(Version))
 		} else {
-			fmt.Printf("✓ Acknowledged upgrade from v%s to v%s\n", lastSeenVersion, Version)
+			fmt.Printf("✓ Acknowledged upgrade from %s to %s\n", displayVersion(lastSeenVersion), displayVersion(Version))
 		}
 		return nil
 	},

--- a/cmd/bd/version_tracking.go
+++ b/cmd/bd/version_tracking.go
@@ -61,9 +61,21 @@ func trackBdVersionFile(persist bool) {
 	localVersionPath := filepath.Join(beadsDir, localVersionFile)
 	lastVersion := readLocalVersion(localVersionPath)
 
-	// Check if version changed (only flag actual upgrades, not downgrades)
+	// Check if version changed (only flag actual upgrades, not downgrades).
+	//
+	// Homebrew --HEAD stamps (HEAD-<sha>) carry no ordering, so CompareVersions
+	// reads them as 0.0.0: a reinstall onto a newer HEAD registers as no change
+	// at all, and moving a release workspace onto HEAD registers as a
+	// downgrade. Treat a changed stamp with a HEAD build on either side as an
+	// upgrade, so the one-shot post-upgrade reconciliation actually runs; brew
+	// reinstalls only move forward. If that assumption is ever wrong the
+	// misfire is bounded — recoverPreV56IfNeeded refuses a non-semver
+	// predecessor, and the workspace's own version markers still refuse a
+	// genuine downgrade. (Those markers cannot arbitrate direction here: they
+	// compare with the same dotted scan and read HEAD stamps as 0.0.0 too.)
 	if lastVersion != "" && lastVersion != Version {
-		if doctor.CompareVersions(Version, lastVersion) > 0 {
+		if doctor.CompareVersions(Version, lastVersion) > 0 ||
+			doctor.IsBrewHeadVersion(Version) || doctor.IsBrewHeadVersion(lastVersion) {
 			// Version upgrade detected!
 			versionUpgradeDetected = true
 			previousVersion = lastVersion

--- a/cmd/bd/version_tracking.go
+++ b/cmd/bd/version_tracking.go
@@ -210,17 +210,7 @@ func autoMigrateOnVersionBump(beadsDir string) {
 		return
 	}
 
-	// GH#2137: If upgrading from pre-0.56, the dolt database may have been
-	// created by the old embedded Dolt mode. Recover by reinitializing.
-	if previousVersion != "" && doctor.CompareVersions(previousVersion, "0.56.0") < 0 {
-		recovered, recErr := doltserver.RecoverPreV56DoltDir(dbPath)
-		if recErr != nil {
-			debug.Logf("auto-migrate: pre-v56 recovery failed: %v", recErr)
-		}
-		if recovered {
-			debug.Logf("auto-migrate: rebuilt pre-v56 dolt database at %s", dbPath)
-		}
-	}
+	recoverPreV56IfNeeded(previousVersion, dbPath)
 
 	// Open database using factory (respects backend config from metadata.json)
 	// Use rootCtx if available and not canceled, otherwise use Background
@@ -285,6 +275,39 @@ func autoMigrateOnVersionBump(beadsDir string) {
 		debug.Logf("auto-migrate: successfully migrated database from %s to version %s", result.Previous, result.Current)
 	default:
 		debug.Logf("auto-migrate: database already at version %s", Version)
+	}
+}
+
+// recoverPreV56IfNeeded rebuilds a Dolt database left behind by the pre-0.56
+// embedded mode (GH#2137) — which means deleting .dolt — but only when the
+// recorded predecessor is an actual semantic version older than 0.56.0.
+//
+// The validity check is not redundant with the comparison. CompareVersions
+// scans every dot-separated part with %d and leaves whatever it cannot read at
+// 0, so any non-semver string writeLocalVersion has recorded compares as
+// pre-0.56 and routes a current workspace into this destructive path:
+// Homebrew's "HEAD-<shortsha>" from a --HEAD install (#5603), and the
+// v-prefixed Go pseudo-version a `go install`-built bd stamps (#5650). Neither
+// is a pre-0.56 workspace; both would lose their database.
+//
+// IsValidSemver rejects exactly the shapes CompareVersions misreads, so this
+// gate can only remove predecessors from the recovery set, never add one: a
+// stamp that reaches RecoverPreV56DoltDir today and still parses keeps its
+// recovery unchanged.
+func recoverPreV56IfNeeded(previousVersion, dbPath string) {
+	if !doctor.IsValidSemver(previousVersion) {
+		return
+	}
+	if doctor.CompareVersions(previousVersion, "0.56.0") >= 0 {
+		return
+	}
+
+	recovered, recErr := doltserver.RecoverPreV56DoltDir(dbPath)
+	if recErr != nil {
+		debug.Logf("auto-migrate: pre-v56 recovery failed: %v", recErr)
+	}
+	if recovered {
+		debug.Logf("auto-migrate: rebuilt pre-v56 dolt database at %s", dbPath)
 	}
 }
 

--- a/cmd/bd/version_tracking.go
+++ b/cmd/bd/version_tracking.go
@@ -121,6 +121,13 @@ func getVersionsSince(sinceVersion string) []VersionChange {
 		return versionChanges
 	}
 
+	// A brew --HEAD stamp names no changelog entry; without this the
+	// unknown-version fallback below would report the entire release history
+	// as new after every --HEAD reinstall.
+	if doctor.IsBrewHeadVersion(sinceVersion) {
+		return []VersionChange{}
+	}
+
 	// Find the index of sinceVersion
 	// versionChanges is ordered newest-first: [0.23.0, 0.22.1, 0.22.0, 0.21.0]
 	startIdx := -1
@@ -155,6 +162,16 @@ func getVersionsSince(sinceVersion string) []VersionChange {
 	return result
 }
 
+// displayVersion formats a version stamp for user-facing messages: semver
+// stamps get the conventional "v" prefix, while a brew --HEAD stamp is shown
+// verbatim ("vHEAD-f925f3f" reads as a typo).
+func displayVersion(version string) string {
+	if doctor.IsBrewHeadVersion(version) {
+		return version
+	}
+	return "v" + version
+}
+
 // maybeShowUpgradeNotification displays a one-time upgrade notification if version changed.
 // This is called by commands like 'bd ready' and 'bd list' to inform users of upgrades.
 func maybeShowUpgradeNotification() {
@@ -167,7 +184,7 @@ func maybeShowUpgradeNotification() {
 	upgradeAcknowledged = true
 
 	// Display notification
-	fmt.Printf("🔄 bd upgraded from v%s to v%s since last use\n", previousVersion, Version)
+	fmt.Printf("🔄 bd upgraded from %s to %s since last use\n", displayVersion(previousVersion), displayVersion(Version))
 	fmt.Println("💡 Run 'bd upgrade review' to see what changed")
 	if usesSQLServer() {
 		fmt.Println("💊 Run 'bd doctor' to verify upgrade completed cleanly")
@@ -375,8 +392,8 @@ func noticeSharedMigrateRefusal(err error) {
 		remedy = "This database has a remote — run 'bd migrate' to see the migrate-or-adopt options before choosing; reads keep working meanwhile."
 	}
 	fmt.Fprintf(os.Stderr,
-		"bd upgraded to v%s: %d schema migration(s) pending on this database — not auto-applying (#5920).\n%s\n",
-		Version, gateErr.Pending, remedy)
+		"bd upgraded to %s: %d schema migration(s) pending on this database — not auto-applying (#5920).\n%s\n",
+		displayVersion(Version), gateErr.Pending, remedy)
 }
 
 // recordedWorkspaceVersion reads the marker through the role's accessor on a

--- a/cmd/bd/version_tracking_test.go
+++ b/cmd/bd/version_tracking_test.go
@@ -46,6 +46,18 @@ func TestGetVersionsSince(t *testing.T) {
 			expectedCount: 0,
 			description:   "Should return empty slice when already on latest in changelog",
 		},
+		{
+			name:          "brew HEAD stamp returns empty",
+			sinceVersion:  "HEAD-f925f3f",
+			expectedCount: 0,
+			description:   "A --HEAD stamp names no changelog entry and must not dump the full history",
+		},
+		{
+			name:          "bare brew HEAD stamp returns empty",
+			sinceVersion:  "HEAD",
+			expectedCount: 0,
+			description:   "A bare HEAD stamp names no changelog entry and must not dump the full history",
+		},
 	}
 
 	for _, tt := range tests {
@@ -54,6 +66,28 @@ func TestGetVersionsSince(t *testing.T) {
 			if len(result) != tt.expectedCount {
 				t.Errorf("getVersionsSince(%q) returned %d versions, want %d: %s",
 					tt.sinceVersion, len(result), tt.expectedCount, tt.description)
+			}
+		})
+	}
+}
+
+func TestDisplayVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "release", version: "1.3.0", want: "v1.3.0"},
+		{name: "pre-release", version: "1.3.0-rc.1", want: "v1.3.0-rc.1"},
+		{name: "brew HEAD stamp", version: "HEAD-f925f3f", want: "HEAD-f925f3f"},
+		{name: "bare brew HEAD stamp", version: "HEAD", want: "HEAD"},
+		{name: "brew HEAD stamp with revision", version: "HEAD-f925f3f_1", want: "HEAD-f925f3f_1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := displayVersion(tt.version); got != tt.want {
+				t.Fatalf("displayVersion(%q) = %q, want %q", tt.version, got, tt.want)
 			}
 		})
 	}

--- a/cmd/bd/version_tracking_test.go
+++ b/cmd/bd/version_tracking_test.go
@@ -395,6 +395,69 @@ func TestMaybeShowUpgradeNotification(t *testing.T) {
 	}
 }
 
+// writePreV56DoltFixture builds the workspace shape RecoverPreV56DoltDir
+// destroys: a .dolt/ directory with no .bd-dolt-ok compatibility marker. It
+// returns a path inside .dolt/ whose survival tells the caller whether the
+// recovery ran.
+func writePreV56DoltFixture(t *testing.T) (doltDir, sentinel string) {
+	t.Helper()
+	doltDir = t.TempDir()
+	sentinel = filepath.Join(doltDir, ".dolt", "sentinel.txt")
+	if err := os.MkdirAll(filepath.Dir(sentinel), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sentinel, []byte("live workspace data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return doltDir, sentinel
+}
+
+// TestRecoverPreV56IfNeeded_OnlySemverPredecessorsAreRecovered pins the
+// destructive edge from #5603/#5625: CompareVersions reads any unparsable
+// version part as 0, so a non-semver predecessor compares as pre-0.56 and
+// hands a live workspace to a path that deletes .dolt. The Homebrew --HEAD
+// stamp and the v-prefixed Go pseudo-version from #5650 are both such
+// predecessors and both reach this call today.
+func TestRecoverPreV56IfNeeded_OnlySemverPredecessorsAreRecovered(t *testing.T) {
+	tests := []struct {
+		name         string
+		previous     string
+		wantRecovery bool
+	}{
+		{name: "brew HEAD stamp", previous: "HEAD-f925f3f"},
+		{name: "bare brew HEAD stamp", previous: "HEAD"},
+		{name: "brew HEAD stamp with revision", previous: "HEAD-f925f3f_1"},
+		{name: "go pseudo-version", previous: "v1.1.1-0.20260805093327-bf97b73749ac"},
+		{name: "unreadable witness", previous: "not-a-version"},
+		{name: "no predecessor", previous: ""},
+		{name: "current release", previous: "1.1.2"},
+		{name: "0.56.0 itself", previous: "0.56.0"},
+		{name: "pre-0.56 release", previous: "0.55.4", wantRecovery: true},
+		{name: "pre-0.56 pre-release", previous: "0.55.4-rc.1", wantRecovery: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doltDir, sentinel := writePreV56DoltFixture(t)
+
+			recoverPreV56IfNeeded(tt.previous, doltDir)
+
+			_, err := os.Stat(sentinel)
+			if tt.wantRecovery {
+				// The reinitializing `dolt init` may fail in a bare
+				// environment; the removal that precedes it is the assertion.
+				if !os.IsNotExist(err) {
+					t.Fatalf("predecessor %q: expected pre-v56 recovery to rebuild .dolt, but %s survived", tt.previous, sentinel)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("predecessor %q: pre-v56 recovery deleted a live .dolt: %v", tt.previous, err)
+			}
+		})
+	}
+}
+
 func TestAutoMigrateOnVersionBump_NoUpgrade(t *testing.T) {
 	// Save original state
 	origUpgradeDetected := versionUpgradeDetected

--- a/cmd/bd/version_tracking_test.go
+++ b/cmd/bd/version_tracking_test.go
@@ -304,6 +304,107 @@ func TestTrackBdVersion_DowngradeIgnored(t *testing.T) {
 	}
 }
 
+// newTrackingWorkspace prepares the minimal .beads a trackBdVersion call needs
+// and pins the globals it mutates, returning the .local_version path.
+func newTrackingWorkspace(t *testing.T, lastVersion, binVersion string) string {
+	t.Helper()
+	ensureCleanGlobalState(t)
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("Failed to create .beads: %v", err)
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+	t.Chdir(tmpDir)
+
+	metadataPath := filepath.Join(beadsDir, "metadata.json")
+	if err := os.WriteFile(metadataPath, []byte(`{"database":"beads.db"}`), 0600); err != nil {
+		t.Fatalf("Failed to create metadata.json: %v", err)
+	}
+
+	localVersionPath := filepath.Join(beadsDir, localVersionFile)
+	if err := writeLocalVersion(localVersionPath, lastVersion); err != nil {
+		t.Fatalf("Failed to write local version: %v", err)
+	}
+
+	origVersion, origDetected, origPrevious := Version, versionUpgradeDetected, previousVersion
+	t.Cleanup(func() {
+		Version, versionUpgradeDetected, previousVersion = origVersion, origDetected, origPrevious
+	})
+	Version = binVersion
+	versionUpgradeDetected = false
+	previousVersion = ""
+
+	return localVersionPath
+}
+
+// TestTrackBdVersion_HeadStampChangeDetectedAsUpgrade covers the stamp changes
+// CompareVersions cannot see: it reads every HEAD stamp as 0.0.0, so a HEAD
+// reinstall looked like no change and a release-to-HEAD move looked like a
+// downgrade. Both skipped the one-shot post-upgrade reconciliation entirely.
+func TestTrackBdVersion_HeadStampChangeDetectedAsUpgrade(t *testing.T) {
+	tests := []struct {
+		name         string
+		lastVersion  string
+		binVersion   string
+		wantDetected bool
+	}{
+		{name: "HEAD stamp to different HEAD stamp", lastVersion: "HEAD-423afdc", binVersion: "HEAD-f925f3f", wantDetected: true},
+		{name: "release to HEAD stamp", lastVersion: "1.1.2", binVersion: "HEAD-f925f3f", wantDetected: true},
+		{name: "HEAD stamp to release", lastVersion: "HEAD-423afdc", binVersion: "1.3.0", wantDetected: true},
+		{name: "same HEAD stamp", lastVersion: "HEAD-f925f3f", binVersion: "HEAD-f925f3f", wantDetected: false},
+		{name: "non-HEAD garbage change stays undetected", lastVersion: "not-a-version", binVersion: "also-not-one", wantDetected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			localVersionPath := newTrackingWorkspace(t, tt.lastVersion, tt.binVersion)
+
+			trackBdVersion()
+
+			if versionUpgradeDetected != tt.wantDetected {
+				t.Errorf("versionUpgradeDetected = %v, want %v", versionUpgradeDetected, tt.wantDetected)
+			}
+			wantPrevious := ""
+			if tt.wantDetected {
+				wantPrevious = tt.lastVersion
+			}
+			if previousVersion != wantPrevious {
+				t.Errorf("previousVersion = %q, want %q", previousVersion, wantPrevious)
+			}
+			if got := readLocalVersion(localVersionPath); got != tt.binVersion {
+				t.Errorf(".local_version = %q, want %q", got, tt.binVersion)
+			}
+		})
+	}
+}
+
+// TestTrackBdVersion_HeadStampNeverReachesPreV56Recovery walks the whole
+// #5603 shape end to end: a workspace last touched by a Homebrew --HEAD build,
+// a .dolt with no .bd-dolt-ok marker, and a release install on top. Detection
+// and the recovery gate have to compose — widening detection is what puts a
+// HEAD stamp into previousVersion in the first place.
+func TestTrackBdVersion_HeadStampNeverReachesPreV56Recovery(t *testing.T) {
+	newTrackingWorkspace(t, "HEAD-f925f3f", "1.3.0")
+	doltDir, sentinel := writePreV56DoltFixture(t)
+
+	trackBdVersion()
+
+	if !versionUpgradeDetected {
+		t.Fatal("installing a release over a --HEAD build should register as an upgrade")
+	}
+	if previousVersion != "HEAD-f925f3f" {
+		t.Fatalf("previousVersion = %q, want the HEAD stamp", previousVersion)
+	}
+
+	recoverPreV56IfNeeded(previousVersion, doltDir)
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("a --HEAD predecessor routed a live workspace into the pre-v56 recovery: %v", err)
+	}
+}
+
 func TestTrackBdVersion_SameVersion(t *testing.T) {
 	// Create temp .beads directory
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## What

Carries the non-guard half of #5625 (@anisoptera) onto `release/1.3.0`, recomposed against the merged #5650. A Homebrew `--HEAD` install stamps `HEAD-<shortsha>` into `main.Version` and `bd` writes it verbatim into `.beads/.local_version`. That string is not semver, and every version-string consumer misread it differently.

The riskiest thing in this diff is the third row below: on `release/1.3.0` today, a workspace whose recorded version is a `HEAD-<sha>` stamp — or a v-prefixed Go pseudo-version — routes into `RecoverPreV56DoltDir`, which `os.RemoveAll`s `.dolt`. That path is reachable now, without any of the other changes here.

## Why

`doctor.CompareVersions` scans each dot-separated part with `%d` and leaves whatever it cannot read at `0`, so every non-semver stamp compares as `0.0.0`. Each consumer then fails in its own way.

| # | Defect (from #5625 / #5603) | This PR |
|---|---|---|
| 1 | **Upgrade guard**: `currentVersionWitness` rejected the stamp, so an explicit-server workspace with a local Dolt root was refused as a legacy schema — the #5603 brick. | **Deferred to `main`.** #5650's `witnessEraUnknown` already keeps such a workspace open on this branch; what remains is the per-run "unreadable version witness" warning, and reclassifying `HEAD-<sha>` as `witnessEraCurrent` to silence it. That is a guard-policy change, not an RC fix. |
| 2 | **Version tracking**: a changed HEAD stamp never registered as an upgrade, so the one-shot post-upgrade reconciliation never ran. | **Fixed.** A changed stamp with a HEAD build on either side is an upgrade. |
| 3 | **Version tracking, destructive**: the pre-0.56 recovery read a HEAD stamp as "older than 0.56" and deleted `.dolt`. | **Fixed**, and the gate also closes the shape from #5650. |
| 4 | **`bd doctor`**: the tracking check reported the stamp as a permanently-unfixable "Invalid version format", and `CheckCLIVersion` warned "update available: brew upgrade beads" forever — advice that would move the user off HEAD. | **Fixed.** Both report a `--HEAD` build as healthy, with no `Fix` line. |
| 5 | **`bd upgrade status`/`review`**: a HEAD-stamp predecessor matched no changelog entry and dumped the entire release history, under a `vHEAD-<sha>` banner. | **Fixed.** No delta, and stamps render verbatim. |

### On row 3, the destructive one

`.beads/.local_version` is written from `main.Version` verbatim, so it holds whatever the last binary was stamped with. Two such stamps read as pre-0.56 through `CompareVersions` and reach the recovery today:

- `HEAD-<shortsha>` — and because the *same* comparison also reads the stamp as `0.0.0` on the other side, installing a release over a `--HEAD` build already registers as an upgrade. So the recovery fires on the very next command, before anything in this PR.
- `v1.1.1-0.20260805093327-bf97b73749ac` — the v-prefixed Go pseudo-version from the #5650 production incident. `CompareVersions` cannot read the `v`, so it compares `0` against `0`, then `1` against `56`.

The fix is the defense-in-depth check @anisoptera proposed: gate on `IsValidSemver` **before** the comparison. It rejects exactly the shapes `CompareVersions` misreads, so it can only *remove* predecessors from the recovery set, never add one — every stamp that reaches `RecoverPreV56DoltDir` today and still parses keeps its recovery unchanged. That "strictly subtractive" property is why this is safe to land during an RC.

## What was recomposed, and why a replacement PR

#5625 targets `main` and predates #5650, which rewrote the same witness classifiers to parse with `golang.org/x/mod/semver` and split "present but unreadable" into its own era. The two overlap in `cmd/bd/legacy_upgrade_guard.go`; @anisoptera's suggestion on the thread (2026-08-11) was that once #5650 landed, the guard side of #5625 could shrink and `versionCore` could drop out in favour of the semver parse.

That is what this is. Per `PR_MAINTAINER_GUIDELINES.md` → Contributor Protection, the replacement route applies because the accepted change had to be substantially reimplemented against a different base:

- `IsBrewHeadVersion` is carried **verbatim**, tests included, into `cmd/bd/doctor` — the placement @anisoptera's own composition uses. Only its doc comment changed, since the guard does not delegate to it on this branch.
- `versionCore` is **dropped**. #5650 replaced the classifiers that needed it, and the pre-0.56 gate does not need it either: `IsValidSemver` already rejects the shapes that matter here, and adding normalization would *widen* the destructive path rather than narrow it.
- `currentVersionWitness` / `legacyVersionMinor` / `classifyVersionWitness` are **untouched** — that is the deferred row 1.
- `docs/getting-started/upgrading.md` is **untouched**: #6038 owns that file on this branch. Follow-up, to land with row 1 on `main`: the current-era witness row in that table should name the Homebrew `--HEAD` stamp alongside `x.y.z` with major ≥ 1.
- `CHANGELOG.md` is untouched for the same reason (#6038 owns the v1.3.0 rollup). Proposed line, for whoever lands the rollup:
  > `fix: recognize Homebrew --HEAD version stamps — bd doctor no longer warns about them forever, bd upgrade no longer replays the whole changelog, and a non-semver recorded version can no longer route a workspace into the pre-0.56 .dolt rebuild (#5603, #5625, #5650)`

**#5625 stays open.** Row 1 and the docs table are still its work, and its branch is the vehicle for the main-line landing. Nothing here closes or supersedes it. Every commit carries `Co-authored-by: Isis Anisoptera <github@lotuswind.net>`.

## Verification

```
CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go build ./...          # clean
CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go vet ./...            # clean
CGO_ENABLED=0 GOFLAGS=-tags=gms_pure_go go test -c ./cmd/bd     # nocgo build clean
./scripts/test.sh ./cmd/bd/doctor                               # pass
./scripts/test.sh ./cmd/bd/                                     # pass
golangci-lint (pre-commit hook, every commit)                   # 0 issues
```

New coverage:

- `doctor.TestIsBrewHeadVersion` — @anisoptera's table, including the `-dirty`, signed-revision, sub-abbreviation and over-length rejections.
- `doctor.TestCheckCLIVersionBrewHeadBuild` — status OK, no `Fix`, and the GitHub release fetch is not even attempted.
- `doctor.TestCheckMetadataVersionTracking_BrewHeadStamp` — healthy, no `Fix`.
- `TestRecoverPreV56IfNeeded_OnlySemverPredecessorsAreRecovered` — ten predecessor shapes against a real fixture (`.dolt/` with no `.bd-dolt-ok` marker), asserting the directory survives or is rebuilt.
- `TestTrackBdVersion_HeadStampChangeDetectedAsUpgrade` — the three directions a `--HEAD` user travels, plus the two non-upgrades.
- `TestTrackBdVersion_HeadStampNeverReachesPreV56Recovery` — the whole #5603 shape end to end, because the halves have to compose: widening detection is what puts a HEAD stamp into `previousVersion`, where the gate then has to refuse it.
- `TestDisplayVersion`, and two `getVersionsSince` cases.

**Prove-it.** Reverting the gate in `recoverPreV56IfNeeded` to the previous `previousVersion != ""` condition and re-running the regression test fails on five shapes, each losing a live `.dolt`:

```
--- FAIL: TestRecoverPreV56IfNeeded_OnlySemverPredecessorsAreRecovered/brew_HEAD_stamp
    predecessor "HEAD-f925f3f": pre-v56 recovery deleted a live .dolt
--- FAIL: .../bare_brew_HEAD_stamp                 predecessor "HEAD"
--- FAIL: .../brew_HEAD_stamp_with_revision        predecessor "HEAD-f925f3f_1"
--- FAIL: .../go_pseudo-version                    predecessor "v1.1.1-0.20260805093327-bf97b73749ac"
--- FAIL: .../unreadable_witness                   predecessor "not-a-version"
```

Reverting the detection change likewise fails `HEAD_stamp_to_different_HEAD_stamp` and `release_to_HEAD_stamp`. (`HEAD_stamp_to_release` still passes, which is the point of the paragraph above: that direction is *already* detected, which is how the destructive path is reachable today.)

## Notes for the reviewer

- `displayVersion` is applied to three `bd upgrade ack` messages that #5625 did not reach, and to the pending-migration notice in `noticeSharedMigrateRefusal` — that one is newly *reachable* for a `--HEAD` user, since detecting the upgrade is what lets `autoMigrateOnVersionBump` run far enough to print it. String-only. The `bd doctor` headers, `bd info --whats-new`, and the `hooks.go` section markers (whose format is parsed back out of user files) are deliberately left alone.
- Extracting `recoverPreV56IfNeeded` out of `autoMigrateOnVersionBump` is what makes the destructive edge testable against the real fixture instead of only through a database open. No behaviour rides on the extraction.
- Rebuilding the `.dolt` of a workspace that was never pre-0.56 is unrecoverable data loss, so this is a protected path under `PR_MAINTAINER_GUIDELINES.md`: it needs a real human review, and I am not merging it.

Refs #5603, #5625, #5650, #6038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-code-claude-opus-5[1m]-unknown-reasoning on behalf of Julian Knutsen_
