### PR TITLE
ci(pr-core): give the -race lane an explicit 30m go-test timeout

### DIFF
--- a/scripts/ci/pr-core.sh
+++ b/scripts/ci/pr-core.sh
@@ -20,5 +20,15 @@ beads_test_env_enter
 GO_TEST_PKG_PARALLEL="${GO_TEST_PKG_PARALLEL:-4}"
 GO_TEST_PARALLEL="${GO_TEST_PARALLEL:-4}"
 
+# Without an explicit -timeout every package gets Go's 10m default, and ./cmd/bd
+# has outgrown it: measured through this wrapper it takes 572s, which leaves 28s
+# — under 5% — of margin. Runner variance eats that, and the package then dies on
+# the alarm at 600.3s/600.7s (two consecutive runs on #6090; #6038 squeaked in
+# just under). No single test is at fault, so the panic names whichever one was
+# in flight and reads like a hang when it is really the whole package running out
+# of clock. 30m is what every other -race lane here already gives this same code:
+# main.yml's integration package and cmd/bd shards, ci-measurements.yml,
+# nightly.yml. Splitting or de-slowing cmd/bd is the real fix and belongs on main
+# — this only stops the clock from being the thing that fails.
 ci_time "pr-core go test" -- \
-    go test -p "$GO_TEST_PKG_PARALLEL" -parallel "$GO_TEST_PARALLEL" -race -short -skip '^TestEmbedded' ./...
+    go test -p "$GO_TEST_PKG_PARALLEL" -parallel "$GO_TEST_PARALLEL" -race -short -timeout=30m -skip '^TestEmbedded' ./...


### PR DESCRIPTION
`scripts/ci/pr-core.sh` passes no `-timeout`, so every package in the `-race` lane gets Go's implicit 10m default. `./cmd/bd` has outgrown it and now fails the required `PR Core (wrapper timing)` check on runner variance alone.

One-line change: add `-timeout=30m`.

## The measurement

Running the wrapper unmodified except for the new flag — `./scripts/ci/pr-core.sh`, so the same hermetic env CI uses (`BEADS_TEST_SKIP=dolt`, `-p 4 -parallel 4 -race -short -skip '^TestEmbedded' ./...`):

```
ok  	github.com/steveyegge/beads/cmd/bd	572.003s
<== pr-core go test succeeded in 591s
```

**572s against a 600s budget — 28s of headroom, under 5%.** That is the whole story. CI runners are slower and noisier than this box, so they land the other side of the line:

| Run | `cmd/bd` |
|---|---|
| #6090 attempt 1 | `FAIL … 600.343s` |
| #6090 attempt 2 (re-run) | `FAIL … 600.728s` |
| #6038 (merged) | passed, 10m58s job wall-clock |

Two failures 0.4s apart, straddling the default. Next-largest package in the lane is `internal/storage/embeddeddolt` at 318s, so `cmd/bd` is the only one anywhere near the limit.

## It is not a hang

The test named in the panic differs every run — it is whichever happened to be in flight when the package-level alarm fired, not a stuck one:

- attempt 1: `TestDoctorPathArgMaintenanceSkippedByTargetFreeze` (18s in)
- attempt 2: `TestMultiIDUpdatePartialFailureExitsNonzero` (6s in)

No single test dominates; the package as a whole runs out of clock. That is worth stating plainly because the panic output invites the opposite conclusion.

## Not caused by any recent change

Bisected while investigating #6090. Same command, same machine, back to back:

| Tree | Result |
|---|---|
| #6090 head `f1c7cd8a7` | `FAIL … cmd/bd 614.703s` |
| `b3ef65c85` (base, without #6090's commits) | `FAIL … cmd/bd 618.049s` |

Identical failure 3s apart, so the RC-prep version bump is not implicated — the condition already exists on `release/1.3.0`.

One caveat on that pair, for the record: those two runs were raw `go test ./cmd/bd` rather than the wrapper, so they ran *without* `BEADS_TEST_SKIP=dolt` and stalled ~4m40s in `TestTryIncrementalExport_ThresholdExceededFallsBack` (a 5001-row bulk seed whose own comment records 269s/316s wall-clocks). That test `t.Skip`s when no Dolt test server is present, so **it does not run in the CI lane** and is not the CI mechanism. The A/B conclusion is unaffected — both sides ran identically — but the CI cause is simply the package's total size, per the 572s measurement above.

## Why 30m

It is the value every other `-race` lane in this repo already gives this same code:

- `.github/workflows/main.yml:746` — integration package shards, `-race … -timeout=30m`
- `.github/workflows/main.yml:830` — `-race … -timeout=30m -run "$run_regex" ./cmd/bd`
- `.github/workflows/ci-measurements.yml` — `-timeout=30m` throughout
- `.github/workflows/nightly.yml:80` — `-race … -timeout=30m ./...`

`main.yml` gives `cmd/bd` 30m *and* sharded; `pr-core` gives it 10m unsharded. This aligns the outlier rather than inventing a number. It is a ceiling, not a target — the lane still finishes in ~10m; 30m only decides when a genuine hang is declared.

## Scope

Deliberately only the timeout. Splitting `cmd/bd`, sharding it the way `main.yml` does, or de-slowing the tests is the real fix and is main-line follow-up work — doing it on a release branch would be the wrong place and the wrong risk. This change stops the clock from being the thing that fails so the branch's merge gate reflects real breakage.

Unblocks the merge gate on #6090 (`release: prep v1.3.0-rc.1`).

## Verification

- `./scripts/ci/pr-core.sh` — **passes**, exit 0, 591s, with the new timeout in place (output above).
- `shellcheck scripts/ci/pr-core.sh` — no new findings; the three pre-existing SC1091 `source` notices are unchanged.
