### PR TITLE
feat(dep): detect cycles through tracks edges

### DIFF
--- a/backend/conformance/cycle_detector_contract.go
+++ b/backend/conformance/cycle_detector_contract.go
@@ -200,8 +200,10 @@ func RunCycleDetectorMergesTheDurableAndEphemeralPlanes(t *testing.T, ctx contex
 
 // RunCycleDetectorFollowsOnlyBlockingEdges pins cycledetector.go:110-119: the
 // walk follows `blocks` and `conditional-blocks`, and nothing else — not
-// `waits-for`, whose gate semantics make a mutual wait legitimate, and not
-// `parent-child`, which the ADD-time gate does walk.
+// `waits-for`, whose gate semantics make a mutual wait legitimate, not
+// `parent-child`, which the ADD-time gate does walk, and not `tracks`, on the
+// DEFAULT (zero-value) request. IncludeTracks's own widened walk is pinned
+// separately by RunCycleDetectorIncludeTracks*, below.
 //
 // The conditional-blocks half is asserted in the same case as the exclusions on
 // purpose: a body narrowed to `blocks` alone would pass an exclusion-only case,
@@ -217,6 +219,7 @@ func RunCycleDetectorFollowsOnlyBlockingEdges(t *testing.T, ctx context.Context,
 		{types.DepWaitsFor, "wait", false},
 		{types.DepParentChild, "kid", false},
 		{types.DepRelated, "rel", false},
+		{types.DepTracks, "trk", false},
 	} {
 		first := fmt.Sprintf("%s-edge-%s-a", fixture.IssuePrefix, test.slug)
 		second := fmt.Sprintf("%s-edge-%s-b", fixture.IssuePrefix, test.slug)
@@ -234,6 +237,53 @@ func RunCycleDetectorFollowsOnlyBlockingEdges(t *testing.T, ctx context.Context,
 			t.Errorf("a mutual %s pair produced %v; that edge type is outside this walk", test.edgeType, found)
 		}
 	}
+}
+
+// RunCycleDetectorIncludeTracksIgnoresAPureTracksLoop pins
+// DetectCyclesRequest.IncludeTracks's own guard: widening the walk to `tracks`
+// must not resurrect the PR #4933 false-positive shape, where ordinary
+// convoy/tracking topology with no scheduling edge at all got reported as a
+// cycle. A loop made entirely of `tracks` edges stays silent even with
+// IncludeTracks set.
+func RunCycleDetectorIncludeTracksIgnoresAPureTracksLoop(t *testing.T, ctx context.Context, fixture CycleDetectorFixture) {
+	t.Helper()
+	first := fixture.IssuePrefix + "-trkloop-a"
+	second := fixture.IssuePrefix + "-trkloop-b"
+	seedCycleDetectorIssue(t, ctx, fixture, first)
+	seedCycleDetectorIssue(t, ctx, fixture, second)
+	seedCycleDetectorEdges(t, ctx, fixture, false,
+		cycleDetectorEdge{Source: first, Target: second, Type: types.DepTracks},
+		cycleDetectorEdge{Source: second, Target: first, Type: types.DepTracks})
+
+	report := cycleDetectorReportIncludingTracks(t, ctx, fixture)
+	if found := cycleDetectorTouching(report, first, second); len(found) > 0 {
+		t.Errorf("a mutual tracks-only pair produced %v under IncludeTracks, want none: a cycle needs at least one scheduling edge", found)
+	}
+}
+
+// RunCycleDetectorIncludeTracksFindsTheMoleculeRootShape pins the gc-818bx
+// deadlock this option exists to surface: a molecule root that
+// blocks-depends on its own entry step, which tracks-depends back to the
+// root. Neither edge alone is a cycle; the shape only closes across both edge
+// types, which is exactly what the default (blocks-only) walk cannot see.
+func RunCycleDetectorIncludeTracksFindsTheMoleculeRootShape(t *testing.T, ctx context.Context, fixture CycleDetectorFixture) {
+	t.Helper()
+	root := fixture.IssuePrefix + "-molroot"
+	step := fixture.IssuePrefix + "-molstep"
+	seedCycleDetectorIssue(t, ctx, fixture, root)
+	seedCycleDetectorIssue(t, ctx, fixture, step)
+	seedCycleDetectorEdges(t, ctx, fixture, false,
+		cycleDetectorEdge{Source: root, Target: step, Type: types.DepBlocks},
+		cycleDetectorEdge{Source: step, Target: root, Type: types.DepTracks})
+
+	// The default request must still see nothing: the closing edge is a
+	// tracks edge, outside the base walk.
+	if found := cycleDetectorTouching(cycleDetectorReport(t, ctx, fixture), root, step); len(found) > 0 {
+		t.Errorf("the default request reported %v; IncludeTracks defaults to false and must leave the base walk unchanged", found)
+	}
+
+	cycle := cycleDetectorFind(t, cycleDetectorReportIncludingTracks(t, ctx, fixture), root, step)
+	assertCycleDetectorPath(t, cycle, root, step)
 }
 
 // RunCycleDetectorReportsAnHonestPartial pins cycledetector.go:140-144 and
