### PR TITLE
Preserve local orchestration state during Linear pulls (SHUN-3389)

### DIFF
--- a/internal/linear/fieldmapper.go
+++ b/internal/linear/fieldmapper.go
@@ -76,6 +76,12 @@ func (m *linearFieldMapper) IssueToBeads(ti *tracker.TrackerIssue) *tracker.Issu
 	}
 }
 
+// MergeLocalFields preserves orchestration controls that Linear cannot own
+// while allowing product fields to continue syncing through the engine.
+func (m *linearFieldMapper) MergeLocalFields(local, remote *types.Issue) {
+	MergeLocalControlState(local, remote, m.config)
+}
+
 func (m *linearFieldMapper) IssueToTracker(issue *types.Issue) map[string]interface{} {
 	updates := map[string]interface{}{
 		"title":       issue.Title,

--- a/internal/linear/mapping.go
+++ b/internal/linear/mapping.go
@@ -160,7 +160,14 @@ type MappingConfig struct {
 	// CustomStatuses holds typed entries from status.custom (beads config).
 	// Used for push-time state_map validation and matching non-built-in statuses.
 	CustomStatuses []types.CustomStatus
+
+	// LocalControlLabels identifies labels owned by a local orchestration layer
+	// rather than Linear. Existing issues carrying one of these labels retain
+	// their local status, assignee, and control labels during Linear pull.
+	LocalControlLabels []string
 }
+
+var defaultLocalControlLabels = []string{"agent-plan", "planner-intake", "human"}
 
 // DefaultMappingConfig returns sensible default mappings.
 func DefaultMappingConfig() *MappingConfig {
@@ -182,8 +189,9 @@ func DefaultMappingConfig() *MappingConfig {
 			"completed": "closed",
 			"canceled":  "closed",
 		},
-		ExplicitStateMap: make(map[string]string),
-		OutboundStateMap: make(map[string]string),
+		ExplicitStateMap:   make(map[string]string),
+		OutboundStateMap:   make(map[string]string),
+		LocalControlLabels: append([]string(nil), defaultLocalControlLabels...),
 		// Label patterns for issue type inference
 		LabelTypeMap: map[string]string{
 			"bug":         "bug",
@@ -207,6 +215,66 @@ func DefaultMappingConfig() *MappingConfig {
 			"related":   "related",
 		},
 	}
+}
+
+// MergeLocalControlState overlays local orchestration controls onto a Linear
+// conversion. Linear remains authoritative for product fields and labels; a
+// local issue carrying a configured control label keeps its status and
+// assignee, and its control labels are merged back into the converted label
+// set. The input local issue is never mutated.
+func MergeLocalControlState(local, remote *types.Issue, config *MappingConfig) {
+	if local == nil || remote == nil {
+		return
+	}
+
+	controlNames := localControlLabelNames(config)
+	localControls := make([]string, 0)
+	for _, label := range local.Labels {
+		trimmed := strings.TrimSpace(label)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := controlNames[strings.ToLower(trimmed)]; ok {
+			localControls = append(localControls, trimmed)
+		}
+	}
+	if len(localControls) == 0 {
+		return
+	}
+
+	remote.Status = local.Status
+	remote.Assignee = local.Assignee
+
+	labels := append([]string(nil), remote.Labels...)
+	seen := make(map[string]struct{}, len(labels)+len(localControls))
+	for _, label := range labels {
+		trimmed := strings.TrimSpace(label)
+		if trimmed != "" {
+			seen[trimmed] = struct{}{}
+		}
+	}
+	for _, label := range localControls {
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		labels = append(labels, label)
+		seen[label] = struct{}{}
+	}
+	remote.Labels = labels
+}
+
+func localControlLabelNames(config *MappingConfig) map[string]struct{} {
+	labels := defaultLocalControlLabels
+	if config != nil && len(config.LocalControlLabels) > 0 {
+		labels = config.LocalControlLabels
+	}
+	names := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		if normalized := strings.ToLower(strings.TrimSpace(label)); normalized != "" {
+			names[normalized] = struct{}{}
+		}
+	}
+	return names
 }
 
 // ConfigLoader is an interface for loading configuration values.

--- a/internal/linear/mapping_test.go
+++ b/internal/linear/mapping_test.go
@@ -464,6 +464,105 @@ func TestIssueToBeads(t *testing.T) {
 	}
 }
 
