### PR TITLE
feat(update): add -l shorthand for --add-label, matching bd create -l

### DIFF
--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -984,7 +984,21 @@ func init() {
 	updateCmd.Flags().String("acceptance-criteria", "", "DEPRECATED: use --acceptance")
 	_ = updateCmd.Flags().MarkHidden("acceptance-criteria") // Only fails if flag missing (caught in tests)
 	updateCmd.Flags().IntP("estimate", "e", 0, "Time estimate in minutes (e.g., 60 for 1 hour)")
-	updateCmd.Flags().StringSlice("add-label", nil, "Add labels (repeatable)")
+	// -l is the shorthand for --add-label, matching `bd create -l`.
+	//
+	// WHY: `bd create` registers labels as StringSliceP("labels", "l", ...), so
+	// `bd create -l foo` works. `bd update -l foo` did not, and cobra's response
+	// to an unknown shorthand is to print usage and exit 1. That is a correct
+	// failure, but it is a SILENT one to any caller that does not check the exit
+	// code — and callers copying the `create` form have no reason to expect the
+	// flag to differ. In one deployment this caused issues to be believed
+	// labeled when they were not, for as long as it took someone to check the
+	// label by hand.
+	//
+	// Additive rather than a rename: --add-label keeps working unchanged.
+	// -l maps to ADD (not set) because add is the non-destructive reading and
+	// matches what `create -l` does on a new issue.
+	updateCmd.Flags().StringSliceP("add-label", "l", nil, "Add labels (repeatable); -l matches `bd create -l`")
 	updateCmd.Flags().StringSlice("remove-label", nil, "Remove labels (repeatable)")
 	updateCmd.Flags().StringSlice("set-labels", nil, "Set labels, replacing all existing (repeatable)")
 	updateCmd.Flags().String("parent", "", "New parent issue ID (reparents the issue, use empty string to remove parent)")


### PR DESCRIPTION
`bd create` registers labels as `StringSliceP("labels", "l", ...)`, so `bd create -l foo` works. `bd update -l foo` did not — `updateCmd` registers `--add-label`, `--remove-label` and `--set-labels` with no shorthands, and cobra's response to an unknown shorthand is to print usage and exit 1.

That is a correct failure, but an easy one to miss in practice. A caller copying the `create` form has no reason to expect the flag to differ, and the output looks like help rather than an error in a scrolled log. In our deployment this left issues believed-labelled that were not, until someone checked a label by hand — the exit code was there, nobody was reading it.

### The change

One flag registration: `StringSlice("add-label", ...)` becomes `StringSliceP("add-label", "l", ...)`.

- **Additive.** `--add-label` is unchanged; this only adds the shorthand.
- **`-l` maps to ADD, not SET.** Add is the non-destructive reading, and it matches what `create -l` does on a new issue. `--set-labels` stays long-form-only, which seems right for a destructive operation.
- **No collision.** `updateCmd`'s existing shorthands are `-s` (status), `-t` (type), `-e` (estimate). `-l` was unregistered.

### Testing

`go build ./cmd/bd`, `go vet ./cmd/bd/`, `gofmt` clean.
`go test ./cmd/bd/ -run Update -count=1` passes (74.7s).

Verified by hand against a scratch embedded DB: `bd update <id> -l human` now exits 0 and applies the label; `bd update <id> --add-label second` still appends, giving `['human', 'second']`.

I did not run the full `./cmd/bd` suite to green on this branch — it spawns Dolt servers and takes ~400s on a shared box, and I have no clean baseline to compare against. If you would like that before merging, say so and I will produce it.
