### PR TITLE
fix(config): a metadata-less server-mode workspace must not open a phantom embedded database

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1592,12 +1592,27 @@ var rootCmd = &cobra.Command{
 		// deployments that empty relic answers every query with an empty
 		// result set and exit 0 (false-empty), which readers misinterpret as
 		// "no work". Absent metadata.json (cfg == nil, cfgErr == nil) keeps
-		// the fresh-repo embedded default below — unless env/config.yaml
-		// supply a remote host (GH#3545): host inference must not depend
-		// on metadata existing, so substitute the default config and let
-		// the normal mode/connection resolution run.
-		if cfg == nil && configfile.DefaultConfig().HostImpliesServerMode() {
-			logConfigDiscovery(beadsDir, "no metadata.json; host inference (GH#3545) selects server mode")
+		// the fresh-repo embedded default below — unless the env/config.yaml
+		// layers already select server mode: that decision must not depend on
+		// metadata existing, so substitute the default config and let the
+		// normal mode/connection resolution run.
+		//
+		// The gate asks IsDoltServerMode — the same resolver the branch below
+		// uses to set doltCfg.ServerMode — rather than HostImpliesServerMode.
+		// Host inference (GH#3545) answers only one layer of that question and
+		// deliberately returns false as soon as config.yaml names a
+		// `dolt.mode`: correct for inferring FROM a host, wrong as the whole
+		// gate. A workspace declaring `dolt.mode: server` in .beads/config.yaml
+		// with no metadata.json therefore kept cfg nil, fell through to the
+		// embedded branch, and answered every query out of a phantom
+		// .beads/embeddeddolt database that same run had just created —
+		// exit 0, no rows, nothing to distinguish it from real emptiness.
+		// BEADS_DOLT_SERVER_MODE=1 did not rescue it either; the old gate
+		// never consulted it. IsDoltServerMode is a superset of
+		// HostImpliesServerMode, so nothing that reached server mode before
+		// stops reaching it now.
+		if cfg == nil && configfile.DefaultConfig().IsDoltServerMode() {
+			logConfigDiscovery(beadsDir, "no metadata.json; env/config.yaml select server mode")
 			cfg = configfile.DefaultConfig()
 		}
 		if cfg != nil {

--- a/cmd/bd/metadataless_server_workspace_test.go
+++ b/cmd/bd/metadataless_server_workspace_test.go
@@ -1,0 +1,259 @@
+//go:build cgo
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/testutil"
+)
+
+// A workspace can declare server mode without ever writing metadata.json:
+// `dolt.mode: server` in .beads/config.yaml, or BEADS_DOLT_SERVER_MODE=1 in the
+// environment. Both are resolved by configfile.IsDoltServerMode, and gc
+// provisions the config.yaml shape on every `gc-beads-bd start`.
+//
+// Before the fix, the metadata-less branch in the root PersistentPreRunE gated
+// its config substitution on HostImpliesServerMode alone. That predicate
+// answers a narrower question — "does a configured HOST imply server mode?" —
+// and deliberately returns false as soon as config.yaml names a dolt.mode; it
+// never consults BEADS_DOLT_SERVER_MODE at all. So cfg stayed nil, ServerMode
+// stayed false, and bd created and then read a brand-new
+// .beads/embeddeddolt/beads database: every query answered out of an empty
+// relic, exit 0, "No issues found." A reader cannot tell that from real
+// emptiness, which is why these tests assert on the phantom directory and on
+// the false-empty separately.
+//
+// The invariant under test is one-directional and does not depend on a server
+// being reachable: a workspace that selects server mode must reach the server
+// or fail loudly. It must never quietly become an embedded workspace.
+
+const phantomEmbeddedDir = "embeddeddolt"
+
+// TestMetadatalessServerModeWorkspaceNeverOpensPhantomEmbeddedDatabase covers
+// the two ways a workspace with no metadata.json selects server mode. Both
+// shapes are admitted by the legacy-upgrade guard as-is, so this test exercises
+// the store-selection gate directly on any branch.
+func TestMetadatalessServerModeWorkspaceNeverOpensPhantomEmbeddedDatabase(t *testing.T) {
+	bd := buildBDUnderTest(t)
+
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, beadsDir string, port int) []string
+	}{
+		{
+			name: "config.yaml dolt.mode server",
+			setup: func(t *testing.T, beadsDir string, port int) []string {
+				t.Helper()
+				writeFile(t, filepath.Join(beadsDir, "config.yaml"),
+					[]byte(fmt.Sprintf("dolt:\n  mode: server\n  port: %d\n", port)))
+				return nil
+			},
+		},
+		{
+			name: "BEADS_DOLT_SERVER_MODE env var",
+			setup: func(t *testing.T, beadsDir string, port int) []string {
+				t.Helper()
+				return []string{
+					"BEADS_DOLT_SERVER_MODE=1",
+					fmt.Sprintf("BEADS_DOLT_SERVER_PORT=%d", port),
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repoDir := t.TempDir()
+			initGitRepo(t, repoDir)
+			beadsDir := filepath.Join(repoDir, ".beads")
+			if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			port := freeLoopbackPort(t)
+			env := tc.setup(t, beadsDir, port)
+			writeFile(t, filepath.Join(beadsDir, localVersionFile), []byte("1.3.0\n"))
+			if err := os.Chmod(beadsDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+
+			// --db names the local Dolt path bd itself computes for this
+			// workspace. It is the shortest route to store selection for a
+			// metadata-less workspace that has no local database directory
+			// yet, which is exactly the state a server-mode workspace is
+			// supposed to stay in.
+			run := runBDInWorkspace(t, bd, repoDir,
+				[]string{"list", "--json", "--limit", "0", "--all"}, env,
+				filepath.Join(beadsDir, "dolt"))
+
+			assertNoPhantomEmbeddedDatabase(t, beadsDir)
+			assertNotFalseEmpty(t, run)
+			if !strings.Contains(run.output, fmt.Sprintf("127.0.0.1:%d", port)) {
+				t.Fatalf("bd did not report the configured server endpoint 127.0.0.1:%d:\n%s", port, run.output)
+			}
+		})
+	}
+}
+
+// TestGCProvisionedServerWorkspaceNeverOpensPhantomEmbeddedDatabase pins the
+// byte shape gc creates: config.yaml declaring server mode, a .beads/dolt data
+// root owned by the sql-server, the gitignored port file, and a current-era
+// version witness — and still no metadata.json.
+//
+// Two different mechanisms keep this shape safe depending on what else has
+// landed, and the assertions deliberately cover only what both guarantee. On a
+// branch without gastownhall/beads#6119 the legacy-upgrade guard refuses the
+// workspace outright (over-broadly — that is what #6119 fixes). Once #6119
+// removes that refusal, the store-selection gate fixed here is the only thing
+// standing between this shape and a phantom embedded database, so the test
+// stays meaningful in exactly the configuration that ships.
+func TestGCProvisionedServerWorkspaceNeverOpensPhantomEmbeddedDatabase(t *testing.T) {
+	bd := buildBDUnderTest(t)
+
+	repoDir := t.TempDir()
+	initGitRepo(t, repoDir)
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDir, "dolt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	port := freeLoopbackPort(t)
+	writeFile(t, filepath.Join(beadsDir, "config.yaml"),
+		[]byte(fmt.Sprintf("dolt:\n  mode: server\n  port: %d\n", port)))
+	writeFile(t, filepath.Join(beadsDir, "dolt-server.port"), []byte(fmt.Sprintf("%d\n", port)))
+	writeFile(t, filepath.Join(beadsDir, localVersionFile), []byte("1.3.0\n"))
+	if err := os.Chmod(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{
+		{"list", "--json", "--limit", "0", "--all"},
+		{"ready", "--json"},
+	} {
+		t.Run(args[0], func(t *testing.T) {
+			run := runBDInWorkspace(t, bd, repoDir, args, nil, "")
+			assertNoPhantomEmbeddedDatabase(t, beadsDir)
+			assertNotFalseEmpty(t, run)
+		})
+	}
+}
+
+type bdRun struct {
+	args     []string
+	output   string
+	stdout   string
+	exitCode int
+	err      error
+}
+
+// runBDInWorkspace runs bd as a subprocess with auto-start disabled, so a
+// server-mode workspace cannot mask a misrouted open by starting a server of
+// its own. dbPath, when non-empty, is passed as --db.
+//
+// Every ambient BEADS_DOLT_* and BEADS_DIR is stripped first. This package's
+// TestMain starts a shared Dolt server and exports its endpoint, and env beats
+// config.yaml in every layer of the precedence chain being tested here — a
+// leaked BEADS_DOLT_SERVER_PORT would retarget the workspace at that server
+// and quietly change what the assertions mean.
+func runBDInWorkspace(t *testing.T, bd, repoDir string, args, extraEnv []string, dbPath string) bdRun {
+	t.Helper()
+	if dbPath != "" {
+		args = append([]string{"--db", dbPath}, args...)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bd, args...)
+	cmd.Dir = repoDir
+	cmd.Env = append(envWithoutBeadsStorageSettings(),
+		"BD_DISABLE_METRICS=1",
+		"BEADS_DOLT_AUTO_START=0",
+	)
+	cmd.Env = append(cmd.Env, extraEnv...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		t.Fatalf("bd %s did not finish before the deadline: %v\n%s%s",
+			strings.Join(args, " "), ctxErr, stdout.String(), stderr.String())
+	}
+	run := bdRun{
+		args:   args,
+		output: stdout.String() + stderr.String(),
+		stdout: stdout.String(),
+		err:    err,
+	}
+	run.exitCode = cmd.ProcessState.ExitCode()
+	return run
+}
+
+// assertNoPhantomEmbeddedDatabase is the load-bearing assertion: bd must not
+// have created .beads/embeddeddolt for a workspace that selects server mode.
+// Once that directory exists it is self-perpetuating — discovery prefers it
+// over .beads/dolt on every later run — so the damage outlives the invocation
+// that caused it.
+func assertNoPhantomEmbeddedDatabase(t *testing.T, beadsDir string) {
+	t.Helper()
+	path := filepath.Join(beadsDir, phantomEmbeddedDir)
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		entries, _ := os.ReadDir(path)
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+		t.Fatalf("bd created a phantom embedded database at %s (contains %v) for a server-mode workspace", path, names)
+	}
+}
+
+// assertNotFalseEmpty rejects the failure this bug produced: a successful,
+// empty answer sourced from somewhere other than the configured server. An
+// error is a fine outcome here — a reader can act on it.
+func assertNotFalseEmpty(t *testing.T, run bdRun) {
+	t.Helper()
+	if run.err == nil {
+		t.Fatalf("bd %s exited 0 for an unreachable server-mode workspace; a silent empty result is indistinguishable from real emptiness:\n%s",
+			strings.Join(run.args, " "), run.output)
+	}
+	if strings.Contains(run.output, "no beads configuration found") {
+		t.Fatalf("bd %s fell through to the embedded default instead of the configured server:\n%s",
+			strings.Join(run.args, " "), run.output)
+	}
+	for _, empty := range []string{"No issues found.", "No ready work"} {
+		if strings.Contains(run.stdout, empty) {
+			t.Fatalf("bd %s reported %q instead of reaching the configured server:\n%s",
+				strings.Join(run.args, " "), empty, run.output)
+		}
+	}
+	if strings.TrimSpace(run.stdout) == "[]" {
+		t.Fatalf("bd %s printed an empty JSON result instead of reaching the configured server:\n%s",
+			strings.Join(run.args, " "), run.output)
+	}
+}
+
+func envWithoutBeadsStorageSettings() []string {
+	kept := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(name, "BEADS_DOLT_") || name == "BEADS_DIR" {
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	return kept
+}
+
+func freeLoopbackPort(t *testing.T) int {
+	t.Helper()
+	port, err := testutil.FindFreePort()
+	if err != nil {
+		t.Fatalf("find free port: %v", err)
+	}
+	return port
+}


### PR DESCRIPTION
## The bug

A workspace whose `.beads/` declares `dolt.mode: server` in `config.yaml` but has **no `metadata.json`** gets no substituted config. `bd` falls through to the embedded branch, creates `.beads/embeddeddolt/beads/.dolt`, and answers every query out of the database it just created:

```
$ bd list
warning: no beads configuration found in .../.beads; using default database name "beads"
No issues found.
$ echo $?
0
$ ls .beads/embeddeddolt/beads/.dolt     # ← did not exist before that run
config.json  noms  repo_state.json  temptf
```

`BEADS_DOLT_SERVER_MODE=1` does not help — verified, see evidence below. Nothing in the output distinguishes this from a genuinely empty database, so a reader (human or agent) concludes "no work". In one probe `bd` even started a real sql-server on the `config.yaml` port *and* read from the phantom: split-brain inside a single invocation.

Once `.beads/embeddeddolt/` exists it is self-perpetuating — `findDatabaseInBeadsDir` prefers it over `.beads/dolt` on every later run, so the wrong answer outlives the invocation that caused it.

`gascity` provisions exactly this shape (`config.yaml` + `dolt/` + `dolt-server.port` + `.local_version`, no `metadata.json`) on **every** `gc-beads-bd start`.

## Evidence

Same metadata-less workspace, same live Dolt sql-server holding one issue, two binaries:

| binary | output | phantom created |
|---|---|---|
| release/1.3.0 | `warning: no beads configuration found` / `No issues found.` / exit 0 | **yes** — `.beads/embeddeddolt/beads` |
| this branch | `○ beads-76k P1 phantom proof issue` / `Total: 1 issues` | no |

And with the server down (`BEADS_DOLT_AUTO_START=0`), this branch fails loudly instead of quietly:

```
Error: failed to open database: Dolt server unreachable at 127.0.0.1:13307: dial tcp ...: connection refused
```

The env-var half, no `config.yaml` at all, `BEADS_DOLT_SERVER_MODE=1` exported:

| binary | output | phantom created |
|---|---|---|
| release/1.3.0 | `No issues found.` / exit 0 | **yes** |
| this branch | the issue, from the server | no |

## Why pre-existing, yet rc.2-blocking

v1.1.0 behaves identically — this is not a v1.3.0 regression. It ships in rc.2 because the only thing that has ever surfaced it is about to be removed.

For the gc shape specifically (`.beads/dolt` present), today's over-broad legacy-upgrade guard refuses the workspace before store selection runs. That refusal is wrong, and #6119 removes it. The moment #6119 lands, the guard stops standing in front of this and the gc shape reaches the buggy gate directly.

The masking is **partial**, though — the bug is already live on release/1.3.0 for any metadata-less server-mode workspace whose `.beads/dolt` root does not exist yet (`hasLegacyDoltRoot` is false, so the guard admits it): an explicit `--db`, or `bd import` / `bd setup`, reaches store selection and creates the phantom. That is the path the prove-it below uses, and it is why this is a fix rather than a pre-emptive guard.

## Root cause: HostImpliesServerMode vs IsDoltServerMode

`cmd/bd/main.go` gated the metadata-less config substitution on `HostImpliesServerMode()`:

```go
if cfg == nil && configfile.DefaultConfig().HostImpliesServerMode() {
```

`HostImpliesServerMode` answers a narrower question than the one being asked here — *"does a configured HOST imply server mode?"* It returns false the moment `config.yaml` declares any `dolt.mode`:

```go
if config.GetYamlConfig("dolt.mode") != "" {
    return false
}
```

That is *correct* for host inference (an explicit mode outranks a host), and *wrong* as the whole gate: a workspace that says `dolt.mode: server` is a server workspace regardless of what the host layer concludes. `HostImpliesServerMode` also never consults `BEADS_DOLT_SERVER_MODE`, which is why setting it explicitly was silently ignored — its own bug, fixed by the same line.

The fix gates on `IsDoltServerMode()` — the seven-layer resolver that the very next branch already uses to set `doltCfg.ServerMode`, that #6119 just taught the legacy guard to use, and that `normalizeLoadedConfig` already hands to `store_factory.go` and `loadServerModeFromBeadsDir`. **`main.go`'s inline gate was the odd one out**; every other nil-config site in the CLI already resolves through the full chain.

## Blast radius

`IsDoltServerMode()` is a strict superset of `HostImpliesServerMode()` for `DefaultConfig()` (it calls it as one of its layers), so **nothing that reached server mode before stops reaching it now**. Newly substituted, i.e. newly routed to server mode:

- metadata-less workspaces with `dolt.mode: server` in `config.yaml` (the gc shape, and the bug being fixed);
- metadata-less workspaces with `BEADS_DOLT_SERVER_MODE=1` exported (previously ignored);
- metadata-less workspaces with `BEADS_DOLT_SHARED_SERVER=1` exported — already rescued by the fallthrough at `main.go:~1652`, so this is idempotent, not new behavior.

**When `config.yaml` says server mode and no server is reachable**, the command now fails with `Dolt server unreachable at <host>:<port>` and the auto-start hint, instead of exiting 0 with an empty list. That is the intended outcome and the point of the change: a loud, addressable connection error strictly dominates a silent empty result, because the empty result is indistinguishable from real emptiness.

**Can a legitimate embedded workspace be misrouted?** Only if something in the env/`config.yaml` precedence chain *says* server mode — which is the operator's own statement of intent, and is exactly what `store_factory.go` and `loadServerModeFromBeadsDir` already honour for the same workspace via `normalizeLoadedConfig`. Before this change those sites and `main.go` could disagree about the same directory; now they agree. A workspace with no metadata.json and no server signal anywhere still takes the embedded default, still prints the `warning: no beads configuration found` line, and is untouched by this change — that is why the gate stays conditional rather than substituting unconditionally like `normalizeLoadedConfig` does.

Call sites checked, and deliberately **not** changed:

- `main.go:~1652` (the `BEADS_DOLT_SHARED_SERVER` fallthrough) — still load-bearing, not redundant: `doltserver.IsSharedServerMode()` also reads `config.yaml`'s `dolt.shared-server`, which `IsDoltServerMode` deliberately does not (it reads only the env var, to avoid a circular import). The overlap it does have is idempotent.
- `main.go:~1324` (workspace discovery: `dbPath = bd` for a metadata-less remote-host workspace) — still reads `HostImpliesServerMode`. Left narrow on purpose: its failure mode is a loud, actionable `Error: no beads database found` with a `bd doctor` hint, not a silent wrong answer; and widening it would newly turn *"run `bd init`"* into an implicit attach to a shared server database for any empty `.beads` under a user-global `dolt.mode: server`. Worth revisiting outside an rc.
- `store_factory.go:173,282` and `main.go:559` — already correct via `normalizeLoadedConfig`.
- `doltserver.ResolveServerMode` (the lifecycle resolver, used by `ApplyCLIAutoStart`) — independent of this gate and already handles `BEADS_DOLT_SERVER_MODE`; unchanged.

Composition with #6119: the two touch different call sites — #6119 the legacy-upgrade guard, this the store-selection substitution — and neither duplicates the other. This branch adds no `workspaceSelectsServerMode` helper, so there is no symbol collision; it inlines `configfile.DefaultConfig().IsDoltServerMode()` exactly where `HostImpliesServerMode()` stood. #6119 removes the refusal that hides the gc shape; this makes what is behind it correct. Merging in either order is safe; both are needed for the gc shape to work in rc.2.

## Test plan

New file `cmd/bd/metadataless_server_workspace_test.go`, two e2e tests driving a real `bd` subprocess with `BEADS_DOLT_AUTO_START=0` (so a misrouted open cannot be masked by a server bd starts for itself) and every ambient `BEADS_DOLT_*` / `BEADS_DIR` stripped (this package's `TestMain` exports a shared test server, and env beats `config.yaml` in every layer under test).

- `TestMetadatalessServerModeWorkspaceNeverOpensPhantomEmbeddedDatabase` — the two ways a metadata-less workspace selects server mode (`config.yaml dolt.mode: server`; `BEADS_DOLT_SERVER_MODE=1`). Asserts no `.beads/embeddeddolt`, non-zero exit, no `no beads configuration found`, no `No issues found.` / `[]`, and that the error names the configured endpoint.
- `TestGCProvisionedServerWorkspaceNeverOpensPhantomEmbeddedDatabase` — the exact gc byte shape (`config.yaml` + `dolt/` + `dolt-server.port` + `.local_version`, no `metadata.json`), over `bd list` and `bd ready`. Asserts only what holds both before and after #6119 (no phantom, no false-empty), since today the guard refuses and after #6119 this fix produces the connection error.

### Prove-it

Fix reverted, tests kept:

```
--- FAIL: .../config.yaml_dolt.mode_server
    bd created a phantom embedded database at .../.beads/embeddeddolt (contains [beads]) for a server-mode workspace
--- FAIL: .../BEADS_DOLT_SERVER_MODE_env_var
    bd created a phantom embedded database at .../.beads/embeddeddolt (contains [beads]) for a server-mode workspace
```

Fix reverted **plus #6119's guard applied** — the exact configuration rc.2 would ship without this change:

```
--- FAIL: TestGCProvisionedServerWorkspaceNeverOpensPhantomEmbeddedDatabase/list
    bd created a phantom embedded database at .../.beads/embeddeddolt (contains [beads]) for a server-mode workspace
--- FAIL: TestGCProvisionedServerWorkspaceNeverOpensPhantomEmbeddedDatabase/ready
```

With the fix, all four pass.

### Verification run

- `go build ./...` — clean
- `go vet ./...` — clean
- `golangci-lint run ./cmd/bd/...` — 0 issues
- `./scripts/test.sh ./internal/configfile/...` — ok
- `./scripts/test.sh ./cmd/bd/...` — ok (cmd/bd 488s, doctor, doctor/fix, protocol, setup all ok)
- `BEADS_TEST_ENV_RUN_DOLT=1 .github/scripts/server-storage-test-shard.sh {1,2,3} 16` — PASS. (This change cannot reach `internal/storage/dolt`, which does not run the CLI; the shards are a sanity check, and the relevant lane is `test-embedded-cmd`, covered by the full `cmd/bd` run above.)

## Proposed changelog line

```
### Fixed
- A workspace declaring `dolt.mode: server` in `.beads/config.yaml` with no
  `metadata.json` no longer opens a phantom embedded database and report an
  empty result with exit 0. `BEADS_DOLT_SERVER_MODE=1` is now honored for such
  workspaces as well.
```

(CHANGELOG.md deliberately not touched in this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
