### PR TITLE
release: prep v1.3.0-rc.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "beads",
       "source": "./plugins/beads",
       "description": "AI-supervised issue tracker for coding workflows",
-      "version": "1.3.0"
+      "version": "1.3.0-rc.1"
     }
   ]
 }

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.3.0 ---
+# --- BEGIN BEADS INTEGRATION v1.3.0-rc.1 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -56,4 +56,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.3.0 ---
+# --- END BEADS INTEGRATION v1.3.0-rc.1 ---

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.3.0 ---
+# --- BEGIN BEADS INTEGRATION v1.3.0-rc.1 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -56,4 +56,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.3.0 ---
+# --- END BEADS INTEGRATION v1.3.0-rc.1 ---

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -40,7 +40,7 @@ if [ -n "$staged_go_files" ]; then
     echo "$staged_go_files" | xargs git add
 fi
 
-# --- BEGIN BEADS INTEGRATION v1.3.0 ---
+# --- BEGIN BEADS INTEGRATION v1.3.0-rc.1 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -97,4 +97,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.3.0 ---
+# --- END BEADS INTEGRATION v1.3.0-rc.1 ---

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -39,7 +39,7 @@ fi
 
 exec < <(printf '%s\n' "$push_refs")
 
-# --- BEGIN BEADS INTEGRATION v1.3.0 ---
+# --- BEGIN BEADS INTEGRATION v1.3.0-rc.1 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -96,4 +96,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.3.0 ---
+# --- END BEADS INTEGRATION v1.3.0-rc.1 ---

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.3.0 ---
+# --- BEGIN BEADS INTEGRATION v1.3.0-rc.1 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -56,4 +56,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.3.0 ---
+# --- END BEADS INTEGRATION v1.3.0-rc.1 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -848,12 +848,6 @@ which dumps the entire release history.)
   `ParentID`. Programmatic callers that set them got unfiltered results back and
   no error — a full list where a scoped one was asked for.
 
-<!-- PROVISIONAL: the four entries below are the proposed changelog lines from
-     #6055 and #6056, which were still OPEN when this rollup was written.
-     The RC is gated on both merging, so this fence comes off at RC-prep time:
-     drop these two comment lines once they have landed, or delete the whole
-     block (entries included) if either PR does not land. -->
-
 - Proxied-server mode (and `bd serve`) ran schema migrations on every store
   open without consulting any migration gate, so an upgraded client silently
   migrated a shared database — including from read-only commands. The gate now
@@ -876,8 +870,6 @@ which dumps the entire release history.)
   set; it reports the pending migration instead. Both gates key on the directory
   doctor was pointed at, not just the one it was launched in. Diagnosis itself
   keeps working under a freeze.
-
-<!-- END PROVISIONAL -->
 
 ### Security
 

--- a/cmd/bd/version.go
+++ b/cmd/bd/version.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	// Version is the current version of bd (overridden by ldflags at build time)
-	Version = "1.3.0"
+	Version = "1.3.0-rc.1"
 	// Build can be set via ldflags at compile time
 	Build = "dev"
 	// Commit and branch the git revision the binary was built from (optional ldflag)

--- a/cmd/bd/winres/winres.json
+++ b/cmd/bd/winres/winres.json
@@ -18,12 +18,12 @@
             "Comments": "AI-supervised issue tracker for coding workflows",
             "CompanyName": "Steve Yegge",
             "FileDescription": "beads - AI-supervised issue tracker",
-            "FileVersion": "1.3.0",
+            "FileVersion": "1.3.0-rc.1",
             "InternalName": "bd",
             "LegalCopyright": "Copyright (c) 2024-2026 Steve Yegge. MIT License.",
             "OriginalFilename": "bd.exe",
             "ProductName": "beads",
-            "ProductVersion": "1.3.0"
+            "ProductVersion": "1.3.0-rc.1"
           }
         }
       }

