### PR TITLE
test(conformance): pin the PLANE of the importer's cross-plane edge assertions

### DIFF
--- a/backend/conformance/importer_contract.go
+++ b/backend/conformance/importer_contract.go
@@ -277,8 +277,10 @@ func RunImporterWiresTheCrossPlaneEdgeBetweenItsRows(t *testing.T, ctx context.C
 	if result.Created != 3 {
 		t.Errorf("Created = %d, want 3", result.Created)
 	}
-	assertImporterEdgeCount(t, ctx, fixture, wisp, durable, 1)
-	assertImporterEdgeCount(t, ctx, fixture, depender, wisp, 1)
+	assertImporterPlaneEdgeCount(t, ctx, fixture, "wisp_dependencies", "depends_on_issue_id", wisp, durable, 1)
+	assertImporterPlaneEdgeCount(t, ctx, fixture, "dependencies", "depends_on_issue_id", wisp, durable, 0)
+	assertImporterPlaneEdgeCount(t, ctx, fixture, "dependencies", "depends_on_wisp_id", depender, wisp, 1)
+	assertImporterPlaneEdgeCount(t, ctx, fixture, "wisp_dependencies", "depends_on_wisp_id", depender, wisp, 0)
 	assertImporterSkipped(t, result, nil)
 }
 
@@ -435,6 +437,26 @@ func assertImporterEdgeCount(t *testing.T, ctx context.Context, fixture Importer
 	t.Helper()
 	if got := importerEdgeCount(t, ctx, fixture, source, target); got != want {
 		t.Errorf("edges %s -> %s = %d, want %d", source, target, got, want)
+	}
+}
+
+// assertImporterPlaneEdgeCount pins WHERE an edge landed: one table and one
+// target column, the way RunImporterWiresTheCrossPlaneEdgeBetweenItsRows
+// documents its claim. importerEdgeCount deliberately sums both planes, which
+// is right for "dropped everywhere" and wrong for "wired in the right place":
+// an edge written to the other plane's table, or under the wrong target
+// column, counts as one there too. The cross-plane case asserts the expected
+// place holds exactly one row AND the other plane holds none.
+func assertImporterPlaneEdgeCount(t *testing.T, ctx context.Context, fixture ImporterFixture, table, column, source, target string, want int) {
+	t.Helper()
+	//nolint:gosec // G201: table and column are hardcoded names from this contract's call sites.
+	query := "SELECT COUNT(*) FROM " + table + " WHERE issue_id = ? AND " + column + " = ?"
+	var got int
+	if err := fixture.QueryScalar(ctx, query, []any{source, target}, &got); err != nil {
+		t.Fatalf("count %s.%s edges %s -> %s: %v", table, column, source, target, err)
+	}
+	if got != want {
+		t.Errorf("%s.%s rows %s -> %s = %d, want %d", table, column, source, target, got, want)
 	}
 }
 

--- a/backend/conformance/importer_contract.go
+++ b/backend/conformance/importer_contract.go
@@ -277,10 +277,17 @@ func RunImporterWiresTheCrossPlaneEdgeBetweenItsRows(t *testing.T, ctx context.C
 	if result.Created != 3 {
 		t.Errorf("Created = %d, want 3", result.Created)
 	}
+	// BOTH BELTS PER DIRECTION: the pinned cell fails a misrouted edge (the
+	// expected cell reads 0), and the summed total fails a DUPLICATE landing in
+	// any of the six table x column cells, which no per-cell count can see. The
+	// two together also make "the other plane holds none" exact: total 1 with
+	// the expected cell at 1 leaves every remaining cell empty.
 	assertImporterPlaneEdgeCount(t, ctx, fixture, "wisp_dependencies", "depends_on_issue_id", wisp, durable, 1)
 	assertImporterPlaneEdgeCount(t, ctx, fixture, "dependencies", "depends_on_issue_id", wisp, durable, 0)
+	assertImporterEdgeCount(t, ctx, fixture, wisp, durable, 1)
 	assertImporterPlaneEdgeCount(t, ctx, fixture, "dependencies", "depends_on_wisp_id", depender, wisp, 1)
 	assertImporterPlaneEdgeCount(t, ctx, fixture, "wisp_dependencies", "depends_on_wisp_id", depender, wisp, 0)
+	assertImporterEdgeCount(t, ctx, fixture, depender, wisp, 1)
 	assertImporterSkipped(t, result, nil)
 }
 
