### PR TITLE
fix(claude): scrub stale NODE_OPTIONS --require before bd prime

### DIFF
--- a/cmd/bd/node_options.go
+++ b/cmd/bd/node_options.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+// scrubStaleNodeOptionsRequire drops inherited NODE_OPTIONS --require/-r
+// entries whose target file no longer exists.
+//
+// Hosts like cmux inject:
+//
+//	NODE_OPTIONS=--require=$TMPDIR/cmux-claude-node-options/restore-node-options.cjs
+//
+// into Claude. When that temp preload disappears, SessionStart/`bd prime`
+// crashes with MODULE_NOT_FOUND. Scrubbing missing require paths keeps
+// unrelated flags (e.g. --max-old-space-size) and unsets NODE_OPTIONS when
+// nothing remains.
+func scrubStaleNodeOptionsRequire() {
+	raw := os.Getenv("NODE_OPTIONS")
+	if raw == "" {
+		return
+	}
+
+	cleaned := scrubStaleNodeOptionsRequireValue(raw)
+	if cleaned == "" {
+		_ = os.Unsetenv("NODE_OPTIONS")
+		return
+	}
+	_ = os.Setenv("NODE_OPTIONS", cleaned)
+}
+
+func scrubStaleNodeOptionsRequireValue(raw string) string {
+	fields := strings.Fields(raw)
+	if len(fields) == 0 {
+		return ""
+	}
+
+	out := make([]string, 0, len(fields))
+	for i := 0; i < len(fields); i++ {
+		tok := fields[i]
+		switch {
+		case strings.HasPrefix(tok, "--require="), strings.HasPrefix(tok, "-r="):
+			path := tok[strings.IndexByte(tok, '=')+1:]
+			if path == "" || !nodeOptionsRequireTargetExists(path) {
+				continue
+			}
+			out = append(out, tok)
+		case tok == "--require", tok == "-r":
+			if i+1 >= len(fields) {
+				continue
+			}
+			path := fields[i+1]
+			i++
+			if path == "" || strings.HasPrefix(path, "-") || !nodeOptionsRequireTargetExists(path) {
+				continue
+			}
+			out = append(out, tok, path)
+		default:
+			out = append(out, tok)
+		}
+	}
+	return strings.Join(out, " ")
+}
+
+func nodeOptionsRequireTargetExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/cmd/bd/node_options.go
+++ b/cmd/bd/node_options.go
@@ -2,20 +2,22 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 )
 
 // scrubStaleNodeOptionsRequire drops inherited NODE_OPTIONS --require/-r
-// entries whose target file no longer exists.
+// entries whose filesystem-path target no longer exists.
 //
 // Hosts like cmux inject:
 //
 //	NODE_OPTIONS=--require=$TMPDIR/cmux-claude-node-options/restore-node-options.cjs
 //
 // into Claude. When that temp preload disappears, SessionStart/`bd prime`