--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@
 }:
 buildGoModule {
   pname = "beads";
-  version = "1.3.0";
+  version = "1.3.0-rc.1";
 
   src = self;
 

--- a/integrations/beads-mcp/pyproject.toml
+++ b/integrations/beads-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "beads-mcp"
-version = "1.3.0"
+version = "1.3.0-rc.1"
 description = "MCP server for beads issue tracker."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/beads-mcp/src/beads_mcp/__init__.py
+++ b/integrations/beads-mcp/src/beads_mcp/__init__.py
@@ -4,4 +4,4 @@ This package provides an MCP (Model Context Protocol) server that exposes
 beads (bd) issue tracker functionality to MCP Clients.
 """
 
-__version__ = "1.3.0"
+__version__ = "1.3.0-rc.1"

--- a/integrations/beads-mcp/uv.lock
+++ b/integrations/beads-mcp/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "beads-mcp"
-version = "1.3.0"
+version = "1.3.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -846,7 +846,7 @@ name = "importlib-metadata"
 version = "9.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/7e/1e7e8dc30634b93ebb3d58a3dea569ad146e656218d3960ab04f62047b29/importlib_metadata-9.0.1.tar.gz", hash = "sha256:ab830580bc0ef3db61ce8fae716389e5462b67e033018bab6d8f80ef17172f99", size = 59124, upload-time = "2026-08-28T15:30:34.646Z" }
 wheels = [

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beads/bd",
-  "version": "1.3.0",
+  "version": "1.3.0-rc.1",
   "description": "Beads issue tracker - lightweight memory system for coding agents with native binary support",
   "main": "bin/bd.js",
   "bin": {

--- a/plugins/beads/.claude-plugin/plugin.json
+++ b/plugins/beads/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beads",
   "description": "AI-supervised issue tracker for coding workflows. Manage tasks, discover work, and maintain context with simple CLI commands.",
-  "version": "1.3.0",
+  "version": "1.3.0-rc.1",
   "author": {
     "name": "Steve Yegge",
     "url": "https://github.com/steveyegge"

--- a/plugins/beads/.codex-plugin/plugin.json
+++ b/plugins/beads/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "beads",
-  "version": "1.3.0",
+  "version": "1.3.0-rc.1",
   "description": "AI-supervised issue tracking for coding workflows with agent skills.",
   "author": {
     "name": "Steve Yegge",

--- a/plugins/beads/.copilot-plugin/plugin.json
+++ b/plugins/beads/.copilot-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beads",
   "description": "AI-supervised issue tracker for coding workflows. Manage tasks, discover work, and maintain context with simple CLI commands.",
-  "version": "1.3.0",
+  "version": "1.3.0-rc.1",
   "author": {
     "name": "Steve Yegge",
     "url": "https://github.com/steveyegge"


### PR DESCRIPTION
RC-prep for `v1.3.0-rc.1`, cut from `release/1.3.0` at `b3ef65c85` (the #6038 merge) per the RC flow in the RELEASING.md that #6038 just landed ([Cut an RC](https://github.com/gastownhall/beads/blob/release/1.3.0/RELEASING.md#cut-an-rc)).

**This PR must merge before the maintainer tags `v1.3.0-rc.1`.** `release.yml`'s `verify-version-consistency` job does an exact string compare of `${GITHUB_REF_NAME#v}` against the `Version = ` literal in `cmd/bd/version.go`. #6038 bumped the tree to the base version `1.3.0`, so tagging `v1.3.0-rc.1` on that commit fails the compare (`1.3.0-rc.1` != `1.3.0`). Every other job `needs:` it, so the run would die with zero artifacts on a tag that can never be rewritten — the rc.1 name burned for nothing, which is exactly how the v1.1.1 tag was lost.

## 1. Version bump (`45d4d8cf4`)

`./scripts/update-versions.sh 1.3.0-rc.1` — the sanctioned bump, run unmodified. 16 files:

| | |
|---|---|
| `cmd/bd/version.go` | `1.3.0` → `1.3.0-rc.1` (the canonical source) |
| `integrations/beads-mcp/pyproject.toml`, `src/beads_mcp/__init__.py` | `1.3.0-rc.1` |
| `integrations/beads-mcp/uv.lock` | `1.3.0rc1` — regenerated by the script's `uv lock` step (PEP 440 normalization) |
| `npm-package/package.json`, `.claude-plugin/marketplace.json`, `plugins/beads/.{claude,codex,copilot}-plugin/plugin.json` | `1.3.0-rc.1` |
| `default.nix` | `1.3.0-rc.1` |
| `.githooks/{post-checkout,post-merge,pre-commit,pre-push,prepare-commit-msg}` | BEGIN/END managed-section markers → `v1.3.0-rc.1` |
| `cmd/bd/winres/winres.json` | `FileVersion`/`ProductVersion` → `1.3.0-rc.1`; `file_version`/`product_version` **stay `1.3.0`** |

The winres split is deliberate and is what the corrected annotations from #6038 describe: Windows PE numeric fields must be purely numeric, so they carry the **base** version. `gen-winres.sh` strips the prerelease suffix the same way at build time, and `check-versions.sh` gates those two fields against `BASE_VERSION` rather than `$CANONICAL` for exactly this reason. `cmd/bd/winres/manifest.xml` is unchanged for the same reason — its `<assemblyIdentity>` version was already `1.3.0.0` and stays there.

Two no-ops worth noting so nobody reads them as drift: the script's `README.md` step targets an `Alpha (v…)` badge string that no longer exists in the README, and the `manifest.xml` sed rewrites `1.3.0.0` → `1.3.0.0`. Neither is gated by `check-versions.sh` in a way this bump can violate.

`cmd/bd/info.go` needs no edit — the `1.3.0` `versionChanges` entry landed in #6038 and an RC does not get its own entry.

### `scripts/check-versions.sh` — all gates green

```
Canonical version (from version.go): 1.3.0-rc.1

✓ MCP pyproject.toml: 1.3.0-rc.1
✓ MCP __init__.py: 1.3.0-rc.1
✓ Claude plugin.json: 1.3.0-rc.1
✓ Codex plugin.json: 1.3.0-rc.1
✓ Copilot plugin.json: 1.3.0-rc.1
✓ Claude marketplace.json: 1.3.0-rc.1
✓ npm package.json: 1.3.0-rc.1
✓ MCP uv.lock (beads-mcp pin): 1.3.0rc1
✓ MCP uv.lock: fresh (uv lock --check)
✓ .githooks/post-checkout BEGIN marker: 1.3.0-rc.1
✓ .githooks/post-checkout END marker: 1.3.0-rc.1
✓ .githooks/post-merge BEGIN marker: 1.3.0-rc.1
✓ .githooks/post-merge END marker: 1.3.0-rc.1
✓ .githooks/pre-commit BEGIN marker: 1.3.0-rc.1
✓ .githooks/pre-commit END marker: 1.3.0-rc.1
✓ .githooks/prepare-commit-msg BEGIN marker: 1.3.0-rc.1
✓ .githooks/prepare-commit-msg END marker: 1.3.0-rc.1
✓ .githooks/pre-push BEGIN marker: 1.3.0-rc.1
✓ .githooks/pre-push END marker: 1.3.0-rc.1
✓ winres.json file_version: 1.3.0
✓ winres.json product_version: 1.3.0
✓ winres.json FileVersion: 1.3.0-rc.1
✓ winres.json ProductVersion: 1.3.0-rc.1
✓ manifest.xml assemblyIdentity version: 1.3.0.0

✓ Version files in sync at: 1.3.0-rc.1
```

24 file gates plus the summary; exit 0. The two prerelease-aware gates both did the right thing: the `uv.lock` pin was compared against the PEP 440 form `1.3.0rc1` (the script normalizes `-rc.` → `rc` before comparing), and the winres numeric fields were compared against `1.3.0`. `uv lock --check` also ran, so the lockfile is fresh — that is the check that did not exist when the stale lock burned v1.1.1 in the tag run.

## 2. CHANGELOG: PROVISIONAL fence removed (`f1c7cd8a7`)

The `[1.3.0]` rollup carried a fence around four `### Fixed` entries:

> the four entries below are the proposed changelog lines from #6055 and #6056, which were still OPEN when this rollup was written. The RC is gated on both merging, so this fence comes off at RC-prep time: drop these two comment lines once they have landed…

Its condition is satisfied — both are merged into `release/1.3.0` and both merge commits are ancestors of this branch:

- #6055 → `94bbeab57756efe6ea6e859fa05882717a597888`
- #6056 → `bcc9052cab05d292b0aa85a4ced7a27e2dcc0bab`

So only the two comment lines come off, per the fence's own instruction. The four entries (three `#5043` proxied-migration-gate lines, one `#6028` doctor line) stay verbatim. Net: `-8` lines, no prose touched.

**The `## [1.3.0] - 2026-08-28` date is deliberately left alone.** The stamp-changelog step owns it at final-release time; RC release notes derive separately. Restamping it here would put a date on a section that has not shipped.

## Preflight run locally at `f1c7cd8a7`

Every deterministic tag-burn mode the release run can hit was reproduced locally first, so the tag cannot fail on a fixable tree.

| Gate | Result |
|---|---|
| `verify-version-consistency` (replicated: `${GITHUB_REF_NAME#v}` vs `version.go`) | `OK: tag and version.go agree on 1.3.0-rc.1` |
| `scripts/check-versions.sh` | pass, exit 0 — 24 file gates (output above) |
| `go build ./...` | pass |
| `go build -tags gms_pure_go ./...` (pure-Go lane, `BUILD_TAGS`) | pass |
| `make ci-package-mcp` | pass — `uv sync --locked` ✓, ruff ✓, mypy ✓, pytest **228 passed / 5 skipped** (344s), build → `beads_mcp-1.3.0rc1.tar.gz` + `-py3-none-any.whl` |
| `make ci-package-npm` | pass — `test:all` **5/5**, `npm pack --dry-run` → `@beads/bd@1.3.0-rc.1`, expected asset URL `…/v1.3.0-rc.1/beads_1.3.0-rc.1_linux_amd64.tar.gz` |
| `goreleaser build --single-target` @ `GORELEASER_CURRENT_TAG=v1.3.0-rc.1` | **build succeeded**; `./dist/…/bd version` → `bd version 1.3.0-rc.1 (f1c7cd8a7: release-prep/v1.3.0-rc.1@f1c7cd8a75ab)` |
| `goreleaser check` | **exit 1** — see below |

Neither package gate publishes anything: `package-mcp.sh` stops at `uv build`, `package-npm.sh` at `npm pack --dry-run`.

### The one non-green gate: `goreleaser check`

```
• DEPRECATED: archives.format should not be used anymore
• DEPRECATED: archives.format_overrides.format should not be used anymore
• .goreleaser.yml   error=configuration is valid, but uses deprecated properties
⨯ check failed
```

**Pre-existing and not a release blocker.** Three points:

1. It is not from this PR. `.goreleaser.yml` is untouched here, and `git show origin/main:.goreleaser.yml` has the identical `format: tar.gz` / `format_overrides.format: zip` at the same lines.
2. `goreleaser check` treats *any* deprecated property as a failure; `goreleaser build`/`release` only warn. Proven, not assumed — the smoke build above emitted both warnings, printed `you are using deprecated options`, and still exited 0 with a correct binary.
3. `release.yml` never runs `check`. Its goreleaser job runs `release --clean --parallelism 1` on `version: '~> v2'`, which is the lane the smoke build exercised.

Worth a separate cleanup PR (rename to `formats: [tar.gz]` / `format_overrides.formats`), but gating the RC on it would be a scope error.

### Not covered locally

The smoke build was `--single-target` (linux/amd64 CGO only). The `linux-arm64`, `windows-amd64/arm64`, `android-arm64` and `freebsd-amd64` legs were skipped — this box has no `aarch64-linux-gnu-gcc` and no `x86_64-w64-mingw32-gcc`. Those legs, the darwin CGO legs (`goreleaser-macos`), Windows Authenticode signing, SBOM and attestation only exist in CI. Archives/checksums were also not produced (`build`, not `release`). No local tag was created at any point — `GORELEASER_CURRENT_TAG` supplied the version instead.

## CI note

`PR Core (wrapper timing)` is red on this PR and **it is not from these commits**. The `cmd/bd` package has outgrown Go's implicit 10m per-package default: measured through the real wrapper it takes **572.003s**, leaving under 5% margin, so CI lands the other side of the line (600.343s and 600.728s on two consecutive runs; #6038 squeaked in just under).

Bisected — the base commit `b3ef65c85` fails identically without these commits (`cmd/bd 618.049s` vs this PR's `614.703s`), so the version bump is not implicated.

Fix is **#6091** (`-timeout=30m` in `scripts/ci/pr-core.sh`, matching every other `-race` lane in the repo). Once it merges, re-running `PR Core` here picks it up via the recomputed merge ref — no rebase needed. See [this comment](https://github.com/gastownhall/beads/pull/6090#issuecomment-5474932791) for the full analysis, including a correction to my first attribution.

`ci-pr-core` is a `pr.yml` job that `release.yml` never runs, so this is a merge gate, not a tag-burn mode. `Test (macos-latest)` passed on re-run.

## Not in this PR

No tag. Tagging is the maintainer's step (`refs/tags/v*` is protected) and happens on the merge commit of this PR:

```
git checkout release/1.3.0 && git pull
git tag -a v1.3.0-rc.1 -m "Release candidate v1.3.0-rc.1"
git push origin v1.3.0-rc.1
```

The rc tag contains a `-`, so `publish-pypi` and `publish-npm` are gated off (`!contains(github.ref_name, '-')`) and the only public artifact is a prerelease-flagged GitHub Release. Nothing reaches npm, PyPI, Homebrew or winget.
