### PR TITLE
test(protocol): propagate TZ to the bd subprocess

### DIFF
--- a/cmd/bd/protocol/helpers_test.go
+++ b/cmd/bd/protocol/helpers_test.go
@@ -236,6 +236,18 @@ func (w *workspace) env() []string {
 	if v := os.Getenv("TMPDIR"); v != "" {
 		env = append(env, "TMPDIR="+v)
 	}
+	// TZ must reach the child. This env is a whitelist, so without this the bd
+	// subprocess inherits no TZ and its time.Local falls back to
+	// /etc/localtime, while the TEST process uses its own TZ. Assertions that
+	// compute an expectation from the parent's time.Local and compare it to a
+	// value the child produced then disagree whenever the two zones differ —
+	// see TestProtocol_FieldsRoundTrip, which parses a date-only due_at in
+	// time.Local and asserts the stored UTC day. CI passes only because its
+	// runners have TZ unset AND a UTC system zone, so both sides agree by
+	// accident.
+	if v := os.Getenv("TZ"); v != "" {
+		env = append(env, "TZ="+v)
+	}
 	return env
 }
 


### PR DESCRIPTION
`TestProtocol_FieldsRoundTrip` fails on any machine whose `TZ` differs from its system zone:

```
roundtrip_test.go:99: field "due_at" = "2099-03-14T23:00:00Z", want prefix "2099-03-15"
roundtrip_test.go:100: field "defer_until" = "2099-01-14T23:00:00Z", want prefix "2099-01-15"
```

## Cause

`workspace.env()` builds a **whitelist** environment for the `bd` child — `PATH`, `HOME`, `GIT_CONFIG_NOSYSTEM`, `BEADS_TEST_MODE`, `BD_DISABLE_METRICS`, and optionally `BEADS_DOLT_PORT` / `TMPDIR`. `TZ` is not on it, so the child inherits none and its `time.Local` falls back to `/etc/localtime`, while the **test process** uses its own `TZ`.

The assertion computes its expectation from the parent's `time.Local`:

```go
dueLocal, _ := time.ParseInLocation("2006-01-02", "2099-03-15", time.Local)
assertFieldPrefix(t, issue, "due_at", dueLocal.UTC().Format("2006-01-02"))
```

and compares it against a value the **child** produced. The two disagree whenever the zones differ.

## Not a product defect

Date-only input parsed as local midnight and stored as UTC is the documented behaviour, and both processes implement it correctly. They simply disagree about which zone is local.

CI does not see this because its runners have `TZ` unset **and** a UTC system zone, so both sides agree by accident.

## Verification

Reproduced on macOS with a `Europe/Paris` system zone. On `main` the test fails under `TZ=UTC`; with this change it passes under `TZ=UTC`, `TZ=Europe/Paris`, and `TZ=America/Los_Angeles` — the west-of-UTC case the assertion's own comment calls out.
