### PR TITLE
fix(doctor): accept a leading v in version strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`bd doctor` no longer flags a `.local_version` that starts with `v`.** The
+  canonical spelling of a Go module version — and the string a build stamped
+  from a Go pseudo-version reports and writes into `.local_version` itself —
+  was rejected by the Version Tracking check (`Invalid version format`), and
+  read as major 0 in version comparisons, because the helpers parsed digits
+  first. They now accept an optional leading `v`; versions without it are
+  unchanged ([#6152](https://github.com/gastownhall/beads/issues/6152)).
+
 - **`bd prime` says when it could NOT read the memory plane**
   ([#5877](https://github.com/gastownhall/beads/issues/5877)). A broken or
   unreachable store made prime omit the memory section entirely, so a session

--- a/cmd/bd/doctor/version.go
+++ b/cmd/bd/doctor/version.go
@@ -253,9 +253,6 @@ func fetchLatestGitHubRelease() (string, error) {
 	return version, nil
 }
 
-// CompareVersions compares two semantic version strings.
-// Returns: -1 if v1 < v2, 0 if v1 == v2, 1 if v1 > v2
-// Handles versions like "0.20.1", "1.2.3", etc.
 // stripVersionPrefix drops the canonical "v" a Go module version carries
 // ("v1.2.3", or the pseudo-version a build stamped from `go install
 // module@version` reports). bd writes its own main.Version into
@@ -266,6 +263,9 @@ func stripVersionPrefix(version string) string {
 	return strings.TrimPrefix(strings.TrimSpace(version), "v")
 }
 
+// CompareVersions compares two semantic version strings.
+// Returns: -1 if v1 < v2, 0 if v1 == v2, 1 if v1 > v2
+// Handles versions like "0.20.1", "1.2.3", etc.
 func CompareVersions(v1, v2 string) int {
 	// Split versions into parts
 	parts1 := strings.Split(stripVersionPrefix(v1), ".")

--- a/cmd/bd/doctor/version.go
+++ b/cmd/bd/doctor/version.go
@@ -256,10 +256,20 @@ func fetchLatestGitHubRelease() (string, error) {
 // CompareVersions compares two semantic version strings.
 // Returns: -1 if v1 < v2, 0 if v1 == v2, 1 if v1 > v2
 // Handles versions like "0.20.1", "1.2.3", etc.
+// stripVersionPrefix drops the canonical "v" a Go module version carries
+// ("v1.2.3", or the pseudo-version a build stamped from `go install
+// module@version` reports). bd writes its own main.Version into
+// .local_version, so a build stamped that way used to fail its own tracking
+// check, and read as major 0 in comparisons (GH#6152). Versions without the
+// prefix are unchanged.
+func stripVersionPrefix(version string) string {
+	return strings.TrimPrefix(strings.TrimSpace(version), "v")
+}
+
 func CompareVersions(v1, v2 string) int {
 	// Split versions into parts
-	parts1 := strings.Split(v1, ".")
-	parts2 := strings.Split(v2, ".")
+	parts1 := strings.Split(stripVersionPrefix(v1), ".")
+	parts2 := strings.Split(stripVersionPrefix(v2), ".")
 
 	// Compare each part
 	maxLen := len(parts1)
@@ -291,6 +301,7 @@ func CompareVersions(v1, v2 string) int {
 
 // IsValidSemver checks if a version string is valid semver-like format (X.Y.Z)
 func IsValidSemver(version string) bool {
+	version = stripVersionPrefix(version)
 	if version == "" {
 		return false
 	}
@@ -321,7 +332,7 @@ func IsValidSemver(version string) bool {
 // ParseVersionParts parses version string into numeric parts
 // Returns [major, minor, patch, ...] or empty slice on error
 func ParseVersionParts(version string) []int {
-	parts := strings.Split(version, ".")
+	parts := strings.Split(stripVersionPrefix(version), ".")
 	result := make([]int, 0, len(parts))
 
 	for _, part := range parts {

--- a/cmd/bd/doctor/version_test.go
+++ b/cmd/bd/doctor/version_test.go
@@ -53,7 +53,9 @@ func TestIsValidSemver(t *testing.T) {
 		{"valid large numbers", "100.200.300", true},
 		{"empty string", "", false},
 		{"invalid letters", "1.2.a", false},
-		{"invalid format", "v1.2.3", false},
+		// A leading "v" is the Go module spelling bd itself may stamp and
+		// write (GH#6152); it used to be rejected here.
+		{"leading v (Go module form)", "v1.2.3", true},
 		{"trailing dot", "1.2.", false},
 		{"leading dot", ".1.2", false},
 		{"double dots", "1..2", false},
@@ -334,5 +336,39 @@ func TestCheckMetadataVersionTracking_SinglePartVersion(t *testing.T) {
 				t.Errorf("Name = %q, want %q", check.Name, "Version Tracking")
 			}
 		})
+	}
+}
+
+// A leading "v" is the canonical spelling of a Go module version, and a build
+// stamped from a Go pseudo-version reports it — bd writes that string into
+// .local_version itself. The version helpers used to parse digits first, so
+// "v1" read as invalid (and as 0 in comparisons) while a prerelease suffix
+// passed by accident (gastownhall/beads#6152).
+func TestVersionHelpersAcceptALeadingV(t *testing.T) {
+	for _, v := range []string{"v1.2.3", "1.2.3", "v1.1.1-0.20260805093327-bf97b73749ac", "1.3.0-rc.1", "v0.30.0"} {
+		if !IsValidSemver(v) {
+			t.Errorf("IsValidSemver(%q) = false, want true", v)
+		}
+	}
+	for _, v := range []string{"", "v", "abc", "1.2.x", "v.1.2"} {
+		if IsValidSemver(v) {
+			t.Errorf("IsValidSemver(%q) = true, want false", v)
+		}
+	}
+	for _, tt := range []struct {
+		v1, v2 string
+		want   int
+	}{
+		{"v1.2.3", "1.2.3", 0},
+		{"v2.0.0", "1.9.9", 1},
+		{"1.0.0", "v1.0.1", -1},
+		{"v1.1.1-0.20260805093327-bf97b73749ac", "1.1.1-0.20260805093327-bf97b73749ac", 0},
+	} {
+		if got := CompareVersions(tt.v1, tt.v2); got != tt.want {
+			t.Errorf("CompareVersions(%q, %q) = %d, want %d", tt.v1, tt.v2, got, tt.want)
+		}
+	}
+	if got := ParseVersionParts("v1.2.3"); len(got) != 3 || got[0] != 1 || got[1] != 2 || got[2] != 3 {
+		t.Errorf("ParseVersionParts(%q) = %v, want [1 2 3]", "v1.2.3", got)
 	}
 }


### PR DESCRIPTION
## Summary

- `bd doctor`'s Version Tracking check rejected a `.local_version` whose value starts with `v` — the canonical Go module spelling, and what a build stamped from a Go pseudo-version reports and writes into that file itself — while a prerelease suffix passed by accident (the digit parse reads the leading digits of `0-rc`). A `v`-prefixed version also compared as major 0 (#6152).
- Fix: `IsValidSemver`, `CompareVersions` and `ParseVersionParts` strip an optional leading `v` before the existing parse (`stripVersionPrefix`). Versions without the prefix are unchanged.
- The riskiest thing in the diff is the deliberate flip of one table row: `TestIsValidSemver` called `v1.2.3` an "invalid format"; it is now valid, with the reason on the row. Prerelease ordering is out of scope — the comparison stays the dot-part parse it was.

Fixes #6152

## Why

bd should accept the form of its own version that it prints and writes: `cmd/bd` already treats `golang.org/x/mod/semver`'s canonical `v`-prefixed form as valid elsewhere (`legacy_upgrade_guard.go`), and the doctor's other env-derived checks tolerate the same spelling. Smallest change that makes the check consistent with the writer.

## Verification

- `TestVersionHelpersAcceptALeadingV` (new): validity with and without the prefix, the pseudo-version form, invalid inputs (`""`, `v`, `abc`, `1.2.x`, `v.1.2`), comparison invariants (`v1.2.3` = `1.2.3`; `v2.0.0` > `1.9.9`; `1.0.0` < `v1.0.1`; the `v` never changes a comparison's result), `ParseVersionParts("v1.2.3")`. **Fails on `main`**: `IsValidSemver("v1.2.3") = false`, `CompareVersions("v2.0.0","1.9.9") = -1`, `ParseVersionParts("v1.2.3") = []`.
- Stock reproduction on `main` @ 40b323245 (server-mode scratch store, Dolt 2.2.4): a build stamped `-X main.Version=v1.1.1-0.20260805093327-bf97b73749ac` writes that value and its own `bd doctor --json` reports `Version Tracking: warning, Invalid version format in .local_version`; the twin stamped without the `v` reports `Version tracking active`. With this change the `v`-stamped build reports `Version tracking active` as well.
- `./scripts/test.sh ./cmd/bd/doctor/` green; `BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint` (golangci-lint v2.10.1, native + Windows): 0 issues; `make ci-pr-policy`: green; `make test`: green (96 packages, exit 0).

## Notes for reviewers
- `stripVersionPrefix` also trims surrounding whitespace before dropping the `v`, so `IsValidSemver(" 1.2.3 ")` flips false→true along with the `v`-prefixed forms; every caller passes a value read from a file or a command's output, where stray whitespace is noise, not meaning.


- Callers are unchanged: the hooks version check (`git.go:198-225`), the CLI-version check, and the MCP plugin comparison all go through these helpers and now agree with a `v`-prefixed CLI version instead of skipping or misordering it.
- Not touched: the check's message text and the `ParseVersionParts` fallback on the first non-numeric part.

_claude-code-claude-fable-5-max on behalf of a3ackerman_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D95BMAo3WieQDwPQMNWJ2e