+func TestMergeLocalControlStatePreservesControlsAndSyncsProductFields(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	tests := []struct {
+		name           string
+		localStatus    types.Status
+		localAssignee  string
+		localLabels    []string
+		remoteStatus   types.Status
+		remoteAssignee string
+		remoteLabels   []string
+		wantLabels     []string
+	}{
+		{
+			name:           "agent plan reservation",
+			localStatus:    types.StatusInProgress,
+			localAssignee:  "planner@example.com",
+			localLabels:    []string{"agent-plan", "planner-intake"},
+			remoteStatus:   types.StatusClosed,
+			remoteAssignee: "linear@example.com",
+			remoteLabels:   []string{"product"},
+			wantLabels:     []string{"agent-plan", "planner-intake", "product"},
+		},
+		{
+			name:           "human gate",
+			localStatus:    types.StatusBlocked,
+			localAssignee:  "operator@example.com",
+			localLabels:    []string{"human"},
+			remoteStatus:   types.StatusOpen,
+			remoteAssignee: "linear@example.com",
+			remoteLabels:   []string{"product"},
+			wantLabels:     []string{"human", "product"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			local := &types.Issue{
+				Status:   tt.localStatus,
+				Assignee: tt.localAssignee,
+				Labels:   append([]string(nil), tt.localLabels...),
+			}
+			remote := &types.Issue{
+				Title:       "Linear title",
+				Description: "Linear description",
+				Priority:    1,
+				Status:      tt.remoteStatus,
+				Assignee:    tt.remoteAssignee,
+				Labels:      append([]string(nil), tt.remoteLabels...),
+			}
+
+			(&linearFieldMapper{config: config}).MergeLocalFields(local, remote)
+
+			if remote.Status != tt.localStatus {
+				t.Fatalf("status = %q, want local %q", remote.Status, tt.localStatus)
+			}
+			if remote.Assignee != tt.localAssignee {
+				t.Fatalf("assignee = %q, want local %q", remote.Assignee, tt.localAssignee)
+			}
+			gotLabels := append([]string(nil), remote.Labels...)
+			slices.Sort(gotLabels)
+			wantLabels := append([]string(nil), tt.wantLabels...)
+			slices.Sort(wantLabels)
+			if !slices.Equal(gotLabels, wantLabels) {
+				t.Fatalf("labels = %v, want %v", gotLabels, wantLabels)
+			}
+			if remote.Title != "Linear title" || remote.Description != "Linear description" || remote.Priority != 1 {
+				t.Fatalf("product fields changed during merge: %+v", remote)
+			}
+			if !slices.Equal(local.Labels, tt.localLabels) {
+				t.Fatalf("local labels mutated: %v", local.Labels)
+			}
+		})
+	}
+}
+
+func TestMergeLocalControlStateLeavesOrdinaryIssueRemoteOwned(t *testing.T) {
+	config := DefaultMappingConfig()
+	local := &types.Issue{
+		Status:   types.StatusOpen,
+		Assignee: "local@example.com",
+		Labels:   []string{"old-product"},
+	}
+	remote := &types.Issue{
+		Status:   types.StatusInProgress,
+		Assignee: "remote@example.com",
+		Labels:   []string{"new-product"},
+	}
+
+	MergeLocalControlState(local, remote, config)
+
+	if remote.Status != types.StatusInProgress || remote.Assignee != "remote@example.com" {
+		t.Fatalf("ordinary issue lost remote ownership: status=%q assignee=%q", remote.Status, remote.Assignee)
+	}
+	if !slices.Equal(remote.Labels, []string{"new-product"}) {
+		t.Fatalf("ordinary issue labels = %v, want [new-product]", remote.Labels)
+	}
+}
+
 func TestIssueToBeadsWithParent(t *testing.T) {
 	config := DefaultMappingConfig()
 

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -497,6 +497,12 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 			}
 		}
 
