### PR TITLE
test(import): resume converges as Created+Unchanged, not Created (wy-7fd89p)

### DIFF
--- a/cmd/bd/import_chunking_embedded_test.go
+++ b/cmd/bd/import_chunking_embedded_test.go
@@ -120,12 +120,28 @@ func TestImportChunkedRealStoreResumeConverges(t *testing.T) {
 	}
 
 	// Re-run the identical import: it must converge.
+	//
+	// Created counts the rows THIS invocation wrote, not the rows the file
+	// put in the store (it is len(ImportedIDs), the post-filter write set).
+	// The durable prefix the crash left behind is proven a no-op by the
+	// resume fast path — same updated_at, same columns, every incoming
+	// label, comment and dependency already stored — so those rows leave the
+	// write set and are reported as Unchanged instead (wy-sbgucn). "All 12
+	// rows accounted for" is therefore Created+Unchanged, which is exactly
+	// the total `bd import` reports as its issue count (ImportData sets
+	// result.Issues = Created + Unchanged). Counting the skipped prefix as
+	// Created again would report rows the import never wrote and would put
+	// the real run out of step with --dry-run, which classifies the same
+	// rows through the same pre-filter.
 	result, err := importIssuesCore(ctx, "", store, makeIssues(), ImportOptions{SkipPrefixValidation: true})
 	if err != nil {
 		t.Fatalf("re-run importIssuesCore: %v", err)
 	}
-	if result.Created != 12 {
-		t.Fatalf("re-run Created = %d, want all 12 rows accounted for", result.Created)
+	// 5 durable rows skipped + 7 written = the 12 input rows, and a nonzero
+	// Unchanged is what proves the fast path skipped the committed prefix
+	// rather than rewriting it (the pre-wy-sbgucn behavior, Created=12).
+	if result.Created != 7 || result.Unchanged != 5 {
+		t.Fatalf("re-run Created = %d, Unchanged = %d; want 7 written + the 5 durable rows skipped (all 12 accounted for)", result.Created, result.Unchanged)
 	}
 	for i := 1; i <= 12; i++ {
 		id := fmt.Sprintf("bd-chunk%02d", i)


### PR DESCRIPTION
`TestImportChunkedRealStoreResumeConverges` has been **red on `main`** since e05000d64 (the wy-sbgucn resume fast path). On a pristine `main` (0efe0adf5):

```
BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd -run TestImportChunkedRealStoreResumeConverges -count=1
--- FAIL: TestImportChunkedRealStoreResumeConverges (23.52s)
    import_chunking_embedded_test.go:128: re-run Created = 7, want all 12 rows accounted for
```

The suite is skipped without `BEADS_TEST_EMBEDDED_DOLT=1`, which is why the wy-sbgucn gate stayed green. It was reproduced independently by two reviewers and isolated *away* from both wy-4276q8 and wy-a648lq — it is a pre-existing `main` red, and while it stands it hides the next real resume regression.

## Which side is wrong

The **test expectation**, not the accounting.

`ImportResult.Created` is `len(importedIDs)` — the rows *this invocation wrote*, taken from the post-filter write set. The resume fast path proves the crash's durable prefix a no-op (same `updated_at`, same columns, every incoming label/comment/dependency already stored) and drops those rows from the write set, reporting them as `Unchanged`. Counting them as `Created` again would report rows the import never wrote, and would put the real run out of step with `--dry-run`, which classifies the same rows through the same pre-filter.

"All 12 rows accounted for" is therefore `Created + Unchanged` — which is already what `bd import` prints: `ImportData` sets `result.Issues = importResult.Created + importResult.Unchanged`.

## Change

Test-only. The re-run now asserts `Created == 7 && Unchanged == 5` against the 5 durable rows the test already pins above, and the comment states the chosen semantics. A nonzero `Unchanged` is also what distinguishes the fast path from the pre-wy-sbgucn behaviour it replaced (which rewrote the prefix and reported `Created = 12`).

No production behaviour changes.

## Verification

- `BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd -run TestImportChunkedRealStoreResumeConverges -count=1` — **FAIL** before, **ok (45.98s)** after.
- `go build ./...` rc=0, `go vet ./...` rc=0, `gofmt -l ./cmd ./internal` clean.
- Full `make test` was not run to completion locally: it times out on this box on tests unrelated to this diff (two prior 25m/35m attempts died in `cmd/bd` on `TestInitReinitLocalConfiguredRemoteWithoutDoltDataSucceeds` and `TestQuickBlockedDuringMigrationFreeze`). CI is the authority here — cf. #6121, which is raising the macOS lane timeout for the same reason.

Tracked as wy-7fd89p.