### PR TITLE
test(metrics): fail the reap test on a persistent zombie, not a transient one

### DIFF
--- a/internal/metrics/spawn_reap_test.go
+++ b/internal/metrics/spawn_reap_test.go
@@ -14,6 +14,12 @@ import (
 // exits while the parent stays alive must be waitpid'd, not left as a zombie.
 // The helper re-execs this test binary and exits immediately; startDetached
 // must reap it so `ps` never reports STAT Z under this process.
+// zombieGrace bounds how long the child may show STAT Z before the test calls
+// it unreaped. The reap window under a live Wait goroutine is scheduler
+// latency (well under 20ms even on a loaded runner); an unreaped child is Z
+// for the rest of this process's life, so 1s separates the two cleanly.
+const zombieGrace = time.Second
+
 func TestStartDetachedReapsExitedChild(t *testing.T) {
 	if os.Getenv("BD_TEST_FLUSHER_HELPER") == "1" {
 		// Stay alive long enough for the parent to observe a live pid.
@@ -45,12 +51,27 @@ func TestStartDetachedReapsExitedChild(t *testing.T) {
 	}
 
 	seenLive := false
+	var zombieSince time.Time
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
 		st, alive := unixProcStat(pid)
 		if strings.Contains(st, "Z") {
-			t.Fatalf("child pid %d became a zombie (stat=%q); startDetached did not reap", pid, st)
+			// Z is the child's state between its exit and the parent's
+			// wait4 returning. startDetached's Wait goroutine closes that
+			// window, but ps can still observe it on a loaded runner, so a
+			// single sighting proves nothing. What proves the old
+			// Process.Release() path is a zombie that STAYS: nothing ever
+			// waits on it, so it is Z for as long as this process lives.
+			if zombieSince.IsZero() {
+				zombieSince = time.Now()
+			} else if time.Since(zombieSince) > zombieGrace {
+				t.Fatalf("child pid %d stayed a zombie for %v (stat=%q); startDetached did not reap", pid, zombieGrace, st)
+			}
+			seenLive = true
+			time.Sleep(20 * time.Millisecond)
+			continue
 		}
+		zombieSince = time.Time{}
 		if alive {
 			seenLive = true
 			time.Sleep(20 * time.Millisecond)


### PR DESCRIPTION
## Main is red on macOS from the test added in #5933

`Test (macos-latest)` on `a0779401` (run 33704496976) fails in `internal/metrics`:

```
spawn_reap_test.go:52: child pid 17198 became a zombie (stat="Z<"); startDetached did not reap
--- FAIL: TestStartDetachedReapsExitedChild (1.53s)
```

`a0779401` is #6072 (migration-test shell scripts only); the test itself came in with #5933 at 01:10Z. Every Main run in that merge batch was concurrency-cancelled, and the PR workflow has no macOS test job, so this was the test's first execution on macOS. The Nightly Full Tests on the same SHA are green.

## Why: the test fails on the reap window itself

`startDetached` is correct — `go func() { _ = cmd.Wait() }()` reaps the child. But between the child's exit and that `wait4` returning, the child *is* a zombie; that window is scheduler latency, not zero. The test polls `ps` every 20ms and fatals on **any** sighting of `Z`, so on the macOS Main runner (every package in parallel, `-race -short`) it can observe the window the Wait goroutine is in the middle of closing. Locally on darwin/arm64 it takes 100 runs under CPU load to not reproduce, which is what a scheduler-latency race looks like.

What actually distinguishes the #5900 regression is a zombie that **stays**: under the old `Process.Release()` path nothing ever waits on the child, so it is `Z` for the rest of the parent's life.

## Fix (test only)

Tolerate a transient `Z`; fail once it persists past a 1s grace (`zombieGrace`), inside the existing 3s deadline. `spawn.go` is untouched.

## Verification (darwin/arm64, go1.26.5)

- `go test ./internal/metrics -run TestStartDetachedReapsExitedChild -count=30` → PASS (30/30)
- Negative control: `startDetached` temporarily reverted to `cmd.Process.Release()` → `stayed a zombie for 1s (stat="Z"); startDetached did not reap` — **FAIL**, as it must
- `gofmt -l` clean, `go vet ./internal/metrics` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CR28QFh19e84aEg97VSSGZ