+		// Some integrations have local-only control fields that the external
+		// tracker cannot own. Merge those fields after all conversion hooks so
+		// comparison, dry-run output, scalar updates, and label sync use the
+		// same ownership policy.
+		mergeLocalPullFields(mapper, existing, conv.Issue)
+
 		pendingDeps = appendFilteredDependencies(pendingDeps, conv.Dependencies, opts.DependencyTypes, opts.DependencySources)
 		if opts.DryRun {
 			dryRunIssue := *conv.Issue
@@ -616,6 +622,17 @@ func pullIssueEqual(local *types.Issue, remote *types.Issue, ref string) bool {
 		localRef = strings.TrimSpace(*local.ExternalRef)
 	}
 	return localRef == strings.TrimSpace(ref)
+}
+
+func mergeLocalPullFields(mapper FieldMapper, local, remote *types.Issue) {
+	if local == nil || remote == nil {
+		return
+	}
+	merger, ok := mapper.(PullFieldMerger)
+	if !ok {
+		return
+	}
+	merger.MergeLocalFields(local, remote)
 }
 
 func buildPullIssueUpdates(existing *types.Issue, remote *types.Issue, ref string) map[string]interface{} {
@@ -1286,9 +1303,22 @@ func (e *Engine) reimportIssue(ctx context.Context, c Conflict) {
 		return
 	}
 
-	conv := e.Tracker.FieldMapper().IssueToBeads(extIssue)
+	mapper := e.Tracker.FieldMapper()
+	conv := mapper.IssueToBeads(extIssue)
 	if conv == nil || conv.Issue == nil {
 		return
+	}
+	if _, ok := mapper.(PullFieldMerger); ok {
+		local, err := e.findLocalIssue(ctx, c.IssueID)
+		if err != nil {
+			e.warn("Failed to read %s before re-import: %v", c.IssueID, err)
+			return
+		}
+		if local == nil {
+			e.warn("Failed to read %s before re-import: local issue not found", c.IssueID)
+			return
+		}
+		mergeLocalPullFields(mapper, local, conv.Issue)
 	}
 
 	updates := map[string]interface{}{
@@ -1308,6 +1338,20 @@ func (e *Engine) reimportIssue(ctx context.Context, c Conflict) {
 	}); err != nil {
 		e.warn("Failed to update %s during reimport: %v", c.IssueID, err)
 	}
+}
+
+// findLocalIssue finds one local issue for an optional pull merge. GetIssue
+// keeps the lookup bounded to the conflict target instead of scanning the
+// local issue collection.
+func (e *Engine) findLocalIssue(ctx context.Context, id string) (*types.Issue, error) {
+	issue, err := e.Store.GetIssue(ctx, id)
+	if errors.Is(err, storage.ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return issue, nil
 }
 
 // createDependencies creates dependencies from the pending list, matching

--- a/internal/tracker/engine_pull_failure_test.go
+++ b/internal/tracker/engine_pull_failure_test.go
@@ -3,6 +3,7 @@ package tracker
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -20,6 +21,18 @@ func (t *pullTestTransaction) UpdateIssue(_ context.Context, _ string, updates m
 	if title, ok := updates["title"].(string); ok {
 		t.issue.Title = title
 	}
+	if description, ok := updates["description"].(string); ok {
+		t.issue.Description = description
+	}
+	if priority, ok := updates["priority"].(int); ok {
+		t.issue.Priority = priority
+	}
+	if issueType, ok := updates["issue_type"].(string); ok {
+		t.issue.IssueType = types.IssueType(issueType)
+	}
+	if assignee, ok := updates["assignee"].(string); ok {
+		t.issue.Assignee = assignee
+	}
 	if status, ok := updates["status"]; ok {
 		switch value := status.(type) {
 		case types.Status:
@@ -29,6 +42,15 @@ func (t *pullTestTransaction) UpdateIssue(_ context.Context, _ string, updates m
 		}
 	}
 	return nil
+}
+
+type localFieldMergingMapper struct {
+	*mockMapper
+	merge func(local, remote *types.Issue)
+}
+
+func (m *localFieldMergingMapper) MergeLocalFields(local, remote *types.Issue) {
+	m.merge(local, remote)
 }
 
 func (t *pullTestTransaction) ReopenIssueWithResult(_ context.Context, _ string, _ string, _ string) (bool, error) {
@@ -99,6 +121,15 @@ func (s *pullFailureStore) GetIssueByExternalRef(_ context.Context, ref string) 
 		}
 	}
 	return nil, nil
+}
+
+func (s *pullFailureStore) GetIssue(_ context.Context, id string) (*types.Issue, error) {
+	for _, issue := range s.issues {
+		if issue != nil && issue.ID == id {
+			return issue, nil
+		}
+	}
+	return nil, storage.ErrNotFound
 }
 
 func TestEngineSyncFailedPullIsNotPushed(t *testing.T) {
@@ -181,6 +212,112 @@ func TestEngineSyncFailedPullIsNotPushed(t *testing.T) {
 	}
 }
 
