### PR TITLE
fix(guard): a config.yaml server-mode workspace is not a legacy workspace

### DIFF
--- a/cmd/bd/legacy_upgrade_guard.go
+++ b/cmd/bd/legacy_upgrade_guard.go
@@ -115,15 +115,18 @@ func guardLegacyUpgradeWorkspace(beadsDir string) error {
 // what this guard refuses, so bd rejected server workspaces it had created
 // itself moments earlier.
 //
-// The config.yaml layer resolves against the SELECTED workspace: main.go binds
-// the discovered target before admission for exactly this reason, which is also
-// what makes doltserver.IsSharedServerMode() above read the target's config
-// rather than the caller's.
+// On the PersistentPreRunE and doctor paths the config.yaml layer resolves
+// against the SELECTED workspace: main.go binds the discovered target before
+// admission for exactly this reason, which is also what makes
+// doltserver.IsSharedServerMode() above read the target's config rather than
+// the caller's. The ancestor scans are the known exception —
+// guardUndiscoveredLegacyWorkspace below and findParentConfig in bootstrap.go
+// pass candidates that are by construction not the bound target, so for those
+// the env and config.yaml layers come from the caller's process-global state,
+// not from the candidate. Do not rely on the binding from a caller that walks
+// ancestors.
 func workspaceSelectsServerMode(cfg *configfile.Config) bool {
-	if cfg == nil {
-		cfg = configfile.DefaultConfig()
-	}
-	return cfg.IsDoltServerMode()
+	return normalizeLoadedConfig(cfg).IsDoltServerMode()
 }
 
 func isHistoricalSQLiteWorkspace(beadsDir string, cfg *configfile.Config) bool {

--- a/cmd/bd/legacy_upgrade_guard.go
+++ b/cmd/bd/legacy_upgrade_guard.go
@@ -39,7 +39,7 @@ func guardLegacyUpgradeWorkspace(beadsDir string) error {
 	if err := validateConfiguredBackend(cfg, beadsDir); err != nil {
 		return err
 	}
-	serverMode := cfg != nil && strings.EqualFold(cfg.DoltMode, configfile.DoltModeServer)
+	serverMode := workspaceSelectsServerMode(cfg)
 	if embeddeddolt.HasRepository(beadsDir) && !serverMode {
 		return nil
 	}
@@ -51,11 +51,31 @@ func guardLegacyUpgradeWorkspace(beadsDir string) error {
 	if !hasLocalDoltRoot {
 		return nil
 	}
+	// Positive evidence that this workspace belongs to the current era settles
+	// it for every mode. Only the ambiguity that remains after these is
+	// mode-specific, so the refusals below are the only part that branches.
+	if classifyVersionWitness(version) == witnessEraCurrent {
+		// A witness naming bd 1.0 or later can only have been written by a
+		// current-era binary, and only after this same guard admitted the
+		// workspace (PersistentPreRunE runs the guard before trackBdVersion,
+		// and doctor runs it before its own copy of that call). No legacy
+		// release could have produced it. Reading it as proof only in server
+		// mode left the escape hatch unreachable for a workspace the running
+		// binary demonstrably created itself.
+		return nil
+	}
+	if doltserver.IsSharedServerMode() && !(present && legacyServerVersion(version)) {
+		// A shared Dolt sql-server owns .beads/dolt, so there is no embedded
+		// historical schema to protect — unless the witness affirmatively names
+		// the 0.55–0.62 server era. This admission used to sit inside the
+		// embedded arm below. Leaving it there while config.yaml started
+		// selecting server mode would have moved shared-server workspaces bd
+		// admits today onto the refusing arm: the mode changed, the evidence
+		// did not.
+		return nil
+	}
 	if serverMode {
-		switch classifyVersionWitness(version) {
-		case witnessEraCurrent:
-			return nil
-		case witnessEraUnknown:
+		if present && classifyVersionWitness(version) == witnessEraUnknown {
 			// A witness that is present but unreadable — including one left
 			// blank or whitespace-only by an interrupted or disk-full
 			// best-effort write — is not evidence of a legacy workspace: every
@@ -66,18 +86,13 @@ func guardLegacyUpgradeWorkspace(beadsDir string) error {
 			// command over an advisory, gitignored file. A genuinely absent
 			// witness is not present and still refuses below, preserving the
 			// pre-1.0 guard invariant.
-			if present {
-				warnUnreadableVersionWitness(beadsDir, version)
-				return nil
-			}
+			warnUnreadableVersionWitness(beadsDir, version)
+			return nil
 		}
 		return legacyUpgradeRefusal("legacy Dolt server workspace")
 	}
 	if cfg == nil || cfg.DoltMode == "" ||
 		strings.EqualFold(cfg.DoltMode, configfile.DoltModeEmbedded) {
-		if doltserver.IsSharedServerMode() && !(present && legacyServerVersion(version)) {
-			return nil
-		}
 		reason := "legacy Dolt workspace"
 		if _, validVersion := legacyVersionMinor(version); present && validVersion {
 			reason = fmt.Sprintf("legacy Dolt workspace from bd %s", version)
@@ -85,6 +100,30 @@ func guardLegacyUpgradeWorkspace(beadsDir string) error {
 		return legacyUpgradeRefusal(reason)
 	}
 	return nil
+}
+
+// workspaceSelectsServerMode reports whether bd will open beadsDir through a
+// Dolt sql-server rather than as an embedded database.
+//
+// It asks configfile's own resolver instead of reading metadata.json's
+// dolt_mode directly. That field is only the highest-priority layer of the
+// decision: a workspace that declares `dolt.mode: server` in .beads/config.yaml
+// and has no metadata.json at all — the shape gc provisions — is just as much a
+// server workspace, and IsDoltServerMode documents the full precedence chain
+// that store selection then uses. Reading the top layer alone classified those
+// as embedded, and an embedded workspace owning a .beads/dolt root is precisely
+// what this guard refuses, so bd rejected server workspaces it had created
+// itself moments earlier.
+//
+// The config.yaml layer resolves against the SELECTED workspace: main.go binds
+// the discovered target before admission for exactly this reason, which is also
+// what makes doltserver.IsSharedServerMode() above read the target's config
+// rather than the caller's.
+func workspaceSelectsServerMode(cfg *configfile.Config) bool {
+	if cfg == nil {
+		cfg = configfile.DefaultConfig()
+	}
+	return cfg.IsDoltServerMode()
 }
 
 func isHistoricalSQLiteWorkspace(beadsDir string, cfg *configfile.Config) bool {

--- a/cmd/bd/legacy_upgrade_guard_config_yaml_test.go
+++ b/cmd/bd/legacy_upgrade_guard_config_yaml_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/config"
+)
+
+// bindSelectedWorkspaceConfig loads beadsDir's config.yaml into the process
+// config state the way PersistentPreRunE does — prepareSelectedCommandContext
+// binds the discovered target before admission precisely so the guard reads the
+// selected workspace's config rather than the caller's. The Dolt env vars are
+// pinned off so a developer's ambient shell cannot decide a mode for the guard.
+func bindSelectedWorkspaceConfig(t *testing.T, beadsDir string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	t.Setenv("BEADS_DIR", beadsDir)
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "0")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+
+	config.ResetForTesting()
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize() = %v", err)
+	}
+	t.Cleanup(config.ResetForTesting)
+}
+
+// writeDoltRootWorkspace lays down the ambiguous shape the guard classifies: a
+// .beads directory that owns a local Dolt root, plus whatever metadata.json,
+// config.yaml and version witness the case needs. An empty string means "do not
+// write this file at all".
+func writeDoltRootWorkspace(t *testing.T, metadata, configYaml, version string) string {
+	t.Helper()
+	beadsDir := t.TempDir()
+	write := func(name, contents string) {
+		if contents == "" {
+			return
+		}
+		if err := os.WriteFile(filepath.Join(beadsDir, name), []byte(contents), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("metadata.json", metadata)
+	write("config.yaml", configYaml)
+	if version != "" {
+		if err := writeLocalVersion(filepath.Join(beadsDir, localVersionFile), version); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(beadsDir, "dolt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	bindSelectedWorkspaceConfig(t, beadsDir)
+	return beadsDir
+}
+
+// configYamlServerMode reproduces the gc-provisioned config.yaml: dolt.mode is
+// declared as a flat dotted key beside a nested dolt map, which is how bd's own
+// `bd config set` writer emits it.
+const configYamlServerMode = "issue_prefix: gc\n" +
+	"dolt:\n" +
+	"  disable-event-flush: true\n" +
+	"dolt.mode: server\n"
+
+// TestLegacyUpgradeGuardAdmitsConfigYamlServerModeWorkspace pins the shape the
+// v1.3.0 release candidate refused after creating it itself: dolt.mode declared
+// in .beads/config.yaml, a local .beads/dolt root, a current-era version
+// witness, and no metadata.json. LoadForDiscovery reads metadata.json only, so
+// the guard classified a server workspace as embedded — and an embedded
+// workspace owning a .beads/dolt root is exactly what it refuses.
+func TestLegacyUpgradeGuardAdmitsConfigYamlServerModeWorkspace(t *testing.T) {
+	versions := []string{
+		"1.3.0",
+		"1.3.0-rc.1",
+		"1.1.0",
+		"v1.1.1-0.20260805093327-bf97b73749ac",
+	}
+
+	for _, version := range versions {
+		t.Run(version, func(t *testing.T) {
+			warnings := captureLegacyUpgradeWarnings(t)
+			beadsDir := writeDoltRootWorkspace(t, "", configYamlServerMode, version)
+
+			if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+				t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want nil", err)
+			}
+			if warnings.Len() != 0 {
+				t.Fatalf("guard warned about a readable witness: %q", warnings.String())
+			}
+		})
+	}
+
+	t.Run("nested dolt.mode mapping", func(t *testing.T) {
+		captureLegacyUpgradeWarnings(t)
+		beadsDir := writeDoltRootWorkspace(t, "", "dolt:\n  mode: server\n", "1.3.0")
+
+		if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+			t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want nil", err)
+		}
+	})
+
+	t.Run("unreadable witness warns and opens", func(t *testing.T) {
+		warnings := captureLegacyUpgradeWarnings(t)
+		beadsDir := writeDoltRootWorkspace(t, "", configYamlServerMode, "not-a-version")
+
+		if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+			t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want nil", err)
+		}
+		if warnings.Len() == 0 {
+			t.Fatal("guard admitted an unreadable witness without warning")
+		}
+	})
+}
+
+// TestLegacyUpgradeGuardStillRefusesLegacyConfigYamlServerWorkspace proves the
+// config.yaml layer classifies the mode without relaxing the era check: a
+// workspace that declares server mode there and carries pre-1.0 evidence — or
+// no evidence at all — is still refused.
+func TestLegacyUpgradeGuardStillRefusesLegacyConfigYamlServerWorkspace(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{name: "historical server era witness", version: "0.62.0"},
+		{name: "historical embedded era witness", version: "0.49.6"},
+		{name: "four component pre-1.0 witness", version: "0.62.0.1"},
+		{name: "no witness at all"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			captureLegacyUpgradeWarnings(t)
+			beadsDir := writeDoltRootWorkspace(t, "", configYamlServerMode, tt.version)
+
+			if err := guardLegacyUpgradeWorkspace(beadsDir); !isLegacyUpgradeRefusal(err) {
+				t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want migration refusal", err)
+			}
+		})
+	}
+
+	t.Run("metadata embedded mode outranks config.yaml server mode", func(t *testing.T) {
+		captureLegacyUpgradeWarnings(t)
+		// metadata.json's dolt_mode is the highest-priority layer, so this stays
+		// an embedded workspace — and the embedded arm deliberately does not
+		// trust an unreadable witness.
+		beadsDir := writeDoltRootWorkspace(t,
+			`{"backend":"dolt","dolt_mode":"embedded"}`, configYamlServerMode, "not-a-version")
+
+		if err := guardLegacyUpgradeWorkspace(beadsDir); !isLegacyUpgradeRefusal(err) {
+			t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want migration refusal", err)
+		}
+	})
+}
+
+// TestCurrentVersionWitnessVetoesLegacyVerdictInEveryMode pins the general
+// safety net: a witness naming bd 1.0 or later can only have been written by a
+// current-era binary, and only after this guard already admitted the workspace,
+// so it settles the era regardless of which mode the workspace resolves to. The
+// escape hatch used to live inside the server-mode arm, where a misclassified
+// workspace could never reach it.
+func TestCurrentVersionWitnessVetoesLegacyVerdictInEveryMode(t *testing.T) {
+	modes := []struct {
+		name     string
+		metadata string
+	}{
+		{name: "metadata-less"},
+		{name: "blank mode", metadata: `{"backend":"dolt"}`},
+		{name: "explicit embedded mode", metadata: `{"backend":"dolt","dolt_mode":"embedded"}`},
+		{name: "explicit server mode", metadata: `{"backend":"dolt","dolt_mode":"server"}`},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			captureLegacyUpgradeWarnings(t)
+			beadsDir := writeDoltRootWorkspace(t, mode.metadata, "", "1.3.0")
+
+			if err := guardLegacyUpgradeWorkspace(beadsDir); err != nil {
+				t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want nil", err)
+			}
+		})
+
+		t.Run(mode.name+"/pre-1.0 witness still refuses", func(t *testing.T) {
+			captureLegacyUpgradeWarnings(t)
+			beadsDir := writeDoltRootWorkspace(t, mode.metadata, "", "0.62.21")
+
+			if err := guardLegacyUpgradeWorkspace(beadsDir); !isLegacyUpgradeRefusal(err) {
+				t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want migration refusal", err)
+			}
+		})
+
+		t.Run(mode.name+"/missing witness still refuses", func(t *testing.T) {
+			captureLegacyUpgradeWarnings(t)
+			beadsDir := writeDoltRootWorkspace(t, mode.metadata, "", "")
+
+			if err := guardLegacyUpgradeWorkspace(beadsDir); !isLegacyUpgradeRefusal(err) {
+				t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want migration refusal", err)
+			}
+		})
+	}
+
+	// The unreadable-witness admission is deliberately NOT hoisted: outside
+	// server mode a .beads/dolt root is itself strong legacy evidence, and
+	// TestLegacyUpgradeGuardRefusesOldDoltRootWithoutTrustingVersionWitness
+	// pins that arm. Keep the boundary explicit so a later cleanup cannot widen
+	// it by accident.
+	t.Run("embedded mode still refuses an unreadable witness", func(t *testing.T) {
+		captureLegacyUpgradeWarnings(t)
+		beadsDir := writeDoltRootWorkspace(t, `{"backend":"dolt"}`, "", "not-a-version")
+
+		if err := guardLegacyUpgradeWorkspace(beadsDir); !isLegacyUpgradeRefusal(err) {
+			t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want migration refusal", err)
+		}
+	})
+}
+
+// TestLegacyUpgradeGuardSharedServerAdmissionSurvivesServerClassification keeps
+// the shared-server escape reachable now that a config.yaml `dolt.mode: server`
+// workspace resolves to the server arm. Before the hoist this admission lived
+// only in the embedded arm, so classifying the same workspace correctly would
+// have turned a workspace bd admits today into a refusal — trading one
+// false-refusal class for another.
+func TestLegacyUpgradeGuardSharedServerAdmissionSurvivesServerClassification(t *testing.T) {
+	tests := []struct {
+		name        string
+		configYaml  string
+		version     string
+		wantRefusal bool
+	}{
+		{name: "config.yaml server mode without witness", configYaml: configYamlServerMode + "dolt.shared-server: true\n"},
+		{name: "shared server only", configYaml: "dolt.shared-server: true\n"},
+		{name: "config.yaml server mode with historical server witness",
+			configYaml: configYamlServerMode + "dolt.shared-server: true\n", version: "0.62.0", wantRefusal: true},
+		{name: "not shared and no witness", configYaml: configYamlServerMode, wantRefusal: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			captureLegacyUpgradeWarnings(t)
+			beadsDir := writeDoltRootWorkspace(t, "", tt.configYaml, tt.version)
+
+			err := guardLegacyUpgradeWorkspace(beadsDir)
+			if tt.wantRefusal && !isLegacyUpgradeRefusal(err) {
+				t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want migration refusal", err)
+			}
+			if !tt.wantRefusal && err != nil {
+				t.Fatalf("guardLegacyUpgradeWorkspace() = %v, want nil", err)
+			}
+		})
+	}
+}

--- a/cmd/bd/legacy_upgrade_guard_e2e_test.go
+++ b/cmd/bd/legacy_upgrade_guard_e2e_test.go
@@ -100,7 +100,17 @@ func TestLegacyUpgradeGuardRefusesBeforeMutatingHistoricalWorkspace(t *testing.T
 					commandCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 					cmd := exec.CommandContext(commandCtx, bd, tc.args...)
 					cmd.Dir = repoDir
-					cmd.Env = append(os.Environ(), "BD_DISABLE_METRICS=1", "BEADS_DOLT_AUTO_START=0")
+					// Pin the mode inputs the guard now reads through
+					// IsDoltServerMode: this child inherits os.Environ(), so
+					// without them a developer's shell decides which refusal
+					// text these historical layouts produce.
+					cmd.Env = append(os.Environ(),
+						"BD_DISABLE_METRICS=1",
+						"BEADS_DOLT_AUTO_START=0",
+						"BEADS_DOLT_SERVER_MODE=0",
+						"BEADS_DOLT_SHARED_SERVER=0",
+						"BEADS_DOLT_SERVER_HOST=",
+					)
 					var stdout, stderr bytes.Buffer
 					cmd.Stdout = &stdout
 					cmd.Stderr = &stderr

--- a/cmd/bd/legacy_upgrade_guard_e2e_test.go
+++ b/cmd/bd/legacy_upgrade_guard_e2e_test.go
@@ -478,6 +478,77 @@ func TestLegacyGuardUsesSelectedTargetSharedServerConfig(t *testing.T) {
 	}
 }
 
+// TestLegacyGuardAdmitsConfigYamlServerWorkspace runs the real binary against
+// the workspace shape gc provisions — `dolt.mode: server` in
+// .beads/config.yaml, a local .beads/dolt root, a metadata.json that names no
+// dolt_mode — and pins that the guard no longer calls it legacy. The in-process
+// guard tests bind the workspace config themselves; only a subprocess proves
+// that PersistentPreRunE's own binding puts the selected workspace's
+// config.yaml in front of the guard.
+//
+// The command still fails: the workspace points at a Dolt server that is not
+// running. That is the point — reaching the connection attempt means admission
+// succeeded and the workspace routed as a server workspace rather than being
+// refused or opened as a phantom embedded database.
+func TestLegacyGuardAdmitsConfigYamlServerWorkspace(t *testing.T) {
+	bd := buildBDUnderTest(t)
+	tests := []struct {
+		name              string
+		version           string
+		wantLegacyRefusal bool
+	}{
+		{name: "current era witness", version: "1.3.0"},
+		{name: "release candidate witness", version: "1.3.0-rc.1"},
+		{name: "historical witness still refuses", version: "0.62.0", wantLegacyRefusal: true},
+		{name: "missing witness still refuses", wantLegacyRefusal: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := t.TempDir()
+			initGitRepo(t, repoDir)
+			beadsDir := filepath.Join(repoDir, ".beads")
+			if err := os.MkdirAll(filepath.Join(beadsDir, "dolt"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			writeFile(t, filepath.Join(beadsDir, "metadata.json"), []byte(`{"backend":"dolt","dolt_database":"hq"}`))
+			writeFile(t, filepath.Join(beadsDir, "config.yaml"), []byte("dolt:\n  mode: server\n  auto-start: false\n"))
+			if tt.version != "" {
+				writeFile(t, filepath.Join(beadsDir, localVersionFile), []byte(tt.version+"\n"))
+			}
+
+			commandCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(commandCtx, bd, "list", "--json", "--limit", "0", "--all")
+			cmd.Dir = repoDir
+			cmd.Env = append(os.Environ(),
+				"BD_DISABLE_METRICS=1",
+				"BD_DISABLE_EVENT_FLUSH=1",
+				"BEADS_DOLT_AUTO_START=0",
+				"BEADS_DOLT_SERVER_PORT=59999",
+				"BEADS_DOLT_SHARED_SERVER=0",
+				"HOME="+t.TempDir(),
+			)
+			output, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("bd list unexpectedly succeeded against an unreachable server:\n%s", output)
+			}
+			hasLegacyRefusal := strings.Contains(string(output), "explicit migration is required")
+			if hasLegacyRefusal != tt.wantLegacyRefusal {
+				t.Fatalf("bd list legacy refusal=%v, want %v:\n%s", hasLegacyRefusal, tt.wantLegacyRefusal, output)
+			}
+			if !tt.wantLegacyRefusal && !strings.Contains(string(output), "Dolt server") {
+				t.Fatalf("admitted workspace did not route as a server workspace:\n%s", output)
+			}
+			if !tt.wantLegacyRefusal {
+				if _, err := os.Stat(filepath.Join(beadsDir, "embeddeddolt")); !os.IsNotExist(err) {
+					t.Fatalf("admitted server workspace created a phantom embedded database: %v", err)
+				}
+			}
+		})
+	}
+}
+
 func legacyUpgradeTreeDigest(t *testing.T, root string) string {
 	t.Helper()
 	var entries []string

--- a/cmd/bd/legacy_upgrade_guard_test.go
+++ b/cmd/bd/legacy_upgrade_guard_test.go
@@ -8,7 +8,22 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 )
 
+// pinLegacyUpgradeGuardEnv pins the process-global inputs the guard now reads
+// through configfile.IsDoltServerMode, so these tables assert the workspace
+// shape each case lays down rather than whatever mode the developer's shell
+// happens to select. CI already unsets these three
+// (scripts/ci/lib/test-env.sh), so the pins make a local `go test ./cmd/bd/`
+// match CI instead of changing what CI checks.
+func pinLegacyUpgradeGuardEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "0")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+}
+
 func TestLegacyUpgradeGuardRefusesHistoricalLayoutsWithoutMutatingMetadata(t *testing.T) {
+	pinLegacyUpgradeGuardEnv(t)
 	tests := []struct {
 		name     string
 		metadata string
@@ -77,6 +92,7 @@ func TestLegacyUpgradeGuardRefusesHistoricalLayoutsWithoutMutatingMetadata(t *te
 }
 
 func TestLegacyUpgradeGuardMetadataLessSQLiteAndCurrentEmbeddedPrecedence(t *testing.T) {
+	pinLegacyUpgradeGuardEnv(t)
 	t.Run("metadata-less v091 vc database", func(t *testing.T) {
 		beadsDir := t.TempDir()
 		if err := os.WriteFile(filepath.Join(beadsDir, "vc.db"), []byte("SQLite format 3\x00"), 0o600); err != nil {
@@ -247,6 +263,7 @@ func TestLegacyUpgradeGuardMetadataLessSQLiteAndCurrentEmbeddedPrecedence(t *tes
 }
 
 func TestLegacyUpgradeGuardServerSelectionBeatsStaleEmbeddedRepository(t *testing.T) {
+	pinLegacyUpgradeGuardEnv(t)
 	tests := []struct {
 		name        string
 		version     string
@@ -296,6 +313,7 @@ func TestLegacyUpgradeGuardServerSelectionBeatsStaleEmbeddedRepository(t *testin
 }
 
 func TestLegacyUpgradeGuardRefusesOldDoltRootWithoutTrustingVersionWitness(t *testing.T) {
+	pinLegacyUpgradeGuardEnv(t)
 	tests := []struct {
 		name     string
 		metadata string
@@ -331,6 +349,9 @@ func TestLegacyUpgradeGuardRefusesOldDoltRootWithoutTrustingVersionWitness(t *te
 }
 
 func TestLegacyUpgradeGuardSharedServerAdmission(t *testing.T) {
+	// The per-case BEADS_DOLT_SHARED_SERVER below is set after this and wins;
+	// the pin is what keeps the other two mode inputs out of the decision.
+	pinLegacyUpgradeGuardEnv(t)
 	tests := []struct {
 		name        string
 		metadata    string
@@ -380,6 +401,7 @@ func TestLegacyUpgradeGuardSharedServerAdmission(t *testing.T) {
 }
 
 func TestLegacyUpgradeGuardLeavesCurrentDoltWorkspaceAlone(t *testing.T) {
+	pinLegacyUpgradeGuardEnv(t)
 	beadsDir := t.TempDir()
 	metadata := `{"backend":"dolt","dolt_mode":"embedded"}`
 	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(metadata), 0o600); err != nil {

--- a/cmd/bd/legacy_upgrade_guard_witness_test.go
+++ b/cmd/bd/legacy_upgrade_guard_witness_test.go
@@ -104,6 +104,7 @@ func writeSelectedServerWorkspace(t *testing.T, version string) string {
 }
 
 func TestLegacyUpgradeGuardAdmitsNonReleaseVersionWitnesses(t *testing.T) {
+	pinLegacyUpgradeGuardEnv(t)
 	versions := []string{
 		"v1.1.1-0.20260805093327-bf97b73749ac",
 		"1.1.0",
@@ -128,6 +129,7 @@ func TestLegacyUpgradeGuardAdmitsNonReleaseVersionWitnesses(t *testing.T) {
 }
 
 func TestLegacyUpgradeGuardStillRefusesPreOneWorkspaces(t *testing.T) {
+	pinLegacyUpgradeGuardEnv(t)
 	versions := []string{
 		"0.9.1",
 		"v0.49.6",
@@ -150,6 +152,7 @@ func TestLegacyUpgradeGuardStillRefusesPreOneWorkspaces(t *testing.T) {
 }
 
 func TestLegacyUpgradeGuardRefusesWorkspaceWithoutAnyWitness(t *testing.T) {
+	pinLegacyUpgradeGuardEnv(t)
 	captureLegacyUpgradeWarnings(t)
 	beadsDir := writeSelectedServerWorkspace(t, "")
 
@@ -166,6 +169,7 @@ func TestLegacyUpgradeGuardRefusesWorkspaceWithoutAnyWitness(t *testing.T) {
 // absent witness must still refuse so the pre-1.0 safety invariant does not
 // relax.
 func TestLegacyUpgradeGuardWarnsInsteadOfRefusingPresentButBlankWitness(t *testing.T) {
+	pinLegacyUpgradeGuardEnv(t)
 	blankWitnesses := []struct {
 		name    string
 		content []byte
@@ -248,6 +252,7 @@ func TestLegacyUpgradeVersionWitnessPresence(t *testing.T) {
 }
 
 func TestLegacyUpgradeGuardWarnsInsteadOfRefusingUnreadableWitness(t *testing.T) {
+	pinLegacyUpgradeGuardEnv(t)
 	warnings := captureLegacyUpgradeWarnings(t)
 	beadsDir := writeSelectedServerWorkspace(t, "not-a-version")
 
@@ -266,6 +271,7 @@ func TestLegacyUpgradeGuardWarnsInsteadOfRefusingUnreadableWitness(t *testing.T)
 // next command reads it cleanly. Only a stamp bd rewrites identically every
 // run (a Homebrew --HEAD build, GH#5603) can warn repeatedly.
 func TestLegacyUpgradeGuardWarningIsSelfHealing(t *testing.T) {
+	pinLegacyUpgradeGuardEnv(t)
 	warnings := captureLegacyUpgradeWarnings(t)
 	beadsDir := writeSelectedServerWorkspace(t, "not-a-version")
 
@@ -297,6 +303,7 @@ func TestLegacyUpgradeGuardWarningIsSelfHealing(t *testing.T) {
 // needs the shape recognizer in GH#5625 (anisoptera), which this does not
 // duplicate.
 func TestLegacyUpgradeGuardAdmitsBrewHeadStamp(t *testing.T) {
+	pinLegacyUpgradeGuardEnv(t)
 	for _, stamp := range []string{"HEAD-f925f3f", "HEAD", "HEAD-f925f3f_1"} {
 		t.Run(stamp, func(t *testing.T) {
 			captureLegacyUpgradeWarnings(t)


### PR DESCRIPTION
## What happens

The v1.3.0 release candidate hard-refuses server-mode workspaces:

```
$ bd list
Error: legacy Dolt workspace detected; explicit migration is required before this
bd version can open or modify the workspace. Preserve .beads unchanged and follow
docs/getting-started/upgrading.md#cross-era-upgrades
```

Found by running gascity's integration suite against `v1.3.0-rc.1`, against
workspaces the RC itself had just been operating on. Every `bd`-backed `gc`
operation fails before any store is constructed.

## The misclassification

`cmd/bd/legacy_upgrade_guard.go` resolved the connection mode from a single
field:

```go
serverMode := cfg != nil && strings.EqualFold(cfg.DoltMode, configfile.DoltModeServer)
```

`cfg` comes from `configfile.LoadForDiscovery`, which reads **metadata.json and
nothing else**. But metadata.json's `dolt_mode` is only the highest-priority
layer of that decision. `Config.IsDoltServerMode` documents six more, and step 6
is `dolt.mode` in the workspace's own `.beads/config.yaml`.

So a workspace that declares `dolt.mode: server` in config.yaml and names no
`dolt_mode` in metadata.json — the shape gc provisions — resolved to
`serverMode=false`, fell through to the embedded arm, found a `.beads/dolt`
directory, and was refused as legacy.

Every other layer of bd already read that same config.yaml and opened the
workspace as a server workspace. Only the guard disagreed, which is why the RC
refused a workspace it was itself using moments earlier.

## The unreachable escape hatch

The guard already held the evidence to acquit these workspaces. Their
`.local_version` witness named a 1.x bd, which #5650 established as proof of a
current-era workspace. But that check sat **inside** the `if serverMode` arm:

```go
if serverMode {
    switch classifyVersionWitness(version) {
    case witnessEraCurrent:
        return nil          // <- unreachable for a misclassified workspace
    ...
```

A workspace misclassified as embedded could never reach it. The one piece of
positive evidence that would have made this entire class impossible was gated on
the very predicate that was wrong.

## The fix

Both shapes, because they are not equivalent and each covers the other's gap.

1. **`workspaceSelectsServerMode` asks `Config.IsDoltServerMode`** — bd's own
   documented resolver, the one store selection uses — instead of reading
   metadata.json's top layer directly. The guard now classifies a workspace the
   same way bd will open it. `LoadForDiscovery` stays metadata-only and stays
   non-migrating; nothing about discovery changes. This is the specific fix.

2. **A current-era version witness vetoes the legacy verdict in every mode.** A
   witness naming bd 1.0 or later can only have been written by a current-era
   binary, and only *after* this same guard already admitted the workspace:
   `PersistentPreRunE` runs the guard before `trackBdVersion`, and `doctor` runs
   it before its own copy of that call. No legacy release could have produced
   one. This is the general safety net; on its own it would also have closed
   this bug, and it would have prevented the class.

The shared-server admission moves up beside (2). It used to live inside the
embedded arm, so leaving it there while config.yaml started selecting server
mode would have pushed shared-server workspaces bd admits *today* onto the
refusing arm — trading one false-refusal class for another. The mode changed;
the evidence did not.

## Blast radius

**Refusal-reducing for every workspace whose legacy verdict turns on the
witness.** (Amended after maintainer review — the original claim here read
"strictly refusal-reducing; nothing bd admits today is refused after this",
which is not accurate. Widening `serverMode` from one layer to seven also
widens the two places where `serverMode == true` *removes* an admission, so
there are two narrow admit -> refuse shapes:

- an embedded repository that also owns a leftover `.beads/dolt` root, under
  env/host-selected server mode (`BEADS_DOLT_SERVER_MODE`,
  `BEADS_DOLT_SHARED_SERVER`, or a non-localhost `BEADS_DOLT_SERVER_HOST`) —
  layer 1 outranks an explicit `metadata.json` `dolt_mode`, so `:43`'s early
  admission is suppressed;
- a config.yaml-declared server workspace carrying a 0.55-0.62 witness and no
  `.beads/dolt` root at all — `:47` sits above the `hasLocalDoltRoot` early
  return and is unchanged by this diff, but its `serverMode` input is not.

Both refusals are loud, non-destructive and pre-store, and any workspace a
current-era bd has opened carries a >=1.0 witness and is admitted before either
is reached; shape two is arguably the intended semantics. Neither was judged to
gate the merge.)

The newly admitted set is exactly:

- config.yaml server-mode workspaces with a current-era or
  present-but-unreadable witness — the reported bug;
- server-mode workspaces under an explicitly configured shared server, which is
  the same admission the embedded arm has always granted for the identical
  evidence.

The guard's real purpose is untouched:

| shape | before | after |
|---|---|---|
| missing witness + `.beads/dolt`, any mode | refuse | refuse |
| any pre-1.0 witness, any mode | refuse | refuse |
| 0.55–0.62 server-era witness | refuse | refuse (still checked *first*, before any hatch) |
| historical SQLite workspace | refuse | refuse |
| removed/unknown backend tombstone | refuse | refuse |
| embedded arm + unreadable witness | refuse | refuse |

That last row matters: outside server mode a `.beads/dolt` root is itself strong
legacy evidence, so the unreadable-witness admission is deliberately **not**
hoisted. `TestLegacyUpgradeGuardRefusesOldDoltRootWithoutTrustingVersionWitness`
pins that arm today; a new test now pins the boundary explicitly so a later
cleanup cannot widen it by accident.

metadata.json keeps its precedence: a workspace whose metadata says `embedded`
stays embedded even when config.yaml says `server`, matching `IsDoltServerMode`.

One property worth naming, unchanged by this PR: the config.yaml layer resolves
through process-global config state, which `main.go` binds to the selected
target before admission (`prepareSelectedCommandContext`) precisely so the guard
reads the target's config and not the caller's — the same mechanism that already
makes `doltserver.IsSharedServerMode()` correct inside this guard, covered by
`TestLegacyGuardUsesSelectedTargetSharedServerConfig`.

## Test plan

New:

- `TestLegacyUpgradeGuardAdmitsConfigYamlServerModeWorkspace` — the reported
  shape, in both the flat `dolt.mode:` and nested `dolt:\n  mode:` config.yaml
  spellings, across four current-era witness forms.
- `TestLegacyUpgradeGuardStillRefusesLegacyConfigYamlServerWorkspace` — the same
  shape with pre-1.0 or absent evidence still refuses; plus metadata `embedded`
  outranking config.yaml `server`.
- `TestCurrentVersionWitnessVetoesLegacyVerdictInEveryMode` — the hoisted hatch
  across all four mode shapes, and in the same table that a pre-1.0 or missing
  witness still refuses in each of them.
- `TestLegacyUpgradeGuardSharedServerAdmissionSurvivesServerClassification` —
  the fix creates no new refusal for shared-server workspaces.
- `TestLegacyGuardAdmitsConfigYamlServerWorkspace` — the real binary, because
  only a subprocess proves `PersistentPreRunE`'s own config binding puts the
  selected workspace's config.yaml in front of the guard. Also asserts the
  admitted workspace routes to the Dolt server rather than creating a phantom
  embedded database.

Prove-it (fix reverted to HEAD, tests unchanged):

```
--- FAIL: TestLegacyUpgradeGuardAdmitsConfigYamlServerModeWorkspace          (6/6 subtests)
--- FAIL: TestCurrentVersionWitnessVetoesLegacyVerdictInEveryMode            (3/4 modes)
        metadata-less, blank mode, explicit embedded mode
        (explicit server mode passes — it was the one arm that could reach the hatch)
--- FAIL: TestLegacyGuardAdmitsConfigYamlServerWorkspace                     (2/2 admitting cases)
```

Green with the fix. Full verification:

- `go build ./...`, `go vet ./...`
- `golangci-lint run ./cmd/bd/...` — 0 issues
- `scripts/ci/fmt-check.sh`
- `./scripts/test.sh ./cmd/bd/` — ok, 482s
- `./scripts/test.sh ./internal/configfile/... ./internal/config/... ./internal/doltserver/...` — ok

Against the captured gascity workspace, `bd list`, RC vs. this build:

```
rc.1   Error: legacy Dolt workspace detected; explicit migration is required...
fixed  Error: failed to open database: Dolt server unreachable at 127.0.0.1:15671
```

The second error is the workspace's own Dolt server not running in the captured
copy — reaching the connection attempt is what proves admission succeeded and
the workspace routed as a server workspace.

## Adjacent finding, not fixed here

Reducing the repro further — deleting metadata.json entirely rather than just
its `dolt_mode` — exposes a second, pre-existing defect that the guard refusal
was masking. At `cmd/bd/main.go:1598`, a workspace with **no metadata.json at
all** only gets a substituted config when `HostImpliesServerMode()` says so, and
that helper returns false by design whenever config.yaml declares a `dolt.mode`.
Such a workspace therefore falls into the `no beads configuration found` arm and
creates a phantom embedded database — a false-empty `bd list` that exits 0 —
even with `BEADS_DOLT_SERVER_MODE=1` exported. That is GH#3817's failure mode
reached through a different door.

It is deliberately out of scope here: it is store selection rather than
admission, and fixing it correctly also has to answer where the database *name*
comes from for a metadata-less workspace (config.yaml has no `dolt.database`
layer), which is a design question this release-branch fix should not settle. It
wants its own issue. Workspaces that carry a metadata.json without a `dolt_mode`
— the realistic provisioned shape, and the one the subprocess test pins — route
correctly with this PR alone.

## Proposed changelog line

(not applied — CHANGELOG.md intentionally untouched)

```
- Fixed: `bd` no longer refuses a Dolt **server-mode workspace as "legacy"** when
  the mode is declared in `.beads/config.yaml` rather than `metadata.json`. The
  upgrade guard now resolves the connection mode through the same precedence
  chain store selection uses, and a `.local_version` witness naming bd 1.0 or
  later vetoes the legacy verdict in every mode.
```

Refs #5682, #5650, #5603.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

