### PR TITLE
fix(storage): stop the #5920 gate refusing fresh-bootstrap retries and bd-owned server migrations

### DIFF
--- a/internal/storage/dolt/shared_server_predicate_test.go
+++ b/internal/storage/dolt/shared_server_predicate_test.go
@@ -1,0 +1,96 @@
+package dolt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSharedServerDatabase pins which topologies the #5920 consent gate
+// applies to. Getting this wrong is expensive in both directions: too broad
+// and bd refuses to migrate a workspace's own database (the release blocker
+// this predicate was introduced to fix), too narrow and an upgraded client
+// silently promotes the schema for a whole team.
+//
+// Every case fixes the environment explicitly — the predicate reads process
+// state, so a leaked BEADS_DOLT_* from another test would otherwise decide the
+// answer.
+func TestSharedServerDatabase(t *testing.T) {
+	// A workspace with no metadata.json: doltserver resolves it as a server
+	// whose lifecycle bd owns.
+	ownedWorkspace := func(t *testing.T) string {
+		t.Helper()
+		dir := filepath.Join(t.TempDir(), ".beads")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		return dir
+	}
+
+	clearEnv := func(t *testing.T) {
+		t.Helper()
+		for _, k := range []string{
+			"BEADS_DOLT_SHARED_SERVER", "BEADS_DOLT_SERVER_MODE",
+			"BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT",
+		} {
+			t.Setenv(k, "")
+		}
+	}
+
+	t.Run("bd-owned local server is not shared", func(t *testing.T) {
+		clearEnv(t)
+		cfg := &Config{BeadsDir: ownedWorkspace(t), ServerHost: "127.0.0.1", ServerPort: 3307}
+		if sharedServerDatabase(cfg) {
+			t.Fatal("a server bd auto-started for this workspace must migrate on open, as embedded does")
+		}
+	})
+
+	t.Run("no workspace fails closed", func(t *testing.T) {
+		clearEnv(t)
+		// A bare dolt.New pointed at an endpoint: nothing proves bd owns it,
+		// and a library caller attached to a team's server must not migrate it.
+		cfg := &Config{ServerHost: "127.0.0.1", ServerPort: 3307}
+		if !sharedServerDatabase(cfg) {
+			t.Fatal("without a workspace to prove ownership, the database must be treated as shared")
+		}
+		if !sharedServerDatabase(nil) {
+			t.Fatal("a nil config must be treated as shared")
+		}
+	})
+
+	t.Run("shared-server mode is shared", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+		cfg := &Config{BeadsDir: ownedWorkspace(t), ServerHost: "127.0.0.1", ServerPort: 3308}
+		if !sharedServerDatabase(cfg) {
+			t.Fatal("shared-server mode is one server for many workspaces — the #5920 shape")
+		}
+	})
+
+	t.Run("explicit external server mode is shared", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("BEADS_DOLT_SERVER_MODE", "1")
+		cfg := &Config{BeadsDir: ownedWorkspace(t), ServerHost: "127.0.0.1", ServerPort: 3307}
+		if !sharedServerDatabase(cfg) {
+			t.Fatal("an operator-managed server is not bd's to migrate unprompted")
+		}
+	})
+
+	for _, tt := range []struct {
+		name string
+		cfg  Config
+	}{
+		{name: "remote host", cfg: Config{ServerHost: "db.example.com", ServerPort: 3307}},
+		{name: "TLS endpoint", cfg: Config{ServerHost: "127.0.0.1", ServerPort: 3307, ServerTLS: true}},
+		{name: "unix socket", cfg: Config{ServerHost: "127.0.0.1", ServerSocket: "/tmp/dolt.sock"}},
+	} {
+		t.Run(tt.name+" is shared", func(t *testing.T) {
+			clearEnv(t)
+			cfg := tt.cfg
+			cfg.BeadsDir = ownedWorkspace(t)
+			if !sharedServerDatabase(&cfg) {
+				t.Fatalf("%s cannot be a server bd auto-started for this workspace", tt.name)
+			}
+		})
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2749,15 +2749,36 @@ func initSchemaOnDBWithRetryAndGateBootstrapHeal(
 	// Must exceed schema.MigrateUpWithLock's 5s GET_LOCK wait so a contended
 	// schema migration can time out once and still retry.
 	schemaBO.MaxElapsedTime = serverRetryMaxElapsed
+
+	// The gate authorizes this LOGICAL open, once — it is not a per-attempt
+	// re-check. Two things make re-checking wrong (gastownhall/beads#5012
+	// shape, caught by the fresh-bootstrap heal tests):
+	//
+	//   - an attempt that dies mid-pass leaves the schema cursor ADVANCED, so
+	//     a re-check no longer sees the fresh database it allowed a moment
+	//     ago. It sees "existing database, migrations pending" and refuses the
+	//     very migration it just authorized, stranding the open half-migrated;
+	//   - fresh-bootstrap heal authority is issued only to the open that won
+	//     the bare CREATE for this exact database incarnation, so it is
+	//     standing proof that creating it was consent for its schema. That
+	//     proof survives a retry; a version read does not.
+	//
+	// Same argument, same shape as the proxied path's skip in
+	// schema.MigrateUpWithLock. Only the ALLOW is latched: a gate whose probes
+	// hit a transient startup/catalog race has not decided anything yet, and
+	// is still retried below.
+	gateSatisfied := bootstrapHeal != nil
+
 	var applied int
 	err := backoff.Retry(func() error {
-		if gate != nil {
+		if gate != nil && !gateSatisfied {
 			if gateErr := gate(ctx, db); gateErr != nil {
 				if !schema.IsRemoteMigrateGateError(gateErr) && isRetryableError(gateErr) {
 					return gateErr
 				}
 				return backoff.Permanent(gateErr)
 			}
+			gateSatisfied = true
 		}
 		var schemaErr error
 		applied, schemaErr = initSchemaOnDBWithBootstrapHeal(ctx, db, bootstrapHeal, endpoint)
@@ -2770,6 +2791,56 @@ func initSchemaOnDBWithRetryAndGateBootstrapHeal(
 		return nil
 	}, backoff.WithContext(schemaBO, ctx))
 	return applied, err
+}
+
+// sharedServerDatabase reports whether this store's database is served to bd
+// clients beyond this workspace — the condition the #5920 consent gate exists
+// for, since migrating promotes the schema version for every one of them at
+// once and locks out any still on an older bd.
+//
+// The line is who owns the server's lifecycle, which doltserver already
+// resolves for the auto-start decision:
+//
+//   - bd auto-started this server for THIS workspace (ServerModeOwned): the
+//     database is this workspace's own, the way an embedded database is, and
+//     bd migrates it on open exactly as it always has. Refusing here would
+//     leave a single-user workspace unable to migrate itself, and would break
+//     the #4566/#5781 dirty-table recovery, whose whole shape is
+//     refuse-then-commit-then-migrate on a bd-owned local server.
+//   - anything else — shared-server mode, an explicit dolt_server_port in
+//     metadata.json, host inference, a caller with no workspace at all —
+//     is someone else's server. Fail closed: without a workspace to prove
+//     ownership from, assume the database is shared.
+//
+// This narrows #6048's original predicate, which treated every DoltStore as
+// shared on the reasoning that "a sql-server accepts co-resident clients by
+// construction". True in the abstract, but it swept in bd's own
+// single-workspace servers and so refused migrations that no other client
+// could ever observe. The #5920 report, and the regression test for it, are
+// both the external-server shape this keeps gated.
+// Every signal it reads is one that is set on EVERY open. Deliberately absent
+// are cfg.AutoStart, cfg.ServerMode and s.autoStartedServerDir, which all name
+// the right idea but are populated only by the CLI (or, for the last, only
+// under BEADS_TEST_MODE): a library caller pointed at a genuinely shared
+// server leaves them false, and reading them would silently ungate it.
+func sharedServerDatabase(cfg *Config) bool {
+	// No workspace to prove ownership from — a bare dolt.New pointed at some
+	// endpoint. Fail closed.
+	if cfg == nil || cfg.BeadsDir == "" {
+		return true
+	}
+	// Somebody else's server by construction: a host that is not this
+	// machine, a TLS endpoint (Hosted Dolt), or a unix socket — bd's own
+	// auto-start only ever creates a local TCP listener.
+	if !isLocalHost(cfg.ServerHost) || cfg.ServerTLS || cfg.ServerSocket != "" {
+		return true
+	}
+	// The one shared topology that is otherwise indistinguishable from an
+	// owned one: same machine, same TCP shape, one server for many workspaces.
+	if doltserver.IsSharedServerMode() {
+		return true
+	}
+	return doltserver.ResolveServerMode(cfg.BeadsDir) != doltserver.ServerModeOwned
 }
 
 func (s *DoltStore) initSchema(ctx context.Context, bootstrapHeal *schema.FreshBootstrapHealCapability) (int, error) {
@@ -2820,14 +2891,16 @@ func (s *DoltStore) initSchema(ctx context.Context, bootstrapHeal *schema.FreshB
 		// depend on that external guard alone.
 		ReadOnly: s.readOnly,
 	}
-	// The shared variant (#5920): a DoltStore is always a sql-server client,
-	// and a sql-server accepts co-resident clients by construction — that is
-	// what distinguishes it from the flock-guarded single-writer embedded
-	// store. So this open must never promote the schema cursor on its own,
-	// with or without a remote. Auto-started servers included: other bd
-	// processes attach to them while they run, which is the exact shape #5920
-	// was reported on.
+	// #5920: on a database served to OTHER workspaces' bd clients, migrating
+	// promotes the schema for all of them at once, so this open must not do it
+	// unprompted. On a server whose lifecycle bd owns for this one workspace,
+	// the pre-existing contract stands and the open migrates (see
+	// sharedServerDatabase).
 	gate := func(ctx context.Context, db *sql.DB) error {
+		if !sharedServerDatabase(s.cfg) {
+			return schema.CheckRemoteMigrateGateForRemoteWithRemoteCheckAndAdopt(
+				ctx, db, s.remote, s.hasPersistedCLIRemote, adopt)
+		}
 		return schema.CheckSharedStoreMigrateGate(ctx, db, s.remote, s.hasPersistedCLIRemote, adopt)
 	}
 	applied, err := initSchemaOnDBWithRetryAndGateBootstrapHeal(ctx, migDB, gate, bootstrapHeal, s.serverEndpoint)


### PR DESCRIPTION
Release blocker. The shared-store consent gate I added in #6048 refuses migrations it has no business refusing, red on the first full Server Dolt matrix run against `release/1.3.0` and blocking #6038 in the merge queue. Three deterministic failures, all in tests #6048 never touched.

Two independent defects, both mine.

## Contract violations

| # | Contract | Source | What #6048 did | Closed by |
|---|---|---|---|---|
| 1 | "creating a database is consent for its schema — fresh bootstraps untouched" | my own #6048 PR body | A mid-pass failure advanced the cursor; the retry's gate then refused the migration it had authorized one attempt earlier | Authorization is decided **once per logical open**, not per attempt |
| 2 | A database this open did not create must reach the #4566 dirty-table guard | #4566 | Gate pre-empted `MigrateUp`, so `DirtyTablesError` was never produced and `errors.As` never matched | Same fix — reaching `MigrateUp` again is what lets the guard fire |
| 3 | A lenient open recovers a dirty database, and still migrates a clean one | #5781 / #5783 | Gate fired on a server bd auto-started for one workspace, so the recovery path was unreachable and a clean lenient open stopped at v51 | `sharedServerDatabase` — bd-owned lifecycle is not "shared" |

## Symptom 1 — authorization lifetime (`TestFreshBootstrapHeal*`, shards 1 and 13)

The gate ran inside the schema-init retry loop, so it was re-asked on every attempt. When an attempt dies mid-pass it leaves the schema cursor **advanced**, so the re-check no longer sees the fresh database it just allowed — it sees "existing database, 65 pending" and refuses:

```
refusing to auto-apply 65 pending schema migrations to a shared server database (v1 -> v66)
```

`v1 -> v66` is the tell: attempt 1 had already applied migration 0001. The gate was refusing its own work.

It is now evaluated once and the **allow is latched**. Only the allow — a gate whose probes hit a transient startup/catalog race has decided nothing and is still retried, which is the property `initSchemaOnDBWithRetryAndGate`'s existing classification depends on. Fresh-bootstrap heal authority short-circuits it outright: that capability is issued only to the open that won the bare `CREATE` for this exact incarnation, so it is standing proof that creating the database was consent for its schema, and it survives a retry where a version read does not. That is the same argument, and the same shape, as the skip I already added on the proxied path in #6055 — the server path simply never got it.

This one change fixes **both** heal tests, including the negative one (`NotArmedWhenDatabasePreexists`): once the gate stops pre-empting, `MigrateUp` runs and the #4566 guard produces the `DirtyTablesError` the test asserts. Symptom 2 needed no separate fix, and deliberately got none — I considered pre-checking the dirty condition inside the gate and rejected it, because the real guard has three documented exemption paths (aux-rekey resume, #4380 encoding drift, staged-table handling) and a hand-rolled second copy would drift from them. Ordering, not duplication.

## Symptom 3 — the predicate was too broad (`TestServerModeLenientOpenDirtyTableGate`, shard 8)

#6048 treated **every** `DoltStore` as shared, on the reasoning that "a sql-server accepts co-resident clients by construction". True in the abstract, and wrong in effect: it swept in the server bd auto-starts for a single workspace — a database no other client can observe — and refused to migrate a workspace's own data. That is what made the clean lenient open stop at v51, and it made the #4566/#5781 recovery unreachable, whose whole shape is refuse → `bd dolt commit` → migrate on a bd-owned local server.

`sharedServerDatabase` draws the line where `doltserver` already draws it for the auto-start decision:

- **bd owns this server's lifecycle for this workspace** (`ServerModeOwned`) → not shared. The database is this workspace's own, the way an embedded database is, and bd migrates it on open exactly as it always has.
- **everything else** → shared, and gated: shared-server mode, an operator-managed server (`BEADS_DOLT_SERVER_MODE`, explicit `dolt_server_port`, host inference), a non-local host, a TLS endpoint, a unix socket, or no workspace at all.

It reads only signals set on **every** open. Notably absent are `cfg.AutoStart`, `cfg.ServerMode` and `autoStartedServerDir`: each names the right idea, but the CLI sets them and library callers leave them false, so reading any of them would silently ungate a library client attached to a team's server. Where ownership cannot be proven — no `BeadsDir` — it fails closed.

This narrows the predicate my #6048 design doc chose, and I think the doc was simply wrong on this point: it argued auto-started servers must be included because "the #5920 incident machine was exactly this shape", but the incident shape is a server *many workspaces connect to*, which is `ServerModeExternal` here and stays gated.

## Prove-it, both directions

The point of the gate must survive the fix, so both directions are checked.

**Still refuses** (the gate's purpose):
- `TestSharedServerVersionBumpDoesNotPromoteCursor` — the #5920 CLI regression on an external server: `bd list` after an upgrade exits 0, renders, and leaves `MAX(version)` unmoved. Green.
- `TestDoltNew_SharedStoreMigrateGate_NoRemote`, `TestDoltNew_RemoteMigrateGate_BlocksReopen`, `TestInitSchemaOnDBWithRetryAndGate*`, `TestSmartGate*`. Green.
- New `TestSharedServerDatabase` pins the predicate directly: shared-server mode, explicit external mode, remote host, TLS, socket and no-workspace all resolve shared; only the bd-owned local workspace does not.

**Now migrates** (what it should never have refused): the three named tests, **unmodified**.

## Verification

- The three named tests: green, unmodified.
- Server Dolt shards **1/16, 8/16 and 13/16** — the exact shards CI reported — run locally via `.github/scripts/server-storage-test-shard.sh` with `BEADS_TEST_ENV_RUN_DOLT=1`: all green (233s, 185s, 209s).
- Full `internal/storage/schema`, `internal/storage/uow` (604s) and `internal/storage/embeddeddolt` suites: green.
- `go build ./...`, `go vet ./...`, `gofmt`, golangci-lint (0 issues), and `CGO_ENABLED=0 go test -tags gms_pure_go -c ./cmd/bd`: clean.

Non-test change is ~30 lines in one file: the latch in the retry loop, and the predicate helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
