### PR TITLE
fix(storage): an env-pointed server is shared, not owned — close the migrate-gate bypass

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -575,12 +575,36 @@ func ReadPortFile(beadsDir string) int {
 // records that foreign PID and the port before reporting Running. So an
 // operator running `dolt sql-server` over .beads/dolt under systemd or a
 // container — exactly the operator portConflictDiagnostics addresses — mints
-// this proof by typing `bd dolt start`. Closing it means recording adoption
-// distinctly from launch (skip the write on the adopt branch, or mark it so
-// this helper declines it), which is a behavior change on the auto-start path
-// and belongs with #6123 rather than in a gate-hardening patch. It is unix-only
-// in practice: isProcessInDir returns false on Windows, so reclaimPort never
-// takes the CWD-match adopt branch there.
+// this proof by typing `bd dolt start`.
+//
+// Typing it is not required, though, and the effect does not wear off. The
+// storage layer dials with a 500 ms timeout, so any open that times out —
+// under load, or inside a systemd/container restart window — reaches the same
+// adopt branch through its auto-start path with no operator action at all.
+// Nothing suppresses that by default for the topology this predicate exists to
+// gate: when the endpoint comes only from BEADS_DOLT_SERVER_PORT,
+// ResolveServerMode still answers Owned (that is the bug being closed here), so
+// EnsureRunningDetailed's ServerModeExternal branch never fires and Start()
+// proceeds. Once the adopt branch has written the two files they stay:
+// IsRunning clears them only for a PID that is corrupt, dead, or not dolt, and
+// an adopted server is a live dolt process on all three counts. The workspace
+// then answers "owned" from that point on, so a single timed-out dial disarms
+// the gate permanently.
+//
+// One setting does suppress it: `dolt.auto-start: false` (or
+// BEADS_DOLT_AUTO_START=0) fails serverOpenCanAutoStart and IsAutoStartDisabled,
+// so a timed-out open errors instead of adopting. That closes the incidental
+// route only — `bd dolt start` never consults either check, so the deliberate
+// route above stays open. It is the one mitigation an operator has while #6123
+// is open.
+//
+// Closing it means recording adoption distinctly from launch (skip the write on
+// the adopt branch, or mark it so this helper declines it), which is a behavior
+// change on the auto-start path and belongs with #6123 rather than in a
+// gate-hardening patch — though incidental and permanent is a sharper argument
+// for #6123 than a resolver tidy-up would be. It is unix-only in practice:
+// isProcessInDir returns false on Windows, so reclaimPort never takes the
+// CWD-match adopt branch there.
 //
 // Recycled PID (narrower). This stops short of IsRunning's isDoltProcess()
 // command-name check, which shells out to `ps` (PowerShell on Windows) —

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -542,6 +542,54 @@ func ReadPortFile(beadsDir string) int {
 	return readPortFile(beadsDir)
 }
 
+// ManagesLiveServerOnPort reports whether beadsDir has a dolt sql-server that
+// bd started FOR IT and that is still alive on port. It is the affirmative
+// proof of ownership: bd writes both state files in Start(), so a workspace
+// that can show a live PID beside a port file naming the port a caller is
+// actually connected on is a workspace whose server bd brought up.
+//
+// The absence of that proof is what matters at the call sites. An operator who
+// points bd at an endpoint — through BEADS_DOLT_SERVER_PORT, a config.yaml
+// pin, `bd init --server-port`, or a hand-built library Config — produces no
+// state files at all, because bd never started anything. Nothing else about
+// the connection distinguishes the two: both end as "a local TCP dolt
+// sql-server on port N".
+//
+// Read-only, deliberately. IsRunning answers a similar question but repairs as
+// it goes: it deletes stale PID and port files, and will stop an orphaned
+// server whose port it cannot determine. Callers that are merely classifying a
+// connection must not mutate a workspace's server state as a side effect, so
+// this duplicates the two cheap checks rather than reusing IsRunning.
+//
+// It stops short of IsRunning's isDoltProcess() command-name check, which
+// shells out to `ps` (PowerShell on Windows) — measured at hundreds of
+// milliseconds on a busy machine, and this runs on every writable open. The
+// residual gap is a recycled PID: the recorded server died, an unrelated live
+// process inherited its PID number, AND the port file still names the port
+// some other server now answers on. That is strictly narrower than the gap
+// left by trusting the port file alone, and it fails toward "owned" only when
+// all three coincide. Callers needing certainty over latency should use
+// IsRunning.
+func ManagesLiveServerOnPort(beadsDir string, port int) bool {
+	if beadsDir == "" || port <= 0 {
+		return false
+	}
+	// The port file first: it is the cheaper read, and a workspace pointed at
+	// somebody else's endpoint usually has no port file at all.
+	if readPortFile(beadsDir) != port {
+		return false
+	}
+	data, err := os.ReadFile(pidPath(beadsDir))
+	if err != nil {
+		return false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return false
+	}
+	return isProcessAlive(pid)
+}
+
 // PortFileSnapshot captures the exact prior contents of a project's port
 // file, so a caller that speculatively lets EnsureRunningDetailed write a
 // new one can restore the pre-call state exactly if it later decides not to

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -543,10 +543,13 @@ func ReadPortFile(beadsDir string) int {
 }
 
 // ManagesLiveServerOnPort reports whether beadsDir has a dolt sql-server that
-// bd started FOR IT and that is still alive on port. It is the affirmative
-// proof of ownership: bd writes both state files in Start(), so a workspace
-// that can show a live PID beside a port file naming the port a caller is
-// actually connected on is a workspace whose server bd brought up.
+// bd brought under management FOR IT and that is still alive on port. It is
+// the affirmative proof of ownership available from local state: bd writes
+// both state files in Start(), so a workspace that can show a live PID beside
+// a port file naming the port a caller is actually connected on is a workspace
+// whose server bd started — or adopted — for itself. Two file reads and a
+// signal 0 cannot separate those two, which is why the invariant is stated
+// that way; see the residual gaps below.
 //
 // The absence of that proof is what matters at the call sites. An operator who
 // points bd at an endpoint — through BEADS_DOLT_SERVER_PORT, a config.yaml
@@ -561,15 +564,34 @@ func ReadPortFile(beadsDir string) int {
 // connection must not mutate a workspace's server state as a side effect, so
 // this duplicates the two cheap checks rather than reusing IsRunning.
 //
-// It stops short of IsRunning's isDoltProcess() command-name check, which
-// shells out to `ps` (PowerShell on Windows) — measured at hundreds of
-// milliseconds on a busy machine, and this runs on every writable open. The
-// residual gap is a recycled PID: the recorded server died, an unrelated live
-// process inherited its PID number, AND the port file still names the port
-// some other server now answers on. That is strictly narrower than the gap
-// left by trusting the port file alone, and it fails toward "owned" only when
-// all three coincide. Callers needing certainty over latency should use
-// IsRunning.
+// Two residual gaps remain, both of which answer "owned" for a server bd did
+// not launch. Both are narrower than what trusting the port file alone — or
+// ResolveServerMode alone — left open, and #6123 owns closing them as part of
+// reconciling the four resolvers that answer "is this dolt server ours?".
+//
+// Adopted server (the wider of the two). Start() writes these same two state
+// files for a server it adopts rather than launches: reclaimPort returns the
+// PID of a dolt process whose CWD is this workspace's dolt dir, and Start
+// records that foreign PID and the port before reporting Running. So an
+// operator running `dolt sql-server` over .beads/dolt under systemd or a
+// container — exactly the operator portConflictDiagnostics addresses — mints
+// this proof by typing `bd dolt start`. Closing it means recording adoption
+// distinctly from launch (skip the write on the adopt branch, or mark it so
+// this helper declines it), which is a behavior change on the auto-start path
+// and belongs with #6123 rather than in a gate-hardening patch. It is unix-only
+// in practice: isProcessInDir returns false on Windows, so reclaimPort never
+// takes the CWD-match adopt branch there.
+//
+// Recycled PID (narrower). This stops short of IsRunning's isDoltProcess()
+// command-name check, which shells out to `ps` (PowerShell on Windows) —
+// measured at hundreds of milliseconds on a busy machine, and this runs on
+// every writable open. So: the recorded server died, an unrelated live process
+// inherited its PID number, AND the port file still names the port some other
+// server now answers on. It fails toward "owned" only when all three coincide.
+// Note that isDoltProcess here would close only this gap, not the adopted-server
+// one — reclaimPort already requires isDoltProcess before it will adopt.
+//
+// Callers needing certainty over latency should use IsRunning.
 func ManagesLiveServerOnPort(beadsDir string, port int) bool {
 	if beadsDir == "" || port <= 0 {
 		return false

--- a/internal/doltserver/managed_server_proof_test.go
+++ b/internal/doltserver/managed_server_proof_test.go
@@ -1,0 +1,112 @@
+package doltserver
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// TestManagesLiveServerOnPort pins the ownership proof: both state files, a
+// live PID, and a port file agreeing with the port the caller is connected on.
+//
+// Every "false" case below is a silent in-place migration of somebody else's
+// database if it ever flips, so each one names the topology it stands for.
+func TestManagesLiveServerOnPort(t *testing.T) {
+	const port = 3307
+
+	// dead is a PID no live process answers to: above every default pid_max.
+	const dead = 2147483646
+
+	newDir := func(t *testing.T) string {
+		t.Helper()
+		dir := filepath.Join(t.TempDir(), ".beads")
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		return dir
+	}
+	write := func(t *testing.T, dir, name string, v int) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(strconv.Itoa(v)), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	t.Run("live pid and matching port file is proof", func(t *testing.T) {
+		dir := newDir(t)
+		write(t, dir, PortFileName, port)
+		write(t, dir, PIDFileName, os.Getpid())
+		if !ManagesLiveServerOnPort(dir, port) {
+			t.Fatal("a workspace with a live recorded server on this port owns it (#6088 must keep migrating)")
+		}
+	})
+
+	t.Run("dead pid is not proof", func(t *testing.T) {
+		// The workspace once ran its own server on this port; it died, and an
+		// externally managed server now answers there. 3307 is both the common
+		// external port and bd's own default, so the collision is likely.
+		dir := newDir(t)
+		write(t, dir, PortFileName, port)
+		write(t, dir, PIDFileName, dead)
+		if ManagesLiveServerOnPort(dir, port) {
+			t.Fatal("a port file records that bd once bound a port, not that bd answers on it now")
+		}
+	})
+
+	t.Run("port file naming a different port is not proof", func(t *testing.T) {
+		dir := newDir(t)
+		write(t, dir, PortFileName, 40083)
+		write(t, dir, PIDFileName, os.Getpid())
+		if ManagesLiveServerOnPort(dir, port) {
+			t.Fatal("bd's server is on another port; this endpoint is somebody else's")
+		}
+	})
+
+	t.Run("missing state files are not proof", func(t *testing.T) {
+		dir := newDir(t)
+		if ManagesLiveServerOnPort(dir, port) {
+			t.Fatal("bd never started a server here")
+		}
+		write(t, dir, PortFileName, port)
+		if ManagesLiveServerOnPort(dir, port) {
+			t.Fatal("a port file with no pid file proves nothing about liveness")
+		}
+	})
+
+	t.Run("garbage pid file is not proof", func(t *testing.T) {
+		dir := newDir(t)
+		write(t, dir, PortFileName, port)
+		if err := os.WriteFile(filepath.Join(dir, PIDFileName), []byte("not-a-pid"), 0o600); err != nil {
+			t.Fatalf("write pid: %v", err)
+		}
+		if ManagesLiveServerOnPort(dir, port) {
+			t.Fatal("an unparseable pid file must fail closed")
+		}
+	})
+
+	t.Run("degenerate inputs fail closed", func(t *testing.T) {
+		if ManagesLiveServerOnPort("", port) {
+			t.Fatal("no workspace, no proof")
+		}
+		if ManagesLiveServerOnPort(newDir(t), 0) {
+			t.Fatal("port 0 means unresolved; there is no endpoint to own")
+		}
+	})
+
+	// Read-only: unlike IsRunning, classifying a connection must never repair
+	// or delete a workspace's server state as a side effect.
+	t.Run("does not mutate workspace state", func(t *testing.T) {
+		dir := newDir(t)
+		write(t, dir, PortFileName, port)
+		write(t, dir, PIDFileName, dead)
+		if ManagesLiveServerOnPort(dir, port) {
+			t.Fatal("dead pid must not be proof")
+		}
+		for _, name := range []string{PortFileName, PIDFileName} {
+			if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+				t.Fatalf("%s was removed: %v — the predicate must not repair state it merely reads", name, err)
+			}
+		}
+	})
+}

--- a/internal/doltserver/managed_server_proof_test.go
+++ b/internal/doltserver/managed_server_proof_test.go
@@ -33,7 +33,16 @@ func TestManagesLiveServerOnPort(t *testing.T) {
 		}
 	}
 
-	t.Run("live pid and matching port file is proof", func(t *testing.T) {
+	// The PID recorded here is this test binary's, which is emphatically not a
+	// dolt sql-server: parseDoltProcessPIDs requires "dolt" followed by
+	// "sql-server" in the command line, so an identity check would never return
+	// it. That is the point — this subtest pins the predicate's liveness-only
+	// contract and is the live demonstration that any live PID beside an
+	// agreeing port file is accepted today, dolt or not. #6123 is expected to
+	// tighten that (a distinct adoption marker, or an identity check); when it
+	// does, this subtest goes red, and that is the signal to re-derive #6088's
+	// guarantee from whatever the new proof is, not to relax the assertion.
+	t.Run("any live pid with an agreeing port file is proof", func(t *testing.T) {
 		dir := newDir(t)
 		write(t, dir, PortFileName, port)
 		write(t, dir, PIDFileName, os.Getpid())

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -284,18 +284,6 @@ func applyResolvedConfig(ctx context.Context, beadsDir string, fileCfg *configfi
 		// precedence chain and carries the source along with the port.
 		ApplyResolvedServerPort(beadsDir, cfg)
 	}
-	// A configured unix socket, exactly as cmd/bd's resolveDoltServerConnection
-	// resolves it. Without this the library open path and the CLI disagree about
-	// the transport for the SAME workspace: the CLI dials the socket while a
-	// library caller (doctor's SharedStore, embedders) silently falls back to
-	// host:port. It also blinded sharedServerDatabase, whose socket arm is meant
-	// to catch exactly this topology — bd's auto-start only ever creates a TCP
-	// listener, so a socket is always someone else's server. A socket that is
-	// configured but not currently connectable stays harmless: newServerMode
-	// normalizes it back to TCP through ResolveSocketTransport.
-	if cfg.ServerSocket == "" {
-		cfg.ServerSocket = fileCfg.GetDoltServerSocket()
-	}
 	// Resolve the server-mode credential (the connection username). In server mode a
 	// configured credential command takes precedence over the static user; it fails
 	// closed (see ApplyGatewayCredential). The command runs only in server mode — an

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -284,6 +284,18 @@ func applyResolvedConfig(ctx context.Context, beadsDir string, fileCfg *configfi
 		// precedence chain and carries the source along with the port.
 		ApplyResolvedServerPort(beadsDir, cfg)
 	}
+	// A configured unix socket, exactly as cmd/bd's resolveDoltServerConnection
+	// resolves it. Without this the library open path and the CLI disagree about
+	// the transport for the SAME workspace: the CLI dials the socket while a
+	// library caller (doctor's SharedStore, embedders) silently falls back to
+	// host:port. It also blinded sharedServerDatabase, whose socket arm is meant
+	// to catch exactly this topology — bd's auto-start only ever creates a TCP
+	// listener, so a socket is always someone else's server. A socket that is
+	// configured but not currently connectable stays harmless: newServerMode
+	// normalizes it back to TCP through ResolveSocketTransport.
+	if cfg.ServerSocket == "" {
+		cfg.ServerSocket = fileCfg.GetDoltServerSocket()
+	}
 	// Resolve the server-mode credential (the connection username). In server mode a
 	// configured credential command takes precedence over the static user; it fails
 	// closed (see ApplyGatewayCredential). The command runs only in server mode — an

--- a/internal/storage/dolt/shared_server_predicate_test.go
+++ b/internal/storage/dolt/shared_server_predicate_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/doltserver"
 )
 
 // TestSharedServerDatabase pins which topologies the #5920 consent gate
@@ -83,6 +85,7 @@ func TestSharedServerDatabase(t *testing.T) {
 		{name: "remote host", cfg: Config{ServerHost: "db.example.com", ServerPort: 3307}},
 		{name: "TLS endpoint", cfg: Config{ServerHost: "127.0.0.1", ServerPort: 3307, ServerTLS: true}},
 		{name: "unix socket", cfg: Config{ServerHost: "127.0.0.1", ServerSocket: "/tmp/dolt.sock"}},
+		{name: "gateway credential", cfg: Config{ServerHost: "127.0.0.1", ServerPort: 3307, Gateway: true}},
 	} {
 		t.Run(tt.name+" is shared", func(t *testing.T) {
 			clearEnv(t)
@@ -93,4 +96,184 @@ func TestSharedServerDatabase(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSharedServerDatabaseEndpointProvenance pins the second half of the
+// predicate: WHO named the endpoint bd connected to.
+//
+// The release blocker this covers is a workspace pointed at an externally
+// managed dolt sql-server purely through BEADS_DOLT_SERVER_PORT. Nothing in
+// metadata.json records the server, so ResolveServerMode — whose port arm reads
+// metadata.json only — called it ServerModeOwned, the gate never ran, and an
+// upgraded bd silently promoted the schema of a server it had never started.
+// The connection path has honored that env var all along
+// (configfile.GetDoltServerPort reads it first), which is the asymmetry.
+//
+// The matrix runs on the resolved Config.ServerPortSource rather than on the raw
+// environment, because the env var alone cannot tell the two cases apart: it is
+// also how a caller TELLS bd which port to bind before doltserver.Start.
+func TestSharedServerDatabaseEndpointProvenance(t *testing.T) {
+	workspace := func(t *testing.T) string {
+		t.Helper()
+		dir := filepath.Join(t.TempDir(), ".beads")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		return dir
+	}
+
+	clearEnv := func(t *testing.T) {
+		t.Helper()
+		for _, k := range []string{
+			"BEADS_DOLT_SHARED_SERVER", "BEADS_DOLT_SERVER_MODE",
+			"BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT",
+		} {
+			t.Setenv(k, "")
+		}
+	}
+
+	for _, tt := range []struct {
+		name   string
+		source doltserver.PortSource
+		shared bool
+		why    string
+	}{
+		{
+			name:   "env var",
+			source: doltserver.PortSourceEnv,
+			shared: true,
+			why:    "BEADS_DOLT_SERVER_PORT points at a server that already existed; bd did not start it",
+		},
+		{
+			name:   "beads config.yaml",
+			source: doltserver.PortSourceConfigYaml,
+			shared: true,
+			why:    "a dolt.port written into config.yaml is an operator recording where a server lives",
+		},
+		{
+			name:   "metadata.json",
+			source: doltserver.PortSourceMetadataJSON,
+			shared: true,
+			why:    "the #5920 shape ResolveServerMode already gated; provenance must agree with it",
+		},
+		{
+			name:   "external host default",
+			source: doltserver.PortSourceExternalHostDefault,
+			shared: true,
+			why:    "the documented 3307 fallback is reached only when a host was configured",
+		},
+		{
+			name:   "shared server default",
+			source: doltserver.PortSourceSharedServerDefault,
+			shared: true,
+			why:    "3308 is the one-server-many-workspaces default",
+		},
+		{
+			name:   "port file",
+			source: doltserver.PortSourcePortFile,
+			shared: false,
+			why:    ".beads/dolt-server.port is bd's own record of the server it started here",
+		},
+		{
+			name:   "dolt config.yaml",
+			source: doltserver.PortSourceDoltConfigYaml,
+			shared: false,
+			why:    "the config of the dolt server living inside this workspace's own dolt dir",
+		},
+		{
+			name:   "caller explicit",
+			source: doltserver.PortSourceCallerExplicit,
+			shared: false,
+			why:    "an in-process assertion (bd init --server-port, the #5781 recovery) outranks ambient env by design",
+		},
+		{
+			name:   "unset",
+			source: doltserver.PortSourceUnset,
+			shared: false,
+			why:    "no endpoint was named at all; auto-start allocates an ephemeral port",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			clearEnv(t)
+			cfg := &Config{
+				BeadsDir:         workspace(t),
+				ServerHost:       "127.0.0.1",
+				ServerPort:       3307,
+				ServerPortSource: tt.source,
+			}
+			if got := sharedServerDatabase(cfg); got != tt.shared {
+				t.Fatalf("sharedServerDatabase(port source %q) = %v, want %v — %s", tt.source, got, tt.shared, tt.why)
+			}
+		})
+	}
+
+	// The escape hatch. doltserver.Start binds a port for THIS workspace and
+	// records it; an operator who then exports the same port in the environment
+	// has not handed the server to anyone else. The env read wins the precedence
+	// chain, so the source reads "env" — the port file is what proves otherwise.
+	t.Run("env port matching this workspace's own port file is owned", func(t *testing.T) {
+		clearEnv(t)
+		dir := workspace(t)
+		if err := os.WriteFile(filepath.Join(dir, doltserver.PortFileName), []byte("34567"), 0o600); err != nil {
+			t.Fatalf("write port file: %v", err)
+		}
+		t.Setenv("BEADS_DOLT_SERVER_PORT", "34567")
+		cfg := &Config{
+			BeadsDir:         dir,
+			ServerHost:       "127.0.0.1",
+			ServerPort:       34567,
+			ServerPortSource: doltserver.PortSourceEnv,
+		}
+		if sharedServerDatabase(cfg) {
+			t.Fatal("bd started this server for this workspace and recorded the port; it must still migrate on open (#6088)")
+		}
+	})
+
+	// ...and the hatch is not a blanket exemption: a port file left behind by an
+	// unrelated server does not launder a different endpoint into ownership.
+	t.Run("env port disagreeing with the port file is shared", func(t *testing.T) {
+		clearEnv(t)
+		dir := workspace(t)
+		if err := os.WriteFile(filepath.Join(dir, doltserver.PortFileName), []byte("34567"), 0o600); err != nil {
+			t.Fatalf("write port file: %v", err)
+		}
+		t.Setenv("BEADS_DOLT_SERVER_PORT", "3307")
+		cfg := &Config{
+			BeadsDir:         dir,
+			ServerHost:       "127.0.0.1",
+			ServerPort:       3307,
+			ServerPortSource: doltserver.PortSourceEnv,
+		}
+		if !sharedServerDatabase(cfg) {
+			t.Fatal("the port file names a different server; the env endpoint is still someone else's")
+		}
+	})
+
+	// The reported shape end to end: dolt_mode=server, NO dolt_server_port,
+	// endpoint supplied entirely by the environment. This is what gascity's
+	// 28-database server on port 3307 looks like from inside bd.
+	t.Run("gascity shape: server mode with no persisted port is shared", func(t *testing.T) {
+		clearEnv(t)
+		dir := workspace(t)
+		metadata := `{"database":"beads","backend":"dolt","dolt_mode":"server","dolt_database":"beads"}`
+		if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte(metadata), 0o600); err != nil {
+			t.Fatalf("write metadata: %v", err)
+		}
+		t.Setenv("BEADS_DOLT_SERVER_PORT", "3307")
+		cfg := &Config{
+			BeadsDir:         dir,
+			ServerHost:       "127.0.0.1",
+			ServerPort:       3307,
+			ServerPortSource: doltserver.PortSourceEnv,
+		}
+		if !sharedServerDatabase(cfg) {
+			t.Fatal("an env-pointed server with no ownership record must be gated, not migrated in place")
+		}
+		// The bypass was exactly this disagreement: the lifecycle resolver said
+		// owned while the connection path was dialing an env-named endpoint.
+		if got := doltserver.ResolveServerMode(dir); got != doltserver.ServerModeOwned {
+			t.Fatalf("ResolveServerMode = %v, want ServerModeOwned — if this changed, the predicate no "+
+				"longer covers a case the lifecycle resolver misses and this test has stopped testing the bug", got)
+		}
+	})
 }

--- a/internal/storage/dolt/shared_server_predicate_test.go
+++ b/internal/storage/dolt/shared_server_predicate_test.go
@@ -1,54 +1,97 @@
 package dolt
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
 )
 
-// TestSharedServerDatabase pins which topologies the #5920 consent gate
-// applies to. Getting this wrong is expensive in both directions: too broad
-// and bd refuses to migrate a workspace's own database (the release blocker
-// this predicate was introduced to fix), too narrow and an upgraded client
-// silently promotes the schema for a whole team.
+// clearPredicateEnv fixes every BEADS_DOLT_* signal the predicate reads. The
+// predicate reads process state, so a leaked variable from a sibling test would
+// otherwise decide the answer. One list, shared by every test in this file: two
+// copies would mean the next signal added to the predicate has to be added to
+// both, and forgetting one silently reintroduces exactly the leak this exists
+// to prevent.
+func clearPredicateEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"BEADS_DOLT_SHARED_SERVER", "BEADS_DOLT_SERVER_MODE",
+		"BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT",
+		"BEADS_DOLT_SERVER_SOCKET", "BEADS_DOLT_SERVER_TLS",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+// unmanagedWorkspace is a .beads directory with no server state files: bd never
+// started a server here. Whatever it is connected to, it was pointed at.
+func unmanagedWorkspace(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	return dir
+}
+
+// managedWorkspace is a .beads directory carrying the state files
+// doltserver.Start writes: a port file naming port, and a PID file naming a
+// live process. This is the auto-started single-workspace server of #6088.
 //
-// Every case fixes the environment explicitly — the predicate reads process
-// state, so a leaked BEADS_DOLT_* from another test would otherwise decide the
-// answer.
+// The PID is this test process, which is alive by construction. That is a
+// faithful stand-in because the predicate deliberately checks liveness only —
+// doltserver.ManagesLiveServerOnPort documents why it stops short of the
+// `ps`-based command-name check that would distinguish a dolt process.
+func managedWorkspace(t *testing.T, port int) string {
+	t.Helper()
+	dir := unmanagedWorkspace(t)
+	writeServerState(t, dir, port, os.Getpid())
+	return dir
+}
+
+func writeServerState(t *testing.T, beadsDir string, port, pid int) {
+	t.Helper()
+	if port > 0 {
+		if err := os.WriteFile(filepath.Join(beadsDir, doltserver.PortFileName),
+			[]byte(strconv.Itoa(port)), 0o600); err != nil {
+			t.Fatalf("write port file: %v", err)
+		}
+	}
+	if pid > 0 {
+		if err := os.WriteFile(filepath.Join(beadsDir, doltserver.PIDFileName),
+			[]byte(strconv.Itoa(pid)), 0o600); err != nil {
+			t.Fatalf("write pid file: %v", err)
+		}
+	}
+}
+
+// deadPID returns a PID that is almost certainly not running. Allocating and
+// reaping a real child would be exact, but the predicate only needs a number
+// no live process answers to; PID 0x7FFFFFFE is above every default pid_max.
+const deadPID = 2147483646
+
+// TestSharedServerDatabase pins which topologies the #5920 consent gate applies
+// to. Getting this wrong is expensive in both directions: too broad and bd
+// refuses to migrate a workspace's own database (#6088, the release blocker
+// this predicate was narrowed to fix), too narrow and an upgraded client
+// silently promotes the schema for a whole team (#5920, and the env-port bypass
+// that reopened it).
 func TestSharedServerDatabase(t *testing.T) {
-	// A workspace with no metadata.json: doltserver resolves it as a server
-	// whose lifecycle bd owns.
-	ownedWorkspace := func(t *testing.T) string {
-		t.Helper()
-		dir := filepath.Join(t.TempDir(), ".beads")
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("mkdir: %v", err)
-		}
-		return dir
-	}
-
-	clearEnv := func(t *testing.T) {
-		t.Helper()
-		for _, k := range []string{
-			"BEADS_DOLT_SHARED_SERVER", "BEADS_DOLT_SERVER_MODE",
-			"BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT",
-		} {
-			t.Setenv(k, "")
-		}
-	}
-
-	t.Run("bd-owned local server is not shared", func(t *testing.T) {
-		clearEnv(t)
-		cfg := &Config{BeadsDir: ownedWorkspace(t), ServerHost: "127.0.0.1", ServerPort: 3307}
+	t.Run("a live bd-managed server for this workspace is not shared", func(t *testing.T) {
+		clearPredicateEnv(t)
+		cfg := &Config{BeadsDir: managedWorkspace(t, 3307), ServerHost: "127.0.0.1", ServerPort: 3307}
 		if sharedServerDatabase(cfg) {
-			t.Fatal("a server bd auto-started for this workspace must migrate on open, as embedded does")
+			t.Fatal("a server bd started for this workspace must migrate on open, as embedded does (#6088)")
 		}
 	})
 
 	t.Run("no workspace fails closed", func(t *testing.T) {
-		clearEnv(t)
+		clearPredicateEnv(t)
 		// A bare dolt.New pointed at an endpoint: nothing proves bd owns it,
 		// and a library caller attached to a team's server must not migrate it.
 		cfg := &Config{ServerHost: "127.0.0.1", ServerPort: 3307}
@@ -61,18 +104,20 @@ func TestSharedServerDatabase(t *testing.T) {
 	})
 
 	t.Run("shared-server mode is shared", func(t *testing.T) {
-		clearEnv(t)
+		clearPredicateEnv(t)
 		t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
-		cfg := &Config{BeadsDir: ownedWorkspace(t), ServerHost: "127.0.0.1", ServerPort: 3308}
+		cfg := &Config{BeadsDir: managedWorkspace(t, 3308), ServerHost: "127.0.0.1", ServerPort: 3308}
 		if !sharedServerDatabase(cfg) {
 			t.Fatal("shared-server mode is one server for many workspaces — the #5920 shape")
 		}
 	})
 
 	t.Run("explicit external server mode is shared", func(t *testing.T) {
-		clearEnv(t)
+		clearPredicateEnv(t)
 		t.Setenv("BEADS_DOLT_SERVER_MODE", "1")
-		cfg := &Config{BeadsDir: ownedWorkspace(t), ServerHost: "127.0.0.1", ServerPort: 3307}
+		// Even with the ownership proof present: an explicit declaration that
+		// the lifecycle is external outranks it.
+		cfg := &Config{BeadsDir: managedWorkspace(t, 3307), ServerHost: "127.0.0.1", ServerPort: 3307}
 		if !sharedServerDatabase(cfg) {
 			t.Fatal("an operator-managed server is not bd's to migrate unprompted")
 		}
@@ -85,12 +130,11 @@ func TestSharedServerDatabase(t *testing.T) {
 		{name: "remote host", cfg: Config{ServerHost: "db.example.com", ServerPort: 3307}},
 		{name: "TLS endpoint", cfg: Config{ServerHost: "127.0.0.1", ServerPort: 3307, ServerTLS: true}},
 		{name: "unix socket", cfg: Config{ServerHost: "127.0.0.1", ServerSocket: "/tmp/dolt.sock"}},
-		{name: "gateway credential", cfg: Config{ServerHost: "127.0.0.1", ServerPort: 3307, Gateway: true}},
 	} {
 		t.Run(tt.name+" is shared", func(t *testing.T) {
-			clearEnv(t)
+			clearPredicateEnv(t)
 			cfg := tt.cfg
-			cfg.BeadsDir = ownedWorkspace(t)
+			cfg.BeadsDir = managedWorkspace(t, 3307)
 			if !sharedServerDatabase(&cfg) {
 				t.Fatalf("%s cannot be a server bd auto-started for this workspace", tt.name)
 			}
@@ -98,182 +142,205 @@ func TestSharedServerDatabase(t *testing.T) {
 	}
 }
 
-// TestSharedServerDatabaseEndpointProvenance pins the second half of the
-// predicate: WHO named the endpoint bd connected to.
+// TestSharedServerDatabaseOwnershipProof covers the bypasses that made the
+// #5920 gate miss the reported deployment, and the false positives that a
+// coarser rule would create.
 //
-// The release blocker this covers is a workspace pointed at an externally
-// managed dolt sql-server purely through BEADS_DOLT_SERVER_PORT. Nothing in
-// metadata.json records the server, so ResolveServerMode — whose port arm reads
-// metadata.json only — called it ServerModeOwned, the gate never ran, and an
-// upgraded bd silently promoted the schema of a server it had never started.
-// The connection path has honored that env var all along
-// (configfile.GetDoltServerPort reads it first), which is the asymmetry.
-//
-// The matrix runs on the resolved Config.ServerPortSource rather than on the raw
-// environment, because the env var alone cannot tell the two cases apart: it is
-// also how a caller TELLS bd which port to bind before doltserver.Start.
-func TestSharedServerDatabaseEndpointProvenance(t *testing.T) {
-	workspace := func(t *testing.T) string {
-		t.Helper()
-		dir := filepath.Join(t.TempDir(), ".beads")
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("mkdir: %v", err)
-		}
-		return dir
-	}
+// The unifying point: a local TCP endpoint on 127.0.0.1 looks identical however
+// bd arrived at it. The env var, a config.yaml pin, `bd init --server-port`, a
+// library caller's hand-built Config and a stale port file all produce one, and
+// each was (or would be) a separate silent bypass. Only the state files bd
+// writes when it starts a server distinguish them.
+func TestSharedServerDatabaseOwnershipProof(t *testing.T) {
+	// 3307 is both the reported deployment's port and
+	// configfile.DefaultDoltServerPort, which is why these collisions are
+	// likely rather than exotic.
+	const port = 3307
 
-	clearEnv := func(t *testing.T) {
-		t.Helper()
-		for _, k := range []string{
-			"BEADS_DOLT_SHARED_SERVER", "BEADS_DOLT_SERVER_MODE",
-			"BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT",
-		} {
-			t.Setenv(k, "")
+	t.Run("env-pointed server with no bd-managed server is shared", func(t *testing.T) {
+		clearPredicateEnv(t)
+		t.Setenv("BEADS_DOLT_SERVER_PORT", strconv.Itoa(port))
+		cfg := &Config{
+			BeadsDir:         unmanagedWorkspace(t),
+			ServerHost:       "127.0.0.1",
+			ServerPort:       port,
+			ServerPortSource: doltserver.PortSourceEnv,
 		}
-	}
-
-	for _, tt := range []struct {
-		name   string
-		source doltserver.PortSource
-		shared bool
-		why    string
-	}{
-		{
-			name:   "env var",
-			source: doltserver.PortSourceEnv,
-			shared: true,
-			why:    "BEADS_DOLT_SERVER_PORT points at a server that already existed; bd did not start it",
-		},
-		{
-			name:   "beads config.yaml",
-			source: doltserver.PortSourceConfigYaml,
-			shared: true,
-			why:    "a dolt.port written into config.yaml is an operator recording where a server lives",
-		},
-		{
-			name:   "metadata.json",
-			source: doltserver.PortSourceMetadataJSON,
-			shared: true,
-			why:    "the #5920 shape ResolveServerMode already gated; provenance must agree with it",
-		},
-		{
-			name:   "external host default",
-			source: doltserver.PortSourceExternalHostDefault,
-			shared: true,
-			why:    "the documented 3307 fallback is reached only when a host was configured",
-		},
-		{
-			name:   "shared server default",
-			source: doltserver.PortSourceSharedServerDefault,
-			shared: true,
-			why:    "3308 is the one-server-many-workspaces default",
-		},
-		{
-			name:   "port file",
-			source: doltserver.PortSourcePortFile,
-			shared: false,
-			why:    ".beads/dolt-server.port is bd's own record of the server it started here",
-		},
-		{
-			name:   "dolt config.yaml",
-			source: doltserver.PortSourceDoltConfigYaml,
-			shared: false,
-			why:    "the config of the dolt server living inside this workspace's own dolt dir",
-		},
-		{
-			name:   "caller explicit",
-			source: doltserver.PortSourceCallerExplicit,
-			shared: false,
-			why:    "an in-process assertion (bd init --server-port, the #5781 recovery) outranks ambient env by design",
-		},
-		{
-			name:   "unset",
-			source: doltserver.PortSourceUnset,
-			shared: false,
-			why:    "no endpoint was named at all; auto-start allocates an ephemeral port",
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			clearEnv(t)
-			cfg := &Config{
-				BeadsDir:         workspace(t),
-				ServerHost:       "127.0.0.1",
-				ServerPort:       3307,
-				ServerPortSource: tt.source,
-			}
-			if got := sharedServerDatabase(cfg); got != tt.shared {
-				t.Fatalf("sharedServerDatabase(port source %q) = %v, want %v — %s", tt.source, got, tt.shared, tt.why)
-			}
-		})
-	}
-
-	// The escape hatch. doltserver.Start binds a port for THIS workspace and
-	// records it; an operator who then exports the same port in the environment
-	// has not handed the server to anyone else. The env read wins the precedence
-	// chain, so the source reads "env" — the port file is what proves otherwise.
-	t.Run("env port matching this workspace's own port file is owned", func(t *testing.T) {
-		clearEnv(t)
-		dir := workspace(t)
-		if err := os.WriteFile(filepath.Join(dir, doltserver.PortFileName), []byte("34567"), 0o600); err != nil {
-			t.Fatalf("write port file: %v", err)
+		if !sharedServerDatabase(cfg) {
+			t.Fatal("BEADS_DOLT_SERVER_PORT names a server that already existed; bd never started it")
 		}
-		t.Setenv("BEADS_DOLT_SERVER_PORT", "34567")
+	})
+
+	// The reported bug's second door. applyConfigDefaults stamps
+	// PortSourceCallerExplicit onto ANY caller-preset port, and
+	// `bd init --server-port` is the documented way to attach a workspace to an
+	// existing server — so treating that source as proof of ownership left the
+	// blocker open through the flag bd's own help text recommends.
+	t.Run("bd init --server-port at an external server is shared", func(t *testing.T) {
+		clearPredicateEnv(t)
+		cfg := &Config{
+			BeadsDir:         unmanagedWorkspace(t),
+			ServerHost:       "127.0.0.1",
+			ServerPort:       port,
+			ServerPortSource: doltserver.PortSourceCallerExplicit,
+		}
+		if !sharedServerDatabase(cfg) {
+			t.Fatal("a caller asserting a port is not bd having started that server")
+		}
+	})
+
+	// Same door, library spelling: an embedder building a Config by hand.
+	t.Run("hand-built library config at an external server is shared", func(t *testing.T) {
+		clearPredicateEnv(t)
+		cfg := &Config{BeadsDir: unmanagedWorkspace(t), ServerHost: "127.0.0.1", ServerPort: port}
+		if !sharedServerDatabase(cfg) {
+			t.Fatal("an embedder pointed at a team's server must not migrate it")
+		}
+	})
+
+	// A port file records that bd once bound a port, not that the process
+	// answering it now is bd's. Without a liveness check, a workspace whose own
+	// server died launders whatever server later occupies that port.
+	t.Run("stale port file whose server died is shared", func(t *testing.T) {
+		clearPredicateEnv(t)
+		dir := unmanagedWorkspace(t)
+		writeServerState(t, dir, port, deadPID)
+		t.Setenv("BEADS_DOLT_SERVER_PORT", strconv.Itoa(port))
 		cfg := &Config{
 			BeadsDir:         dir,
+			ServerHost:       "127.0.0.1",
+			ServerPort:       port,
+			ServerPortSource: doltserver.PortSourceEnv,
+		}
+		if !sharedServerDatabase(cfg) {
+			t.Fatal("the recorded server is gone; an external server now on that port is not ours to migrate")
+		}
+	})
+
+	t.Run("port file with no pid file is shared", func(t *testing.T) {
+		clearPredicateEnv(t)
+		dir := unmanagedWorkspace(t)
+		writeServerState(t, dir, port, 0)
+		cfg := &Config{BeadsDir: dir, ServerHost: "127.0.0.1", ServerPort: port}
+		if !sharedServerDatabase(cfg) {
+			t.Fatal("a port file alone is a record, not a live server")
+		}
+	})
+
+	// The port file must name the port we actually connected on: a live server
+	// bd manages on one port says nothing about a different endpoint.
+	t.Run("live bd server on a different port is shared", func(t *testing.T) {
+		clearPredicateEnv(t)
+		cfg := &Config{BeadsDir: managedWorkspace(t, 40083), ServerHost: "127.0.0.1", ServerPort: port}
+		if !sharedServerDatabase(cfg) {
+			t.Fatal("bd's server is on another port; this endpoint is somebody else's")
+		}
+	})
+
+	// The #6088 direction, and the false positive a coarser rule would create:
+	// a single-user workspace that pinned dolt.port in config.yaml — the very
+	// configuration bd's own auto-start warning recommends ("To pin a port: set
+	// dolt.port in .beads/config.yaml") — with bd auto-starting its own server
+	// on that port. Classifying the pin itself as shared would hard-refuse it.
+	t.Run("config.yaml-pinned port with a live bd server still migrates", func(t *testing.T) {
+		clearPredicateEnv(t)
+		cfg := &Config{
+			BeadsDir:         managedWorkspace(t, port),
+			ServerHost:       "127.0.0.1",
+			ServerPort:       port,
+			ServerPortSource: doltserver.PortSourceConfigYaml,
+		}
+		if sharedServerDatabase(cfg) {
+			t.Fatal("a pinned port bd auto-started on is still this workspace's own server")
+		}
+	})
+
+	// Same, for the env var: exporting BEADS_DOLT_SERVER_PORT is also how a
+	// caller tells bd which port to BIND before doltserver.Start, which is the
+	// shape #5781's lenient-open recovery runs in.
+	t.Run("env port that bd itself bound still migrates", func(t *testing.T) {
+		clearPredicateEnv(t)
+		t.Setenv("BEADS_DOLT_SERVER_PORT", "34567")
+		cfg := &Config{
+			BeadsDir:         managedWorkspace(t, 34567),
 			ServerHost:       "127.0.0.1",
 			ServerPort:       34567,
 			ServerPortSource: doltserver.PortSourceEnv,
 		}
 		if sharedServerDatabase(cfg) {
-			t.Fatal("bd started this server for this workspace and recorded the port; it must still migrate on open (#6088)")
+			t.Fatal("bd started this server for this workspace and recorded it; it must still migrate on open")
 		}
 	})
 
-	// ...and the hatch is not a blanket exemption: a port file left behind by an
-	// unrelated server does not launder a different endpoint into ownership.
-	t.Run("env port disagreeing with the port file is shared", func(t *testing.T) {
-		clearEnv(t)
-		dir := workspace(t)
-		if err := os.WriteFile(filepath.Join(dir, doltserver.PortFileName), []byte("34567"), 0o600); err != nil {
-			t.Fatalf("write port file: %v", err)
-		}
-		t.Setenv("BEADS_DOLT_SERVER_PORT", "3307")
+	// dolt's own config.yaml inside the workspace's dolt dir is not written by
+	// bd as an ownership record — an operator can run their own long-lived
+	// sql-server over that directory, or leave a stale file behind.
+	t.Run("dolt config.yaml port without a live bd server is shared", func(t *testing.T) {
+		clearPredicateEnv(t)
 		cfg := &Config{
-			BeadsDir:         dir,
+			BeadsDir:         unmanagedWorkspace(t),
 			ServerHost:       "127.0.0.1",
-			ServerPort:       3307,
-			ServerPortSource: doltserver.PortSourceEnv,
+			ServerPort:       port,
+			ServerPortSource: doltserver.PortSourceDoltConfigYaml,
 		}
 		if !sharedServerDatabase(cfg) {
-			t.Fatal("the port file names a different server; the env endpoint is still someone else's")
+			t.Fatal("nothing in bd writes dolt's config.yaml as proof of ownership")
 		}
 	})
+}
 
-	// The reported shape end to end: dolt_mode=server, NO dolt_server_port,
-	// endpoint supplied entirely by the environment. This is what gascity's
-	// 28-database server on port 3307 looks like from inside bd.
-	t.Run("gascity shape: server mode with no persisted port is shared", func(t *testing.T) {
-		clearEnv(t)
-		dir := workspace(t)
-		metadata := `{"database":"beads","backend":"dolt","dolt_mode":"server","dolt_database":"beads"}`
-		if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte(metadata), 0o600); err != nil {
-			t.Fatalf("write metadata: %v", err)
-		}
-		t.Setenv("BEADS_DOLT_SERVER_PORT", "3307")
-		cfg := &Config{
-			BeadsDir:         dir,
-			ServerHost:       "127.0.0.1",
-			ServerPort:       3307,
-			ServerPortSource: doltserver.PortSourceEnv,
-		}
-		if !sharedServerDatabase(cfg) {
-			t.Fatal("an env-pointed server with no ownership record must be gated, not migrated in place")
-		}
-		// The bypass was exactly this disagreement: the lifecycle resolver said
-		// owned while the connection path was dialing an env-named endpoint.
-		if got := doltserver.ResolveServerMode(dir); got != doltserver.ServerModeOwned {
-			t.Fatalf("ResolveServerMode = %v, want ServerModeOwned — if this changed, the predicate no "+
-				"longer covers a case the lifecycle resolver misses and this test has stopped testing the bug", got)
-		}
-	})
+// TestSharedServerDatabaseThroughResolvedConfig closes the gap between the unit
+// tests above, which hand-build a Config, and what a real open produces.
+//
+// Every other test here asserts the predicate's behavior for a given Config. If
+// the config path stopped producing that Config — a caller presetting the port,
+// a change to ApplyResolvedServerPort's precedence, applyConfigDefaults'
+// re-stamp condition (store.go, be-9tju) — the bug would return with every one
+// of them still green. This one drives the real path.
+func TestSharedServerDatabaseThroughResolvedConfig(t *testing.T) {
+	clearPredicateEnv(t)
+
+	// The reported deployment's exact workspace shape: server mode, and NO
+	// dolt_server_port. The endpoint exists only in the environment.
+	//
+	// The port is deliberately NOT 3307. This test binary runs with
+	// BEADS_TEST_MODE=1, whose production-port firewall rewrites a resolved
+	// production port to 1 (applyConfigDefaults) — which would mask the very
+	// resolution this test exists to pin. Provenance is what is under test, not
+	// the number.
+	const envPort = 45671
+
+	dir := unmanagedWorkspace(t)
+	metadata := `{"database":"beads","backend":"dolt","dolt_mode":"server","dolt_database":"beads"}`
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte(metadata), 0o600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	t.Setenv("BEADS_DOLT_SERVER_PORT", strconv.Itoa(envPort))
+
+	fileCfg, err := configfile.Load(dir)
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	cfg := &Config{}
+	if err := applyResolvedConfig(context.Background(), dir, fileCfg, cfg); err != nil {
+		t.Fatalf("applyResolvedConfig: %v", err)
+	}
+	applyConfigDefaults(cfg)
+
+	// The connection path honors the env var...
+	if cfg.ServerPort != envPort {
+		t.Fatalf("resolved ServerPort = %d, want %d — the env var must decide the endpoint",
+			cfg.ServerPort, envPort)
+	}
+	// ...while the lifecycle resolver, which reads metadata.json only, does
+	// not. That disagreement IS the bug; if it ever closes, this test should be
+	// revisited rather than silently continuing to pass for a new reason.
+	if got := doltserver.ResolveServerMode(dir); got != doltserver.ServerModeOwned {
+		t.Logf("note: ResolveServerMode now returns %v for the env-port shape (was ServerModeOwned)", got)
+	}
+	// The predicate must gate it regardless.
+	if !sharedServerDatabase(cfg) {
+		t.Fatal("a workspace whose endpoint came only from BEADS_DOLT_SERVER_PORT must be gated, " +
+			"not migrated in place (#5920 bypass)")
+	}
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2832,14 +2832,16 @@ func initSchemaOnDBWithRetryAndGateBootstrapHeal(
 // A workspace pointed at an externally-managed server purely by that env var
 // therefore resolved ServerModeOwned while bd was connected to a server it had
 // never started: bd believed it owned a private server and silently promoted
-// the schema of a shared one. So this predicate asks the stricter question
-// directly — did THIS workspace's own bookkeeping produce the endpoint we
-// connected to? — and keeps ResolveServerMode as one arm of the answer.
+// the schema of a shared one.
 //
-// Each check below can only ADD a shared classification; none can remove one.
-// That is deliberate, and it is what makes the #6088 narrowing survive: a
-// topology that was gated before this function returns at the same place it
-// always did.
+// So ownership is not inferred from the connection at all. It is PROVEN, by
+// the state files bd writes when it starts a server (see
+// doltserver.ManagesLiveServerOnPort), and everything else is shared. The
+// inverse — enumerating the ways an endpoint can be foreign — was tried and is
+// unbounded: an env var, a config.yaml pin, `bd init --server-port`, a
+// hand-built library Config and a stale port file all produce a local TCP
+// endpoint indistinguishable from an owned one, and each is a separate silent
+// bypass. There is exactly one way to be sure, and it is cheap.
 func sharedServerDatabase(cfg *Config) bool {
 	// No workspace to prove ownership from — a bare dolt.New pointed at some
 	// endpoint. Fail closed.
@@ -2852,76 +2854,28 @@ func sharedServerDatabase(cfg *Config) bool {
 	if !isLocalHost(cfg.ServerHost) || cfg.ServerTLS || cfg.ServerSocket != "" {
 		return true
 	}
-	// A gateway credential command mints a short-lived token to present as the
-	// connection username to an authenticating server. bd's auto-start brings up
-	// a plain local root@localhost dolt sql-server and never issues tokens, so
-	// anything reached this way is operator-managed. In practice such a
-	// deployment also names its endpoint from the environment and would be
-	// caught below; asserting it here makes the case independent of that.
-	if cfg.Gateway {
-		return true
-	}
 	// The one shared topology that is otherwise indistinguishable from an
 	// owned one: same machine, same TCP shape, one server for many workspaces.
 	if doltserver.IsSharedServerMode() {
 		return true
 	}
-	// The endpoint was named from outside this workspace's own bookkeeping.
-	if !workspaceOwnsEndpoint(cfg) {
+	// The proof. Without a live server bd started for THIS workspace on the
+	// very port this store is connected to, the database belongs to someone
+	// else and migrating it is not this open's call to make.
+	//
+	// cfg.BeadsDir, not doltserver.ResolveServerDir(cfg.BeadsDir): the two
+	// differ only in shared-server mode, which returned above. Resolving here
+	// would read another directory's state files for the one topology this
+	// line can no longer be reached in.
+	if !doltserver.ManagesLiveServerOnPort(cfg.BeadsDir, cfg.ServerPort) {
 		return true
 	}
+	// Proof of a bd-managed server does not override an explicit declaration
+	// that the lifecycle is external (metadata dolt_server_port, host
+	// inference, BEADS_DOLT_SERVER_MODE). Keeping this last means the change
+	// above can only ever ADD shared classifications to what #5920/#6048
+	// already gated, never remove one.
 	return doltserver.ResolveServerMode(cfg.BeadsDir) != doltserver.ServerModeOwned
-}
-
-// workspaceOwnsEndpoint reports whether the port this store connected on came
-// from bd's own record of a server it started for THIS workspace, rather than
-// from an operator naming a pre-existing endpoint.
-//
-// The distinction matters because the two are otherwise identical from inside
-// the process: both end as "a local TCP dolt sql-server on port N". What
-// separates them is provenance, which doltserver already records on every open
-// as Config.ServerPortSource (stamped by applyConfigDefaults, so it is present
-// on the library path as well as the CLI's).
-//
-// The port file escape hatch covers the overlap: bd started the server for this
-// workspace AND the operator spelled the same port again in the environment.
-// The env read wins the precedence chain, so the source reads "env" even though
-// bd owns the server — .beads/dolt-server.port naming that same port is bd's
-// own proof that it did. That is the shape #5781's lenient-open recovery runs
-// in, and it must keep migrating on open.
-func workspaceOwnsEndpoint(cfg *Config) bool {
-	if portSourceIsWorkspaceBookkeeping(cfg.ServerPortSource) {
-		return true
-	}
-	return cfg.ServerPort > 0 && doltserver.ReadPortFile(cfg.BeadsDir) == cfg.ServerPort
-}
-
-// portSourceIsWorkspaceBookkeeping reports whether a port-resolution step names
-// an endpoint this workspace established for itself. The complement — the env
-// vars, beads' config.yaml, metadata.json, and the two documented fallback
-// defaults — are all an operator writing down where a server already lives.
-func portSourceIsWorkspaceBookkeeping(src doltserver.PortSource) bool {
-	switch src {
-	case doltserver.PortSourceUnset:
-		// Nothing resolved a port: there is no external endpoint to be pointed
-		// at, and auto-start will allocate an ephemeral one.
-		return true
-	case doltserver.PortSourcePortFile:
-		// .beads/dolt-server.port — written by doltserver.Start with the port
-		// bd actually bound. This is the ownership record itself.
-		return true
-	case doltserver.PortSourceDoltConfigYaml:
-		// The config.yaml of the dolt server living inside this workspace's own
-		// dolt directory, which only exists because bd put a server there.
-		return true
-	case doltserver.PortSourceCallerExplicit:
-		// An in-process caller asserted the port before New ran (be-wf9a.1).
-		// It outranks the ambient environment by design, and the callers that
-		// do it — bd init --server-port, the #5781 recovery tests — are
-		// operating on a server this process is managing.
-		return true
-	}
-	return false
 }
 
 func (s *DoltStore) initSchema(ctx context.Context, bootstrapHeal *schema.FreshBootstrapHealCapability) (int, error) {

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2823,6 +2823,23 @@ func initSchemaOnDBWithRetryAndGateBootstrapHeal(
 // the right idea but are populated only by the CLI (or, for the last, only
 // under BEADS_TEST_MODE): a library caller pointed at a genuinely shared
 // server leaves them false, and reading them would silently ungate it.
+//
+// ResolveServerMode alone is not enough, because it answers a DIFFERENT
+// question. Its contract is "may bd manage this server's lifecycle", and its
+// port arm reads dolt_server_port from metadata.json ONLY — while the
+// connection path (configfile.GetDoltServerPort, and doltserver's precedence
+// chain behind ApplyResolvedServerPort) takes BEADS_DOLT_SERVER_PORT first.
+// A workspace pointed at an externally-managed server purely by that env var
+// therefore resolved ServerModeOwned while bd was connected to a server it had
+// never started: bd believed it owned a private server and silently promoted
+// the schema of a shared one. So this predicate asks the stricter question
+// directly — did THIS workspace's own bookkeeping produce the endpoint we
+// connected to? — and keeps ResolveServerMode as one arm of the answer.
+//
+// Each check below can only ADD a shared classification; none can remove one.
+// That is deliberate, and it is what makes the #6088 narrowing survive: a
+// topology that was gated before this function returns at the same place it
+// always did.
 func sharedServerDatabase(cfg *Config) bool {
 	// No workspace to prove ownership from — a bare dolt.New pointed at some
 	// endpoint. Fail closed.
@@ -2835,12 +2852,76 @@ func sharedServerDatabase(cfg *Config) bool {
 	if !isLocalHost(cfg.ServerHost) || cfg.ServerTLS || cfg.ServerSocket != "" {
 		return true
 	}
+	// A gateway credential command mints a short-lived token to present as the
+	// connection username to an authenticating server. bd's auto-start brings up
+	// a plain local root@localhost dolt sql-server and never issues tokens, so
+	// anything reached this way is operator-managed. In practice such a
+	// deployment also names its endpoint from the environment and would be
+	// caught below; asserting it here makes the case independent of that.
+	if cfg.Gateway {
+		return true
+	}
 	// The one shared topology that is otherwise indistinguishable from an
 	// owned one: same machine, same TCP shape, one server for many workspaces.
 	if doltserver.IsSharedServerMode() {
 		return true
 	}
+	// The endpoint was named from outside this workspace's own bookkeeping.
+	if !workspaceOwnsEndpoint(cfg) {
+		return true
+	}
 	return doltserver.ResolveServerMode(cfg.BeadsDir) != doltserver.ServerModeOwned
+}
+
+// workspaceOwnsEndpoint reports whether the port this store connected on came
+// from bd's own record of a server it started for THIS workspace, rather than
+// from an operator naming a pre-existing endpoint.
+//
+// The distinction matters because the two are otherwise identical from inside
+// the process: both end as "a local TCP dolt sql-server on port N". What
+// separates them is provenance, which doltserver already records on every open
+// as Config.ServerPortSource (stamped by applyConfigDefaults, so it is present
+// on the library path as well as the CLI's).
+//
+// The port file escape hatch covers the overlap: bd started the server for this
+// workspace AND the operator spelled the same port again in the environment.
+// The env read wins the precedence chain, so the source reads "env" even though
+// bd owns the server — .beads/dolt-server.port naming that same port is bd's
+// own proof that it did. That is the shape #5781's lenient-open recovery runs
+// in, and it must keep migrating on open.
+func workspaceOwnsEndpoint(cfg *Config) bool {
+	if portSourceIsWorkspaceBookkeeping(cfg.ServerPortSource) {
+		return true
+	}
+	return cfg.ServerPort > 0 && doltserver.ReadPortFile(cfg.BeadsDir) == cfg.ServerPort
+}
+
+// portSourceIsWorkspaceBookkeeping reports whether a port-resolution step names
+// an endpoint this workspace established for itself. The complement — the env
+// vars, beads' config.yaml, metadata.json, and the two documented fallback
+// defaults — are all an operator writing down where a server already lives.
+func portSourceIsWorkspaceBookkeeping(src doltserver.PortSource) bool {
+	switch src {
+	case doltserver.PortSourceUnset:
+		// Nothing resolved a port: there is no external endpoint to be pointed
+		// at, and auto-start will allocate an ephemeral one.
+		return true
+	case doltserver.PortSourcePortFile:
+		// .beads/dolt-server.port — written by doltserver.Start with the port
+		// bd actually bound. This is the ownership record itself.
+		return true
+	case doltserver.PortSourceDoltConfigYaml:
+		// The config.yaml of the dolt server living inside this workspace's own
+		// dolt directory, which only exists because bd put a server there.
+		return true
+	case doltserver.PortSourceCallerExplicit:
+		// An in-process caller asserted the port before New ran (be-wf9a.1).
+		// It outranks the ambient environment by design, and the callers that
+		// do it — bd init --server-port, the #5781 recovery tests — are
+		// operating on a server this process is managing.
+		return true
+	}
+	return false
 }
 
 func (s *DoltStore) initSchema(ctx context.Context, bootstrapHeal *schema.FreshBootstrapHealCapability) (int, error) {


### PR DESCRIPTION
## The bug

A workspace pointed at an externally-managed, genuinely shared dolt sql-server is classified as owning that server, so `CheckSharedStoreMigrateGate` — the gate added by #5920/#6048/#6055 to stop exactly this — never fires. bd migrates the shared server's database in place: no prompt, no warning, exit 0. Every older bd attached to that same server is then hard-refused with `schema version mismatch`.

Found by running gascity's integration suite against `v1.3.0-rc.1`.

## The asymmetry

Two resolvers disagree about what names the server:

| | reads `BEADS_DOLT_SERVER_PORT`? |
|---|---|
| **connection path** — `configfile.GetDoltServerPort`, and doltserver's precedence chain behind `ApplyResolvedServerPort` | **yes, first**, before `BEADS_DOLT_PORT` and metadata.json |
| **ownership path** — `ResolveServerMode` step 4 | **no** — `dolt_server_port` from metadata.json only |

So a workspace whose `metadata.json` says `dolt_mode: server` with no port, and whose port arrives from the environment, connects to a server it never started while believing it owns a private one. `sharedServerDatabase` delegated to `ResolveServerMode`, inherited the blind spot, and the gate was silently disarmed.

## The fix: prove ownership, don't infer it

The first cut of this PR tried to enumerate the ways an endpoint can be *foreign* — env var, config.yaml pin, metadata port — and treat everything else as owned. Review found that list is unbounded, and that two more doors were still open behind it:

- **`bd init --server-port 3307`** at an existing server. `applyConfigDefaults` stamps `PortSourceCallerExplicit` onto *any* caller-preset port, and that flag is the documented way to attach a workspace to an existing server. Still migrated in place, exit 0.
- **A stale port file.** A port file records that bd once *bound* a port, not that the process answering it now is bd's. Workspace runs its own server on 3307 → it dies → an external server takes 3307 → laundered into ownership. 3307 is both the reported deployment's port *and* `configfile.DefaultDoltServerPort`, so the collision is likely rather than exotic.

Both have the same cause, and so did two false positives the first cut introduced. A local TCP endpoint on `127.0.0.1` looks identical however bd arrived at it, so **there is exactly one reliable question**: did bd start a server here, and is it still alive on the port we are connected to?

```go
// doltserver.ManagesLiveServerOnPort
if readPortFile(beadsDir) != port { return false }   // the port bd bound
...
return isProcessAlive(pid)                            // and it is still up
```

`sharedServerDatabase` now requires that proof. Everything else is shared.

### Signal matrix

| signal | classification | why |
|---|---|---|
| live PID file + port file naming the connected port | **owned** | bd started this server for this workspace |
| `BEADS_DOLT_SERVER_PORT` / `BEADS_DOLT_PORT` | shared | operator named a pre-existing endpoint… |
| `dolt.port` pinned in config.yaml | shared | …unless bd started the server on it, which the proof shows |
| `bd init --server-port`, hand-built library `Config` | shared | a caller asserting a port is not bd having started that server |
| stale port file, dead PID | shared | a record of a past binding, not a live server |
| port from dolt's own config.yaml | shared | bd never writes that file as an ownership record |
| non-local host, TLS, unix socket | shared | auto-start only ever creates a local TCP listener |
| shared-server mode, `BEADS_DOLT_SERVER_MODE=1`, metadata `dolt_server_port` | shared | pre-existing arms, unchanged and checked last |
| `BEADS_DOLT_SERVER_USER` / password / database name | not an ownership signal | names an identity or a database, not a server |

The ordering matters: the explicit-external arms run **after** the proof, so proof of a bd-managed server can never *un-gate* a topology #5920/#6048 already gated.

### Two claims from the first cut that were wrong, now withdrawn

Review found both, and neither is in the diff any more:

- **`cfg.Gateway` was unreachable.** `newServerMode` only calls `initSchema` when `!cfg.Gateway`, so a gateway config never reaches this predicate. It was listed as a closed asymmetry and closed nothing. Removed.
- **The `dolt_server_socket` read in `applyResolvedConfig` was both harmful and useless.** It disabled auto-start on the library path whenever the server was cold (`ResolveSocketTransport` returns the socket unchanged when neither socket nor TCP answers; `serverOpenCanAutoStart` requires an empty socket), and it never armed the predicate anyway, because `newServerMode` overwrites `cfg.ServerSocket` with the *normalized transport* before `initSchema` runs. Reverted — `open.go` is byte-identical to the base branch. The socket topology is covered by the ownership proof instead, without touching the transport.

### Deliberate limits

- **`ManagesLiveServerOnPort` is read-only.** `IsRunning` answers a similar question but repairs as it goes — it deletes stale PID/port files and can stop an orphaned server. A predicate classifying a connection must not mutate workspace state as a side effect.
- **It omits `IsRunning`'s `isDoltProcess()` command-name check**, which shells out to `ps` (PowerShell on Windows) — measured at **765ms** on a loaded machine, and this runs on every writable open. The residual gap needs a recycled PID **and** a stale port file **and** a foreign server on that same port; strictly narrower than the gap left by trusting the port file alone. Documented at the definition.
- **`ResolveServerMode` is unchanged**, so auto-start still is not suppressed for an env-named port — the shadow-server hazard. Filed as **#6123** rather than changed inside an RC.

## Why #6088's narrowing survives

The auto-started single-workspace server is *precisely* what the new rule recognizes: `doltserver.Start` writes both state files, so it carries the proof by construction.

- `TestServerModeLenientOpenDirtyTableGate` — the #4566/#5781 recovery, whose whole shape is refuse-then-commit-then-migrate on a bd-owned local server, and which itself sets `BEADS_DOLT_SERVER_PORT` — passes **unmodified**, both subtests. `TestFreshBootstrapHealIncarnation` likewise.
- End to end: `bd init --server` (bd auto-starts its own server), rolled back to v65 → `bd create` **migrates to v66, exit 0, no gate**.
- The two false positives the first cut created are now explicitly pinned as *still migrating*: a config.yaml-pinned port, and an env port that bd itself bound.

## Prove-it, both directions

**Revert the proof** → 8 subtests go red, including both new bypasses and the real-config-path test. The two "still migrates" cases stay green, confirming the proof is what adds shared classifications rather than something else.

**End to end on a scratch server**, comparing the first-cut binary against this one on the same workspace and database:

| door | first cut | this PR |
|---|---|---|
| `BEADS_DOLT_SERVER_PORT` only | refused ✅ | refused ✅ |
| `bd init --server-port 47311 --external` | **migrated v65→v66, exit 0** ❌ | refused, exit 1 ✅ |
| stale port file + dead PID | **migrated v65→v66, exit 0** ❌ | refused, exit 1 ✅ |
| bd auto-started its own server (#6088) | migrated ✅ | migrated ✅ |

## Test plan

- `TestManagesLiveServerOnPort` — the proof itself: live PID, dead PID, mismatched port, missing/garbage files, degenerate inputs, and that it **does not mutate** the state it reads.
- `TestSharedServerDatabaseOwnershipProof` — the real topologies, both bypasses among them, plus the two "still migrates" false-positive guards.
- `TestSharedServerDatabaseThroughResolvedConfig` — drives `applyResolvedConfig` + `applyConfigDefaults` so the link between `BEADS_DOLT_SERVER_PORT` and the classification is pinned by behavior, not by a hand-stamped field. (Uses a non-production port deliberately: `BEADS_TEST_MODE`'s production-port firewall rewrites 3307 to 1, which would mask the resolution under test.)
- The port-source matrix from the first cut is gone. Three of its nine rows asserted source/host combinations that cannot coexist in production and passed only because the table hand-set both.
- Workspace/env helpers hoisted to package level — one env list, so the next `BEADS_DOLT_*` signal is a one-place change.

## Verification run

| command | result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `golangci-lint run ./internal/storage/dolt/... ./internal/doltserver/...` | 0 issues |
| `go test ./internal/storage/schema/...` | ok (57.6s) |
| `go test ./internal/storage/uow/...` | ok (709.3s) |
| `go test ./internal/doltserver/...` | ok |
| `go test ./internal/configfile/...` | ok |
| `go test -tags integration ./internal/storage/dolt/ -run 'TestServerModeLenientOpenDirtyTableGate\|TestFreshBootstrapHealIncarnation'` | ok (56.6s) |
| `BEADS_TEST_ENV_RUN_DOLT=1 .github/scripts/server-storage-test-shard.sh <n> 16`, n = 1..16 | all 16 shards PASS |

## Proposed changelog line

> **Fixed:** bd could treat an externally-managed dolt sql-server as its own — when the port came from `BEADS_DOLT_SERVER_PORT`, from `bd init --server-port`, or from a stale port file — and silently promote the schema for every client of that server. Ownership is now proven from bd's own live server record rather than inferred from the endpoint.

(CHANGELOG.md intentionally not edited in this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
