### PR TITLE
fix(utils): refuse a bare jq/JS sentinel (null, undefined, empty) as an issue ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`bd` refuses a bare tooling sentinel (`null`, `undefined`, an empty string)
+  as an issue ID** ([#6214](https://github.com/gastownhall/beads/issues/6214)).
+  `jq -r` prints the literal `null` when a selector misses and JS tooling prints
+  `undefined`, so `bd update "$(bd list --json | jq -r '.[0].id')" --status
+  closed` arrived at ID resolution as a plain four-character token. Those tokens
+  are a valid partial-ID shape, so they reached the leading-prefix abbreviation
+  branch and resolved to whichever issue's hash began with them — closing an
+  issue the caller never named and exiting 0 with a success line. `bd update
+  null`, `bd comment null` and every other command that resolves an ID now fail
+  before any lookup, because the guard sits in the shared resolver. An ID that
+  merely contains a token (`bd-null`, `null3t0`, `undefined-behavior`) still
+  resolves, and abbreviation matching is otherwise unchanged. The empty string
+  already failed; it now says why.
+
 - **`bd prime` says when it could NOT read the memory plane**
   ([#5877](https://github.com/gastownhall/beads/issues/5877)). A broken or
   unreachable store made prime omit the memory section entirely, so a session

--- a/internal/utils/id_parser.go
+++ b/internal/utils/id_parser.go
@@ -47,9 +47,19 @@ func parseIssueID(input string, prefix string) string {
 // - Hierarchical: "a3f8e9.1" → "bd-a3f8e9.1"
 //
 // Returns an error if:
+// - The input is a bare tooling sentinel ("", "null", "undefined")
 // - No issue found matching the ID
 // - Multiple issues match (ambiguous prefix)
 func ResolvePartialID(ctx context.Context, store PartialIDResolverStore, input string) (string, error) {
+	// Refuse before any lookup: these tokens are a valid partial-ID shape, so
+	// they otherwise reach the leading-prefix abbreviation branch below.
+	switch strings.ToLower(strings.TrimSpace(input)) {
+	case "":
+		return "", fmt.Errorf("refusing an empty string as an issue ID")
+	case "null", "undefined":
+		return "", fmt.Errorf("refusing %q as an issue ID: that is what jq and JS tooling print for a missing value, so the caller's selector matched nothing", input)
+	}
+
 	if store == nil {
 		return "", fmt.Errorf("cannot resolve issue ID %q: storage is nil", input)
 	}

--- a/internal/utils/id_parser_sentinel_test.go
+++ b/internal/utils/id_parser_sentinel_test.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// A nil store makes the ordering observable: reaching the "storage is nil"
+// error proves the sentinel guard did NOT fire for that input.
+func TestResolvePartialIDRefusesSentinelTokens(t *testing.T) {
+	ctx := context.Background()
+
+	refused := []string{
+		"null", "NULL", "Null", " null ",
+		"undefined", "UNDEFINED",
+		"", "   ",
+	}
+	for _, input := range refused {
+		got, err := ResolvePartialID(ctx, nil, input)
+		if err == nil {
+			t.Errorf("ResolvePartialID(%q) = %q, nil; want a refusal", input, got)
+			continue
+		}
+		if strings.Contains(err.Error(), "storage is nil") {
+			t.Errorf("ResolvePartialID(%q) reached the store; the sentinel guard did not fire: %v", input, err)
+		}
+	}
+}
+
+func TestResolvePartialIDAcceptsIDsContainingSentinelTokens(t *testing.T) {
+	ctx := context.Background()
+
+	accepted := []string{
+		"bd-a3f8e9",
+		"a3f8",
+		"nullos",
+		"null3t0",
+		"bd-null",
+		"bd-null.1",
+		"undefined-behavior",
+	}
+	for _, input := range accepted {
+		_, err := ResolvePartialID(ctx, nil, input)
+		if err == nil || !strings.Contains(err.Error(), "storage is nil") {
+			t.Errorf("ResolvePartialID(%q) = %v; want it to pass the sentinel guard and reach the store", input, err)
+		}
+	}
+}


### PR DESCRIPTION
## What

`bd update null`, `bd comment undefined`, and every other command that resolves an issue ID now fail before any lookup when the ID argument is a bare tooling sentinel — `null`, `undefined`, or an empty string — instead of resolving it as a leading-prefix abbreviation of some unrelated issue's hash and writing to that issue with exit 0.

The guard is a single `switch` at the top of `ResolvePartialID` in `internal/utils/id_parser.go`, the only ID-resolution entry point in the repository (52 non-test call sites across 29 files, plus 2 through the `ResolvePartialIDs` wrapper, including the four `cmd/bd/*_proxied_server.go` twins) — so the direct, embedded, and proxied-server paths are covered uniformly. An ID that merely *contains* a token (`bd-null`, `null3t0`, `undefined-behavior`) still resolves, and abbreviation matching is otherwise unchanged. The empty string already failed; it now says why.

## Why

Fixes #6214.

`jq -r` prints the literal string `null` when a selector misses, and JS tooling prints `undefined`. Both are a valid partial-ID shape (`looksLikePartialIDHash` accepts alphanumerics, `-`, `.`), so the common shell shape

```bash
bd update "$(bd list --json | jq -r '.[0].id')" --status closed
```

turns a missed selector into a silent write against whichever issue's hash begins with `null` — success line, exit 0, an issue the caller never named. Full deterministic repro at `main` (a07794015) is in #6214.

#4939 already removed the interior-substring match here (`Contains` → `HasPrefix`), so today this requires a hash that *begins* with the token — exactly the failure class #5393 reports hitting in production with `list` and the wisp `ga-wisp-list3t0` (15+ automated sessions writing to the wrong wisp over two days).

Refs #5393 — this is **not** a supersession of it. That PR makes `bd comment` resolve exact-only, and its own description notes that `bd close`, `bd update`, `bd label`, and the other write commands keep the abbreviation-tolerant resolver. This change is narrower and orthogonal: it refuses only the three tokens that are never a legitimate ID, at the shared resolver, for every command. The two compose — sentinel refusal here, exact-only comment resolution there. #5421, #5369, and #5350 are merged precedent for refusing a non-ID token before a write.

Case folding is deliberate (`NULL` is what SQL-shaped tooling prints). Whitespace is trimmed for the comparison only, never for resolution.

## Verification

```console
$ go test ./internal/utils/
ok      github.com/steveyegge/beads/internal/utils
```

New tests in `internal/utils/id_parser_sentinel_test.go` use a nil store so the ordering is observable: reaching the `"storage is nil"` error proves the guard did *not* fire for that input. Eight refused inputs (`null`/`NULL`/`Null`/` null `/`undefined`/`UNDEFINED`/empty/whitespace), seven accepted inputs that merely contain a token. Mutation-tested: with the guard reverted, all eight refused inputs fail and the seven accepted inputs still pass.

Manual repro from #6214 re-run against a `bd` built from this branch (`-tags gms_pure_go`, fresh scratch workspace with a `bd-null3t0` decoy, darwin/arm64):

```console
$ bd update null --status closed
Error resolving null: refusing "null" as an issue ID: that is what jq and JS tooling print for a missing value, so the caller's selector matched nothing
Error: 1 of 1 issues failed to update
  null: resolving issue: refusing "null" as an issue ID: that is what jq and JS tooling print for a missing value, so the caller's selector matched nothing
$ echo $?
1
$ bd comment undefined "should refuse"
Error: resolving undefined: refusing "undefined" as an issue ID: that is what jq and JS tooling print for a missing value, so the caller's selector matched nothing
$ bd show bd-null3t0
○ bd-null3t0 · decoy: must not be touched   [P2 · OPEN]
$ bd update bd-null3t0 --status in_progress
✓ Updated issue: bd-null3t0 — decoy: must not be touched
```

---

_claude-code (Fable 5) on behalf of Cherub Kumar_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AL62dwyzjkxbzFLH1GZmMo
