### PR TITLE
test(migration): match freeze-marker paths symlink-safely — fix the macOS-only doctor freeze-gate failures (#6038)

### DIFF
--- a/cmd/bd/migration_freeze_gate_test.go
+++ b/cmd/bd/migration_freeze_gate_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -865,7 +866,7 @@ func TestAutoMigrateSkippedDuringMigrationFreeze(t *testing.T) {
 // hang here is the failure).
 func TestDoctorMutationBlockedDuringMigrationFreeze(t *testing.T) {
 	bd, dir := setupMigrationFreezeWorkspace(t)
-	marker := writeFreezeMarker(t, dir, "migrator", "dolt v2 migration")
+	writeFreezeMarker(t, dir, "migrator", "dolt v2 migration")
 	before := doctorWorkspaceFingerprint(t, dir)
 
 	for _, tt := range doctorMutationSurfaces() {
@@ -877,7 +878,17 @@ func TestDoctorMutationBlockedDuringMigrationFreeze(t *testing.T) {
 			}
 			for _, want := range []string{
 				"workspace is frozen for migration",
-				"bd " + tt.op + " is blocked by the freeze marker at " + marker,
+				// The operation label and the marker path are asserted
+				// separately: the path is matched from the workspace
+				// directory's own name down, the same way
+				// TestCreateBlockedDuringMigrationFreeze does it, because the
+				// refusal reports the marker as the subprocess's cwd walk
+				// found it. On macOS that walk starts from an os.Getwd() the
+				// kernel has already resolved, so a /var/folders temp root
+				// arrives as /private/var/folders and a full-path expectation
+				// never matches.
+				"bd " + tt.op + " is blocked by the freeze marker at ",
+				filepath.Join(filepath.Base(dir), migration.FileName),
 				"To resume writes, remove that file.",
 			} {
 				if !strings.Contains(stderr, want) {
@@ -891,6 +902,52 @@ func TestDoctorMutationBlockedDuringMigrationFreeze(t *testing.T) {
 	}
 }
 
+// TestFreezeRefusalPathMatchesUnderSymlinkedTempRoot builds, deliberately, the
+// filesystem shape that made #6038 a macOS-only red lane: a temp root reached
+// through a symlink. A subprocess's os.Getwd() is already symlink-resolved, so
+// a marker found by the cwd walk is reported under its real path while the test
+// still holds the unresolved one — on macOS every t.TempDir() is /var/folders,
+// and /var is a symlink to /private/var, so full-path expectations never match
+// there and always match on Linux, where temp roots are real directories.
+//
+// Constructing the symlink here is what makes that class reproducible on the
+// Linux lane every contributor actually runs.
+func TestFreezeRefusalPathMatchesUnderSymlinkedTempRoot(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("creating symlinks needs elevated privileges on Windows")
+	}
+	root := t.TempDir()
+	real := filepath.Join(root, "real")
+	if err := os.MkdirAll(real, 0755); err != nil {
+		t.Fatalf("creating %s: %v", real, err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable on this filesystem: %v", err)
+	}
+
+	bd := setupMigrationFreezeWorkspaceIn(t, real)
+	writeFreezeMarker(t, real, "migrator", "dolt v2 migration")
+
+	// cwd expressed through the symlink — the shape macOS hands every
+	// subprocess without anyone asking for it.
+	stdout, stderr, code := runBDFrozen(t, bd, link, "create", "should not be created", "-p", "2")
+	if code != ExitMigrationFrozen {
+		t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, ExitMigrationFrozen, stdout, stderr)
+	}
+	if want := filepath.Join(filepath.Base(real), migration.FileName); !strings.Contains(stderr, want) {
+		t.Errorf("refusal should name the marker by its resolved path, matched from %q down:\n%s", want, stderr)
+	}
+	// The other half, and the one that keeps this honest: the unresolved path
+	// must NOT appear. Without it, someone could satisfy the check above while
+	// reintroducing a full-path expectation elsewhere.
+	if unresolved := filepath.Join(link, migration.FileName); strings.Contains(stderr, unresolved) {
+		t.Errorf("refusal named the unresolved symlink path %q; assertions that pin it break on macOS:\n%s",
+			unresolved, stderr)
+	}
+	assertVendorNeutral(t, stderr)
+}
+
 // TestDoctorPathArgBlockedByTargetFreeze covers the reason doctor's gate takes
 // the resolved target path: doctor is the only write-capable command that
 // operates on a directory named on the command line, so keying the lookup on
@@ -899,7 +956,7 @@ func TestDoctorMutationBlockedDuringMigrationFreeze(t *testing.T) {
 func TestDoctorPathArgBlockedByTargetFreeze(t *testing.T) {
 	target := t.TempDir()
 	bd := setupMigrationFreezeWorkspaceIn(t, target)
-	marker := writeFreezeMarker(t, target, "migrator", "dolt v2 migration")
+	writeFreezeMarker(t, target, "migrator", "dolt v2 migration")
 	before := doctorWorkspaceFingerprint(t, target)
 
 	// cwd is an unrelated, unfrozen workspace; only the target is frozen.
@@ -911,8 +968,14 @@ func TestDoctorPathArgBlockedByTargetFreeze(t *testing.T) {
 	if code != ExitMigrationFrozen {
 		t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, ExitMigrationFrozen, stdout, stderr)
 	}
-	if !strings.Contains(stderr, marker) {
-		t.Errorf("refusal should name the target's own marker %q:\n%s", marker, stderr)
+	// Same path-tail convention as the table test above. This assertion happens
+	// to survive the macOS symlink split today — the target arrives from argv,
+	// which nothing resolves — but it would break the moment discovery
+	// canonicalizes its roots, and target/outside are distinct temp
+	// subdirectories, so the tail still proves it named the target and not cwd.
+	wantMarker := filepath.Join(filepath.Base(target), migration.FileName)
+	if !strings.Contains(stderr, wantMarker) {
+		t.Errorf("refusal should name the target's own marker %q:\n%s", wantMarker, stderr)
 	}
 	assertVendorNeutral(t, stderr)
 	assertDoctorRefusalIsClean(t, stdout)


### PR DESCRIPTION
Fixes the macOS-only red lane on `release/1.3.0` reported in #6038 (fallout from #6056).

Test-only. No product behavior changes.

## What broke

`TestDoctorMutationBlockedDuringMigrationFreeze` failed all five subtests on `macos-latest` and passed everywhere else:

```
stderr missing "bd doctor --fix is blocked by the freeze marker at
  /var/folders/df/.../001/MIGRATION-FREEZE":
  ...
  bd doctor --fix is blocked by the freeze marker at
  /private/var/folders/df/.../001/MIGRATION-FREEZE.
```

The assertion pinned the full `t.TempDir()` marker path. A subprocess's `os.Getwd()` is already symlink-resolved, so a marker found by the **cwd walk** is reported under its real path — and on macOS every temp dir lives in `/var/folders`, where `/var` is a symlink to `/private/var`. The test held `/var/...`, the product printed `/private/var/...`.

It was invisible on Linux for a mundane reason: Linux temp roots are real directories, so the resolved and unresolved forms are the same string and the assertion always passed.

## The fix

`TestCreateBlockedDuringMigrationFreeze` — landed in #6043, in this same file — already hit this and solved it, with a comment naming the macOS case explicitly:

```go
// Matched from the workspace directory's own name down, so a symlinked
// temp root (macOS /var → /private/var) doesn't fail the assertion.
filepath.Join(filepath.Base(dir), migration.FileName),
```

So this adopts the existing convention rather than inventing one. The bundled expectation is split in two so both properties still hold: the operation label (`bd doctor --fix is blocked by the freeze marker at `) and the path tail (`001/MIGRATION-FREEZE`).

I deliberately did **not** reach for `filepath.EvalSymlinks` on the expectation. It would have fixed these five and broken `TestDoctorPathArgBlockedByTargetFreeze`, which currently **passes** on macOS: the two discovery paths disagree there. A marker found by the cwd walk comes back resolved, while one found via an explicit root passed on the command line comes back exactly as it was given, because nothing canonicalizes argv. Canonicalizing the expectation would have matched the first and missed the second. The path-tail form is agnostic to which arm found the marker.

That test gets the same treatment anyway — it is correct today by luck, not by design, and would break the moment discovery canonicalizes its roots.

## Sweep for the same latent bug

The macOS log confirms this was the **only** failure in the whole `cmd/bd` package, so every other path assertion in the freeze and doctor suites is already safe — including #6043's env-override tests, which are immune because `BD_MIGRATION_FREEZE_FILE` is returned verbatim with no walk.

Rather than rely on grep for that, I re-ran the entire freeze/doctor suite under a symlinked `TMPDIR` (below), which exercises the real condition on every assertion at once. All green.

Then I ran the **whole `cmd/bd` package** the same way, as a sweep for latent macOS path assumptions beyond these suites: `ok github.com/steveyegge/beads/cmd/bd 475s`. Nothing else in the package pins an unresolved temp path against command output, so this was the only instance.

## Verification, without a Mac

I have no macOS runner locally — CI's `macos-latest` is the real proof, and this PR needs that lane to confirm. But the failure does not actually require macOS, only a symlinked temp root, so I reproduced the mechanism on Linux instead of reasoning about it:

```
ln -s /tmp/6038tmpreal /tmp/6038tmplink
TMPDIR=/tmp/6038tmplink go test ./cmd/bd/ -run TestDoctorMutationBlockedDuringMigrationFreeze
```

- **Pre-fix** (this file at `release/1.3.0`): `FAIL` — all five subtests, the same assertion, the same way CI reported it.
- **Post-fix**: `PASS` — all five.
- Whole freeze/doctor suite under the symlinked `TMPDIR`: `ok`.
- Normal `TMPDIR`: unaffected, as expected.

Direct check of the product's behavior under a symlinked cwd, which is the mechanism itself:

```
cwd passed as : /tmp/6038sym/link/ws
refusal printed: /tmp/6038sym/real/ws/MIGRATION-FREEZE
```

## New regression test

`TestFreezeRefusalPathMatchesUnderSymlinkedTempRoot` builds that symlinked root deliberately, so this class stops being macOS-only and becomes catchable on the Linux lane every contributor runs. It asserts both directions: the resolved path is named, and the unresolved one is not — the second half is what stops someone reintroducing a full-path expectation. Skipped on Windows, where creating symlinks needs elevated privileges.

Also run: `go vet ./cmd/bd/`, `gofmt`, `golangci-lint run ./cmd/bd/...` (0 issues), and the full `./scripts/test.sh ./cmd/bd/` shard under the symlinked `TMPDIR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
