### PR TITLE
perf(storage): stop burning two wasted MySQL sessions per bd invocation (wy-s8ytnw)

### DIFF
--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -632,24 +632,16 @@ func readAndDial(rootDir string) adoptionResult {
 		}
 	}
 
+	// The authenticated identity reply above IS the liveness proof. Do not
+	// add a dial-and-close TCP probe of the data port here: the proxy dials
+	// its backend for every accepted client connection BEFORE any bytes flow
+	// (handleConn), so a zero-byte probe costs the shared dolt server a full
+	// MySQL session on every bd invocation while proving nothing the control
+	// port did not — ListenAndServe binds the data listener before the
+	// control listener exists, so an identity reply carrying this DataPort
+	// already implies the data listener is bound (wy-s8ytnw).
 	ep := Endpoint{Host: "127.0.0.1", Port: pf.Port}
-	if !probePort(ep, identityProbeTimeout) {
-		return adoptionResult{
-			status:  adoptionIdentityMismatch,
-			pidfile: pf,
-			err:     fmt.Errorf("authenticated proxy data port %d is not accepting connections", pf.Port),
-		}
-	}
 	return adoptionResult{status: adoptionAdopted, endpoint: ep, pidfile: pf}
-}
-
-func probePort(ep Endpoint, timeout time.Duration) bool {
-	conn, err := net.DialTimeout("tcp", ep.Address(), timeout)
-	if err != nil {
-		return false
-	}
-	_ = conn.Close()
-	return true
 }
 
 func isMalformedPIDFileError(err error) bool {

--- a/internal/storage/dbproxy/proxy/endpoint_no_data_probe_test.go
+++ b/internal/storage/dbproxy/proxy/endpoint_no_data_probe_test.go
@@ -1,0 +1,92 @@
+package proxy
+
+import (
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/steveyegge/beads/internal/procid"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/identity"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
+)
+
+// Adoption must be proven by the authenticated control-port identity reply
+// alone. A dial-and-close probe of the DATA port is not free: the proxy dials
+// its backend for every accepted client connection before any bytes flow, so
+// such a probe burns one full MySQL session on the shared dolt server per bd
+// invocation (wy-s8ytnw). This pins that readAndDial adopts a live proxy
+// without ever connecting to its data port.
+func TestReadAndDialAdoptsWithoutDialingDataPort(t *testing.T) {
+	root := t.TempDir()
+	token, err := procid.Capture(os.Getpid())
+	require.NoError(t, err)
+	rootID, err := identity.RootID(root)
+	require.NoError(t, err)
+
+	dataListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dataListener.Close() })
+	dataPort := dataListener.Addr().(*net.TCPAddr).Port
+
+	var dataAccepts atomic.Int32
+	go func() {
+		for {
+			conn, acceptErr := dataListener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			dataAccepts.Add(1)
+			_ = conn.Close()
+		}
+	}()
+
+	_, err = identity.WriteSecret(root)
+	require.NoError(t, err)
+	var reply identity.IdentReply
+	var replyMu sync.RWMutex
+	control, err := startControl(root, func() identity.IdentReply {
+		replyMu.RLock()
+		defer replyMu.RUnlock()
+		return reply
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = control.Close() })
+	replyMu.Lock()
+	reply = identity.IdentReply{
+		Schema:      pidfile.SchemaV2,
+		Role:        pidfile.KindProxy,
+		RootID:      rootID,
+		UpstreamID:  "upstream",
+		PID:         os.Getpid(),
+		Birth:       string(token),
+		DataPort:    dataPort,
+		ControlPort: control.Port(),
+	}
+	replyMu.Unlock()
+	require.NoError(t, pidfile.Write(root, PIDFileName, pidfile.PidFile{
+		Schema:      pidfile.SchemaV2,
+		Kind:        pidfile.KindProxy,
+		Pid:         os.Getpid(),
+		Birth:       string(token),
+		Port:        dataPort,
+		ControlPort: control.Port(),
+		RootID:      rootID,
+		UpstreamID:  "upstream",
+	}))
+
+	got := readAndDial(root)
+	require.Equal(t, adoptionAdopted, got.status)
+	assert.Equal(t, dataPort, got.endpoint.Port)
+
+	// A probe would have been accepted synchronously with the dial; give the
+	// accept goroutine a moment anyway so a regression cannot hide behind
+	// scheduling.
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(0), dataAccepts.Load(), "readAndDial must not open a connection to the proxy data port")
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2422,15 +2422,6 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, se
 		return db, connStr, serverConnFacts{}, nil
 	}
 
