### PR TITLE
fix(import): wire in-batch regular<->wisp edges instead of dropping them (wy-a648lq)

### DIFF
--- a/backend/conformance/audit_molecule_wisp_batch_iter.go
+++ b/backend/conformance/audit_molecule_wisp_batch_iter.go
@@ -501,9 +501,13 @@ func testAuditCreateAllWispsInlineDependencies(t *testing.T, f Factory) {
 	}
 }
 
-// A mixed regular+wisp batch with a cross-bucket edge is rejected before insert;
-// with SkipDependencyValidationErrors the edge is dropped and both issues persist
-// (create.go:288-361).
+// A mixed regular+wisp batch with a cross-bucket edge is rejected before insert
+// (the strict plane rule, issueops.ValidateCreateIssuesMixedBucketDependencies);
+// with SkipDependencyValidationErrors — the import mode — both issues persist
+// AND the edge is wired: every row of both planes is written on the one
+// transaction before the dependency pass, which resolves the target on its own
+// plane. Until wy-a648lq the tolerant arm dropped the edge instead, and a
+// re-import could never backfill it.
 func testAuditCreateCrossBucketDependency(t *testing.T, f Factory) {
 	s := f(t)
 	c := ctx()
@@ -520,7 +524,7 @@ func testAuditCreateCrossBucketDependency(t *testing.T, f Factory) {
 		t.Errorf("(a) test-a persisted despite rejected batch: %v", err)
 	}
 
-	// (b) With skip: both persist, edge dropped.
+	// (b) With skip: both persist, and the cross-bucket edge is wired.
 	must(t, s.CreateIssuesWithFullOptions(c, []*types.Issue{
 		withDefaults(&types.Issue{ID: "test-c", Title: "C"}),
 		withDefaults(&types.Issue{ID: "test-d", Title: "D", Ephemeral: true, Dependencies: []*types.Dependency{{IssueID: "test-d", DependsOnID: "test-c", Type: types.DepBlocks}}}),
@@ -532,8 +536,8 @@ func testAuditCreateCrossBucketDependency(t *testing.T, f Factory) {
 		t.Errorf("(b) test-d missing: %v", err)
 	}
 	recs, _ := s.GetAllDependencyRecords(c)
-	if len(recs["test-d"]) != 0 {
-		t.Errorf("(b) cross-bucket edge not dropped: %v", auditDepTargets(recs["test-d"]))
+	if got := auditDepTargets(recs["test-d"]); !slices.Equal(got, []string{"test-c"}) {
+		t.Errorf("(b) test-d deps = %v, want [test-c] (in-batch cross-bucket edge wired, not dropped)", got)
 	}
 }
 

--- a/backend/conformance/importer_contract.go
+++ b/backend/conformance/importer_contract.go
@@ -235,45 +235,54 @@ func RunImporterReportsTheAbsentTargetItDroppedOnce(t *testing.T, ctx context.Co
 	assertImporterSkipped(t, result, []publicops.SkippedDependency{{IssueID: source, DependsOnID: absent}})
 }
 
-// RunImporterReportsTheCrossPlaneEdgeItDropped pins the same obligation for the
-// plane rule. The request is the one RunBatchCreatorRefusesACrossPlaneInBatchEdge
+// RunImporterWiresTheCrossPlaneEdgeBetweenItsRows pins the plane rule's OTHER
+// branch. The request is the one RunBatchCreatorRefusesACrossPlaneInBatchEdge
 // sends and refuses whole — a durable item and an ephemeral item created
-// together with an edge between them — where the import keeps BOTH ROWS and
-// drops only the edge.
+// together with an edge between them. BatchCreator refuses because its
+// unit-of-work body creates item by item and cannot promise the edge; the
+// importer writes every row of BOTH planes in one transaction before it
+// persists any edge, so the edge is writable. Until wy-a648lq the engine's
+// per-batch plane filter dropped it anyway — skip-reported, but a re-import
+// upserts both rows unchanged and never backfills it, so an exported snapshot
+// lost every regular<->wisp edge for good (wy-4276q8). A report justifies a
+// drop only when the drop is forced; this one was not.
 //
-// BOTH ROWS ARE ASSERTED, on their own tables. The dropped edge is the visible
-// part, and an implementation that dropped the ephemeral item along with it
-// would satisfy every statement about the edge: there is no edge because there
-// is no wisp. The audit twin's arm (b) reads both rows back through GetIssue,
-// which resolves across planes and so cannot say WHICH table either landed in.
-//
-// The report is again an exact list. Arm (b) of the audit case asserts no
-// report at all — it passes a nil skip callback — so a silent cross-plane drop
-// is invisible to it, which is precisely the drop BatchCreator calls data
-// loss.
-func RunImporterReportsTheCrossPlaneEdgeItDropped(t *testing.T, ctx context.Context, fixture ImporterFixture) {
+// BOTH DIRECTIONS ARE ASSERTED, because they land in different places: a wisp
+// depending on a durable row writes wisp_dependencies.depends_on_issue_id, a
+// durable row depending on a wisp writes dependencies.depends_on_wisp_id, and
+// an implementation could wire one and drop the other. Every row is asserted
+// on its own table, and the skip report must be EMPTY — an entry naming an
+// edge the batch actually wrote is the report lying in the other direction.
+func RunImporterWiresTheCrossPlaneEdgeBetweenItsRows(t *testing.T, ctx context.Context, fixture ImporterFixture) {
 	t.Helper()
 	durable := fixture.IssuePrefix + "-impplane-durable"
 	wisp := fixture.IssuePrefix + "-impplane-wisp"
+	depender := fixture.IssuePrefix + "-impplane-depender"
 
 	ephemeral := importerIssue(wisp, "the ephemeral end")
 	ephemeral.Ephemeral = true
 	ephemeral.Dependencies = []*types.Dependency{
 		{IssueID: wisp, DependsOnID: durable, Type: types.DepBlocks},
 	}
+	durableDepender := importerIssue(depender, "the durable row blocked by the wisp")
+	durableDepender.Dependencies = []*types.Dependency{
+		{IssueID: depender, DependsOnID: wisp, Type: types.DepBlocks},
+	}
 	result := runImporterBatch(t, ctx, fixture, "cross-plane",
-		importerIssue(durable, "the durable end"), ephemeral)
+		importerIssue(durable, "the durable end"), ephemeral, durableDepender)
 
 	assertImporterRowCount(t, ctx, fixture, "issues", durable, 1)
 	assertImporterRowCount(t, ctx, fixture, "wisps", wisp, 1)
-	if result.Created != 2 {
-		t.Errorf("Created = %d, want 2: dropping an edge costs the batch neither row", result.Created)
+	assertImporterRowCount(t, ctx, fixture, "issues", depender, 1)
+	if result.Created != 3 {
+		t.Errorf("Created = %d, want 3", result.Created)
 	}
-	assertImporterEdgeCount(t, ctx, fixture, wisp, durable, 0)
-	assertImporterSkipped(t, result, []publicops.SkippedDependency{{IssueID: wisp, DependsOnID: durable}})
+	assertImporterEdgeCount(t, ctx, fixture, wisp, durable, 1)
+	assertImporterEdgeCount(t, ctx, fixture, depender, wisp, 1)
+	assertImporterSkipped(t, result, nil)
 }
 
-// RunImporterReportsTheCycleEdgeItDropped pins the last of the three drops: an
+// RunImporterReportsTheCycleEdgeItDropped pins the last of the drops: an
 // in-batch dependency cycle. Both rows land, the graph stays acyclic, and the
 // ONE edge given up to keep it acyclic is named.
 //

--- a/backend/conformance/role_bundle_cases.go
+++ b/backend/conformance/role_bundle_cases.go
@@ -323,7 +323,7 @@ var roleContractCases = []roleContract{
 		func(b RoleContractBundle) func(t *testing.T) *ImporterFixture { return b.Importer },
 		RunImporterRejectsAStaleRowAndNamesIt,
 		RunImporterReportsTheAbsentTargetItDroppedOnce,
-		RunImporterReportsTheCrossPlaneEdgeItDropped,
+		RunImporterWiresTheCrossPlaneEdgeBetweenItsRows,
 		RunImporterReportsTheCycleEdgeItDropped,
 	),
 

--- a/cmd/bd/import_chunking_embedded_test.go
+++ b/cmd/bd/import_chunking_embedded_test.go
@@ -566,21 +566,16 @@ func TestImportChunkedStaleRejectedRowKeepsDeferredDepsOut(t *testing.T) {
 	}
 }
 
-// Cross-bucket (regular<->wisp) edges across a chunk boundary. The engine's
-// per-batch cross-bucket filter (issueops.filterCreateIssuesMixedBucketDependencies)
-// skip-reports a regular<->wisp edge whose endpoints are both rows of one mixed
-// batch and short-circuits on a single-plane batch. The import used to apply
-// that filter over the FULL set up front and so dropped every such edge; it now
-// defers the edge to a single-plane dependency pass. This exercises it end to
-// end against the real engine: a regular -> wisp edge straddling a chunk
-// boundary must be wired, not skip-reported, and a same-bucket wisp -> wisp
-// edge straddling the same boundary must survive as before.
-// A regular<->wisp edge between two rows of the import is never dropped: the
-// engine's per-batch cross-bucket filter would skip-report it when both
-// endpoints are rows of one mixed batch, so the import defers it to a
-// single-plane dependency pass where the target is a committed row outside
-// the batch (wy-4276q8). Pre-fix the up-front cross-bucket filter dropped
-// it and skip-reported it, and every export→import lost such edges for good.
+// Cross-bucket (regular<->wisp) edges across a chunk boundary. Pre-wy-4276q8
+// the import applied the engine's per-batch cross-bucket filter over the FULL
+// set up front and so dropped every such edge; it now defers a same-chunk one
+// to a single-plane dependency pass (a workaround the engine no longer needs
+// since wy-a648lq, which writes in-batch cross-plane edges under
+// SkipDependencyValidationErrors; wy-y52syc retires it). This exercises the
+// outcome end to end against the real engine: a regular -> wisp edge
+// straddling a chunk boundary must be wired, not skip-reported, and a
+// same-bucket wisp -> wisp edge straddling the same boundary must survive as
+// before. Every export→import used to lose such edges for good.
 func TestImportChunkedMixedRegularWispCrossBucketEdgesWired(t *testing.T) {
 	requireEmbeddedDolt(t)
 	setImportChunkSize(t, 5)

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -190,11 +190,12 @@ func importIssuesCore(ctx context.Context, _ string, store storage.DoltStorage, 
 	var err error
 	if len(issues) <= importChunkSize && !hasCrossBucketBatchEdge(issues) {
 		// Small import: one transaction, dependencies inline — exactly the
-		// pre-chunking behavior. A batch carrying a regular<->wisp edge takes
-		// the chunked path instead: the engine's per-batch cross-bucket filter
-		// (issueops.filterCreateIssuesMixedBucketDependencies) skip-reports
-		// such an edge whenever both endpoints are rows of one mixed batch, so
-		// it needs the single-plane dependency pass.
+		// pre-chunking behavior. A batch carrying a regular<->wisp edge still
+		// takes the chunked path: until wy-a648lq the engine's per-batch
+		// cross-bucket filter skip-reported such an edge whenever both
+		// endpoints were rows of one mixed batch, so it needed the single-plane
+		// dependency pass; the engine now writes it inline, and wy-y52syc
+		// retires this routing.
 		err = store.CreateIssuesWithFullOptions(ctx, issues, actor, batchOpts)
 	} else {
 		err = importIssuesChunked(ctx, store, issues, actor, batchOpts)
@@ -272,10 +273,11 @@ func assembleImportResult(issues []*types.Issue, staleSkippedIDs []string, chang
 // member is left spuriously ready — can differ from the single-transaction
 // import, which checks the whole cycle in file order), non-readiness edges
 // (related, discovered-from) that point at a later chunk, and regular<->wisp
-// edges whose target is first written in the same chunk: the engine's
-// per-batch cross-bucket filter (issueops.filterCreateIssuesMixedBucketDependencies)
-// skip-reports any regular<->wisp edge whose endpoints are both rows of one
-// mixed batch, whatever the transaction layout. Deferring such an edge opens
+// edges whose target is first written in the same chunk: until wy-a648lq the
+// engine's per-batch cross-bucket filter skip-reported any regular<->wisp edge
+// whose endpoints were both rows of one mixed batch, whatever the transaction
+// layout (it now writes such an edge under SkipDependencyValidationErrors, and
+// wy-y52syc retires this deferral). Deferring such an edge opens
 // a ready window like a cycle member's deferred edge — and a common one, since
 // Kahn's order tends to place a blocker directly before its dependent, i.e. in
 // the same chunk; dropping it — the import's former policy — lost it for good,
@@ -303,13 +305,14 @@ func assembleImportResult(issues []*types.Issue, staleSkippedIDs []string, chang
 // regular<->wisp readiness edges); every other readiness edge commits with its
 // row.
 func importIssuesChunked(ctx context.Context, store storage.DoltStorage, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) error {
-	// Cross-bucket (regular<->wisp) edges are deliberately NOT filtered out
-	// up front. The engine's per-batch filter skip-reports such an edge only
-	// when both endpoints are rows of one mixed batch, so
-	// partitionChunkedImportDeps defers one whose target lands in the same or
-	// a later chunk to the single-plane dependency pass and wires one into an
-	// earlier chunk inline (its target is then a committed row outside the
-	// batch). See the ordering notes above.
+	// Cross-bucket (regular<->wisp) edges are never filtered: since wy-a648lq
+	// the engine writes an in-batch one under SkipDependencyValidationErrors
+	// (every row of both planes is on the chunk's one tx before its dependency
+	// pass). partitionChunkedImportDeps still defers one whose target is first
+	// written in the SAME chunk to the single-plane dependency pass — the
+	// wy-4276q8 workaround for the per-batch filter the engine no longer
+	// applies, retired by wy-y52syc — and wires one into an earlier chunk
+	// inline (its target is then a committed row). See the ordering notes above.
 	ordered := orderImportIssuesForChunking(issues)
 
 	// Partitioning narrows each issue's dependency slice to its inline subset in
@@ -380,7 +383,7 @@ type deferredImportEdges struct {
 func partitionChunkedImportDeps(ordered []*types.Issue) []deferredImportEdges {
 	firstChunkOf := make(map[string]int, len(ordered))
 	// Last row wins for the bucket, mirroring the engine's own per-batch
-	// cross-bucket check (issueops.filterCreateIssuesMixedBucketDependencies).
+	// plane check (issueops.validateCreateIssuesMixedBucketDependencies).
 	wispByID := make(map[string]bool, len(ordered))
 	for pos, issue := range ordered {
 		if issue.ID == "" {
@@ -410,11 +413,12 @@ func partitionChunkedImportDeps(ordered []*types.Issue) []deferredImportEdges {
 // into edges that can be wired inline and edges that must be deferred: the
 // target is first written in a later chunk, or the edge crosses the
 // regular/wisp bucket boundary and its target is first written in the SAME
-// chunk. The engine's per-batch cross-bucket filter skip-reports a
-// regular<->wisp edge whose endpoints are both rows of one mixed batch, and
-// the import would lose it (wy-4276q8). A cross-bucket edge into an earlier
-// chunk points at a committed row outside the batch and rides inline like any
-// other.
+// chunk. Until wy-a648lq the engine's per-batch cross-bucket filter
+// skip-reported a regular<->wisp edge whose endpoints were both rows of one
+// mixed batch, and the import lost it (wy-4276q8); the engine now writes such
+// an edge, and this deferral is kept only until wy-y52syc retires it. A
+// cross-bucket edge into an earlier chunk points at a committed row outside
+// the batch and rides inline like any other.
 func splitDepsByChunk(deps []*types.Dependency, rowChunk int, rowIsWisp bool, firstChunkOf map[string]int, wispByID map[string]bool) (inline, later []*types.Dependency) {
 	for _, dep := range deps {
 		if dep == nil {
@@ -450,10 +454,11 @@ func crossesBucket(dep *types.Dependency, rowIsWisp bool, wispByID map[string]bo
 }
 
 // hasCrossBucketBatchEdge reports whether any row's dependency points at
-// another row of the same batch on the other plane (regular<->wisp). The
-// engine's per-batch cross-bucket filter would skip-report such an edge, so an
-// import carrying one must take the chunked path and defer it to the
-// single-plane dependency pass.
+// another row of the same batch on the other plane (regular<->wisp). Until
+// wy-a648lq the engine's per-batch cross-bucket filter skip-reported such an
+// edge, so an import carrying one takes the chunked path and defers it to the
+// single-plane dependency pass; the engine now writes it inline, and
+// wy-y52syc retires this routing.
 func hasCrossBucketBatchEdge(issues []*types.Issue) bool {
 	wispByID := make(map[string]bool, len(issues))
 	for _, issue := range issues {
@@ -524,12 +529,12 @@ func wireDeferredImportDeps(ctx context.Context, store storage.DoltStorage, defe
 	// whose phase-1 write committed.
 	depOpts.OnStaleRejected = nil
 	// Regular-source rows and wisp-source rows go in separate transactions.
-	// The engine's per-batch cross-bucket filter
-	// (issueops.filterCreateIssuesMixedBucketDependencies) skip-reports a
-	// regular<->wisp edge whose target row is in the same mixed batch, and a
-	// deferred cross-bucket edge's target may itself carry deferred edges — a
-	// mixed batch could re-trigger exactly the skip this pass exists to avoid.
-	// The filter short-circuits on a single-plane batch, so with every batch
+	// Until wy-a648lq the engine's per-batch cross-bucket filter skip-reported
+	// a regular<->wisp edge whose target row was in the same mixed batch, and
+	// a deferred cross-bucket edge's target may itself carry deferred edges —
+	// a mixed batch could re-trigger exactly the skip this pass existed to
+	// avoid. (The engine now writes such an edge; wy-y52syc retires the split.)
+	// That filter short-circuited on a single-plane batch, so with every batch
 	// on one plane nothing can be filtered, and every target is a committed
 	// phase-1 row.
 	depTotal := len(depRows)

--- a/internal/storage/embeddeddolt/create_issue_test.go
+++ b/internal/storage/embeddeddolt/create_issue_test.go
@@ -982,7 +982,12 @@ func TestCreateIssues(t *testing.T) {
 		te.assertRowNotExists(t, ctx, "wisps", wisp.ID)
 	})
 
-	t.Run("skips_mixed_batch_dependency_when_validation_errors_are_tolerated", func(t *testing.T) {
+	// A tolerant mixed batch (the importer's shape, SkipDependencyValidationErrors)
+	// keeps its regular->wisp edge: every row of both planes is written on the
+	// one transaction before the dependency pass, so the edge is writable
+	// (wy-a648lq). Nothing is skip-reported, and the edge lands in
+	// dependencies.depends_on_wisp_id — the regular source's own table.
+	t.Run("wires_mixed_batch_dependency_when_validation_errors_are_tolerated", func(t *testing.T) {
 		te := newTestEnv(t, "sk")
 		ctx := t.Context()
 
@@ -1019,17 +1024,15 @@ func TestCreateIssues(t *testing.T) {
 		}
 		te.assertRowExists(t, ctx, "issues", regular.ID)
 		te.assertRowExists(t, ctx, "wisps", wisp.ID)
-		if len(skipped) != 1 ||
-			!strings.Contains(skipped[0], "sk-regular-source -> sk-wisp-target") ||
-			!strings.Contains(skipped[0], "cross-bucket dependency") {
-			t.Fatalf("skipped = %#v, want cross-bucket dependency detail", skipped)
+		if len(skipped) != 0 {
+			t.Fatalf("skipped = %#v, want the in-batch cross-plane edge wired, not skip-reported", skipped)
 		}
 
 		var regularDeps, wispDeps int
-		te.queryScalar(t, ctx, "SELECT COUNT(*) FROM dependencies WHERE issue_id = ?", []any{regular.ID}, &regularDeps)
+		te.queryScalar(t, ctx, "SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND depends_on_wisp_id = ? AND depends_on_issue_id IS NULL", []any{regular.ID, wisp.ID}, &regularDeps)
 		te.queryScalar(t, ctx, "SELECT COUNT(*) FROM wisp_dependencies WHERE issue_id = ?", []any{regular.ID}, &wispDeps)
-		if regularDeps != 0 || wispDeps != 0 {
-			t.Fatalf("persisted dependency counts = regular:%d wisp:%d, want none", regularDeps, wispDeps)
+		if regularDeps != 1 || wispDeps != 0 {
+			t.Fatalf("persisted dependency counts = regular(depends_on_wisp_id):%d wisp:%d, want 1 and 0", regularDeps, wispDeps)
 		}
 	})
 

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -276,11 +276,22 @@ func CreateIssuesInTxWithResult(ctx context.Context, tx DBTX, issues []*types.Is
 // The caller's bc is not modified, so one context can serve several calls.
 func CreateIssuesInTxWithContext(ctx context.Context, tx DBTX, bc *BatchContext, issues []*types.Issue, actor string) (CreateIssuesResult, error) {
 	opts := bc.Opts
-	filteredIssues, err := filterCreateIssuesMixedBucketDependencies(issues, opts)
-	if err != nil {
-		return CreateIssuesResult{}, err
+	// The plane rule is a REFUSAL, never a filter. A strict batch (BatchCreator's
+	// contract) is refused whole before any row is written. A tolerant batch
+	// (SkipDependencyValidationErrors — the import mode) keeps every in-batch
+	// regular<->wisp edge: every row of BOTH planes is written on this one tx
+	// below before PersistDependenciesWithOptionsResult runs, and that pass
+	// resolves each target on its own plane, so the edge is writable — the
+	// old per-batch filter skip-reported it, and since a re-import upserts the
+	// rows unchanged the edge was never backfilled (wy-4276q8, wy-a648lq). A
+	// caller that writes the two planes on different SQL sessions
+	// (doltTransaction.CreateIssues) validates up front and passes one plane
+	// per call, so a mixed batch reaching here always shares one tx.
+	if !opts.SkipDependencyValidationErrors {
+		if err := validateCreateIssuesMixedBucketDependencies(issues); err != nil {
+			return CreateIssuesResult{}, err
+		}
 	}
-	issues = filteredIssues
 
 	// This function already runs a slice-wide ReconcileChildCounters below,
 	// covering every accepted issue; skip the redundant per-issue reconcile.
@@ -377,16 +388,20 @@ func stageableChangedTables(changed map[string]bool) map[string]bool {
 	return dirty
 }
 
-// ValidateCreateIssuesMixedBucketDependencies rejects same-batch dependency
-// edges between regular issues and wisps. Dependencies are stored in separate
-// backing tables per bucket, so a batch cannot create both ends atomically when
-// the edge crosses buckets.
+// ValidateCreateIssuesMixedBucketDependencies refuses same-batch dependency
+// edges between regular issues and wisps. It is the plane rule of the STRICT
+// batch (BatchCreator's contract, CrossPlaneBatchEdgeError): a caller whose
+// regular and wisp rows are written on different SQL sessions
+// (doltTransaction.CreateIssues) cannot create both ends of such an edge
+// atomically, so the batch is refused whole before any row is written. It is
+// deliberately NOT applied to a tolerant batch (SkipDependencyValidationErrors):
+// on one tx the dependency pass runs after every row of both planes exists and
+// writes the edge (see CreateIssuesInTxWithContext).
 func ValidateCreateIssuesMixedBucketDependencies(issues []*types.Issue) error {
-	_, err := filterCreateIssuesMixedBucketDependencies(issues, storage.BatchCreateOptions{})
-	return err
+	return validateCreateIssuesMixedBucketDependencies(issues)
 }
 
-func filterCreateIssuesMixedBucketDependencies(issues []*types.Issue, opts storage.BatchCreateOptions) ([]*types.Issue, error) {
+func validateCreateIssuesMixedBucketDependencies(issues []*types.Issue) error {
 	batchWispByID := make(map[string]bool, len(issues))
 	hasRegular := false
 	hasWisp := false
@@ -405,21 +420,15 @@ func filterCreateIssuesMixedBucketDependencies(issues []*types.Issue, opts stora
 		}
 	}
 	if !hasRegular || !hasWisp {
-		return issues, nil
+		return nil
 	}
 
-	var filteredIssues []*types.Issue
-	for issueIndex, issue := range issues {
+	for _, issue := range issues {
 		if issue == nil {
 			continue
 		}
-		var keptDeps []*types.Dependency
-		filteredDeps := false
-		for depIndex, dep := range issue.Dependencies {
+		for _, dep := range issue.Dependencies {
 			if dep == nil {
-				if filteredDeps {
-					keptDeps = append(keptDeps, dep)
-				}
 				continue
 			}
 			sourceID := issue.ID
@@ -432,37 +441,15 @@ func filterCreateIssuesMixedBucketDependencies(issues []*types.Issue, opts stora
 			}
 			targetIsWisp, targetInBatch := batchWispByID[dep.DependsOnID]
 			if targetInBatch && sourceIsWisp != targetIsWisp {
-				if !opts.SkipDependencyValidationErrors {
-					// Through the shared constructor, so the two bodies raise
-					// one message AND one sentinel: the role promises this
-					// refusal is the caller's fault, and an untyped error left
-					// callers classifying it by prose.
-					return nil, CrossPlaneBatchEdgeError(sourceID, dep.DependsOnID)
-				}
-				if !filteredDeps {
-					keptDeps = append([]*types.Dependency(nil), issue.Dependencies[:depIndex]...)
-					filteredDeps = true
-				}
-				recordSkippedDependencyEdge(opts, sourceID, dep.DependsOnID, "cross-bucket dependency between regular issue and wisp in the same batch")
-				continue
-			}
-			if filteredDeps {
-				keptDeps = append(keptDeps, dep)
+				// Through the shared constructor, so the two bodies raise
+				// one message AND one sentinel: the role promises this
+				// refusal is the caller's fault, and an untyped error left
+				// callers classifying it by prose.
+				return CrossPlaneBatchEdgeError(sourceID, dep.DependsOnID)
 			}
 		}
-		if filteredDeps {
-			if filteredIssues == nil {
-				filteredIssues = append([]*types.Issue(nil), issues...)
-			}
-			issueCopy := *issue
-			issueCopy.Dependencies = keptDeps
-			filteredIssues[issueIndex] = &issueCopy
-		}
 	}
-	if filteredIssues != nil {
-		return filteredIssues, nil
-	}
-	return issues, nil
+	return nil
 }
 
 func createBlockedRecomputeIDs(ctx context.Context, tx DBTX, issues []*types.Issue, dependencies []persistedDependency) ([]string, []string, error) {

--- a/internal/storage/issueops/create_batch.go
+++ b/internal/storage/issueops/create_batch.go
@@ -187,7 +187,7 @@ func ExecuteCreateBatch(ctx context.Context, tx *sql.Tx, request publicops.Creat
 }
 
 // CrossPlaneBatchEdgeError is the refusal the store-backed body raises from
-// filterCreateIssuesMixedBucketDependencies, spelled here so the unit-of-work
+// validateCreateIssuesMixedBucketDependencies, spelled here so the unit-of-work
 // body can raise the identical one before it starts writing.
 func CrossPlaneBatchEdgeError(sourceID, targetID string) error {
 	return fmt.Errorf("mixed regular/wisp CreateIssues batch cannot include cross-bucket dependency %s -> %s; create the issues first, then add the in-batch dependency after both issues exist%.0w",

--- a/internal/storage/issueops/create_test.go
+++ b/internal/storage/issueops/create_test.go
@@ -111,46 +111,6 @@ func TestValidateCreateIssuesMixedBucketDependenciesRejectsCrossBucketEdges(t *t
 	}
 }
 
-func TestFilterCreateIssuesMixedBucketDependenciesSkipsWhenConfigured(t *testing.T) {
-	regular := &types.Issue{
-		ID:        "test-regular-source",
-		IssueType: types.TypeTask,
-		Dependencies: []*types.Dependency{{
-			DependsOnID: "test-wisp-target",
-			Type:        types.DepBlocks,
-		}},
-	}
-	wisp := &types.Issue{
-		ID:        "test-wisp-target",
-		IssueType: types.TypeTask,
-		Ephemeral: true,
-	}
-	var skipped []string
-
-	filtered, err := filterCreateIssuesMixedBucketDependencies([]*types.Issue{regular, wisp}, storage.BatchCreateOptions{
-		SkipDependencyValidationErrors: true,
-		OnSkippedDependency: func(issueID, dependsOnID, reason string) {
-			skipped = append(skipped, issueID+" -> "+dependsOnID+": "+reason)
-		},
-	})
-	if err != nil {
-		t.Fatalf("filterCreateIssuesMixedBucketDependencies error = %v, want nil", err)
-	}
-	if len(filtered) != 2 {
-		t.Fatalf("len(filtered) = %d, want 2", len(filtered))
-	}
-	if len(filtered[0].Dependencies) != 0 {
-		t.Fatalf("filtered[0].Dependencies = %#v, want none", filtered[0].Dependencies)
-	}
-	if len(regular.Dependencies) != 1 {
-		t.Fatalf("regular.Dependencies was mutated to %#v, want original dependency preserved", regular.Dependencies)
-	}
-	if len(skipped) != 1 || !strings.Contains(skipped[0], "test-regular-source -> test-wisp-target") ||
-		!strings.Contains(skipped[0], "cross-bucket dependency") {
-		t.Fatalf("skipped = %#v, want cross-bucket dependency detail", skipped)
-	}
-}
-
 func TestPersistDependenciesHonorsImportedCreatedBy(t *testing.T) {
 	ctx := context.Background()
 	db, mock, tx := beginMockTx(t)

--- a/internal/storage/leg_contract_wiring_test.go
+++ b/internal/storage/leg_contract_wiring_test.go
@@ -36,18 +36,18 @@ const importerOneAccessorWaiverReason = "Importer has one accessor (uow.Importer
 // brings its waivers the same way; see unwiredContractEntrypoints.
 func init() {
 	registerContractLegWaivers("dolt", map[string]string{
-		"RunImporterRejectsAStaleRowAndNamesIt":          importerOneAccessorWaiverReason,
-		"RunImporterReportsTheAbsentTargetItDroppedOnce": importerOneAccessorWaiverReason,
-		"RunImporterReportsTheCrossPlaneEdgeItDropped":   importerOneAccessorWaiverReason,
-		"RunImporterReportsTheCycleEdgeItDropped":        importerOneAccessorWaiverReason,
-		"RunBootstrapperRecordsExactlyOneHistoryEntry":   bootstrapSplitWaiverReason,
+		"RunImporterRejectsAStaleRowAndNamesIt":           importerOneAccessorWaiverReason,
+		"RunImporterReportsTheAbsentTargetItDroppedOnce":  importerOneAccessorWaiverReason,
+		"RunImporterWiresTheCrossPlaneEdgeBetweenItsRows": importerOneAccessorWaiverReason,
+		"RunImporterReportsTheCycleEdgeItDropped":         importerOneAccessorWaiverReason,
+		"RunBootstrapperRecordsExactlyOneHistoryEntry":    bootstrapSplitWaiverReason,
 	})
 	registerContractLegWaivers("embeddeddolt", map[string]string{
-		"RunImporterRejectsAStaleRowAndNamesIt":          importerOneAccessorWaiverReason,
-		"RunImporterReportsTheAbsentTargetItDroppedOnce": importerOneAccessorWaiverReason,
-		"RunImporterReportsTheCrossPlaneEdgeItDropped":   importerOneAccessorWaiverReason,
-		"RunImporterReportsTheCycleEdgeItDropped":        importerOneAccessorWaiverReason,
-		"RunBootstrapperRecordsExactlyOneHistoryEntry":   bootstrapSplitWaiverReason,
+		"RunImporterRejectsAStaleRowAndNamesIt":           importerOneAccessorWaiverReason,
+		"RunImporterReportsTheAbsentTargetItDroppedOnce":  importerOneAccessorWaiverReason,
+		"RunImporterWiresTheCrossPlaneEdgeBetweenItsRows": importerOneAccessorWaiverReason,
+		"RunImporterReportsTheCycleEdgeItDropped":         importerOneAccessorWaiverReason,
+		"RunBootstrapperRecordsExactlyOneHistoryEntry":    bootstrapSplitWaiverReason,
 	})
 	registerContractLegWaivers("uow", map[string]string{
 		"RunBootstrapperRecordsNoHistoryEntryOfItsOwn":                   bootstrapSplitWaiverReason,

--- a/internal/storage/uow/importer_contract_test.go
+++ b/internal/storage/uow/importer_contract_test.go
@@ -34,8 +34,8 @@ func TestImporterContract(t *testing.T) {
 	t.Run("ReportsTheAbsentTargetItDroppedOnce", func(t *testing.T) {
 		conformance.RunImporterReportsTheAbsentTargetItDroppedOnce(t, ctx, fixture)
 	})
-	t.Run("ReportsTheCrossPlaneEdgeItDropped", func(t *testing.T) {
-		conformance.RunImporterReportsTheCrossPlaneEdgeItDropped(t, ctx, fixture)
+	t.Run("WiresTheCrossPlaneEdgeBetweenItsRows", func(t *testing.T) {
+		conformance.RunImporterWiresTheCrossPlaneEdgeBetweenItsRows(t, ctx, fixture)
 	})
 	t.Run("ReportsTheCycleEdgeItDropped", func(t *testing.T) {
 		conformance.RunImporterReportsTheCycleEdgeItDropped(t, ctx, fixture)

--- a/internal/storage/uow/importer_uow_test.go
+++ b/internal/storage/uow/importer_uow_test.go
@@ -118,6 +118,57 @@ func TestImporterUOW(t *testing.T) {
 		}
 	})
 
+	t.Run("CrossPlaneInBatchEdgesAreWiredInTheOneCommit", func(t *testing.T) {
+		// wy-a648lq: a regular<->wisp edge whose BOTH ends are rows of this
+		// batch used to be skip-reported by the engine's per-batch plane filter,
+		// and since a re-import upserts the rows unchanged it could never be
+		// backfilled. Both directions are asserted because they land in
+		// different tables and columns.
+		before := countHistory(t)
+		when := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+		result, err := imp.ImportBatch(ctx, publicops.ImportBatchRequest{
+			Actor: "importer-test",
+			Issues: []*types.Issue{
+				{
+					ID: "imp-plane-d", Title: "Durable end", Status: types.StatusOpen,
+					IssueType: types.TypeTask, Priority: 2,
+					CreatedAt: when, UpdatedAt: when,
+				},
+				{
+					ID: "imp-plane-w", Title: "Ephemeral end", Status: types.StatusOpen,
+					IssueType: types.TypeTask, Priority: 2, Ephemeral: true,
+					Dependencies: []*types.Dependency{{IssueID: "imp-plane-w", DependsOnID: "imp-plane-d", Type: types.DepBlocks}},
+					CreatedAt:    when, UpdatedAt: when,
+				},
+				{
+					ID: "imp-plane-d2", Title: "Durable row blocked by the wisp", Status: types.StatusOpen,
+					IssueType: types.TypeTask, Priority: 2,
+					Dependencies: []*types.Dependency{{IssueID: "imp-plane-d2", DependsOnID: "imp-plane-w", Type: types.DepBlocks}},
+					CreatedAt:    when, UpdatedAt: when,
+				},
+			},
+			Source: "planes.jsonl",
+		})
+		if err != nil {
+			t.Fatalf("ImportBatch: %v", err)
+		}
+		if result.Created != 3 {
+			t.Errorf("Created = %d, want 3", result.Created)
+		}
+		if len(result.SkippedDependencies) != 0 {
+			t.Errorf("SkippedDependencies = %+v, want none: both ends of each edge are rows of this batch", result.SkippedDependencies)
+		}
+		if after := countHistory(t); after != before+1 {
+			t.Errorf("history entries = %d, want %d (the edges ride the batch's ONE commit)", after, before+1)
+		}
+		if got := queryInt(t, "SELECT COUNT(*) FROM wisp_dependencies WHERE issue_id = 'imp-plane-w' AND depends_on_issue_id = 'imp-plane-d' AND type = 'blocks'"); got != 1 {
+			t.Errorf("wisp -> durable blocks edge = %d, want 1", got)
+		}
+		if got := queryInt(t, "SELECT COUNT(*) FROM dependencies WHERE issue_id = 'imp-plane-d2' AND depends_on_wisp_id = 'imp-plane-w' AND type = 'blocks'"); got != 1 {
+			t.Errorf("durable -> wisp blocks edge = %d, want 1", got)
+		}
+	})
+
 	t.Run("ReimportConvergesWithoutDuplicatingAuxData", func(t *testing.T) {
 		when := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
 		row := func() *types.Issue {


### PR DESCRIPTION
Proxied-mode `bd import` (one ImportBatch -> uow/importer.go ->
issueops.CreateIssuesInTxWithResult with SkipDependencyValidationErrors)
still lost every regular<->wisp dependency edge whose both endpoints were
rows of the batch: the engine's in-memory per-batch plane filter
skip-reported it, and since a re-import upserts both rows unchanged the
edge could never be backfilled. The classic path only dodged the same
filter by deferring such edges to a single-plane pass (wy-4276q8, 2878c5373).

The filter was never needed on a single-transaction batch: every row of BOTH
planes is written on the one tx before PersistDependenciesWithOptions runs,
and that pass resolves each target on its own plane, so the edge is writable.
The plane rule is now a REFUSAL only — a strict batch (BatchCreator's
contract, CrossPlaneBatchEdgeError) is still refused whole; a tolerant batch
keeps the edge. doltTransaction.CreateIssues (two SQL sessions) already
validates up front and passes one plane per call, so no mixed batch on split
sessions can reach the engine.

- issueops/create.go: validate only when !SkipDependencyValidationErrors; the
  filter shrinks to a validator. FilterCreateIssuesMixedBucketDependencies
  (dead) is gone, and with it the wy-4276q8 F6 case.
- Contracts flipped to the corrected promise: conformance
  RunImporterReportsTheCrossPlaneEdgeItDropped ->
  RunImporterWiresTheCrossPlaneEdgeBetweenItsRows (both directions, both
  tables, empty skip report); the wisp-batch audit's tolerant arm (b) asserts
  the edge is wired.
- New TestImporterUOW/CrossPlaneInBatchEdgesAreWiredInTheOneCommit (real
  Dolt): wisp->durable and durable->wisp wired in ONE history entry, no
  SkippedDependencies.
- Classic-path comments corrected; its same-chunk deferral is now redundant
  (retired separately in wy-y52syc).

Review: Fable adversarial review PASS on wy-mmvhrn (vacuity performed: all
three new/flipped instruments go red against the pre-fix create.go).
Bead: wy-a648lq (follow-up to wy-4276q8).