### PR TITLE
ci(macos): give the macOS test lane the 30m timeout the Linux lane already has

### DIFF
--- a/.github/workflows/ci-measurements.yml
+++ b/.github/workflows/ci-measurements.yml
@@ -86,7 +86,10 @@ jobs:
           ci_time "install golangci-lint" -- go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
           status=0
           ci_time "pr-policy wrapper" -- make ci-pr-policy || status=$?
-          ci_time "pr-core gotestsum" -- gotestsum --junitfile artifacts/pr-core-junit.xml --format testdox -- -race -short -skip '^TestEmbedded' ./... || status=$?
+          # -timeout=30m keeps this in step with the lane it measures
+          # (scripts/ci/pr-core.sh). Without it ./cmd/bd can die on `go test`'s
+          # 10m default and the measurement reports a panic instead of a duration.
+          ci_time "pr-core gotestsum" -- gotestsum --junitfile artifacts/pr-core-junit.xml --format testdox -- -race -short -timeout=30m -skip '^TestEmbedded' ./... || status=$?
           ci_time "pr-lint wrapper" -- make ci-pr-lint || status=$?
           exit "$status"
 
@@ -128,7 +131,10 @@ jobs:
           source scripts/ci/lib/timing.sh
           source ./.buildflags
 
-          ci_time "macos short go test" -- go test -v -race -short -skip '^TestEmbedded' ./...
+          # -timeout=30m matches the macOS lanes this measures (pr.yml, main.yml).
+          # This is the job that produced the ./cmd/bd duration distribution, and
+          # at 10m it clips its own longest samples into timeout panics.
+          ci_time "macos short go test" -- go test -v -race -short -timeout=30m -skip '^TestEmbedded' ./...
 
   macos-candidates:
     name: Measure macOS no-short candidates

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -542,6 +542,13 @@ jobs:
           GOCACHE: ${{ runner.temp }}/go-cache/non-race
         run: go build -v -tags gms_pure_go ./cmd/bd
 
+      # Both lanes below pass -timeout=30m explicitly. ./cmd/bd has outgrown
+      # `go test`'s 10m per-package default (see scripts/ci/pr-core.sh and
+      # #6091), and when it trips the alarm the panic names whichever test was
+      # in flight, so it reads like a hang rather than the package running out
+      # of clock. The flag lives on the invocation, not in matrix.test-flags,
+      # so editing the matrix cannot silently drop it. 30m matches every other
+      # -race lane here for this same code.
       - name: Test (with coverage + JUnit XML)
         if: matrix.coverage
         env:
@@ -551,14 +558,14 @@ jobs:
           gotestsum \
             --junitfile junit.xml \
             --format testdox \
-            -- -tags gms_pure_go -race -short -coverprofile=coverage.out -skip '^TestEmbedded' ./...
+            -- -tags gms_pure_go -race -short -timeout=30m -coverprofile=coverage.out -skip '^TestEmbedded' ./...
 
       - name: Test
         if: ${{ !matrix.coverage }}
         env:
           BEADS_TEST_BD_BINARY: ${{ github.workspace }}/bd
           GOCACHE: ${{ runner.temp }}/go-cache/race
-        run: go test -tags gms_pure_go ${{ matrix.test-flags }} -skip '^TestEmbedded' ./...
+        run: go test -tags gms_pure_go ${{ matrix.test-flags }} -timeout=30m -skip '^TestEmbedded' ./...
 
       - name: Upload coverage to Codecov
         if: matrix.coverage && !cancelled()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -904,7 +904,14 @@ jobs:
         env:
           BEADS_TEST_BD_BINARY: ${{ github.workspace }}/bd
           GOCACHE: ${{ runner.temp }}/go-cache/race