@@ -417,7 +424,9 @@ func assertImporterRowCount(t *testing.T, ctx context.Context, fixture ImporterF
 // importerEdgeCount counts the stored edges from source to target across BOTH
 // dependency tables and all three target columns. A dropped edge is dropped on
 // every plane, so the cases that expect zero want zero everywhere, and a
-// per-table count could report one while the row sat in the other.
+// per-table count could report one while the row sat in the other. WHICH of the
+// six cells a row landed in is a placement detail the cases that care about it
+// assert through assertImporterPlaneEdgeCount instead.
 func importerEdgeCount(t *testing.T, ctx context.Context, fixture ImporterFixture, source, target string) int {
 	t.Helper()
 	var got int
@@ -445,8 +454,11 @@ func assertImporterEdgeCount(t *testing.T, ctx context.Context, fixture Importer
 // documents its claim. importerEdgeCount deliberately sums both planes, which
 // is right for "dropped everywhere" and wrong for "wired in the right place":
 // an edge written to the other plane's table, or under the wrong target
-// column, counts as one there too. The cross-plane case asserts the expected
-// place holds exactly one row AND the other plane holds none.
+// column, counts as one there too. ONE CALL PINS ONE CELL, so the cross-plane
+// case asserts the expected cell holds exactly one row and the mirror cell of
+// the other plane holds none, and keeps importerEdgeCount's summed total
+// alongside them — a duplicate under one of the four cells neither call names
+// is invisible to this helper and is exactly what the sum still catches.
 func assertImporterPlaneEdgeCount(t *testing.T, ctx context.Context, fixture ImporterFixture, table, column, source, target string, want int) {
 	t.Helper()
 	//nolint:gosec // G201: table and column are hardcoded names from this contract's call sites.


### PR DESCRIPTION
## The cross-plane importer case documents a check it does not make

`RunImporterWiresTheCrossPlaneEdgeBetweenItsRows` (`backend/conformance/importer_contract.go`) says both directions are asserted "on its own table" — `wisp_dependencies.depends_on_issue_id` for wisp→durable, `dependencies.depends_on_wisp_id` for durable→wisp. Its edge assertions go through `importerEdgeCount`, which sums **both** dependency tables across all three target columns. So the case passes with either edge written to the other plane's table, or under the wrong target column. Only the uow-tier test (`internal/storage/uow/importer_uow_test.go`) pins placement, and a conformance case is where a second backend would be caught.

## Fix (test only)

`assertImporterPlaneEdgeCount(table, column, source, target, want)` in the idiom of `assertBatchApplyPlaneEdgeCount`. The case now asserts exactly one row in the expected table and column for each direction, and zero in the other plane's table. `importerEdgeCount` stays for the drop cases, where "zero everywhere" is the right question.

## Verification (darwin/arm64)

- `go test ./internal/storage/uow -run TestImporterContract -count=1` → ok
- Negative control: pointing the wisp→durable assertion at `dependencies` fails with `dependencies.depends_on_issue_id rows imp-impplane-wisp -> imp-impplane-durable = 0, want 1`, so the assertion discriminates the plane table.
- `BEADS_TEST_EMBEDDED_DOLT=1 go test ./internal/storage/embeddeddolt -run 'TestConformance/Audit/molecule-wisp-batch-iter'` → ok (the env-gated leg this epic's earlier review asked to run explicitly)
- `gofmt -l` clean, `go vet ./backend/conformance` clean

Found in the wy-a648lq review (the change that wires in-batch regular↔wisp edges instead of dropping them, 85b07f9be), finding F1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173FRLuAy3NUjVvwFaLVj2r