-// crashes with MODULE_NOT_FOUND. Scrubbing missing require paths keeps
-// unrelated flags (e.g. --max-old-space-size) and unsets NODE_OPTIONS when
-// nothing remains.
+// crashes with MODULE_NOT_FOUND. Module specifiers (e.g. ts-node/register,
+// node:module) are left alone because Node resolves those via require(),
+// not as paths. Scrubbing missing require paths keeps unrelated flags
+// (e.g. --max-old-space-size) and unsets NODE_OPTIONS when nothing remains.
 func scrubStaleNodeOptionsRequire() {
 	raw := os.Getenv("NODE_OPTIONS")
 	if raw == "" {
@@ -41,8 +43,8 @@ func scrubStaleNodeOptionsRequireValue(raw string) string {
 		tok := fields[i]
 		switch {
 		case strings.HasPrefix(tok, "--require="), strings.HasPrefix(tok, "-r="):
-			path := tok[strings.IndexByte(tok, '=')+1:]
-			if path == "" || !nodeOptionsRequireTargetExists(path) {
+			target := tok[strings.IndexByte(tok, '=')+1:]
+			if target == "" || !keepNodeOptionsRequireTarget(target) {
 				continue
 			}
 			out = append(out, tok)
@@ -50,12 +52,12 @@ func scrubStaleNodeOptionsRequireValue(raw string) string {
 			if i+1 >= len(fields) {
 				continue
 			}
-			path := fields[i+1]
+			target := fields[i+1]
 			i++
-			if path == "" || strings.HasPrefix(path, "-") || !nodeOptionsRequireTargetExists(path) {
+			if target == "" || strings.HasPrefix(target, "-") || !keepNodeOptionsRequireTarget(target) {
 				continue
 			}
-			out = append(out, tok, path)
+			out = append(out, tok, target)
 		default:
 			out = append(out, tok)
 		}
@@ -63,7 +65,31 @@ func scrubStaleNodeOptionsRequireValue(raw string) string {
 	return strings.Join(out, " ")
 }
 
-func nodeOptionsRequireTargetExists(path string) bool {
-	_, err := os.Stat(path)
+// keepNodeOptionsRequireTarget reports whether a --require/-r target should
+// stay in NODE_OPTIONS. Module specifiers are always kept. Filesystem paths
+// are kept only when the file still exists.
+func keepNodeOptionsRequireTarget(target string) bool {
+	if !nodeOptionsRequireIsFilesystemPath(target) {
+		return true
+	}
+	_, err := os.Stat(target)
 	return err == nil
+}
+
+// nodeOptionsRequireIsFilesystemPath reports whether target is a filesystem
+// path in the same sense Node's require() uses: absolute, or relative
+// starting with ./ or ../ (and the Windows backslash forms). Everything
+// else is a module specifier — including package subpaths like
+// ts-node/register and node: protocol builtins.
+func nodeOptionsRequireIsFilesystemPath(target string) bool {
+	if target == "" {
+		return false
+	}
+	if filepath.IsAbs(target) {
+		return true
+	}
+	return strings.HasPrefix(target, "./") ||
+		strings.HasPrefix(target, "../") ||
+		strings.HasPrefix(target, `.\`) ||
+		strings.HasPrefix(target, `..\`)
 }

--- a/cmd/bd/node_options_test.go
+++ b/cmd/bd/node_options_test.go
@@ -79,3 +79,15 @@ func TestScrubStaleNodeOptionsRequireEnv(t *testing.T) {
 		t.Fatalf("NODE_OPTIONS after scrub = %q, want %q", got, want)
 	}
 }
+
+func TestScrubStaleNodeOptionsRequireEnvUnsetsWhenOnlyMissing(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "gone.cjs")
+	t.Setenv("NODE_OPTIONS", "--require="+missing)
+
+	scrubStaleNodeOptionsRequire()
+
+	if got, ok := os.LookupEnv("NODE_OPTIONS"); ok {
+		t.Fatalf("NODE_OPTIONS still set after scrubbing only-missing require: %q", got)
+	}
+}

--- a/cmd/bd/node_options_test.go
+++ b/cmd/bd/node_options_test.go
@@ -54,6 +54,36 @@ func TestScrubStaleNodeOptionsRequireValue(t *testing.T) {
 			in:   "--max-old-space-size=4096",
 			want: "--max-old-space-size=4096",
 		},
+		{
+			name: "preserve module specifier ts-node/register spaced",
+			in:   "--require ts-node/register --max-old-space-size=4096",
+			want: "--require ts-node/register --max-old-space-size=4096",
+		},
+		{
+			name: "preserve module specifier ts-node/register equals",
+			in:   "--require=ts-node/register",
+			want: "--require=ts-node/register",
+		},
+		{
+			name: "preserve node protocol specifier",
+			in:   "--require=node:module --max-old-space-size=512",
+			want: "--require=node:module --max-old-space-size=512",
+		},
+		{
+			name: "preserve scoped package specifier",
+			in:   "-r @babel/register",
+			want: "-r @babel/register",
+		},
+		{
+			name: "preserve specifier while scrubbing missing path",
+			in:   "--require ts-node/register --require=" + missing,
+			want: "--require ts-node/register",
+		},
+		{
+			name: "drop missing relative filesystem path",
+			in:   "--require ./gone.cjs --max-old-space-size=256",
+			want: "--max-old-space-size=256",
+		},
 	}
 
 	for _, tt := range tests {
@@ -89,5 +119,43 @@ func TestScrubStaleNodeOptionsRequireEnvUnsetsWhenOnlyMissing(t *testing.T) {
 
 	if got, ok := os.LookupEnv("NODE_OPTIONS"); ok {
 		t.Fatalf("NODE_OPTIONS still set after scrubbing only-missing require: %q", got)
+	}
+}
+
+func TestKeepExistingRelativeFilesystemRequire(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "present.cjs"), []byte("module.exports = {}\n"), 0o644); err != nil {
+		t.Fatalf("write existing require target: %v", err)
+	}
+	t.Chdir(dir)
+
+	got := scrubStaleNodeOptionsRequireValue("--require=./present.cjs --max-old-space-size=128")
+	want := "--require=./present.cjs --max-old-space-size=128"
+	if got != want {
+		t.Fatalf("scrubStaleNodeOptionsRequireValue() = %q, want %q", got, want)
+	}
+}
+
+func TestNodeOptionsRequireIsFilesystemPath(t *testing.T) {
+	tests := []struct {
+		target string
+		want   bool
+	}{
+		{target: "ts-node/register", want: false},
+		{target: "node:module", want: false},
+		{target: "@babel/register", want: false},
+		{target: "esm", want: false},
+		{target: "./gone.cjs", want: true},
+		{target: "../gone.cjs", want: true},
+		{target: `.\gone.cjs`, want: true},
+		{target: `..\gone.cjs`, want: true},
+		{target: filepath.Join(string(filepath.Separator), "tmp", "gone.cjs"), want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			if got := nodeOptionsRequireIsFilesystemPath(tt.target); got != tt.want {
+				t.Fatalf("nodeOptionsRequireIsFilesystemPath(%q) = %v, want %v", tt.target, got, tt.want)
+			}
+		})
 	}
 }

--- a/cmd/bd/node_options_test.go
+++ b/cmd/bd/node_options_test.go
@@ -75,6 +75,16 @@ func TestScrubStaleNodeOptionsRequireValue(t *testing.T) {
 			want: "-r @babel/register",
 		},
 		{
+			name: "preserve short equals module specifier",
+			in:   "-r=ts-node/register --max-old-space-size=256",
+			want: "-r=ts-node/register --max-old-space-size=256",
+		},
+		{
+			name: "drop missing short equals filesystem path",
+			in:   "-r=" + missing + " --max-old-space-size=256",
+			want: "--max-old-space-size=256",
+		},
+		{
 			name: "preserve specifier while scrubbing missing path",
 			in:   "--require ts-node/register --require=" + missing,
 			want: "--require ts-node/register",
@@ -147,8 +157,8 @@ func TestNodeOptionsRequireIsFilesystemPath(t *testing.T) {
 		{target: "esm", want: false},
 		{target: "./gone.cjs", want: true},
 		{target: "../gone.cjs", want: true},
-		{target: `.\gone.cjs`, want: true},
-		{target: `..\gone.cjs`, want: true},
+		{target: `.\\gone.cjs`, want: true},
+		{target: `..\\gone.cjs`, want: true},
 		{target: filepath.Join(string(filepath.Separator), "tmp", "gone.cjs"), want: true},
 	}
 	for _, tt := range tests {

--- a/cmd/bd/node_options_test.go
+++ b/cmd/bd/node_options_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScrubStaleNodeOptionsRequireValue(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "present.cjs")
+	if err := os.WriteFile(existing, []byte("module.exports = {}\n"), 0o644); err != nil {
+		t.Fatalf("write existing require target: %v", err)
+	}
+	missing := filepath.Join(dir, "missing.cjs")
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "drop missing equals form",
+			in:   "--require=" + missing + " --max-old-space-size=4096",
+			want: "--max-old-space-size=4096",
+		},
+		{
+			name: "keep existing equals form",
+			in:   "--require=" + existing + " --max-old-space-size=4096",
+			want: "--require=" + existing + " --max-old-space-size=4096",
+		},
+		{
+			name: "drop missing spaced form",
+			in:   "--require " + missing + " --max-old-space-size=4096",
+			want: "--max-old-space-size=4096",
+		},
+		{
+			name: "keep existing spaced short form",
+			in:   "-r " + existing + " --max-old-space-size=512",
+			want: "-r " + existing + " --max-old-space-size=512",
+		},
+		{
+			name: "unset when only missing require remains",
+			in:   "--require=" + missing,
+			want: "",
+		},
+		{
+			name: "preserve unrelated flags only",
+			in:   "--max-old-space-size=4096",
+			want: "--max-old-space-size=4096",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scrubStaleNodeOptionsRequireValue(tt.in)
+			if got != tt.want {
+				t.Fatalf("scrubStaleNodeOptionsRequireValue(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScrubStaleNodeOptionsRequireEnv(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "gone.cjs")
+	t.Setenv("NODE_OPTIONS", "--require="+missing+" --max-old-space-size=1024")
+
+	scrubStaleNodeOptionsRequire()
+
+	got := os.Getenv("NODE_OPTIONS")
+	want := "--max-old-space-size=1024"
+	if got != want {
+		t.Fatalf("NODE_OPTIONS after scrub = %q, want %q", got, want)
+	}
+}

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -124,6 +124,11 @@ Memory injection caps:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Hosts like cmux may inject NODE_OPTIONS=--require=<tmp preload>.
+		// If that preload vanishes, SessionStart/`bd prime` crashes with
+		// MODULE_NOT_FOUND. Drop missing --require targets first.
+		scrubStaleNodeOptionsRequire()
+
 		evt := metrics.NewCommandEvent("prime")
 		defer func() {
 			if c := metrics.Global(); c != nil {


### PR DESCRIPTION
## What
Scrub inherited `NODE_OPTIONS --require` entries whose target file is missing before `bd prime` runs.

## Why
cmux injects `NODE_OPTIONS=--require=$TMPDIR/.../restore-node-options.cjs` into Claude. When that temp preload disappears, SessionStart/`bd prime` crashes with MODULE_NOT_FOUND and Claude shows repeated SessionStart hook errors.

Fixes #6093

## Test plan
- [x] unit tests for scrub helper (`CGO_ENABLED=0 go test ./cmd/bd -run ScrubStaleNodeOptions`)
- [ ] SessionStart under cmux no longer MODULE_NOT_FOUND when preload missing