-	// Ensure database exists (may need to create it)
-	// First connect without database to create it
-	initConnStr := buildServerDSN(cfg, "")
-	initDB, err := sql.Open("mysql", initConnStr)
-	if err != nil {
-		return nil, "", serverConnFacts{}, fmt.Errorf("failed to open init connection: %w", err)
-	}
-	defer func() { _ = initDB.Close() }()
-
 	// Validate database name to prevent SQL injection via backtick escaping
 	if err := ValidateDatabaseName(cfg.Database); err != nil {
 		return nil, "", serverConnFacts{}, fmt.Errorf("invalid database name %q: %w", cfg.Database, err)
@@ -2447,6 +2438,36 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, se
 				"this is a test database name on the production server (see DOLT-WAR-ROOM.md)",
 			cfg.Database, cfg.ServerPort)
 	}
+
+	// Fast path (wy-s8ytnw), keyed the same way as Gateway above rather than
+	// by deleting the probe: connect straight to the target database. A
+	// successful connect IS the existence proof, so the steady-state open —
+	// a database that already exists, which is every open but the very
+	// first — skips the no-database init connection (one full MySQL
+	// session per bd invocation on a shared server) and its SHOW DATABASES.
+	// The facts are exact, not merely unproven as for Gateway: existence is
+	// established, and `created` is honestly false — this call created
+	// nothing, so fresh-bootstrap heal stays unarmed and the CreateIfMissing
+	// identity gate (GH#4637) sees alreadyExisted exactly as the SHOW
+	// DATABASES probe would have reported it.
+	//
+	// Any failure — Unknown database (1049) because it does not exist yet,
+	// server down, bad credentials — falls through to the historical
+	// probe-then-create path, which owns creation, the #5042 ownership
+	// signal, databaseNotFoundError, and every error message callers match.
+	if pingErr := db.PingContext(ctx); pingErr == nil {
+		connReady = true
+		return db, connStr, serverConnFacts{alreadyExisted: true}, nil
+	}
+
+	// Ensure database exists (may need to create it)
+	// First connect without database to create it
+	initConnStr := buildServerDSN(cfg, "")
+	initDB, err := sql.Open("mysql", initConnStr)
+	if err != nil {
+		return nil, "", serverConnFacts{}, fmt.Errorf("failed to open init connection: %w", err)
+	}
+	defer func() { _ = initDB.Close() }()
 
 	// Check if the database already exists before deciding whether to create it.
 	// This prevents the shadow database bug: without CreateIfMissing, connecting

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2455,10 +2455,20 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, se
 	// server down, bad credentials — falls through to the historical
 	// probe-then-create path, which owns creation, the #5042 ownership
 	// signal, databaseNotFoundError, and every error message callers match.