+func TestEnginePullPreservesLocalControlState(t *testing.T) {
+	tests := []struct {
+		name          string
+		localLabels   []string
+		localStatus   types.Status
+		localAssignee string
+		wantLabels    []string
+	}{
+		{
+			name:          "agent plan reservation",
+			localLabels:   []string{"agent-plan", "planner-intake", "old-product"},
+			localStatus:   types.StatusInProgress,
+			localAssignee: "planner@example.com",
+			wantLabels:    []string{"agent-plan", "planner-intake", "new-product"},
+		},
+		{
+			name:          "human gate",
+			localLabels:   []string{"human"},
+			localStatus:   types.StatusBlocked,
+			localAssignee: "operator@example.com",
+			wantLabels:    []string{"human", "new-product"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			extRef := "https://linear.app/team/issue/TEAM-3389"
+			local := &types.Issue{
+				ID:          "bd-linear-control",
+				Title:       "Local title",
+				Description: "Local description",
+				Status:      tt.localStatus,
+				IssueType:   types.TypeTask,
+				Priority:    2,
+				Assignee:    tt.localAssignee,
+				Labels:      append([]string(nil), tt.localLabels...),
+				ExternalRef: &extRef,
+				UpdatedAt:   time.Now().UTC().Add(-time.Hour),
+			}
+			store := &pullFailureStore{
+				pureTestStore: newPureTestStore(local),
+				tx:            &pullTestTransaction{issue: local},
+			}
+			mock := newMockTracker("linear")
+			mock.issues = []TrackerIssue{{
+				ID:          "TEAM-3389",
+				Identifier:  "TEAM-3389",
+				URL:         extRef,
+				Title:       "Linear title",
+				Description: "Linear description",
+				Priority:    1,
+				State:       types.StatusClosed,
+				Assignee:    "linear@example.com",
+				Labels:      []string{"new-product"},
+				UpdatedAt:   time.Now().UTC(),
+			}}
+			mock.fieldMapper = &localFieldMergingMapper{
+				mockMapper: &mockMapper{issueToBeads: func(ti *TrackerIssue) *IssueConversion {
+					return &IssueConversion{Issue: &types.Issue{
+						ID:          local.ID,
+						Title:       ti.Title,
+						Description: ti.Description,
+						Priority:    ti.Priority,
+						Status:      ti.State.(types.Status),
+						IssueType:   types.TypeTask,
+						Assignee:    ti.Assignee,
+						Labels:      append([]string(nil), ti.Labels...),
+					}}
+				},
+				},
+				merge: func(local, remote *types.Issue) {
+					for _, label := range local.Labels {
+						if label == "agent-plan" || label == "planner-intake" || label == "human" {
+							remote.Labels = append(remote.Labels, label)
+						}
+					}
+					remote.Status = local.Status
+					remote.Assignee = local.Assignee
+				},
+			}
+
+			result, err := NewEngine(mock, store, "sync").Sync(ctx, SyncOptions{Pull: true})
+			if err != nil {
+				t.Fatalf("Sync: %v", err)
+			}
+			if result.PullStats.Updated != 1 || result.PullStats.Errors != 0 {
+				t.Fatalf("PullStats = %+v, want one successful update", result.PullStats)
+			}
+			if local.Title != "Linear title" || local.Description != "Linear description" || local.Priority != 1 {
+				t.Fatalf("product fields did not sync: %+v", local)
+			}
+			if local.Status != tt.localStatus || local.Assignee != tt.localAssignee {
+				t.Fatalf("local controls changed: status=%q assignee=%q", local.Status, local.Assignee)
+			}
+			gotLabels := append([]string(nil), local.Labels...)
+			slices.Sort(gotLabels)
+			wantLabels := append([]string(nil), tt.wantLabels...)
+			slices.Sort(wantLabels)
+			if !slices.Equal(gotLabels, wantLabels) {
+				t.Fatalf("labels = %v, want %v", gotLabels, wantLabels)
+			}
+		})
+	}
+}
+
 func TestReimportIssuePreservesLabels(t *testing.T) {
 	ctx := context.Background()
 	local := &types.Issue{
@@ -214,5 +351,58 @@ func TestReimportIssuePreservesLabels(t *testing.T) {
 	}
 	if len(local.Labels) != 1 || local.Labels[0] != "keep-local-label" {
 		t.Fatalf("reimport changed local labels: %v", local.Labels)
+	}
+}
+
+func TestReimportIssuePreservesLocalControlState(t *testing.T) {
+	ctx := context.Background()
+	local := &types.Issue{
+		ID:          "reimport-control-state",
+		Title:       "local",
+		Description: "local description",
+		Status:      types.StatusInProgress,
+		Priority:    2,
+		IssueType:   types.TypeTask,
+		Assignee:    "planner@example.com",
+		Labels:      []string{"agent-plan", "planner-intake", "human"},
+	}
+	store := &pullFailureStore{
+		pureTestStore: newPureTestStore(local),
+		tx:            &pullTestTransaction{issue: local},
+	}
+	mock := newMockTracker("linear")
+	mock.issues = []TrackerIssue{{ID: "TEAM-3389", Identifier: "TEAM-3389", Title: "remote"}}
+	mock.fieldMapper = &localFieldMergingMapper{
+		mockMapper: &mockMapper{issueToBeads: func(*TrackerIssue) *IssueConversion {
+			return &IssueConversion{Issue: &types.Issue{
+				Title:       "remote",
+				Description: "remote description",
+				Status:      types.StatusClosed,
+				Priority:    1,
+				IssueType:   types.TypeTask,
+				Assignee:    "linear@example.com",
+				Labels:      []string{"remote-product"},
+			}}
+		}},
+		merge: func(local, remote *types.Issue) {
+			remote.Status = local.Status
+			remote.Assignee = local.Assignee
+		},
+	}
+
+	engine := NewEngine(mock, store, "sync")
+	engine.reimportIssue(ctx, Conflict{IssueID: local.ID, ExternalIdentifier: "TEAM-3389"})
+
+	if store.commits != 1 {
+		t.Fatalf("reimport transaction commits = %d, want 1", store.commits)
+	}
+	if local.Title != "remote" || local.Description != "remote description" || local.Priority != 1 {
+		t.Fatalf("product fields did not sync: %+v", local)
+	}
+	if local.Status != types.StatusInProgress || local.Assignee != "planner@example.com" {
+		t.Fatalf("reimport changed local controls: status=%q assignee=%q", local.Status, local.Assignee)
+	}
+	if !slices.Equal(local.Labels, []string{"agent-plan", "planner-intake", "human"}) {
+		t.Fatalf("reimport changed control labels: %v", local.Labels)
 	}
 }

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -76,6 +76,15 @@ type PullStatsProvider interface {
 	LastPullStats() (queried int, candidates int)
 }
 
+// PullFieldMerger is an optional capability for integrations with fields that
+// are owned locally rather than by the external tracker. The engine calls it
+// only for an existing local issue, after the remote issue has been converted
+// and pull hooks have run. Implementations may overlay local-only fields onto
+// the converted issue before the engine compares or persists it.
+type PullFieldMerger interface {
+	MergeLocalFields(local *types.Issue, remote *types.Issue)
+}
+
 // FieldMapper handles bidirectional conversion of issue fields between
 // an external tracker and beads. Each tracker provides its own mapper.
 type FieldMapper interface {


### PR DESCRIPTION
## What

Preserve local orchestration status, assignee, and control labels when an existing Beads issue is updated by a Linear pull. Product fields and Linear-owned labels continue to synchronize; the merge is an optional mapper capability so other integrations retain their existing behavior.

## Why

Linear does not own local orchestration controls. The previous conversion copied external status, assignee, and the complete label set into local issues, which could erase active planning and human-gate state. The pull engine now applies the mapper local-field merge after conversion and hooks, before comparison and persistence. The default control labels are agent-plan, planner-intake, and human.

## Verification

- env GOROOT=/opt/homebrew/Cellar/go/1.27.0/libexec CGO_ENABLED=0 ./scripts/test.sh ./internal/linear ./internal/tracker - passed.
- Focused cgo mapper, engine, and CLI tests with the installed ICU include and library paths - passed.
- env GOROOT=/opt/homebrew/Cellar/go/1.27.0/libexec CGO_ENABLED=0 go vet -tags gms_pure_go ./internal/linear ./internal/tracker - passed.
- git diff --check - passed.
- make test - affected packages passed. The full repository run remains red on unrelated baseline/environment cases: cmd/bd TestAutoMigrateStillRunsWithoutFreeze timed out at 25 minutes, and three Dolt-server-user configuration tests expected configured users but observed root.
- make ci-pr-lint - stopped at pre-existing formatting failures in internal/storage/dolt/role_fixture_kit_test.go, internal/storage/embeddeddolt/role_fixture_kit_test.go, and internal/storage/uow/role_fixture_kit_test.go. The standalone golangci-lint invocation is unavailable on this host.

No Beads database data is included in this PR.
