### PR TITLE
fix(doctor): run the Blocked State count on the long-timeout read path

### DIFF
--- a/cmd/bd/doctor/blocked.go
+++ b/cmd/bd/doctor/blocked.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/steveyegge/beads/internal/storage/dolt"
-	"github.com/steveyegge/beads/internal/storage/issueops"
 )
 
 // BlockedConsistencyCheckName is the doctor check name; applyFixList dispatches
@@ -33,7 +32,12 @@ func CheckBlockedConsistencyWithStore(ss *SharedStore) DoctorCheck {
 }
 
 func checkBlockedConsistencyWithStore(ctx context.Context, store *dolt.DoltStore) DoctorCheck {
-	stale, err := issueops.CountIsBlockedInconsistenciesInTx(ctx, store.UnderlyingDB())
+	// Store-level rather than issueops-over-UnderlyingDB(): the shared pool's
+	// read deadline kills this known-long scan on loaded stores, and the store
+	// method routes it through the sanctioned long-timeout path (which also
+	// pins the store's checked-out branch — a fresh connection would otherwise
+	// silently read the default branch).
+	stale, err := store.CountIsBlockedInconsistencies(ctx)
 	if err != nil {
 		return DoctorCheck{
 			Name:    BlockedConsistencyCheckName,

--- a/internal/storage/dolt/blocked_consistency_test.go
+++ b/internal/storage/dolt/blocked_consistency_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"testing"
 
+	mysql "github.com/go-sql-driver/mysql"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -175,5 +176,76 @@ func TestRecomputeAllIsBlocked_CascadesThroughParentChild(t *testing.T) {
 	}
 	if n := countInconsistencies(ctx, t, store.db); n != 0 {
 		t.Fatalf("after repair: want 0 inconsistencies, got %d", n)
+	}
+}
+
+// TestCountIsBlockedInconsistencies_UsesDedicatedLongTimeoutConnection guards
+// against regressing the doctor Blocked State detection to the shared pool's
+// ReadTimeout: the correlated-EXISTS count over every issue and wisp is a
+// known-long read on large or busy stores, and on the shared pool it dies as
+// an intermittent MySQL i/o timeout / invalid connection error — blinding the
+// one check that detects stale is_blocked rows exactly where they matter.
+// Mirrors TestHistory_UsesDedicatedLongTimeoutConnection (ga-ahnxx).
+//
+// store.db (the shared pool) is opened once at store-creation time with a
+// baked-in DSN — mutating store.connStr afterward cannot affect it. Only a
+// call path that re-parses store.connStr per invocation (openLongTimeoutConn,
+// via withReadTxLongTimeout) is affected. So: break store.connStr after setup,
+// then confirm the count still routes through it (and fails) rather than
+// silently falling back to the still-healthy shared pool.
+func TestCountIsBlockedInconsistencies_UsesDedicatedLongTimeoutConnection(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// A genuinely stale flag on the store's checked-out test branch: bm-w is
+	// blocked on open bm-x through the write path; clearing the flag with raw
+	// SQL (bypassing the write path) is exactly the stale shape the check
+	// detects. Committed so the state is durable to any session.
+	seedBlockedPair(ctx, t, store, true)
+	if _, err := store.db.ExecContext(ctx, "UPDATE issues SET is_blocked = 0 WHERE id = 'bm-w'"); err != nil {
+		t.Fatalf("clear is_blocked: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_COMMIT('-am', 'stale is_blocked fixture')"); err != nil {
+		t.Fatalf("commit fixture: %v", err)
+	}
+
+	// Sanity check: the count works before we break anything, and it must
+	// actually read the store's checked-out branch — setupTestStore checks
+	// out an isolated test branch via a raw CALL DOLT_CHECKOUT on store.db
+	// (testutil.StartTestBranch), which bypasses Store.Checkout and never
+	// updates s.branch. If openLongTimeoutConn's fresh connection doesn't
+	// also select that branch, the count silently reads the (schema-only,
+	// row-less) default branch and returns 0 with a nil error — a passing
+	// err check alone would not catch that.
+	stale, err := store.CountIsBlockedInconsistencies(ctx)
+	if err != nil {
+		t.Fatalf("CountIsBlockedInconsistencies failed before connStr corruption: %v", err)
+	}
+	if stale == 0 {
+		t.Fatal("expected >=1 stale is_blocked row on the test branch, got 0 — " +
+			"the count is likely reading the default branch instead of the " +
+			"store's actual checked-out branch (see withReadTxLongTimeout)")
+	}
+
+	// Break store.connStr to an address that fails DNS resolution fast and
+	// permanently (RFC 2606 .invalid TLD) — a clean signal distinct from
+	// "connection refused", which the retry layer treats as transient and
+	// would spend up to serverRetryMaxElapsed (30s) retrying.
+	cfg, err := mysql.ParseDSN(store.connStr)
+	if err != nil {
+		t.Fatalf("failed to parse store.connStr: %v", err)
+	}
+	cfg.Addr = "blocked-count-test.invalid:3306"
+	store.connStr = cfg.FormatDSN()
+
+	if _, err := store.CountIsBlockedInconsistencies(ctx); err == nil {
+		t.Fatal("expected CountIsBlockedInconsistencies to fail after store.connStr " +
+			"was broken; if it still succeeds, the count is reading through the " +
+			"shared pool (store.db) instead of a fresh connection via " +
+			"openLongTimeoutConn/withReadTxLongTimeout, which is what lets the " +
+			"pool's ReadTimeout keep killing the doctor Blocked State check")
 	}
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -4539,6 +4539,28 @@ func (s *DoltStore) recomputeBlockedAfterPullUnchecked(ctx context.Context, from
 	return nil
 }
 
+// CountIsBlockedInconsistencies reports how many issue and wisp rows carry a
+// stale is_blocked flag — the read-only detection behind the bd doctor
+// "Blocked State" check (bd-6dnrw.37); the repair is RecomputeAllBlocked.
+//
+// Uses withReadTxLongTimeout rather than withReadTx: the count runs a
+// correlated-EXISTS scan over every issue and wisp, a known-long read on
+// large or busy stores, and the shared pool's ReadTimeout (see buildServerDSN)
+// otherwise kills it with an intermittent "invalid connection" / i/o timeout —
+// blinding exactly the check that detects stale flags, on precisely the loaded
+// shared servers where a stale is_blocked row is most likely to hide ready
+// work. The full-pass repair takes the same route for the same reason
+// (see recomputeAllBlocked).
+func (s *DoltStore) CountIsBlockedInconsistencies(ctx context.Context) (int64, error) {
+	var stale int64
+	err := s.withReadTxLongTimeout(ctx, func(tx *sql.Tx) error {
+		var err error
+		stale, err = issueops.CountIsBlockedInconsistenciesInTx(ctx, tx)
+		return err
+	})
+	return stale, err
+}
+
 // RecomputeAllBlocked recomputes is_blocked for every issue and wisp in one full
 // pass and returns the number of rows it corrected. It is the mode-independent
 // repair behind 'bd recompute-blocked' and 'bd doctor --fix' (bd-6dnrw.37): the


### PR DESCRIPTION
## Problem

The doctor **"Blocked State"** check counts stale `is_blocked` rows via `issueops.CountIsBlockedInconsistenciesInTx(ctx, store.UnderlyingDB())` — i.e. on the shared pool, whose per-I/O read deadline (see `buildServerDSN`) is tuned for point reads. The count is a correlated-EXISTS scan over every issue and wisp, so on a large or busy store the check dies as an intermittent MySQL `invalid connection` / i/o timeout.

That blinds exactly the wrong check in exactly the wrong place: a stale `is_blocked` flag silently hides ready work from `bd ready`, stale flags are most likely on loaded shared servers, and those are the servers where the pool deadline kills the detection. (We hit this in production: the check went blind on a shared hub while a stale flag kept an issue undrawable until it was cleared by hand.)

## Fix

Known-long reads already have a sanctioned route in this codebase — the `Config` comment on `PoolReadTimeout` says not to lean on the pool deadline and to use the long-timeout path instead; `History` does so (ga-ahnxx), and the full-pass **repair** behind this very check (`recomputeAllBlocked`) does too (bd-bn8jo). Only the detection half was left on the pool.

- Export `DoltStore.CountIsBlockedInconsistencies`, wrapping `issueops.CountIsBlockedInconsistenciesInTx` in `withReadTxLongTimeout`. Routing through the existing helper also inherits `pinStoreBranch`, so the fresh one-shot connection cannot silently read the default branch instead of the store's checked-out branch.
- Route `cmd/bd/doctor`'s `checkBlockedConsistencyWithStore` through the new method instead of `UnderlyingDB()`.
- Guard test `TestCountIsBlockedInconsistencies_UsesDedicatedLongTimeoutConnection` mirrors `TestHistory_UsesDedicatedLongTimeoutConnection`, with one addition: the fixture commits a genuinely stale row first, so a silent default-branch read (which counts 0 with a nil error) cannot masquerade as a clean count.

## Verification

- `go build -tags gms_pure_go ./...` and `go vet` clean.
- New guard test passes against the real Dolt test server, alongside the existing `TestRecomputeAllIsBlocked_*` suite and `TestHistory_UsesDedicatedLongTimeoutConnection` (all green).
- Mutation-checked: reverting the method to `withReadTx` makes the guard test fail with its intended diagnostic; restoring the long-timeout path makes it pass.

One concern per PR; no behavior change other than the connection the count runs on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mq33wjDjqNmwKAzzt1QWns