@@ -427,6 +477,17 @@ func cycleDetectorSeed(id string) *types.Issue {
 func cycleDetectorReport(t *testing.T, ctx context.Context, fixture CycleDetectorFixture) publicops.CycleReport {
 	t.Helper()
 	report, err := fixture.Detector.DetectCycles(ctx, publicops.DetectCyclesRequest{})
+	if err != nil {
+		t.Fatalf("DetectCycles: %v", err)
+	}
+	return report
+}
+
+// cycleDetectorReportIncludingTracks is cycleDetectorReport with
+// IncludeTracks set, for the cases pinning that option's own widened walk.
+func cycleDetectorReportIncludingTracks(t *testing.T, ctx context.Context, fixture CycleDetectorFixture) publicops.CycleReport {
+	t.Helper()
+	report, err := fixture.Detector.DetectCycles(ctx, publicops.DetectCyclesRequest{IncludeTracks: true})
 	if err != nil {
 		t.Fatalf("DetectCycles: %v", err)
 	}

--- a/backend/conformance/role_bundle_cases.go
+++ b/backend/conformance/role_bundle_cases.go
@@ -204,6 +204,8 @@ var roleContractCases = []roleContract{
 		RunCycleDetectorReportsTheSameCyclesEveryRun,
 		RunCycleDetectorMergesTheDurableAndEphemeralPlanes,
 		RunCycleDetectorFollowsOnlyBlockingEdges,
+		RunCycleDetectorIncludeTracksIgnoresAPureTracksLoop,
+		RunCycleDetectorIncludeTracksFindsTheMoleculeRootShape,
 		RunCycleDetectorReportsAnHonestPartial,
 		RunCycleDetectorCountsAWhollyUndescribableCycle,
 		RunCycleDetectorWritesNothing,

--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -1261,7 +1261,8 @@ var depCyclesCmd = &cobra.Command{
 
 		// Both routes, one body: the only difference between them is which
 		// accessor answers, and that is inside openCycleDetector.
-		return runDepCycles()
+		includeTracks, _ := cmd.Flags().GetBool("include-tracks")
+		return runDepCycles(includeTracks)
 	},
 }
 
@@ -1563,6 +1564,11 @@ func init() {
 
 	depListCmd.Flags().String("direction", "down", "Direction: 'down' (dependencies), 'up' (dependents)")
 	depListCmd.Flags().StringP("type", "t", "", "Filter by dependency type (e.g., tracks, blocks, parent-child)")
+
+	// Widens the walk, never narrows it: a cycle is still reported only when it
+	// contains a blocks/conditional-blocks edge, so ordinary tracks-only convoy
+	// topology stays silent. See issueops.DetectCyclesRequest.IncludeTracks.
+	depCyclesCmd.Flags().Bool("include-tracks", false, "Also walk 'tracks' edges, reporting a cycle only when it also contains a blocks/conditional-blocks edge (diagnostic for molecule-root deadlocks hidden by tracks-only propagation)")
 
 	// Issue ID completions for dep subcommands
 	depAddCmd.ValidArgsFunction = issueIDCompletion

--- a/cmd/bd/dep_cycles.go
+++ b/cmd/bd/dep_cycles.go
@@ -36,13 +36,15 @@ func proxiedCycleDetector() (issueops.CycleDetector, error) {
 	return src.CycleDetector()
 }
 
-// runDepCycles is the whole of `bd dep cycles` on both routes.
-func runDepCycles() error {
+// runDepCycles is the whole of `bd dep cycles` on both routes. includeTracks
+// widens the walk per issueops.DetectCyclesRequest.IncludeTracks; the default
+// invocation leaves it false and the walk unchanged.
+func runDepCycles(includeTracks bool) error {
 	detector, err := openCycleDetector()
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
-	report, err := detector.DetectCycles(rootCtx, issueops.DetectCyclesRequest{})
+	report, err := detector.DetectCycles(rootCtx, issueops.DetectCyclesRequest{IncludeTracks: includeTracks})
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}

--- a/cmd/bd/dep_cycles_test.go
+++ b/cmd/bd/dep_cycles_test.go
@@ -136,9 +136,72 @@ func printCycleReportForTest(t *testing.T, report issueops.CycleReport) {
 		jsonOutput = previousJSON
 	}()
 
-	if err := runDepCycles(); err != nil {
+	if err := runDepCycles(false); err != nil {
 		t.Fatalf("runDepCycles: %v", err)
 	}
+}
+
+// TestDepCyclesFlagRegistration pins the --include-tracks flag itself: it
+// exists on the command, is a bool, and defaults to false so an invocation
+// with no flag leaves the base (blocks/conditional-blocks-only) walk
+// unchanged.
+func TestDepCyclesFlagRegistration(t *testing.T) {
+	flag := depCyclesCmd.Flags().Lookup("include-tracks")
+	if flag == nil {
+		t.Fatal("depCyclesCmd has no --include-tracks flag")
+	}
+	if flag.Value.Type() != "bool" {
+		t.Errorf("--include-tracks is a %s, want bool", flag.Value.Type())
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--include-tracks defaults to %q, want \"false\"", flag.DefValue)
+	}
+}
+
+// TestRunDepCyclesThreadsIncludeTracks pins dep_cycles.go's one line of real
+// logic for this option: the includeTracks parameter lands on
+// DetectCyclesRequest.IncludeTracks unchanged, in both directions.
+func TestRunDepCyclesThreadsIncludeTracks(t *testing.T) {
+	for _, includeTracks := range []bool{false, true} {
+		recorder := &recordingCycleStore{}
+		previousStore := store
+		previousJSON := jsonOutput
+		store = recorder
+		jsonOutput = false
+		func() {
+			defer func() {
+				store = previousStore
+				jsonOutput = previousJSON
+			}()
+			if err := runDepCycles(includeTracks); err != nil {
+				t.Fatalf("runDepCycles(%v): %v", includeTracks, err)
+			}
+		}()
+
+		if recorder.gotRequest.IncludeTracks != includeTracks {
+			t.Errorf("runDepCycles(%v) called DetectCycles with IncludeTracks=%v",
+				includeTracks, recorder.gotRequest.IncludeTracks)
+		}
+	}
+}
+
+// recordingCycleStore is a store whose cycle detector remembers the last
+// request it was asked to detect, so the flag-threading test can look inside
+// runDepCycles rather than only at its rendered output.
+type recordingCycleStore struct {
+	storage.DoltStorage
+	gotRequest issueops.DetectCyclesRequest
+}
+
+func (s *recordingCycleStore) CycleDetector() (issueops.CycleDetector, error) {
+	return &recordingCycleDetector{store: s}, nil
+}
+
+type recordingCycleDetector struct{ store *recordingCycleStore }
+
+func (d *recordingCycleDetector) DetectCycles(_ context.Context, req issueops.DetectCyclesRequest) (issueops.CycleReport, error) {
+	d.store.gotRequest = req
+	return issueops.CycleReport{}, nil
 }
 
 // fixedCycleStore is a store whose only real method is the cycle accessor. It

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -84,7 +84,7 @@ func (emptyDeps) GetIssueDependencyRecords(context.Context, []string) (map[strin
 // DetectCycleReport answers for a workspace with no cycles. Without it the
 // promoted method on the embedded nil interface panics, and the provider-backed
 // cycle route would 500 through the panic recovery rather than answering.
-func (emptyDeps) DetectCycleReport(context.Context) (issueops.CycleReport, error) {
+func (emptyDeps) DetectCycleReport(context.Context, issueops.DetectCyclesRequest) (issueops.CycleReport, error) {
 	return issueops.CycleReport{Cycles: []issueops.Cycle{}}, nil
 }
 

--- a/internal/storage/dolt/cycle_detector.go
+++ b/internal/storage/dolt/cycle_detector.go
@@ -30,11 +30,11 @@ type cycleDetector struct{ store *DoltStore }
 
 var _ issueops.CycleDetector = (*cycleDetector)(nil)
 
-func (c *cycleDetector) DetectCycles(ctx context.Context, _ issueops.DetectCyclesRequest) (issueops.CycleReport, error) {
+func (c *cycleDetector) DetectCycles(ctx context.Context, req issueops.DetectCyclesRequest) (issueops.CycleReport, error) {
 	var report issueops.CycleReport
 	err := c.store.withReadTx(ctx, func(tx *sql.Tx) error {
 		var err error
-		report, err = storeops.DetectCycleReportInTx(ctx, tx)
+		report, err = storeops.DetectCycleReportInTx(ctx, tx, req)
 		return err
 	})
 	if err != nil {

--- a/internal/storage/dolt/cycle_detector_contract_test.go
+++ b/internal/storage/dolt/cycle_detector_contract_test.go
@@ -35,6 +35,12 @@ func TestCycleDetectorContract(t *testing.T) {
 	t.Run("FollowsOnlyBlockingEdges", func(t *testing.T) {
 		conformance.RunCycleDetectorFollowsOnlyBlockingEdges(t, ctx, fixture)
 	})
+	t.Run("IncludeTracksIgnoresAPureTracksLoop", func(t *testing.T) {
+		conformance.RunCycleDetectorIncludeTracksIgnoresAPureTracksLoop(t, ctx, fixture)
+	})
+	t.Run("IncludeTracksFindsTheMoleculeRootShape", func(t *testing.T) {
+		conformance.RunCycleDetectorIncludeTracksFindsTheMoleculeRootShape(t, ctx, fixture)
+	})
 	t.Run("ReportsAnHonestPartial", func(t *testing.T) {
 		conformance.RunCycleDetectorReportsAnHonestPartial(t, ctx, fixture)
 	})

--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -886,8 +886,8 @@ func (r *dependencySQLRepositoryImpl) DetectCycles(ctx context.Context) ([][]*ty
 	return out, nil
 }
 
-func (r *dependencySQLRepositoryImpl) DetectCycleReport(ctx context.Context) (publicops.CycleReport, error) {
-	out, err := issueops.DetectCycleReportInTx(ctx, r.runner)
+func (r *dependencySQLRepositoryImpl) DetectCycleReport(ctx context.Context, req publicops.DetectCyclesRequest) (publicops.CycleReport, error) {
+	out, err := issueops.DetectCycleReportInTx(ctx, r.runner, req)
 	if err != nil {
 		return publicops.CycleReport{}, fmt.Errorf("db: DependencySQLRepository.DetectCycleReport: %w", err)
 	}

--- a/internal/storage/domain/dependency.go
+++ b/internal/storage/domain/dependency.go
@@ -158,8 +158,9 @@ type DependencySQLRepository interface {
 	// DetectCycleReport answers the same walk in the shape issueops.CycleDetector
 	// publishes: canonically ordered, and carrying every member of a cycle
 	// whether or not this database can describe it. DetectCycles above is the
-	// lossy legacy shape.
-	DetectCycleReport(ctx context.Context) (issueops.CycleReport, error)
+	// lossy legacy shape. req.IncludeTracks widens the walk; see
+	// issueops.DetectCyclesRequest.
+	DetectCycleReport(ctx context.Context, req issueops.DetectCyclesRequest) (issueops.CycleReport, error)
 
 	GetTree(ctx context.Context, rootID string, opts DepTreeOpts) ([]*types.TreeNode, error)
 	// WalkDependencyTree answers the tree walk in the shape issueops.TreeWalker
@@ -202,7 +203,7 @@ type DependencyUseCase interface {
 	DetectCycles(ctx context.Context) ([][]*types.Issue, error)
 	// DetectCycleReport is the shape issueops.CycleDetector publishes; see the
 	// repository method of the same name.
-	DetectCycleReport(ctx context.Context) (issueops.CycleReport, error)
+	DetectCycleReport(ctx context.Context, req issueops.DetectCyclesRequest) (issueops.CycleReport, error)
 
 	GetDependencyTree(ctx context.Context, rootID string, opts DepTreeOpts) ([]*types.TreeNode, error)
 	// WalkDependencyTree is the shape issueops.TreeWalker publishes; see the
@@ -638,8 +639,8 @@ func (u *dependencyUseCaseImpl) DetectCycles(ctx context.Context) ([][]*types.Is
 	return out, nil
 }
 
-func (u *dependencyUseCaseImpl) DetectCycleReport(ctx context.Context) (issueops.CycleReport, error) {
-	out, err := u.depRepo.DetectCycleReport(ctx)
+func (u *dependencyUseCaseImpl) DetectCycleReport(ctx context.Context, req issueops.DetectCyclesRequest) (issueops.CycleReport, error) {
+	out, err := u.depRepo.DetectCycleReport(ctx, req)
 	if err != nil {
 		return issueops.CycleReport{}, fmt.Errorf("DetectCycleReport: %w", err)
 	}

--- a/internal/storage/embeddeddolt/cycle_detector.go
+++ b/internal/storage/embeddeddolt/cycle_detector.go
@@ -31,11 +31,11 @@ type cycleDetector struct{ store *EmbeddedDoltStore }
 
 var _ issueops.CycleDetector = (*cycleDetector)(nil)
 
-func (c *cycleDetector) DetectCycles(ctx context.Context, _ issueops.DetectCyclesRequest) (issueops.CycleReport, error) {
+func (c *cycleDetector) DetectCycles(ctx context.Context, req issueops.DetectCyclesRequest) (issueops.CycleReport, error) {
 	var report issueops.CycleReport
 	err := c.store.withConn(ctx, false, func(tx *sql.Tx) error {
 		var err error
-		report, err = storeops.DetectCycleReportInTx(ctx, tx)
+		report, err = storeops.DetectCycleReportInTx(ctx, tx, req)
 		return err
 	})
 	if err != nil {

--- a/internal/storage/embeddeddolt/cycle_detector_contract_test.go
+++ b/internal/storage/embeddeddolt/cycle_detector_contract_test.go
@@ -39,6 +39,12 @@ func TestCycleDetectorContract(t *testing.T) {
 	t.Run("FollowsOnlyBlockingEdges", func(t *testing.T) {
 		conformance.RunCycleDetectorFollowsOnlyBlockingEdges(t, ctx, fixture)
 	})
+	t.Run("IncludeTracksIgnoresAPureTracksLoop", func(t *testing.T) {
+		conformance.RunCycleDetectorIncludeTracksIgnoresAPureTracksLoop(t, ctx, fixture)
+	})
+	t.Run("IncludeTracksFindsTheMoleculeRootShape", func(t *testing.T) {
+		conformance.RunCycleDetectorIncludeTracksFindsTheMoleculeRootShape(t, ctx, fixture)
+	})
 	t.Run("ReportsAnHonestPartial", func(t *testing.T) {
 		conformance.RunCycleDetectorReportsAnHonestPartial(t, ctx, fixture)
 	})

--- a/internal/storage/issueops/cycle_report.go
+++ b/internal/storage/issueops/cycle_report.go
@@ -11,8 +11,9 @@ import (
 // The cycle REPORT: the shared body behind issueops.CycleDetector on all three
 // backends, split into a pure half and a transactional half so the part that
 // decides what the answer MEANS is testable without a database.
-// CanonicalCyclePaths holds the determinism ruling and BuildCycles the
-// honest-partial one; both are pinned in cycle_report_test.go.
+// CanonicalCyclePaths holds the determinism ruling, CanonicalMixedCyclePaths
+// the IncludeTracks widening, and BuildCycles the honest-partial one; all
+// three are pinned in cycle_report_test.go.
 
 // CanonicalCyclePaths returns the cycles of a blocking graph as id paths, in a
 // canonical form: each path rotated so its lowest id comes first, and the paths
@@ -80,6 +81,94 @@ func CanonicalCyclePaths(graph map[string][]string) [][]string {
 	return cycles
 }
 
+// CanonicalMixedCyclePaths is CanonicalCyclePaths widened to a graph that also
+// carries `tracks` edges (MixedCycleEdge.Scheduling false), with one added
+// requirement: a reported cycle must contain at least one scheduling edge —
+// the closing edge counts. Without that requirement this would rediscover the
+// "thousands of cycles" regression AppendMixedCycleGraphInTx documents:
+// ordinary convoy/tracking topology loops constantly through tracks alone,
+// and none of those loops is a deadlock. WITH it, the shape this exists for —
+// a molecule root that blocks-depends (transitively) on its own entry step,
+// which tracks-depends back to the root — is reported, because the blocks
+// edges on that path satisfy the requirement even though the closing edge
+// does not.
+//
+// Determinism and rotation follow CanonicalCyclePaths for the same reason: a
+// depth-first walk over Go maps and unordered SQL reads must not let the
+// answer, or which cycles are even found, depend on iteration order.
+func CanonicalMixedCyclePaths(graph map[string][]MixedCycleEdge) [][]string {
+	adjacency := make(map[string][]MixedCycleEdge, len(graph))
+	roots := make([]string, 0, len(graph))
+	for node, edges := range graph {
+		roots = append(roots, node)
+		scheduling := make(map[string]bool, len(edges))
+		for _, edge := range edges {
+			scheduling[edge.To] = scheduling[edge.To] || edge.Scheduling
+		}
+		targets := make([]string, 0, len(scheduling))
+		for to := range scheduling {
+			targets = append(targets, to)
+		}
+		slices.Sort(targets)
+		deduped := make([]MixedCycleEdge, 0, len(targets))
+		for _, to := range targets {
+			deduped = append(deduped, MixedCycleEdge{To: to, Scheduling: scheduling[to]})
+		}
+		adjacency[node] = deduped
+	}
+	slices.Sort(roots)
+
+	var cycles [][]string
+	visited := make(map[string]bool, len(roots))
+	onPath := make(map[string]bool, len(roots))
+	path := make([]string, 0, len(roots))
+	// pathScheduling[i] is whether the edge that reached path[i] (from
+	// path[i-1]) is a scheduling edge. Index 0 is a placeholder: nothing
+	// reaches a root from inside the walk, and it is never read as part of a
+	// cycle's edge set (a cycle's slice starts at start+1, never at 0 itself).
+	pathScheduling := make([]bool, 0, len(roots))
+
+	var walk func(node string, enteredViaScheduling bool)
+	walk = func(node string, enteredViaScheduling bool) {
+		visited[node] = true
+		onPath[node] = true
+		path = append(path, node)
+		pathScheduling = append(pathScheduling, enteredViaScheduling)
+
+		for _, edge := range adjacency[node] {
+			switch {
+			case !visited[edge.To]:
+				walk(edge.To, edge.Scheduling)
+			case onPath[edge.To]:
+				// A back edge: the cycle is the suffix of the current path that
+				// starts at the neighbor, closed by this edge.
+				if start := slices.Index(path, edge.To); start >= 0 {
+					hasScheduling := edge.Scheduling
+					for _, sched := range pathScheduling[start+1:] {
+						hasScheduling = hasScheduling || sched
+					}
+					if hasScheduling {
+						cycles = append(cycles, rotateToLowest(path[start:]))
+					}
+				}
+			}
+		}
+
+		path = path[:len(path)-1]
+		pathScheduling = pathScheduling[:len(pathScheduling)-1]
+		onPath[node] = false
+	}
+
+	for _, root := range roots {
+		if !visited[root] {
+			walk(root, false)
+		}
+	}
+
+	slices.SortFunc(cycles, slices.Compare)
+	return cycles
+}
+
 // rotateToLowest returns a copy of a cycle path rotated so its lowest id comes
 // first, preserving edge order. The members of a cycle are distinct — the path
 // it is taken from is a simple path — so the lowest id is unique and names
@@ -133,18 +222,30 @@ func BuildCycles(paths [][]string, hydrate func(id string) *types.Issue) []publi
 
 // DetectCycleReportInTx is the whole read: build the blocking graph across both
 // planes, canonicalize it, and hydrate what it can. It reads the same two tables
-// and the same two edge types DetectCyclesInTx reads, because it is the same
-// question.
-func DetectCycleReportInTx(ctx context.Context, tx DBTX) (publicops.CycleReport, error) {
-	graph := make(map[string][]string)
-	if err := AppendBlockingGraphInTx(ctx, tx, cycleDetectionTables(), graph); err != nil {
-		return publicops.CycleReport{}, err
-	}
+// and, by default, the same two edge types DetectCyclesInTx reads, because it
+// is the same question. req.IncludeTracks answers a wider question instead —
+// see DetectCyclesRequest and CanonicalMixedCyclePaths.
+func DetectCycleReportInTx(ctx context.Context, tx DBTX, req publicops.DetectCyclesRequest) (publicops.CycleReport, error) {
 	hydrate := func(id string) *types.Issue {
 		// The error is deliberately not distinguished from a miss: both mean the
 		// same thing to the answer, that this database did not describe the node.
 		issue, _ := GetIssueInTx(ctx, tx, id)
 		return issue
+	}
+
+	if req.IncludeTracks {
+		graph := make(map[string][]MixedCycleEdge)
+		if err := AppendMixedCycleGraphInTx(ctx, tx, cycleDetectionTables(), graph); err != nil {
+			return publicops.CycleReport{}, err
+		}
+		return publicops.CycleReport{
+			Cycles: BuildCycles(CanonicalMixedCyclePaths(graph), hydrate),
+		}, nil
+	}
+
+	graph := make(map[string][]string)
+	if err := AppendBlockingGraphInTx(ctx, tx, cycleDetectionTables(), graph); err != nil {
+		return publicops.CycleReport{}, err
 	}
 	return publicops.CycleReport{
 		Cycles: BuildCycles(CanonicalCyclePaths(graph), hydrate),

--- a/internal/storage/issueops/cycle_report.go
+++ b/internal/storage/issueops/cycle_report.go
@@ -156,8 +156,8 @@ func CanonicalMixedCyclePaths(graph map[string][]MixedCycleEdge) [][]string {
 		}
 
 		returnPath := reachPath(plain, to, from)
-		if returnPath == nil {
-			continue // Impossible for two members of one strongly connected component.
+		if len(returnPath) == 0 {
+			panic("mixed cycle component has no return path")
 		}
 		cycle := append([]string{from}, returnPath[:len(returnPath)-1]...)
 		cycles = append(cycles, rotateToLowest(cycle))

--- a/internal/storage/issueops/cycle_report.go
+++ b/internal/storage/issueops/cycle_report.go
@@ -81,28 +81,32 @@ func CanonicalCyclePaths(graph map[string][]string) [][]string {
 	return cycles
 }
 
-// CanonicalMixedCyclePaths is CanonicalCyclePaths widened to a graph that also
-// carries `tracks` edges (MixedCycleEdge.Scheduling false), with one added
-// requirement: a reported cycle must contain at least one scheduling edge —
-// the closing edge counts. Without that requirement this would rediscover the
-// "thousands of cycles" regression AppendMixedCycleGraphInTx documents:
-// ordinary convoy/tracking topology loops constantly through tracks alone,
-// and none of those loops is a deadlock. WITH it, the shape this exists for —
-// a molecule root that blocks-depends (transitively) on its own entry step,
-// which tracks-depends back to the root — is reported, because the blocks
-// edges on that path satisfy the requirement even though the closing edge
-// does not.
+// CanonicalMixedCyclePaths finds one qualifying cycle per strongly connected
+// component in a graph that also carries `tracks` edges
+// (MixedCycleEdge.Scheduling false). A component qualifies only when it
+// contains a scheduling edge: every internal edge of a strongly connected
+// component lies on a cycle, so choosing one such edge and a stable return
+// path cannot miss a mixed cycle merely because a tracks-only back edge was
+// visited first.
 //
-// Determinism and rotation follow CanonicalCyclePaths for the same reason: a
-// depth-first walk over Go maps and unordered SQL reads must not let the
-// answer, or which cycles are even found, depend on iteration order.
+// Requiring a scheduling edge avoids the "thousands of cycles" regression
+// AppendMixedCycleGraphInTx documents: ordinary convoy/tracking topology loops
+// constantly through tracks alone, and none of those loops is a deadlock.
+// WITH the requirement, the shape this exists for — a molecule root that
+// blocks-depends (transitively) on its own entry step, which tracks-depends
+// back to the root — is reported.
+//
+// Nodes, adjacency lists, components, the chosen scheduling edge, and its
+// return path are all ordered. The answer therefore depends only on the graph,
+// not Go map or SQL row order.
 func CanonicalMixedCyclePaths(graph map[string][]MixedCycleEdge) [][]string {
 	adjacency := make(map[string][]MixedCycleEdge, len(graph))
-	roots := make([]string, 0, len(graph))
+	nodeSet := make(map[string]struct{}, len(graph))
 	for node, edges := range graph {
-		roots = append(roots, node)
+		nodeSet[node] = struct{}{}
 		scheduling := make(map[string]bool, len(edges))
 		for _, edge := range edges {
+			nodeSet[edge.To] = struct{}{}
 			scheduling[edge.To] = scheduling[edge.To] || edge.Scheduling
 		}
 		targets := make([]string, 0, len(scheduling))
@@ -116,57 +120,107 @@ func CanonicalMixedCyclePaths(graph map[string][]MixedCycleEdge) [][]string {
 		}
 		adjacency[node] = deduped
 	}
-	slices.Sort(roots)
+	nodes := make([]string, 0, len(nodeSet))
+	plain := make(map[string][]string, len(nodeSet))
+	for node := range nodeSet {
+		nodes = append(nodes, node)
+		for _, edge := range adjacency[node] {
+			plain[node] = append(plain[node], edge.To)
+		}
+	}
+	slices.Sort(nodes)
 
 	var cycles [][]string
-	visited := make(map[string]bool, len(roots))
-	onPath := make(map[string]bool, len(roots))
-	path := make([]string, 0, len(roots))
-	// pathScheduling[i] is whether the edge that reached path[i] (from
-	// path[i-1]) is a scheduling edge. Index 0 is a placeholder: nothing
-	// reaches a root from inside the walk, and it is never read as part of a
-	// cycle's edge set (a cycle's slice starts at start+1, never at 0 itself).
-	pathScheduling := make([]bool, 0, len(roots))
+	for _, component := range mixedStronglyConnectedComponents(adjacency, nodes) {
+		members := make(map[string]bool, len(component))
+		for _, node := range component {
+			members[node] = true
+		}
 
-	var walk func(node string, enteredViaScheduling bool)
-	walk = func(node string, enteredViaScheduling bool) {
-		visited[node] = true
-		onPath[node] = true
-		path = append(path, node)
-		pathScheduling = append(pathScheduling, enteredViaScheduling)
+		var from, to string
+		found := false
+		for _, node := range component {
+			for _, edge := range adjacency[node] {
+				if edge.Scheduling && members[edge.To] {
+					from, to = node, edge.To
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			continue
+		}
+
+		returnPath := reachPath(plain, to, from)
+		if returnPath == nil {
+			continue // Impossible for two members of one strongly connected component.
+		}
+		cycle := append([]string{from}, returnPath[:len(returnPath)-1]...)
+		cycles = append(cycles, rotateToLowest(cycle))
+	}
+	slices.SortFunc(cycles, slices.Compare)
+	return cycles
+}
+
+// mixedStronglyConnectedComponents returns Tarjan components with both their
+// members and the component list sorted. Targets without outgoing edges are in
+// nodes too, so singleton sinks remain part of the traversal even though they
+// can never qualify on their own.
+func mixedStronglyConnectedComponents(adjacency map[string][]MixedCycleEdge, nodes []string) [][]string {
+	nextIndex := 0
+	index := make(map[string]int, len(nodes))
+	lowlink := make(map[string]int, len(nodes))
+	onStack := make(map[string]bool, len(nodes))
+	stack := make([]string, 0, len(nodes))
+	components := make([][]string, 0)
+
+	var visit func(string)
+	visit = func(node string) {
+		nextIndex++
+		index[node] = nextIndex
+		lowlink[node] = nextIndex
+		stack = append(stack, node)
+		onStack[node] = true
 
 		for _, edge := range adjacency[node] {
-			switch {
-			case !visited[edge.To]:
-				walk(edge.To, edge.Scheduling)
-			case onPath[edge.To]:
-				// A back edge: the cycle is the suffix of the current path that
-				// starts at the neighbor, closed by this edge.
-				if start := slices.Index(path, edge.To); start >= 0 {
-					hasScheduling := edge.Scheduling
-					for _, sched := range pathScheduling[start+1:] {
-						hasScheduling = hasScheduling || sched
-					}
-					if hasScheduling {
-						cycles = append(cycles, rotateToLowest(path[start:]))
-					}
-				}
+			neighbor := edge.To
+			if index[neighbor] == 0 {
+				visit(neighbor)
+				lowlink[node] = min(lowlink[node], lowlink[neighbor])
+			} else if onStack[neighbor] {
+				lowlink[node] = min(lowlink[node], index[neighbor])
 			}
 		}
 
-		path = path[:len(path)-1]
-		pathScheduling = pathScheduling[:len(pathScheduling)-1]
-		onPath[node] = false
+		if lowlink[node] != index[node] {
+			return
+		}
+		component := make([]string, 0)
+		for {
+			last := len(stack) - 1
+			member := stack[last]
+			stack = stack[:last]
+			onStack[member] = false
+			component = append(component, member)
+			if member == node {
+				break
+			}
+		}
+		slices.Sort(component)
+		components = append(components, component)
 	}
 
-	for _, root := range roots {
-		if !visited[root] {
-			walk(root, false)
+	for _, node := range nodes {
+		if index[node] == 0 {
+			visit(node)
 		}
 	}
-
-	slices.SortFunc(cycles, slices.Compare)
-	return cycles
+	slices.SortFunc(components, slices.Compare)
+	return components
 }
 
 // rotateToLowest returns a copy of a cycle path rotated so its lowest id comes

--- a/internal/storage/issueops/cycle_report_test.go
+++ b/internal/storage/issueops/cycle_report_test.go
@@ -237,6 +237,28 @@ func TestCanonicalMixedCyclePathsFindsTheMoleculeRootShape(t *testing.T) {
 	}
 }
 
+// TestCanonicalMixedCyclePathsFindsASchedulingCycleAfterATracksOnlyBackEdge
+// pins the edge-labelled DFS trap from the exact-head review of gc-818bx. A
+// global visited set can first close and ignore the tracks-only a-b loop, then
+// miss the qualifying a-c-b-a loop because b is visited but no longer on the
+// active path when c reaches it.
+func TestCanonicalMixedCyclePathsFindsASchedulingCycleAfterATracksOnlyBackEdge(t *testing.T) {
+	graph := map[string][]MixedCycleEdge{
+		"a": {
+			{To: "b"},
+			{To: "c", Scheduling: true},
+		},
+		"b": {{To: "a"}},
+		"c": {{To: "b"}},
+	}
+
+	got := CanonicalMixedCyclePaths(graph)
+	want := [][]string{{"a", "c", "b"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cycles = %v, want %v: a tracks-only back edge must not hide a different cycle containing a scheduling edge", got, want)
+	}
+}
+
 // TestCanonicalMixedCyclePathsStillFindsAPureSchedulingCycle keeps parity with
 // CanonicalCyclePaths for the case that needs no tracks edge at all.
 func TestCanonicalMixedCyclePathsStillFindsAPureSchedulingCycle(t *testing.T) {

--- a/internal/storage/issueops/cycle_report_test.go
+++ b/internal/storage/issueops/cycle_report_test.go
@@ -195,3 +195,148 @@ func TestBuildCyclesLeavesACompleteCycleUnmarked(t *testing.T) {
 		t.Error("Partial = true for a fully described cycle")
 	}
 }
+
+// The IncludeTracks widening: CanonicalMixedCyclePaths adds `tracks` edges to
+// the walk but must report a cycle only when a scheduling (blocks/
+// conditional-blocks) edge is also on it. This is the gc-818bx guard: the
+// shape it exists to surface is a molecule root that blocks-depends
+// (transitively) on its own entry step, which tracks-depends back to the
+// root, WITHOUT reopening the "thousands of cycles" regression a
+// tracks-in-the-plain-walk change caused and had to revert (ordinary convoy
+// topology loops constantly through tracks alone).
+
+// TestCanonicalMixedCyclePathsIgnoresAPureTracksLoop pins the regression
+// guard directly: a loop made entirely of tracks edges — the shape a convoy
+// and its tracked issues form routinely — must not be reported.
+func TestCanonicalMixedCyclePathsIgnoresAPureTracksLoop(t *testing.T) {
+	graph := map[string][]MixedCycleEdge{
+		"a": {{To: "b"}},
+		"b": {{To: "c"}},
+		"c": {{To: "a"}},
+	}
+	if got := CanonicalMixedCyclePaths(graph); len(got) != 0 {
+		t.Errorf("pure-tracks loop reported %v, want no cycles: tracks-only convoy topology is not a deadlock", got)
+	}
+}
+
+// TestCanonicalMixedCyclePathsFindsTheMoleculeRootShape pins the case gc-818bx
+// exists for: a root that blocks-depends (transitively) on its own entry
+// step, closed by a tracks edge back to the root. Neither
+// CanonicalCyclePaths (no tracks edge at all) nor a plain-tracks walk (no
+// scheduling requirement) would report this correctly — the former misses it
+// entirely, the latter would drown it in every other tracks loop.
+func TestCanonicalMixedCyclePathsFindsTheMoleculeRootShape(t *testing.T) {
+	graph := map[string][]MixedCycleEdge{
+		"root": {{To: "step", Scheduling: true}},
+		"step": {{To: "root"}}, // tracks edge closing the loop
+	}
+	got := CanonicalMixedCyclePaths(graph)
+	want := [][]string{{"root", "step"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cycles = %v, want %v: a blocks edge plus a closing tracks edge is exactly the deadlock this option surfaces", got, want)
+	}
+}
+
+// TestCanonicalMixedCyclePathsStillFindsAPureSchedulingCycle keeps parity with
+// CanonicalCyclePaths for the case that needs no tracks edge at all.
+func TestCanonicalMixedCyclePathsStillFindsAPureSchedulingCycle(t *testing.T) {
+	graph := map[string][]MixedCycleEdge{
+		"a": {{To: "b", Scheduling: true}},
+		"b": {{To: "a", Scheduling: true}},
+	}
+	got := CanonicalMixedCyclePaths(graph)
+	want := [][]string{{"a", "b"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cycles = %v, want %v", got, want)
+	}
+}
+
+// TestCanonicalMixedCyclePathsAcceptsASchedulingEdgeAnywhereOnTheLoop checks
+// that the requirement is "at least one scheduling edge on the cycle", not
+// specifically on the closing edge — a longer chain where the blocks edge
+// sits in the middle must still be reported.
+func TestCanonicalMixedCyclePathsAcceptsASchedulingEdgeAnywhereOnTheLoop(t *testing.T) {
+	graph := map[string][]MixedCycleEdge{
+		"a": {{To: "b"}},                   // tracks
+		"b": {{To: "c", Scheduling: true}}, // blocks, in the middle of the loop
+		"c": {{To: "a"}},                   // tracks, closes the loop
+	}
+	got := CanonicalMixedCyclePaths(graph)
+	want := [][]string{{"a", "b", "c"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cycles = %v, want %v: a scheduling edge anywhere on the loop must qualify it, not only the closing edge", got, want)
+	}
+}
+
+// TestCanonicalMixedCyclePathsSelfLoop mirrors
+// TestCanonicalCyclePathsFindsSelfLoopsAndReportsNoneForAnAcyclicGraph for the
+// mixed graph: a self-loop qualifies exactly when its own edge is scheduling.
+func TestCanonicalMixedCyclePathsSelfLoop(t *testing.T) {
+	if got := CanonicalMixedCyclePaths(map[string][]MixedCycleEdge{"a": {{To: "a", Scheduling: true}}}); !reflect.DeepEqual(got, [][]string{{"a"}}) {
+		t.Errorf("blocking self-loop = %v, want [[a]]", got)
+	}
+	if got := CanonicalMixedCyclePaths(map[string][]MixedCycleEdge{"a": {{To: "a"}}}); len(got) != 0 {
+		t.Errorf("tracks-only self-loop = %v, want no cycles", got)
+	}
+	if got := CanonicalMixedCyclePaths(nil); len(got) != 0 {
+		t.Errorf("empty graph produced %v, want no cycles", got)
+	}
+}
+
+// TestCanonicalMixedCyclePathsCollapsesParallelEdgesByOringScheduling mirrors
+// TestCanonicalCyclePathsCollapsesParallelEdges: two rows for the same pair of
+// nodes — one a tracks edge, one blocking — must collapse to one edge that is
+// scheduling, not fall out of the requirement because the dedup happened to
+// keep the tracks-flavored copy.
+func TestCanonicalMixedCyclePathsCollapsesParallelEdgesByOringScheduling(t *testing.T) {
+	graph := map[string][]MixedCycleEdge{
+		"a": {{To: "b"}, {To: "b", Scheduling: true}},
+		"b": {{To: "a"}},
+	}
+	got := CanonicalMixedCyclePaths(graph)
+	want := [][]string{{"a", "b"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cycles = %v, want %v: a duplicated edge where either copy is scheduling must count as scheduling", got, want)
+	}
+}
+
+// TestCanonicalMixedCyclePathsIsIndependentOfMapOrder mirrors
+// TestCanonicalCyclePathsIsIndependentOfMapOrder against the mixed walk: it is
+// a separate implementation and must earn the same determinism guarantee
+// independently.
+func TestCanonicalMixedCyclePathsIsIndependentOfMapOrder(t *testing.T) {
+	type rawEdge struct {
+		from, to   string
+		scheduling bool
+	}
+	edges := []rawEdge{
+		{"a", "b", true}, {"b", "c", false}, {"c", "a", false},
+		{"c", "d", true}, {"d", "b", false},
+		{"e", "f", false}, {"f", "e", false},
+		{"a", "e", true}, {"g", "a", false}, {"g", "f", false},
+	}
+
+	rng := rand.New(rand.NewSource(1))
+	var first [][]string
+	for attempt := range 40 {
+		shuffled := slices.Clone(edges)
+		rng.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+
+		graph := map[string][]MixedCycleEdge{}
+		for _, edge := range shuffled {
+			graph[edge.from] = append(graph[edge.from], MixedCycleEdge{To: edge.to, Scheduling: edge.scheduling})
+		}
+
+		got := CanonicalMixedCyclePaths(graph)
+		if attempt == 0 {
+			first = got
+			continue
+		}
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("run %d produced %v, run 0 produced %v: the same graph must produce the same report", attempt, got, first)
+		}
+	}
+	if len(first) == 0 {
+		t.Fatal("the fixture graph has qualifying cycles; the detector found none")
+	}
+}

--- a/internal/storage/issueops/cycles.go
+++ b/internal/storage/issueops/cycles.go
@@ -120,6 +120,58 @@ func appendDependencyGraphInTx(ctx context.Context, tx DBTX, depTables []string,
 	return nil
 }
 
+// MixedCycleEdge is one edge in the widened graph AppendMixedCycleGraphInTx
+// builds: a neighbor plus whether the edge that reaches it is a blocking
+// (scheduling) edge, as opposed to a `tracks` edge kept only to complete a
+// path. CanonicalMixedCyclePaths uses the flag to require a blocking edge on
+// every cycle it reports.
+type MixedCycleEdge struct {
+	To         string
+	Scheduling bool
+}
+
+// AppendMixedCycleGraphInTx adds blocks, conditional-blocks, and tracks
+// dependency edges from the given tables on tx into graph, tagging each edge
+// scheduling or not. It is the edge set behind
+// issueops.DetectCyclesRequest.IncludeTracks: wide enough to see a molecule
+// root's `tracks` edge back to its own entry step, while a cycle made
+// ENTIRELY of tracks edges is excluded downstream — ordinary convoy topology
+// loops constantly through tracks alone, and reporting every one of those
+// loops is the "thousands of cycles" regression a previous change to the
+// plain (blocks-only) walk caused and had to revert; this widened walk must
+// not reintroduce it under a different name.
+//
+//nolint:gosec // G201: depTable is hardcoded to "dependencies" or "wisp_dependencies"
+func AppendMixedCycleGraphInTx(ctx context.Context, tx DBTX, depTables []string, graph map[string][]MixedCycleEdge) error {
+	for _, depTable := range depTables {
+		rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+			SELECT issue_id, %s AS depends_on_id, type
+			FROM %s
+		`, DepTargetExpr, depTable))
+		if err != nil {
+			return fmt.Errorf("mixed cycle graph: query %s: %w", depTable, err)
+		}
+		for rows.Next() {
+			var issueID, dependsOnID, depType string
+			if err := rows.Scan(&issueID, &dependsOnID, &depType); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("mixed cycle graph: scan %s: %w", depTable, err)
+			}
+			switch types.DependencyType(depType) {
+			case types.DepBlocks, types.DepConditionalBlocks:
+				graph[issueID] = append(graph[issueID], MixedCycleEdge{To: dependsOnID, Scheduling: true})
+			case types.DepTracks:
+				graph[issueID] = append(graph[issueID], MixedCycleEdge{To: dependsOnID})
+			}
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("mixed cycle graph: rows %s: %w", depTable, err)
+		}
+	}
+	return nil
+}
+
 // CycleThroughEdgesInGraph reports a rendered cycle that traverses
 // one of the new edges (issueID -> dependsOnID pairs), or "" when no new edge
 // lies on a cycle. An edge u -> v is on a cycle exactly when u is reachable

--- a/internal/storage/uow/cycle_detector.go
+++ b/internal/storage/uow/cycle_detector.go
@@ -40,8 +40,8 @@ var _ publicops.CycleDetector = (*cycleDetector)(nil)
 // rows that were on the cycle, rather than the rows that exist by the time the
 // second query runs. The two store-backed bodies get the same property from
 // their own read transaction.
-func (c *cycleDetector) DetectCycles(ctx context.Context, _ publicops.DetectCyclesRequest) (publicops.CycleReport, error) {
+func (c *cycleDetector) DetectCycles(ctx context.Context, req publicops.DetectCyclesRequest) (publicops.CycleReport, error) {
 	return RunTxRead(ctx, c.provider, func(ctx context.Context, uw UnitOfWork) (publicops.CycleReport, error) {
-		return uw.DependencyUseCase().DetectCycleReport(ctx)
+		return uw.DependencyUseCase().DetectCycleReport(ctx, req)
 	})
 }

--- a/internal/storage/uow/cycle_detector_contract_test.go
+++ b/internal/storage/uow/cycle_detector_contract_test.go
@@ -36,6 +36,12 @@ func TestCycleDetectorContract(t *testing.T) {
 	t.Run("FollowsOnlyBlockingEdges", func(t *testing.T) {
 		conformance.RunCycleDetectorFollowsOnlyBlockingEdges(t, ctx, fixture)
 	})
+	t.Run("IncludeTracksIgnoresAPureTracksLoop", func(t *testing.T) {
+		conformance.RunCycleDetectorIncludeTracksIgnoresAPureTracksLoop(t, ctx, fixture)
+	})
+	t.Run("IncludeTracksFindsTheMoleculeRootShape", func(t *testing.T) {
+		conformance.RunCycleDetectorIncludeTracksFindsTheMoleculeRootShape(t, ctx, fixture)
+	})
 	t.Run("ReportsAnHonestPartial", func(t *testing.T) {
 		conformance.RunCycleDetectorReportsAnHonestPartial(t, ctx, fixture)
 	})

--- a/issueops/cycledetector.go
+++ b/issueops/cycledetector.go
@@ -99,18 +99,20 @@ type CycleReport struct {
 	// Cycles is the canonical, sorted set. It is empty — never nil — when the
 	// graph is acyclic.
 	//
-	// ITS LENGTH IS THE TOTAL, and that is the point of carrying unhydratable
+	// ITS LENGTH IS THE TOTAL FOUND BY THE SELECTED WALK, and that is the point
+	// of carrying unhydratable
 	// members rather than dropping them: a cycle nothing can describe is still
 	// counted here, so "found N cycles" cannot shrink because a row went
 	// missing. There is no separate count field, because there is no cycle this
 	// slice omits.
 	//
 	// IT IS NOT PROMISED TO BE EVERY SIMPLE CYCLE IN THE GRAPH. Enumerating
-	// those is exponential in the worst case; the detector records one cycle per
-	// back edge of a depth-first walk, so two cycles sharing every node but one
-	// edge may be reported as one. What IS promised is that the slice is empty
-	// exactly when the graph is acyclic, and that the same graph always yields
-	// the same slice.
+	// those is exponential in the worst case. The default detector records one
+	// cycle per back edge of a depth-first walk, while IncludeTracks records one
+	// qualifying cycle per strongly connected component. Two cycles sharing
+	// every node but one edge may therefore be reported as one. What IS promised
+	// is that the slice is empty exactly when the selected walk has no qualifying
+	// cycle, and that the same graph and request always yield the same slice.
 	Cycles []Cycle `json:"cycles"`
 }
 

--- a/issueops/cycledetector.go
+++ b/issueops/cycledetector.go
@@ -8,16 +8,37 @@ import (
 
 // DetectCyclesRequest asks for the whole blocking graph's cycles.
 //
-// It carries NOTHING, and the empty struct is the honest shape rather than a
-// placeholder. A cycle is a property of the graph as a whole: there is no
-// predicate that narrows it, because narrowing the EDGE set would delete
-// cycles that exist and narrowing the reported set would need an anchor this
-// question does not have. `bd dep cycles` takes no flags for the same reason.
+// The zero value carries no NARROWING predicate, and that absence is the
+// honest shape rather than a placeholder: a cycle is a property of the graph
+// as a whole, so there is no predicate that narrows it — narrowing the EDGE
+// set would delete cycles that exist and narrowing the reported set would need
+// an anchor this question does not have. `bd dep cycles` takes no flags to
+// narrow either question for the same reason.
 //
-// It exists as a type so that a later option — a bound on how much of the graph
-// is walked, say — is a new field rather than a new method or a changed
-// signature, which is what every other role's request buys.
-type DetectCyclesRequest struct{}
+// IncludeTracks is the one WIDENING option, not a narrowing one, which is why
+// it does not contradict the paragraph above. It exists as a field rather than
+// a new method precisely for the reason this type does: a later option is a
+// field, not a changed signature.
+type DetectCyclesRequest struct {
+	// IncludeTracks additionally walks `tracks` edges on top of the default
+	// blocks/conditional-blocks graph, so a cycle that closes through a
+	// tracking edge is reported — the shape where a molecule root
+	// blocks-depends (transitively) on its own entry step, which
+	// tracks-depends back to the root.
+	//
+	// It does not report a cycle made ENTIRELY of tracks edges. Ordinary
+	// convoy/tracking topology is densely interconnected through tracks
+	// alone, and reporting every loop in it is the regression a previous
+	// change to `bd doctor`'s cycle check caused and had to revert (it
+	// produced "thousands of cycles" that were not deadlocks). A cycle is
+	// therefore reported under this option only when at least one of its
+	// edges — the closing edge included — is a blocks/conditional-blocks
+	// edge; tracks edges may only complete a path, never make one up alone.
+	//
+	// Default false: the base walk this type's doc above describes is
+	// unchanged.
+	IncludeTracks bool `json:"include_tracks,omitempty"`
+}
 
 // CycleMember is one node on a detected cycle.
 //
@@ -115,7 +136,8 @@ type CycleReport struct {
 // scheduling livelock the editor refuses). A graph this role calls acyclic can
 // therefore still refuse an edge, and that is not a contradiction: the editor
 // answers "would this be a livelock", this answers "is there a blocking cycle
-// now".
+// now". DetectCyclesRequest.IncludeTracks widens this walk to also follow
+// `tracks`, under the guard documented on that field.
 //
 // BOTH PLANES ARE ONE GRAPH. Durable and ephemeral edges are merged before the
 // walk, so a cycle that runs issue → wisp → issue is found; it is the reason


### PR DESCRIPTION
## Summary

- add an opt-in `bd dep cycles --include-tracks` mode that also walks `tracks` edges
- in that mode, report a cycle only when at least one of its edges is `blocks` or `conditional-blocks`, so loops made only of `tracks` edges stay silent
- leave the default `bd dep cycles` walk, the `bd dep add` cycle refusal, and the `bd doctor`, `bd ready` and `bd graph` cycle warnings unchanged
- apply the contract to the Dolt, embedded Dolt and UoW backends and the conformance suite. The HTTP cycles endpoint takes no query and still runs the default walk.

## Why

`bd dep cycles` could not report a deadlock that closes through a `tracks` edge. The motivating shape is a molecule root that blocks on its own entry step while that step tracks back to the root. A single-pass traversal also missed valid mixed cycles depending on visit order.

## What the widened report contains

The `--include-tracks` report is the deduplicated union of two sets:

1. every cycle the default walk reports on the same data, so turning the flag on never hides a blocks-only deadlock
2. for each `blocks` or `conditional-blocks` edge that lies on a cycle once `tracks` edges are included, the cycle that edge closes by its shortest way back over either edge type

The report holds at most twice as many cycles as there are blocking edges, and it is not every simple cycle in the graph. Because of the second set it can list more than the default even on a blocks-only graph. Given a -> b -> c -> a plus a -> c, the default reports a-b-c and the widened report adds a-c. If the detector's internal invariant breaks, it returns an error instead of panicking.

Blocking edges into the same issue share one breadth-first search from that issue, confined to its component. The report runs one search per issue a blocking edge points into, instead of one per blocking edge, which matters on a densely connected tangle.

## Verification

- `go test ./internal/storage/issueops/`, including a seeded property test over 600 random graphs that checks the superset property, the size bound, and independence from input order, and a test that the shared search closes every edge to the same cycle a search per edge would
- `BenchmarkCanonicalMixedCyclePathsDenseTangle`: 80 issues with a blocks edge for every ordered pair, 5.4 ms and 2.8 MB per call
- `TestCycleDetectorContract` on the UoW, Dolt (`dolthub/dolt-sql-server:2.2.0`) and embedded Dolt (`BEADS_TEST_EMBEDDED_DOLT=1`) backends, including a three-node case that fails when the edge direction in `AppendMixedCycleGraphInTx` is reversed
- `TestDepCycles` and `TestRunDepCycles` in `cmd/bd`