-        run: go test -tags gms_pure_go -v -race -short -skip '^TestEmbedded' ./...
+        # -timeout is explicit for the same reason it is in scripts/ci/pr-core.sh
+        # (#6091): ./cmd/bd has outgrown `go test`'s 10m per-package default. On
+        # this runner it lands between 357s and 600s across recent runs — #6091's
+        # own macOS lane passed at 596.7s, 3.3s under the wall — so the package
+        # intermittently dies on the alarm and the panic names whichever test was
+        # in flight, which reads like a hang instead of the clock running out. 30m
+        # matches every other -race lane here for this same code.
+        run: go test -tags gms_pure_go -v -race -short -timeout=30m -skip '^TestEmbedded' ./...
 
   # Producer-side guard for the Beads<->consumer CLI contract. Runs the whole
   # cmd/bd/protocol package: the golden corpus (regenerated from this branch's

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -265,8 +265,12 @@ func TestMacOSTestJobsReuseWorkspaceBDBinary(t *testing.T) {
 	const (
 		workspaceBDBinary = "${{ github.workspace }}/bd"
 		buildCommand      = "go build -v -tags gms_pure_go ./cmd/bd"
-		prTestCommand     = "go test -tags gms_pure_go -v -race -short -skip '^TestEmbedded' ./..."
-		mainTestCommand   = "go test -tags gms_pure_go ${{ matrix.test-flags }} -skip '^TestEmbedded' ./..."
+		// -timeout=30m is pinned on both lanes because ./cmd/bd has outgrown
+		// `go test`'s 10m per-package default (#6091). In main.yml it sits on
+		// the invocation rather than in matrix.test-flags, so editing the
+		// matrix cannot silently drop it.
+		prTestCommand   = "go test -tags gms_pure_go -v -race -short -timeout=30m -skip '^TestEmbedded' ./..."
+		mainTestCommand = "go test -tags gms_pure_go ${{ matrix.test-flags }} -timeout=30m -skip '^TestEmbedded' ./..."
 	)
 
 	workflows := map[string]ciWorkflow{


### PR DESCRIPTION
## What

Adds an explicit `-timeout=30m` to the `go test` invocations that run the full
`./...` suite under `-race` and were still relying on Go's implicit **10 minute**
per-package default.

## Why

PR #6091 fixed exactly this for the Linux lane by adding `-timeout=30m` to
`scripts/ci/pr-core.sh`. The macOS lanes call `go test` inline in workflow YAML
and never received it, so `Test (macos-latest)` still runs against a 10m wall.

`./cmd/bd` on the macOS runner sits at roughly **93% utilization** of that wall.
Measured `./cmd/bd` durations across 17 recent macOS runs:

```
357  387  389  418  419  422  486  494  536  542
547  549  558  560  590  597  600
```

The most damning data point: **#6091's own macOS lane passed at 596.719s** —
3.3 seconds of margin. That is a coin flip, not a green lane.

There is no product bug and no single slow test here. Because no one test is
responsible, when the alarm fires the resulting `panic: test timed out after
10m0s` names whichever test happened to be in flight, so it reads like a hang
rather than the package simply running out of clock. That is the last source of
red noise before rc.2.

## Why 30m

30m is not an invented number — it is what this repo already gives this same
code on every other `-race` lane: `main.yml`'s integration package and `cmd/bd`
shards, `ci-measurements.yml`, and `nightly.yml`. #6091 chose it for the Linux
lane for exactly this reason. This change just makes the macOS lanes consistent.

## Exactly what changed

| File | Invocation | Before | After |
| --- | --- | --- | --- |
| `.github/workflows/pr.yml` | `Test (macos-latest)` — `-v -race -short ./...` | implicit 10m | `-timeout=30m` |
| `.github/workflows/main.yml` | `Test` (macos-latest, `matrix.test-flags = -v -race -short`) | implicit 10m | `-timeout=30m` |
| `.github/workflows/main.yml` | `Test (with coverage + JUnit XML)` (ubuntu-latest, `gotestsum -- -race -short -coverprofile ./...`) | implicit 10m | `-timeout=30m` |
| `.github/workflows/ci-measurements.yml` | `macos short go test` | implicit 10m | `-timeout=30m` |
| `.github/workflows/ci-measurements.yml` | `pr-core gotestsum` | implicit 10m | `-timeout=30m` |

Three notes on scope:

- The **ubuntu coverage lane** in `main.yml` is the same class of bug and was
  arguably at higher risk than macOS: it runs the same `./...` under `-race`
  *with coverage instrumentation on* and had no explicit timeout either. Fixed
  alongside.
- The two **`ci-measurements.yml`** lanes are the measurement twins of the lanes
  above — including the very job that produced the duration distribution quoted
  here. At 10m they clip their own longest samples into timeout panics, and the
  `pr-core` one would otherwise diverge from `pr-core.sh`, which #6091 just set
  to 30m.
- In `main.yml` the flag is placed **on the invocation, not in
  `matrix.test-flags`**, so a future edit to the matrix cannot silently drop it.

## Audit: every other `go test` in `.github/` and `scripts/ci/`

Already had an explicit timeout — untouched:

| Location | Timeout |
| --- | --- |
| `scripts/ci/pr-core.sh:34` | 30m (#6091) |
| `pr.yml:204` (js/wasm hook refusal) | 2m |
| `pr.yml:818` / `main.yml:661` (domain/uow/tracker) | 15m |
| `pr.yml:828` / `main.yml:671` (`cmd/bd/doctor/fix`) | 10m |
| `pr.yml:962` (`cmd/bd/protocol`) | 30m |
| `main.yml:742`, `main.yml:826` (integration shards) | 30m |
| `ci-measurements.yml` 162, 163, 196, 257, 325, 393, 461, 568, 614 | 30m |
| `nightly.yml:80` | 30m |
| `regression.yml:121` | 20m |
| `.github/scripts/embedded-test-shard.sh` (both prebuilt + fallback paths) | 20m |
| `.github/scripts/{proxied,embedded-storage,server-storage}-test-shard.sh` (both paths) | 15m |

Deliberately left on the implicit default, with reasons:

| Location | Why left |
| --- | --- |
| `pr.yml:254`, `main.yml:184` | `-short` `-run` subset of 13 named `cmd/bd` tests, no `-race`; a `CGO_ENABLED=0` compile-contamination check that finishes in seconds |
| `pr.yml:275` | single test `^TestIsServerProbablyRunning` |
| `pr.yml:299` | `./internal/doltversion/`, tiny package, no `-race` |
| `pr.yml:336` | single test `^TestWorktreeRemove` |
| `pr.yml:374` | `./internal/storage/dbproxy/server/`, no `-race` |
| `pr.yml:476`, `508`, `512` | single named tests in `./scripts` |
| `pr.yml:479` | `./scripts/gitattributespolicy` policy check |
| `pr.yml:516` | single named test `^TestGeneratedHookTimeoutProcessBoundary$` |
| `pr.yml:521` | two named tests in `./scripts/repro-dolt-prod-timeouts` |
| `docs-mintlify.yml:46` | `./test/docsync` doc-sync check, no `-race` |
| `main.yml` 98/172-174/948/953, `pr.yml` 242-244, `pr-risk.yml` 165/170/187, `proxied-local-smoke.yml:88` | `go test -c -o` — compile-only, never runs a test, so `-timeout` is meaningless |

`scripts/ci/pr-policy.sh` and `scripts/ci/pr-lint.sh` run no `go test` at all.

## Verification

- All 18 files in `.github/workflows/` parse under `python3 yaml.safe_load`.
- `actionlint` is clean on all three changed files.
- The exact flag combination was smoke-tested against the real toolchain on a
  fast package: `go test -tags gms_pure_go -count=1 -timeout=30m -skip
  '^TestEmbedded' ./internal/doltversion/` → `ok ... 4.911s`.
- **I could not run a macOS runner from this environment**, so I am making no
  claim that I observed the macOS lane go green. The change is a CI flag whose
  correctness rests on the audit and linting above, plus the fact that it is the
  identical flag #6091 already landed for the same code on Linux.

## Not the real fix

De-slowing or sharding `./cmd/bd` is the actual fix and belongs on `main`. This
only stops the clock from being the thing that fails.

No `CHANGELOG.md` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
