### PR TITLE
fix(prime): describe the memory split instead of prohibiting MEMORY.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`bd prime` describes the memory split instead of prohibiting `MEMORY.md`**
+  ([#6111](https://github.com/gastownhall/beads/pull/6111), refs
+  [#5169](https://github.com/gastownhall/beads/issues/5169)). The guidance
+  line used to read `Do NOT use MEMORY.md files — they fragment across
+  accounts`. That warning predates harnesses that ship a first-party,
+  machine-local memory whose index file is also named `MEMORY.md`, so in a
+  workspace running both, prime told the agent every session not to use a file
+  the harness was actively maintaining. The line now says what each store is
+  for: durable **project** facts go in `bd remember`, because per-tool memory
+  files fragment across accounts; per-operator preferences stay in the
+  harness's own memory. Output text only, no behaviour change. The same
+  sentence is updated in its sibling renderings — the MCP/minimal context, the
+  generated AGENTS.md sections for the minimal and Codex harness templates,
+  and the README snippet — so `bd init` and copy-paste do not re-introduce the
+  prohibition.
+
 - **`bd gate check` resolves bead gates whose target lives in a prefix-routed
   rig** ([#5859](https://github.com/gastownhall/beads/pull/5859)). After a local
   miss, the evaluator follows the target bead ID through `routes.jsonl` and

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This project uses bd (beads) for issue tracking.
 
 - Run `bd prime` for workflow context and command guidance.
 - Use `bd ready`, `bd show <id>`, `bd update <id> --claim`, and `bd close <id>`.
-- Use `bd remember "insight"` for persistent project memory; do not create MEMORY.md files.
+- Use `bd remember "insight"` for durable project facts; keep per-operator preferences in your harness's own memory.
 - Do not use markdown TODO lists for task tracking.
 ```
 

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -724,7 +724,7 @@ func outputMCPContext(w io.Writer, stealthMode bool) error {
 - **Default**: Use beads for ALL task tracking (` + "`bd create`" + `, ` + "`bd ready`" + `, ` + "`bd close`" + `)
 - **Prohibited**: Do NOT use TodoWrite, TaskCreate, or markdown files for task tracking
 - **Workflow**: Create beads issue BEFORE writing code, mark in_progress when starting
-- **Memory**: Use ` + "`bd remember`" + ` for persistent knowledge. Do NOT use MEMORY.md files.
+- **Memory**: Use ` + "`bd remember`" + ` for durable project facts, not per-tool memory files. Per-operator preferences belong in your harness's own memory.
 - Persistence you don't need beats lost context
 - ` + profileRule + `
 
@@ -918,7 +918,7 @@ git status                  # Check changed files
 - **Default**: Use beads for ALL task tracking (` + "`bd create`" + `, ` + "`bd ready`" + `, ` + "`bd close`" + `)
 - **Prohibited**: Do NOT use TodoWrite, TaskCreate, or markdown files for task tracking
 - **Workflow**: Create beads issue BEFORE writing code, mark in_progress when starting
-- **Memory**: Use ` + "`bd remember \"insight\"`" + ` for persistent knowledge across sessions. Do NOT use MEMORY.md files — they fragment across accounts. Search with ` + "`bd memories <keyword>`" + `.
+- **Memory**: Use ` + "`bd remember \"insight\"`" + ` for durable **project** facts — keep them here rather than in per-tool memory files, which fragment across accounts and are often capped. Per-operator preferences and agent-specific corrections belong in your harness's own memory; they aren't project knowledge and beads doesn't store them. Search with ` + "`bd memories <keyword>`" + `.
 - Persistence you don't need beats lost context
 - ` + profileRule + `
 - ` + gitWorkflowRule + `

--- a/internal/templates/agents/defaults/beads-section-codex.md
+++ b/internal/templates/agents/defaults/beads-section-codex.md
@@ -16,6 +16,6 @@ bd prime                # Refresh Beads context
 
 - Use `bd` for all task tracking; do not create markdown TODO lists.
 - Run `bd prime` when Beads context is missing or stale. Codex 0.129.0+ can load Beads context automatically through native hooks; use `/hooks` to inspect or toggle them.
-- Keep persistent project memory in Beads via `bd remember`; do not create ad hoc memory files.
+- Keep durable project facts in Beads via `bd remember` rather than in per-tool memory files, which fragment across accounts; per-operator preferences belong in your harness's own memory.
 
 **Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/core-concepts/sync-concepts.md for details and anti-patterns.

--- a/internal/templates/agents/defaults/beads-section-minimal.md
+++ b/internal/templates/agents/defaults/beads-section-minimal.md
@@ -15,7 +15,7 @@ bd close <id>         # Complete work
 
 - Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
 - Run `bd prime` for detailed command reference and session close protocol
-- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+- Use `bd remember` for durable project facts — not per-tool memory files, which fragment across accounts; keep per-operator preferences in your harness's own memory
 
 **Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/core-concepts/sync-concepts.md for details and anti-patterns.
 


### PR DESCRIPTION
## What

Rewrites the `bd prime` memory guidance, and its three sibling renderings, from a blanket "do NOT use MEMORY.md files" prohibition into a description of the split the two stores actually have: durable **project** facts in `bd remember`, per-operator preferences in the harness's own memory.

Four lines, three files, no behaviour change — output text only:

| file | rendering |
|---|---|
| `cmd/bd/prime.go:727` | MCP / minimal context (kept terse for the ~50-token budget) |
| `cmd/bd/prime.go:921` | full CLI context |
| `internal/templates/agents/defaults/beads-section-minimal.md:18` | generated AGENTS.md section |
| `README.md:56` | the copy-paste AGENTS.md snippet |

#5169 only names the `bd prime` output. i included the other two because they are the same sentence in different renderings — leaving them would re-introduce the same collision through `bd init` / copy-paste. happy to drop either if you would rather keep the diff to `prime.go`.

## Why

Refs #5169 — deliberately **not** "Fixes". that issue asks for a config key; this is only the wording half, which @The1nk and i converged on in the thread. the configurability ask stands on its own and this does not close it.

The line predates Claude Code shipping first-party auto memory, whose index file is also named `MEMORY.md` (`~/.claude/projects/<project>/memory/MEMORY.md`). that file is machine-local and harness-managed — it is not the multi-account fragmentation case the warning was written against. so in a repo running both, `bd prime` injects "do NOT use MEMORY.md files" every session while the harness actively maintains one of its own, and the two instructions fight.

The remedy over-reaches in a specific way. fragmentation is a real problem for **project knowledge** — facts about the repo that every teammate needs and that must survive an account rotation. that is exactly what `bd remember` is for, and for that class the advice is right. it is not the right advice for per-operator content: corrections to one agent's habits, on one host, from one incident. pushing that into `bd remember` does not defragment it — it publishes personal working preferences into a store that syncs to everyone, and spends the always-loaded budget that project facts need.

The split is bidirectional, which is why the new text names both directions rather than just flipping the arrow: harness memory files are typically capped and drop entries silently, so they are unsafe for a corpus that grows with the repo. a prohibition pointed *either* way loses content. that clause is in the text on purpose, so the rule does not get "simplified" back into a prohibition in the opposite direction later.

Net effect: the fragmentation warning stays, pointed at the case where it is true, and beads stops giving advice about a class it does not store.

## Verification

```bash
go build -tags=gms_pure_go ./cmd/bd          # clean
gofmt -l cmd/bd/prime.go                     # no output
go vet -tags=gms_pure_go ./cmd/bd/           # clean
go test -tags=gms_pure_go ./internal/templates/...   # ok
go test -tags=gms_pure_go ./test/docsync             # ok
go test -tags=gms_pure_go -run "Prime|prime" ./cmd/bd/
```

No test asserts the old string (`grep -rn "MEMORY\.md\|fragment across accounts" --include="*_test.go" .` is empty), so nothing needed updating alongside it.

**One pre-existing failure, not from this change**: `TestPrimeBinaryPortfolio/TestPrime_HookJSON_GlobalPrimeOverride` fails on my Windows box. i checked it against a control rather than assuming — a second pristine worktree at the same commit (`d530cddfa`, no changes) fails identically:

```
--- FAIL: TestPrimeBinaryPortfolio/TestPrime_HookJSON_GlobalPrimeOverride
    want "# Global PRIME override\nGreetings from XDG.\n"
```

it wants the global `~/.config/beads/PRIME.md` override and gets the generated default, which looks like `os.UserConfigDir()` not following `XDG_CONFIG_HOME` on Windows. unrelated to wording; flagging it rather than folding a fix into this PR. every other subtest in that run passes, on both the branch and the control.

Rendered output was confirmed in context (the failing test dumps the full generated block, which shows the new line escaping and rendering correctly in the CLI path).
