### PR TITLE
fix(dolt): apply the pool read/write deadline knobs on every open path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`BEADS_DOLT_POOL_READ_TIMEOUT` / `dolt.pool-read-timeout` (and the write
+  twins) now apply to every `bd` command in server mode.** The knobs shipped in
+  #5089, but their env/config ladder ran only for callers of `NewFromConfig*`;
+  the CLI's own store open and `bd serve`'s provider hand-build their config
+  and go straight to `New`, so every `bd` command kept the built-in 10 s pool
+  deadline whatever the knob said — on a large shared server that is what made
+  `bd close` of a bead with dependents die in its recompute with `i/o timeout`
+  and no relief valve. The ladder now runs from the constructor every open path
+  shares ([#6144](https://github.com/gastownhall/beads/issues/6144)).
+
 - **`bd prime` says when it could NOT read the memory plane**
   ([#5877](https://github.com/gastownhall/beads/issues/5877)). A broken or
   unreachable store made prime omit the memory section entirely, so a session

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,8 +187,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and go straight to `New`, so every `bd` command kept the built-in 10 s pool
   deadline whatever the knob said — on a large shared server that is what made
   `bd close` of a bead with dependents die in its recompute with `i/o timeout`
-  and no relief valve. The ladder now runs from the constructor every open path
-  shares ([#6144](https://github.com/gastownhall/beads/issues/6144)).
+  and no relief valve. The ladder now runs from the constructor every DoltStore
+  open shares — the CLI's store, `bd serve`'s store provider and library
+  callers of `New`/`NewFromConfig*`; `bd serve`'s HTTP data path builds its own
+  DSN without pool deadlines and is unchanged
+  ([#6144](https://github.com/gastownhall/beads/issues/6144)). Note for
+  operators of loaded servers: the documented precedence now reaches `bd
+  import` as well — it used to inherit the 5 m long-read fallback
+  unconditionally because the CLI's knob value was always 0, so a
+  `BEADS_DOLT_POOL_READ_TIMEOUT` set below that now bounds import too; size the
+  knob for your largest import, or leave it unset for the fallback.
 
 - **`bd prime` says when it could NOT read the memory plane**
   ([#5877](https://github.com/gastownhall/beads/issues/5877)). A broken or

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -330,10 +330,21 @@ func applyResolvedConfig(ctx context.Context, beadsDir string, fileCfg *configfi
 		}
 	}
 
-	// Pool per-I/O deadlines: caller override > env var > config.yaml > default
-	// (10s, see buildServerDSN). The default fast-fail is right for healthy
-	// local servers; overloaded shared-server deployments raise it so ordinary
-	// queries stop dying with "i/o timeout" under load (bd-vz0y9).
+	ApplyPoolTimeouts(cfg)
+
+	return nil
+}
+
+// ApplyPoolTimeouts fills the shared pool's per-I/O deadlines when the caller
+// left them unset: caller override > env var > config.yaml > default (10s, see
+// buildServerDSN). The default fast-fail is right for healthy local servers;
+// overloaded shared-server deployments raise it so ordinary queries stop dying
+// with "i/o timeout" under load (bd-vz0y9). It is idempotent, and it runs from
+// New (applyConfigDefaults) so every open path honors the knob — the CLI's own
+// store open and bd serve's provider hand-build their Config and never pass
+// through applyResolvedConfig, which is how the knob shipped in #5089 stayed
+// inert for every bd command in server mode (gastownhall/beads#6144).
+func ApplyPoolTimeouts(cfg *Config) {
 	if cfg.PoolReadTimeout == 0 {
 		cfg.PoolReadTimeout = timeoutFromEnv("BEADS_DOLT_POOL_READ_TIMEOUT", 0)
 	}
@@ -346,8 +357,6 @@ func applyResolvedConfig(ctx context.Context, beadsDir string, fileCfg *configfi
 	if cfg.PoolWriteTimeout == 0 {
 		cfg.PoolWriteTimeout = parseTimeout(config.GetString("dolt.pool-write-timeout"), 0)
 	}
-
-	return nil
 }
 
 // applyCentralConfigDefaults loads the central server config from

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -330,33 +330,46 @@ func applyResolvedConfig(ctx context.Context, beadsDir string, fileCfg *configfi
 		}
 	}
 
-	ApplyPoolTimeouts(cfg)
+	applyPoolTimeouts(cfg)
 
 	return nil
 }
 
-// ApplyPoolTimeouts fills the shared pool's per-I/O deadlines when the caller
+// applyPoolTimeouts fills the shared pool's per-I/O deadlines when the caller
 // left them unset: caller override > env var > config.yaml > default (10s, see
 // buildServerDSN). The default fast-fail is right for healthy local servers;
 // overloaded shared-server deployments raise it so ordinary queries stop dying
 // with "i/o timeout" under load (bd-vz0y9). It is idempotent, and it runs from
-// New (applyConfigDefaults) so every open path honors the knob — the CLI's own
+// New (applyConfigDefaults) so every DoltStore open honors the knob — the CLI's own
 // store open and bd serve's provider hand-build their Config and never pass
 // through applyResolvedConfig, which is how the knob shipped in #5089 stayed
 // inert for every bd command in server mode (gastownhall/beads#6144).
-func ApplyPoolTimeouts(cfg *Config) {
+func applyPoolTimeouts(cfg *Config) {
 	if cfg.PoolReadTimeout == 0 {
 		cfg.PoolReadTimeout = timeoutFromEnv("BEADS_DOLT_POOL_READ_TIMEOUT", 0)
 	}
 	if cfg.PoolReadTimeout == 0 {
-		cfg.PoolReadTimeout = parseTimeout(config.GetString("dolt.pool-read-timeout"), 0)
+		cfg.PoolReadTimeout = parseTimeout(poolTimeoutFromConfig(cfg, "dolt.pool-read-timeout"), 0)
 	}
 	if cfg.PoolWriteTimeout == 0 {
 		cfg.PoolWriteTimeout = timeoutFromEnv("BEADS_DOLT_POOL_WRITE_TIMEOUT", 0)
 	}
 	if cfg.PoolWriteTimeout == 0 {
-		cfg.PoolWriteTimeout = parseTimeout(config.GetString("dolt.pool-write-timeout"), 0)
+		cfg.PoolWriteTimeout = parseTimeout(poolTimeoutFromConfig(cfg, "dolt.pool-write-timeout"), 0)
 	}
+}
+
+// poolTimeoutFromConfig reads a pool-deadline key from the initialized config
+// and, like the auto-start ladder above, falls back to the .beads directory's
+// own config.yaml for library consumers that never called config.Initialize.
+func poolTimeoutFromConfig(cfg *Config, key string) string {
+	if v := config.GetString(key); v != "" {
+		return v
+	}
+	if cfg.BeadsDir == "" {
+		return ""
+	}
+	return config.GetStringFromDir(cfg.BeadsDir, key)
 }
 
 // applyCentralConfigDefaults loads the central server config from

--- a/internal/storage/dolt/pool_timeouts_test.go
+++ b/internal/storage/dolt/pool_timeouts_test.go
@@ -1,0 +1,61 @@
+package dolt
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestApplyConfigDefaultsAppliesPoolTimeoutLadder pins the pool-deadline knobs
+// at the seam every open path shares. applyResolvedConfig applied the
+// BEADS_DOLT_POOL_READ_TIMEOUT / dolt.pool-read-timeout ladder (#5089), but
+// only callers of NewFromConfig* pass through it: the CLI's own store open and
+// bd serve's provider hand-build their Config and go straight to New →
+// applyConfigDefaults, so every `bd` command in server mode kept the built-in
+// 10s deadline whatever the knob said (gastownhall/beads#6144). New is the one
+// constructor all of them call, so the ladder has to hold there.
+func TestApplyConfigDefaultsAppliesPoolTimeoutLadder(t *testing.T) {
+	t.Run("env vars populate the pool deadlines on the constructor path", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_POOL_READ_TIMEOUT", "90s")
+		t.Setenv("BEADS_DOLT_POOL_WRITE_TIMEOUT", "45")
+		cfg := &Config{ServerMode: true, Database: "ladder", Path: t.TempDir()}
+
+		applyConfigDefaults(cfg)
+
+		if cfg.PoolReadTimeout != 90*time.Second {
+			t.Fatalf("PoolReadTimeout = %v, want 90s from BEADS_DOLT_POOL_READ_TIMEOUT", cfg.PoolReadTimeout)
+		}
+		if cfg.PoolWriteTimeout != 45*time.Second {
+			t.Fatalf("PoolWriteTimeout = %v, want 45s (bare number = seconds)", cfg.PoolWriteTimeout)
+		}
+		if dsn := buildServerDSN(cfg, cfg.Database); !strings.Contains(dsn, "readTimeout=1m30s") {
+			t.Fatalf("buildServerDSN did not carry the env deadline: %s", dsn)
+		}
+	})
+
+	t.Run("caller-set pool deadlines win over env vars", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_POOL_READ_TIMEOUT", "90s")
+		cfg := &Config{ServerMode: true, Database: "ladder", Path: t.TempDir(), PoolReadTimeout: 2 * time.Minute}
+
+		applyConfigDefaults(cfg)
+
+		if cfg.PoolReadTimeout != 2*time.Minute {
+			t.Fatalf("PoolReadTimeout = %v, want the caller's 2m", cfg.PoolReadTimeout)
+		}
+	})
+
+	t.Run("unset knobs leave the built-in default in place", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_POOL_READ_TIMEOUT", "")
+		t.Setenv("BEADS_DOLT_POOL_WRITE_TIMEOUT", "")
+		cfg := &Config{ServerMode: true, Database: "ladder", Path: t.TempDir()}
+
+		applyConfigDefaults(cfg)
+
+		if cfg.PoolReadTimeout != 0 || cfg.PoolWriteTimeout != 0 {
+			t.Fatalf("pool deadlines = %v/%v, want 0/0 so buildServerDSN applies its default", cfg.PoolReadTimeout, cfg.PoolWriteTimeout)
+		}
+		if dsn := buildServerDSN(cfg, cfg.Database); !strings.Contains(dsn, "readTimeout=10s") {
+			t.Fatalf("buildServerDSN default deadline missing: %s", dsn)
+		}
+	})
+}

--- a/internal/storage/dolt/pool_timeouts_test.go
+++ b/internal/storage/dolt/pool_timeouts_test.go
@@ -1,13 +1,14 @@
 package dolt
 
 import (
+	"github.com/steveyegge/beads/internal/config"
 	"strings"
 	"testing"
 	"time"
 )
 
 // TestApplyConfigDefaultsAppliesPoolTimeoutLadder pins the pool-deadline knobs
-// at the seam every open path shares. applyResolvedConfig applied the
+// at the seam every DoltStore open shares. applyResolvedConfig applied the
 // BEADS_DOLT_POOL_READ_TIMEOUT / dolt.pool-read-timeout ladder (#5089), but
 // only callers of NewFromConfig* pass through it: the CLI's own store open and
 // bd serve's provider hand-build their Config and go straight to New →
@@ -47,6 +48,8 @@ func TestApplyConfigDefaultsAppliesPoolTimeoutLadder(t *testing.T) {
 	t.Run("unset knobs leave the built-in default in place", func(t *testing.T) {
 		t.Setenv("BEADS_DOLT_POOL_READ_TIMEOUT", "")
 		t.Setenv("BEADS_DOLT_POOL_WRITE_TIMEOUT", "")
+		config.ResetForTesting() // the config.yaml rung reads package state, not just env
+		t.Cleanup(config.ResetForTesting)
 		cfg := &Config{ServerMode: true, Database: "ladder", Path: t.TempDir()}
 
 		applyConfigDefaults(cfg)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1545,9 +1545,10 @@ func applyConfigDefaults(cfg *Config) {
 	if cfg.RemotePassword == "" {
 		cfg.RemotePassword = os.Getenv("DOLT_REMOTE_PASSWORD")
 	}
-	// Pool deadlines last: every open path (CLI, bd serve, library) reaches
-	// New, so the knob ladder holds here regardless of how cfg was built.
-	ApplyPoolTimeouts(cfg)
+	// Pool deadlines last: every DoltStore open (the CLI's store, bd serve's
+	// store provider, library callers of New/NewFromConfig*) reaches New, so
+	// the knob ladder holds here regardless of how cfg was built.
+	applyPoolTimeouts(cfg)
 }
 
 // New creates a new Dolt storage backend.

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1545,6 +1545,9 @@ func applyConfigDefaults(cfg *Config) {
 	if cfg.RemotePassword == "" {
 		cfg.RemotePassword = os.Getenv("DOLT_REMOTE_PASSWORD")
 	}
+	// Pool deadlines last: every open path (CLI, bd serve, library) reaches
+	// New, so the knob ladder holds here regardless of how cfg was built.
+	ApplyPoolTimeouts(cfg)
 }
 
 // New creates a new Dolt storage backend.


### PR DESCRIPTION
## Summary

- `BEADS_DOLT_POOL_READ_TIMEOUT` / `dolt.pool-read-timeout` (and the write twins, #5089) had no effect on any `bd` command in server mode: their env/config ladder lived only in `applyResolvedConfig`, which runs for `NewFromConfig*` callers, while the CLI's own store open and `bd serve`'s provider hand-build their `Config` (`resolveDoltServerConnection`, which documents that it bypasses `applyResolvedConfig`) and go straight to `New`. Every `bd` command kept the built-in 10 s pool deadline whatever the knob said (#6144).
- Fix: the ladder becomes `ApplyPoolTimeouts` and runs from `applyConfigDefaults`, the constructor step every open path shares (CLI, `bd serve`, library); `applyResolvedConfig` calls the same helper, so there is one ladder, not two. Idempotent — a caller-set deadline still wins.
- Riskiest thing in the diff: a deadline that previously never applied on the CLI now does. It applies only when the operator set the knob; the default stays 10 s; `bd import`'s `PoolReadTimeoutFallback` precedence is unchanged (`buildServerDSN`: explicit knob > fallback > default).

Fixes #6144

## Why

`CONTRIBUTING_PR_GUIDELINES.md` asks for a beads-only reproduction; it is in the issue and the test. The fix follows the pattern `applyConfigDefaults` already uses for the other server settings it reads from env (`BEADS_DOLT_SERVER_SOCKET`, `BEADS_DOLT_SERVER_HOST`, the port ladder), and puts the knob where the port-source fix for the same hand-built path went (be-9tju, `resolveDoltServerConnection` propagating `ServerPortSource`): the constructor is the seam that cannot be bypassed.

## Verification

- `TestApplyConfigDefaultsAppliesPoolTimeoutLadder` (new, `internal/storage/dolt/pool_timeouts_test.go`): env populates both deadlines on the constructor path and the DSN carries `readTimeout=1m30s`; a caller-set deadline wins; unset knobs leave the built-in default (`readTimeout=10s`). **Fails on `main`** with `PoolReadTimeout = 0s, want 90s`.
- Existing `applyResolvedConfig` pool-timeout cases in `open_test.go` still pass (same helper).
- Stock reproduction on `main` @ e05000d64 with a throwaway Dolt 2.2.4 sql-server and a fresh workspace: `bd sql "SELECT SLEEP(15)"` died at ~10 s with `BEADS_DOLT_POOL_READ_TIMEOUT=60s` and with `dolt.pool-read-timeout: 60s`; after this change (build of fe2059470, same store, same env scrubbing) the control without the knob still dies at ~10 s, and the same command with the env — or with `dolt.pool-read-timeout: 60s` — returns `slept 0` after 15 s.
- `BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint` (golangci-lint v2.10.1, native + `GOOS=windows CGO_ENABLED=0`): 0 issues; `make ci-pr-policy`: green; `make test`: green (96 packages ok, exit 0). Pre-commit hook lint on the commit: 0 issues.

## Notes for reviewers
- Scope, precisely: the ladder reaches every `DoltStore` open through `New`; `bd serve`'s HTTP data path (`resolveServerModeUOWTopology` → `uow.buildDSN`) sets no pool deadlines at all and is unchanged, as are the uow / dbproxy / doltserver / doctor-probe DSNs.
- Behavior change worth knowing: `bd import` used to inherit the 5 m long-read fallback unconditionally because the CLI's knob value was always 0; with the ladder working, an operator-set `BEADS_DOLT_POOL_READ_TIMEOUT` below that bounds import too (documented precedence; called out in the CHANGELOG entry).


- Prior work: a second deployment on a pre-#5089 base hit the same failure (13 consecutive `bd close` failures under load) and carries a local fix that makes the pooled deadline settable through a new env read lazily in `buildServerDSN` (`quickserve-ai/beads@a22f4092a`, Cherub Kumar). That shape is right for a base without #5089; on `main` the existing knob just has to reach every open path, which is this change. Their diagnosis and measurements are on #6144.
- `bd close`'s in-transaction recompute still runs on the pooled connection (#5939); this PR gives operators the documented relief valve back and does not change the close path.
- Not touched: `PoolReadTimeoutFallback` (`bd import`), the long-timeout one-shot connections, embedded mode (the DSN is unused there, so the ladder is inert by construction).

_claude-code-claude-fable-5-max on behalf of a3ackerman_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFPUYZEQjsBK2nBjsSQTij