### PR TITLE
test(show): assert the string revision token in the two show suites (#6053 follow-up)

### DIFF
--- a/cmd/bd/show_embedded_test.go
+++ b/cmd/bd/show_embedded_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // bdShowRaw runs "bd show" with the given args and returns raw stdout.
@@ -57,6 +59,41 @@ func bdShowDetails(t *testing.T, bd, dir, id string) map[string]interface{} {
 		t.Fatalf("parse show JSON: %v\n%s", err, s)
 	}
 	return m
+}
+
+// assertLiveRevisionToken holds a `revision` read off a `bd show --json` detail
+// view to the wire contract the token carries: a decimal STRING, never a JSON
+// number.
+//
+// THE TYPE IS ASSERTED BEFORE THE VALUE, and that ordering is the point. The
+// token spans the full int64 range, and a JSON number past 2^53 is rounded by
+// every double-based consumer — jq, JavaScript, Go's own `any` — so a guard
+// composed from one is refused against a row nothing else touched. Decoding a
+// detail view into `map[string]any` is exactly the shape that hides it, which is
+// why both callers here go through this helper instead of a local cast.
+//
+// "LIVE" IS THE SECOND HALF. A row the caller just created carries a freshly
+// minted token, so "0" — the migration-0054 backfill value — means the producer
+// published a member it never filled in: the one failure a legacy-zero row makes
+// otherwise indistinguishable from success.
+func assertLiveRevisionToken(t *testing.T, value any) {
+	t.Helper()
+	token, ok := value.(string)
+	if !ok {
+		t.Errorf("revision = %#v (%T), want the decimal string the wire contract declares", value, value)
+		return
+	}
+	parsed, err := types.ParseRevisionToken(token)
+	if err != nil {
+		t.Errorf("revision = %q, which is not a decimal token: %v", token, err)
+		return
+	}
+	if got := types.RevisionToken(parsed); got != token {
+		t.Errorf("revision = %q does not round-trip through the token codec (got %q back)", token, got)
+	}
+	if parsed == 0 {
+		t.Errorf("revision = %q on a row this test just created; the token was not read off the row", token)
+	}
 }
 
 // bdShowFail2 runs "bd show" expecting failure.
@@ -129,9 +166,7 @@ func TestEmbeddedShow(t *testing.T) {
 		if m["description"] != "A description" {
 			t.Errorf("expected description, got %v", m["description"])
 		}
-		if revision, ok := m["revision"].(float64); !ok || revision == 0 {
-			t.Errorf("expected non-zero revision, got %v", m["revision"])
-		}
+		assertLiveRevisionToken(t, m["revision"])
 	})
 
 	t.Run("show_json_includes_labels", func(t *testing.T) {

--- a/cmd/bd/show_proxied_integration_test.go
+++ b/cmd/bd/show_proxied_integration_test.go
@@ -122,9 +122,7 @@ func TestProxiedServerShow(t *testing.T) {
 		if m["priority"] != float64(1) {
 			t.Errorf("priority: got %v, want 1", m["priority"])
 		}
-		if revision, ok := m["revision"].(float64); !ok || revision == 0 {
-			t.Errorf("revision: got %v, want a non-zero opaque token", m["revision"])
-		}
+		assertLiveRevisionToken(t, m["revision"])
 		if _, ok := m["created_at"]; !ok {
 			t.Errorf("missing created_at")
 		}


### PR DESCRIPTION
Follow-up to #6053. Test-only; no production code changes.

## What broke

#6053 made the optimistic-concurrency token a decimal **string** on the wire. Two assertions were missed by that PR's sweep, and the first full Embedded/Proxied Cmd matrix on `release/1.3.0` caught them (blocking #6038's merge queue):

- `cmd/bd/show_embedded_test.go` — `TestEmbeddedShow/show_json`
- `cmd/bd/show_proxied_integration_test.go` — `TestProxiedServerShow/show_json_fields_round_trip`

Both did `m["revision"].(float64)` on a `map[string]any` decode and failed with `expected non-zero revision, got <19-digit token>`.

**The product is correct.** The `ok == false` branch printing the raw value is what proves it — the value it prints is the intended string. Only the assertions are stale. They were missed in #6053 because a `map[string]any` decode makes a number/string mix-up invisible to the compiler, so nothing flagged them; they read as ordinary map lookups.

## The fix

Both call sites now go through one shared helper, `assertLiveRevisionToken`, placed beside the other `bdShow*` helpers (both files are `//go:build cgo`, `package main`, so one spelling serves both):

- **Type before value.** A `map[string]any` decode is exactly the shape that hides this — and it is the same shape that silently rounded tokens past 2^53 before #6053, which is why the member became a string in the first place. Asserting the type first is the point of the helper.
- **Round-trips** through `types.ParseRevisionToken` / `types.RevisionToken`, so it holds the same semantics the httpapi tests assert rather than just "is a non-empty string".
- **Keeps the original "non-zero" intent.** A row the test just created must not carry the migration-0054 backfill `"0"` — the one failure a legacy-zero row makes otherwise indistinguishable from success.

## Verification

- Both suites run under their env gates: `BEADS_TEST_EMBEDDED_DOLT=1 -run TestEmbeddedShow` and `BEADS_TEST_PROXIED_SERVER=1 -run TestProxiedServerShow` — **both green**.
- `go build ./...`, `go vet ./...` clean.
- **No test function renamed.** The proxied shard discovers by `^func TestProxiedServer`; `TestProxiedServerShow`, `TestProxiedServerShow2` and `TestProxiedServerShow3` are untouched. The new symbol is a plain helper, not a `Test*`.
- **Mutation-checked that the assertion is genuinely reached** rather than passing vacuously: forcing the helper to fail reports

  ```
  show_embedded_test.go:173: PROVEIT reached with "-3792633769313385388" (string)
  ```

  which is both the live wire type and a token comfortably past 2^53 — the exact case the string spelling exists for.

## Sweep

Grepped the whole tree for other number-typed spellings of `revision` / `expected_version`. **No further stale assertions.** For the record, everything else the sweep surfaced is correct:

- `revisionOf(...) int64` (httpapi + cmd/bd) parses the string then returns the internal int64 — correct.
- `releasedIssue(id, revision int64)` / `revisionedIssue(id, revision int64)` take the internal `RowVersion` — correct.
- Every numeric `"expected_version":<n>` literal left in the tree is inside a deliberate **refusal** test asserting a 400 — correct.
- All production `Revision` fields are `string`.

Two inert mentions are deliberately left alone rather than churned:

- `internal/httpapi/related_test.go:142` — `Revision *int64` is a never-populated **absence marker** on an element that carries no token by design; its real guard is the byte-level `TestListRelatedIssuesCarriesNoRevision`, and a regression is caught either way.
- `internal/httpapi/get_issue_test.go:497` — `Revision int64` appears only in prose describing a hypothetical mutation; the point it illustrates holds regardless of the type.

Happy to change either if a reviewer prefers accuracy over minimal diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