-	if pingErr := db.PingContext(ctx); pingErr == nil {
+	pingErr := db.PingContext(ctx)
+	if pingErr == nil {
 		connReady = true
 		return db, connStr, serverConnFacts{alreadyExisted: true}, nil
 	}
+
+	// Advisory only: the probe-then-create path below is the historical open,
+	// so a failure here is never fatal. But a silently discarded error is a
+	// fast path that has quietly stopped firing — here that means every open
+	// is back to burning the extra MySQL session this path exists to remove,
+	// with nothing to say so. Same reasoning as the convergence probe in
+	// internal/storage/schema/lock.go.
+	debug.Logf("dolt: direct-connect fast path unavailable for %q on %s:%d, using the no-database init connection: %v\n",
+		cfg.Database, cfg.ServerHost, cfg.ServerPort, pingErr)
 
 	// Ensure database exists (may need to create it)
 	// First connect without database to create it

--- a/internal/storage/schema/converged.go
+++ b/internal/storage/schema/converged.go
@@ -36,12 +36,17 @@ func alreadyConverged(ctx context.Context, db DBConn, databaseName string, selec
 		return false, nil
 	}
 
-	// Put the session on the target database first. The hot path — the proxied
-	// CLI open in uow.openAndInitSchema — pins its schema-init pool with an
-	// EMPTY DSN database and only USEs the database after GET_LOCK, so a probe
-	// that merely ASKED whether the session was already on databaseName read
-	// NULL from DATABASE() and declined on every single invocation: the fast
-	// path never fired where it was needed.
+	// Put the session on the target database first. Callers arrive in two
+	// shapes. The proxied CLI open in uow.openAndInitSchema now connects
+	// straight to the target database on its own steady-state path
+	// (wy-s8ytnw), so the session is already there and the DATABASE() read
+	// below is the whole cost. Its fall-through open — and, before that fast
+	// path existed, every invocation of the hot path — pins the schema-init
+	// pool with an EMPTY DSN database and only USEs the database after
+	// GET_LOCK, so a probe that merely ASKED whether the session was already
+	// on databaseName read NULL from DATABASE() and declined every single
+	// time: the fast path never fired where it was needed. The selector is
+	// what keeps that second shape working.
 	onTarget, qualifier, err := selectTargetDatabase(ctx, db, databaseName, selector)
 	if err != nil {
 		return false, err

--- a/internal/storage/schema/migrations/README.md
+++ b/internal/storage/schema/migrations/README.md
@@ -62,6 +62,19 @@ duplicate primary key given: [w2,external:e1]
 Normalize *after* dropping the generated column and its key, not before. (0058
 normalizes before, and reaches the abort on any store whose rows collide.)
 
+**Restore any session variable you set, in the script that set it.** Six
+migrations here clear `FOREIGN_KEY_CHECKS` and restore it (0041, 0043, 0047,
+0050, 0053, 0058); keep that shape. Since wy-s8ytnw the steady-state open in
+`uow.openAndInitSchema` hands the pool that ran the migration straight to the
+provider for live queries, so a system session variable still changed when a
+script reports success leaks into ordinary queries. Pairing the SETs inside one
+script is what makes that safe — `initSchemaAttempt` pins one session per
+attempt, so both statements land on the same session, and an attempt that dies
+between them returns its connection to the pool, which is why the restore
+cannot be the caller's job. User variables (`SET @sql`, `SET @needs_add`) are
+exempt: nothing outside these scripts reads one, and each assigns before it
+reads.
+
 **The `dolt` CLI is not a safe harness for guarded migrations, twice over.**
 `dolt sql -f`/`-q`/piped-stdin silently no-ops `PREPARE`/`EXECUTE`-driven
 `ALTER TABLE` — every guarded migration here uses exactly that shape — and

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -480,19 +480,49 @@ func openDB(ctx context.Context, dsn string) (*sql.DB, error) {
 }
 
 func openAndInitSchema(ctx context.Context, ep proxy.Endpoint, database, rootUser, rootPassword, tlsConfigName string, teamServer bool, expectedProjectID string, opts providerOptions) (UnitOfWorkProvider, error) {
+	newProvider := func(pool *sql.DB) *doltSQLProvider {
+		return &doltSQLProvider{
+			defaultBranch:     defaultBranch,
+			db:                pool,
+			serverEndpoint:    "tcp:" + ep.Address(),
+			teamServer:        teamServer,
+			expectedProjectID: expectedProjectID,
+			preview:           opts.preview,
+		}
+	}
+
+	// Fast path (wy-s8ytnw): connect straight to the target database. A
+	// successful connect IS the existence proof (the same reasoning the
+	// dolt store applies to Gateway servers), so the steady-state open —
+	// a database that already exists, which is every open but the very
+	// first — costs ONE MySQL session instead of two: initSchema runs on
+	// this pool (USE + the converged-schema reads, or a real migration
+	// when one is pending; the bare CREATE DATABASE inside the locked
+	// preparation is refused with 1007 exactly as it is on a no-database
+	// connection, so `created` stays false and fresh-bootstrap heal can
+	// never be armed by a database this call did not create), and the
+	// same pool is then handed to the provider. Nothing in the migration
+	// path mutates session state, so reusing its pool is safe.
+	//
+	// Any connect failure — the database does not exist yet (1049), the
+	// server is down, bad credentials — falls through to the historical
+	// no-database init connection, which owns creation, the ownership
+	// signal, and every error message callers already match on.
+	if dbConn, err := openDB(ctx, buildDSN(ep, database, rootUser, rootPassword, tlsConfigName)); err == nil {
+		provider := newProvider(dbConn)
+		if err := provider.initSchema(ctx, database); err != nil {
+			_ = dbConn.Close()
+			return nil, fmt.Errorf("uow: init schema: %w", err)
+		}
+		return provider, nil
+	}
+
 	initDB, err := openDB(ctx, buildDSN(ep, "", rootUser, rootPassword, tlsConfigName))
 	if err != nil {
 		return nil, err
 	}
 
-	initProvider := &doltSQLProvider{
-		defaultBranch:     defaultBranch,
-		db:                initDB,
-		serverEndpoint:    "tcp:" + ep.Address(),
-		teamServer:        teamServer,
-		expectedProjectID: expectedProjectID,
-		preview:           opts.preview,
-	}
+	initProvider := newProvider(initDB)
 
 	if err := initProvider.initSchema(ctx, database); err != nil {
 		_ = initDB.Close()
@@ -508,12 +538,5 @@ func openAndInitSchema(ctx context.Context, ep proxy.Endpoint, database, rootUse
 		return nil, err
 	}
 
-	return &doltSQLProvider{
-		defaultBranch:     defaultBranch,
-		db:                dbConn,
-		serverEndpoint:    "tcp:" + ep.Address(),
-		teamServer:        teamServer,
-		expectedProjectID: expectedProjectID,
-		preview:           opts.preview,
-	}, nil
+	return newProvider(dbConn), nil
 }

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/go-sql-driver/mysql"
 
+	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
@@ -167,10 +168,14 @@ func (p *doltSQLProvider) BeginTx(ctx context.Context) (Tx, error) {
 }
 
 // selectProbeDatabase lets schema's pre-lock convergence probe reach the
-// database on a session that is not yet on one. openAndInitSchema pins its
-// schema-init pool with an EMPTY DSN database, so without this the probe reads
-// NULL from DATABASE(), declines, and every invocation queues on the
-// server-wide migration lock it exists to skip.
+// database on a session that is not yet on one. openAndInitSchema has two entry
+// shapes since wy-s8ytnw, and only one of them needs this: the steady-state
+// open connects straight to the target database, so the probe reads it from
+// DATABASE() and returns before consulting the selector at all
+// (schema.selectTargetDatabase). The fall-through open still pins its
+// schema-init pool with an EMPTY DSN database, and there, without this, the
+// probe reads NULL from DATABASE(), declines, and every invocation queues on
+// the server-wide migration lock it exists to skip.
 //
 // The USE MUST remain the DDL repository's own UseDatabase — the exact
 // statement prepareBootstrap issues below. That identity is the reason the
@@ -466,14 +471,48 @@ func pingWithRetry(ctx context.Context, p pinger, bo *backoff.ExponentialBackOff
 	}, backoff.WithContext(bo, ctx))
 }
 
+// openDB opens dsn and waits out a server that is still coming up, retrying
+// transient ping failures for up to 30s (#6003).
 func openDB(ctx context.Context, dsn string) (*sql.DB, error) {
+	bo := backoff.NewExponentialBackOff()
+	bo.MaxElapsedTime = 30 * time.Second
+	return openPool(dsn, func(conn *sql.DB) error {
+		return pingWithRetry(ctx, conn, bo, pingAttemptTimeout)
+	})
+}
+
+// openDBProbe opens dsn and proves it with ONE bounded ping instead of
+// openDB's 30s retry budget. It exists for openAndInitSchema's fast path,
+// whose failure is not terminal: every error there falls through to the
+// historical open, which keeps the retry budget it has always owned. Retrying
+// here as well would charge an unreachable server twice — this budget and then
+// the fall-through's, ~60s where the pre-fast-path code spent 30s — to answer
+// a question one ping answers. The sibling fast path in internal/storage/dolt
+// (openServerConnection's bare PingContext ahead of its no-database init
+// connection) is deliberately the same shape.
+//
+// The one attempt is still capped at pingAttemptTimeout, for the reason
+// pingWithRetry caps its own attempts: the DSN sets no ReadTimeout, so a server
+// that accepts TCP and then stalls mid-handshake is otherwise bounded only by
+// the caller's context.
+func openDBProbe(ctx context.Context, dsn string) (*sql.DB, error) {
+	return openPool(dsn, func(conn *sql.DB) error {
+		pingCtx, cancel := context.WithTimeout(ctx, pingAttemptTimeout)
+		defer cancel()
+		return conn.PingContext(pingCtx)
+	})
+}
+
+// openPool opens dsn and hands the pool to prove, which must establish that
+// the server answers on it. The error texts are load-bearing — callers match
+// on "uow: open db" and "uow: ping db" — and a pool whose prove fails is
+// closed here rather than leaked to a caller that only sees an error.
+func openPool(dsn string, prove func(*sql.DB) error) (*sql.DB, error) {
 	conn, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("uow: open db: %w", err)
 	}
-	bo := backoff.NewExponentialBackOff()
-	bo.MaxElapsedTime = 30 * time.Second
-	if err := pingWithRetry(ctx, conn, bo, pingAttemptTimeout); err != nil {
+	if err := prove(conn); err != nil {
 		return nil, errors.Join(fmt.Errorf("uow: ping db: %w", err), conn.Close())
 	}
 	return conn, nil
@@ -501,21 +540,55 @@ func openAndInitSchema(ctx context.Context, ep proxy.Endpoint, database, rootUse
 	// preparation is refused with 1007 exactly as it is on a no-database
 	// connection, so `created` stays false and fresh-bootstrap heal can
 	// never be armed by a database this call did not create), and the
-	// same pool is then handed to the provider. Nothing in the migration
-	// path mutates session state, so reusing its pool is safe.
+	// same pool is then handed to the provider.
+	//
+	// Reusing the migrating pool is safe — but NOT because migrations leave
+	// the session alone. They do not: six shipped migrations issue
+	// `SET FOREIGN_KEY_CHECKS = 0` and restore `= 1` (0041, 0043, 0047,
+	// 0050, 0053, 0058 under internal/storage/schema/migrations), and the
+	// guarded ones leave user variables (`SET @sql`, `SET @needs_add`) set.
+	// It is safe because of three narrower facts:
+	//   - initSchemaAttempt pins ONE session per attempt (p.db.Conn), so a
+	//     script's SET and its restoring SET cannot land on different
+	//     sessions;
+	//   - every script that clears FOREIGN_KEY_CHECKS restores it before it
+	//     can report success, and a leftover user variable is inert: nothing
+	//     outside these scripts reads one, and each script assigns before it
+	//     reads;
+	//   - every initSchema failure below closes this whole pool, so a script
+	//     that died between the two SETs never hands its session back.
+	// That is a convention where it used to be structural: before this fast
+	// path the schema-init pool was always discarded, so a migration could
+	// leak session state with impunity. Now a migration that leaves a system
+	// session variable changed on the success path would leak it into live
+	// query sessions — and an attempt that dies mid-script returns its
+	// connection to the pool, so the restore has to be part of the script,
+	// not of the caller. See internal/storage/schema/migrations/README.md.
 	//
 	// Any connect failure — the database does not exist yet (1049), the
 	// server is down, bad credentials — falls through to the historical
 	// no-database init connection, which owns creation, the ownership
-	// signal, and every error message callers already match on.
-	if dbConn, err := openDB(ctx, buildDSN(ep, database, rootUser, rootPassword, tlsConfigName)); err == nil {
-		provider := newProvider(dbConn)
+	// signal, and every error message callers already match on. The probe is
+	// single-shot (openDBProbe) precisely so that fall-through cannot cost a
+	// second full retry budget.
+	probeConn, probeErr := openDBProbe(ctx, buildDSN(ep, database, rootUser, rootPassword, tlsConfigName))
+	if probeErr == nil {
+		provider := newProvider(probeConn)
 		if err := provider.initSchema(ctx, database); err != nil {
-			_ = dbConn.Close()
+			_ = probeConn.Close()
 			return nil, fmt.Errorf("uow: init schema: %w", err)
 		}
 		return provider, nil
 	}
+
+	// Advisory only: the fall-through below is the historical open, so this is
+	// never fatal. But a silently discarded error is a fast path that has
+	// quietly stopped firing — here that means every bd invocation is back to
+	// burning two MySQL sessions, the exact cost this path exists to remove,
+	// with nothing to say so. Same reasoning as the convergence probe in
+	// internal/storage/schema/lock.go.
+	debug.Logf("uow: single-session open unavailable for %q, using the no-database init connection: %v\n",
+		database, probeErr)
 
 	initDB, err := openDB(ctx, buildDSN(ep, "", rootUser, rootPassword, tlsConfigName))
 	if err != nil {


### PR DESCRIPTION
Every bd store-open against a shared dolt sql-server cost two sessions that
did no work:

1. readAndDial's data-port probe (internal/storage/dbproxy/proxy/endpoint.go)
   dialed the proxy data port and closed it to "prove" it accepts. The proxy's
   handleConn dials the BACKEND for every accepted client connection before a
   byte flows, so the zero-byte probe was a full backend MySQL session on every
   invocation from a proxied clone — and it proved nothing the authenticated
   control-port identity reply had not: ListenAndServe binds the data listener
   before the control listener exists. Drop the probe; the identity reply is
   the liveness proof. (Deferring the backend dial until the first client byte
   was considered and rejected: MySQL is server-speaks-first, so a real client
   waits for the greeting and would deadlock.)

2. The no-database init connection. On the proxied/server uow path
   (openAndInitSchema) and the dolt.New server path (openServerConnection) bd
   opened a second, database-less pool per store-open purely to probe
   existence (SHOW DATABASES / the schema-init preparation) before opening
   the real pool. Both sites now try the database-scoped connection FIRST —
   keyed the way the Gateway case already is, not by deleting the probe: a
   successful connect is the existence proof, so the steady-state open (every
   open but the very first) costs one session. Any connect failure (1049
   Unknown database, server down, bad credentials) falls through to the
   historical no-database path, which still owns creation, the #5042
   ownership signal that arms FreshBootstrapHeal, databaseNotFoundError, and
   every existing error message. `created` is honestly false on the fast
   path; the uow provider reuses the init pool (nothing in the migration path
   mutates session state).

New test TestReadAndDialAdoptsWithoutDialingDataPort pins the probe removal;
it fails (1 accept) against the previous endpoint.go and passes now.

Why the live server still saw a bare CREATE DATABASE per open despite
openServerConnection's SHOW DATABASES guard (the question on wy-s8ytnw): that
guard is not on the proxied path at all — the CREATE came from the uow
schema-init preparation, already fixed upstream by #6022 (alreadyConverged);
the deployed binary (71e5ad700) predates it (wy-7sx6cj).

---
Verification run by the author (plato, headless, 75-min unit): `go build ./...`, `go vet` on the three packages, `go test ./internal/storage/dbproxy/proxy/` (full package, green), vacuity check of the new test against the pre-fix endpoint.go (fails as designed). NOT run locally: the uow / dolt server-backed suites and `make test` — PR CI is the full gate for this change. Adversarial review verdict is recorded on wy-s8ytnw.