### PR TITLE
fix(storage): name a client read-deadline kill instead of blaming the transport

### DIFF
--- a/internal/storage/dolt/client_timeout_test.go
+++ b/internal/storage/dolt/client_timeout_test.go
@@ -1,0 +1,148 @@
+package dolt
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Pins the discriminator from ga-2xwhcz: the MySQL driver reports a client
+// deadline kill and a genuinely dead server with the SAME string ("invalid
+// connection"), so only elapsed-vs-deadline separates them. During the
+// 2026-08-31 stalls that ambiguity sent responders at connectivity while the
+// real fault was a slow server.
+func TestLooksLikeClientReadTimeout(t *testing.T) {
+	invalid := errors.New("invalid connection")
+	badConn := errors.New("driver: bad connection")
+	other := errors.New("Error 1049 (HY000): database not found: nope")
+
+	cases := []struct {
+		name     string
+		err      error
+		elapsed  time.Duration
+		deadline time.Duration
+		want     bool
+	}{
+		{"deadline kill at the deadline", invalid, defaultPoolReadTimeout, defaultPoolReadTimeout, true},
+		{"deadline kill just past it", invalid, defaultPoolReadTimeout + time.Second, defaultPoolReadTimeout, true},
+		{"bad-connection form counts too", badConn, defaultPoolReadTimeout, defaultPoolReadTimeout, true},
+		// A server that vanishes does not wait for our deadline to expire.
+		{"fast failure is a real connection loss", invalid, 200 * time.Millisecond, defaultPoolReadTimeout, false},
+		{"fast bad-connection is a real loss", badConn, time.Second, defaultPoolReadTimeout, false},
+		// A slow non-connection error is slow, but it is not this class.
+		{"unrelated error, even when slow", other, 30 * time.Second, defaultPoolReadTimeout, false},
+		{"nil is never a timeout", nil, time.Minute, defaultPoolReadTimeout, false},
+		// The deadline is the knob's value, not a hard-coded 10s: on a rig at
+		// 60s a 15s failure is NOT a deadline kill, and the old constant
+		// claimed it was (lens C3).
+		{"raised knob: below the real deadline is not a kill", invalid, 15 * time.Second, time.Minute, false},
+		{"raised knob: at the real deadline is a kill", invalid, time.Minute, time.Minute, true},
+		// No read deadline on the connection means no deadline kill is possible.
+		{"no deadline configured", invalid, time.Hour, 0, false},
+	}
+	for _, tc := range cases {
+		if got := looksLikeClientReadTimeout(tc.err, tc.elapsed, tc.deadline); got != tc.want {
+			t.Errorf("%s: looksLikeClientReadTimeout(%v, %v, %v) = %v, want %v",
+				tc.name, tc.err, tc.elapsed, tc.deadline, got, tc.want)
+		}
+	}
+}
+
+func TestExplainClientReadTimeoutNamesTheRealCause(t *testing.T) {
+	orig := errors.New("invalid connection")
+	got := explainClientReadTimeout(orig, defaultPoolReadTimeout+250*time.Millisecond, defaultPoolReadTimeout, "schema init")
+	if got == nil {
+		t.Fatal("explainClientReadTimeout returned nil for a deadline kill")
+	}
+	msg := got.Error()
+	for _, want := range []string{"schema init", "server is SLOW", "not the connection broken"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message %q missing %q — it must not blame the transport", msg, want)
+		}
+	}
+	// The original must stay unwrapped-reachable so existing classification
+	// (isRetryableError and callers matching on the driver string) is unchanged.
+	if !errors.Is(got, orig) {
+		t.Error("wrapped error lost the original; retry classification would change")
+	}
+	if !isRetryableError(got) {
+		t.Error("wrapping must NOT alter retry classification — that is a separate, measured decision")
+	}
+}
+
+func TestExplainClientReadTimeoutPassesThroughOtherErrors(t *testing.T) {
+	orig := errors.New("Error 1049 (HY000): database not found: nope")
+	if got := explainClientReadTimeout(orig, time.Minute, defaultPoolReadTimeout, "schema init"); got != orig {
+		t.Errorf("unrelated error was rewritten: %v", got)
+	}
+	if got := explainClientReadTimeout(nil, time.Minute, defaultPoolReadTimeout, "schema init"); got != nil {
+		t.Errorf("nil error was rewritten: %v", got)
+	}
+	// A fast connection loss is a REAL transport failure and must keep saying so.
+	fast := errors.New("invalid connection")
+	if got := explainClientReadTimeout(fast, 100*time.Millisecond, defaultPoolReadTimeout, "schema init"); got != fast {
+		t.Errorf("fast connection loss was rewritten as a timeout: %v", got)
+	}
+	// A connection with no read deadline (openMigrationDB, embedded mode) can
+	// never suffer a deadline kill, however long the call took.
+	if got := explainClientReadTimeout(fast, time.Hour, 0, "schema init"); got != fast {
+		t.Errorf("deadline-less connection was blamed on a deadline: %v", got)
+	}
+}
+
+// The DSN and the classifier must read one value; drift between them would make
+// the discriminator silently wrong. buildServerDSN writes the deadline and
+// DoltStore.poolReadDeadline reads it back, so every input to the deadline —
+// the knob (dolt.pool-read-timeout / BEADS_DOLT_POOL_READ_TIMEOUT, be-4at) and
+// the per-command PoolReadTimeoutFallback (wy-sbgucn) — reaches both without
+// the classifier having to re-derive any of that precedence. A second
+// hard-coded constant is what blamed a rig running at 60s on "the 10s client
+// read deadline" — the real value at 1/6 scale.
+func TestPoolReadTimeoutIsTheDSNValue(t *testing.T) {
+	cases := []struct {
+		name     string
+		knob     time.Duration
+		fallback time.Duration
+		wantDSN  string
+		want     time.Duration
+	}{
+		{"unset knob keeps the built-in default", 0, 0, "readTimeout=10s", defaultPoolReadTimeout},
+		{"knob at 60s reaches the DSN and the blame text", time.Minute, 0, "readTimeout=1m0s", time.Minute},
+		// PoolReadTimeoutFallback replaces the built-in default when nothing
+		// set the knob, so the classifier must name IT and not 10s.
+		{"fallback replaces the built-in default", 0, 5 * time.Minute, "readTimeout=5m0s", 5 * time.Minute},
+		// An explicit knob still wins over the fallback, in the DSN and
+		// therefore in the blame text too.
+		{"explicit knob beats the fallback", time.Minute, 5 * time.Minute, "readTimeout=1m0s", time.Minute},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				ServerHost:              "127.0.0.1",
+				ServerPort:              51361,
+				ServerUser:              "root",
+				PoolReadTimeout:         tc.knob,
+				PoolReadTimeoutFallback: tc.fallback,
+			}
+			dsn := buildServerDSN(cfg, "hq")
+			if !strings.Contains(dsn, tc.wantDSN) {
+				t.Fatalf("DSN %q does not carry %s", dsn, tc.wantDSN)
+			}
+			s := &DoltStore{connStr: dsn}
+			if got := s.poolReadDeadline(); got != tc.want {
+				t.Fatalf("poolReadDeadline() = %v, want %v — classifier and DSN have drifted", got, tc.want)
+			}
+			// The blame text must name the deadline the DSN was built with.
+			msg := explainClientReadTimeout(
+				errors.New("invalid connection"), tc.want+time.Second, s.poolReadDeadline(), "schema init").Error()
+			if !strings.Contains(msg, tc.want.String()) {
+				t.Errorf("blame text %q does not name the %s deadline it was built with", msg, tc.want)
+			}
+			if tc.want != defaultPoolReadTimeout && strings.Contains(msg, defaultPoolReadTimeout.String()) {
+				t.Errorf("blame text %q still names the built-in %s instead of the configured %s",
+					msg, defaultPoolReadTimeout, tc.want)
+			}
+		})
+	}
+}

--- a/internal/storage/dolt/fresh_bootstrap_heal_integration_test.go
+++ b/internal/storage/dolt/fresh_bootstrap_heal_integration_test.go
@@ -181,7 +181,7 @@ func TestFreshBootstrapHealIncarnation(t *testing.T) {
 		prepareFreshBootstrapV51Dirty(t, ctx, replacement, "foreign_debris")
 
 		_, migrateErr := initSchemaOnDBWithRetryAndGateBootstrapHeal(
-			ctx, creatorDB, nil, facts.bootstrapHeal, serverEndpointIdentity(cfg),
+			ctx, creatorDB, nil, facts.bootstrapHeal, serverEndpointIdentity(cfg), defaultPoolReadTimeout,
 		)
 		var dirtyErr *schema.DirtyTablesError
 		if !errors.As(migrateErr, &dirtyErr) {

--- a/internal/storage/dolt/initschema_concurrent_test.go
+++ b/internal/storage/dolt/initschema_concurrent_test.go
@@ -76,7 +76,7 @@ func TestConcurrentInitSchema(t *testing.T) {
 
 			<-ready // wait for all goroutines to be ready
 
-			if _, err := initSchemaOnDBWithRetry(ctx, db); err != nil {
+			if _, err := initSchemaOnDBWithRetry(ctx, db, defaultPoolReadTimeout); err != nil {
 				errs <- fmt.Errorf("goroutine %d: initSchemaOnDB: %w", n, err)
 			}
 		}(i)
@@ -180,7 +180,7 @@ func TestInitSchemaBlocksOnMigrationLock(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := initSchemaOnDBWithRetry(ctx, initDB2)
+		_, err := initSchemaOnDBWithRetry(ctx, initDB2, defaultPoolReadTimeout)
 		errCh <- err
 	}()
 
@@ -264,7 +264,7 @@ func TestInitSchemaCanceledLockWaitDoesNotBlockFutureInit(t *testing.T) {
 	callerCtx, callerCancel := context.WithCancel(ctx)
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := initSchemaOnDBWithRetry(callerCtx, blockedDB)
+		_, err := initSchemaOnDBWithRetry(callerCtx, blockedDB, defaultPoolReadTimeout)
 		errCh <- err
 	}()
 
@@ -296,7 +296,7 @@ func TestInitSchemaCanceledLockWaitDoesNotBlockFutureInit(t *testing.T) {
 
 	verifyCtx, verifyCancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer verifyCancel()
-	if _, err := initSchemaOnDBWithRetry(verifyCtx, secondDB); err != nil {
+	if _, err := initSchemaOnDBWithRetry(verifyCtx, secondDB, defaultPoolReadTimeout); err != nil {
 		t.Fatalf("second initSchemaOnDB after canceled lock wait: %v", err)
 	}
 }
@@ -357,7 +357,7 @@ func TestMigrationLockReleaseIgnoresCanceledCallerContext(t *testing.T) {
 
 	verifyCtx, verifyCancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer verifyCancel()
-	if _, err := initSchemaOnDBWithRetry(verifyCtx, secondDB); err != nil {
+	if _, err := initSchemaOnDBWithRetry(verifyCtx, secondDB, defaultPoolReadTimeout); err != nil {
 		t.Fatalf("second initSchemaOnDB after canceled-context release: %v", err)
 	}
 }

--- a/internal/storage/dolt/initschema_gate_test.go
+++ b/internal/storage/dolt/initschema_gate_test.go
@@ -35,7 +35,7 @@ func TestInitSchemaOnDBWithRetryAndGate_GateErrorClassification(t *testing.T) {
 			}
 			return &schema.RemoteMigrateGateError{CurrentVersion: 1, LatestVersion: 2, Pending: 1}
 		}
-		_, err := initSchemaOnDBWithRetryAndGate(ctx, db, gate)
+		_, err := initSchemaOnDBWithRetryAndGate(ctx, db, gate, defaultPoolReadTimeout)
 		if !schema.IsRemoteMigrateGateError(err) {
 			t.Fatalf("err = %T (%v), want *schema.RemoteMigrateGateError after retries", err, err)
 		}
@@ -66,7 +66,7 @@ func TestInitSchemaOnDBWithRetryAndGate_GateErrorClassification(t *testing.T) {
 				}
 				return &schema.RemoteMigrateGateError{CurrentVersion: 1, LatestVersion: 2, Pending: 1}
 			}
-			_, err := initSchemaOnDBWithRetryAndGate(ctx, db, gate)
+			_, err := initSchemaOnDBWithRetryAndGate(ctx, db, gate, defaultPoolReadTimeout)
 			if !schema.IsRemoteMigrateGateError(err) {
 				t.Fatalf("err = %T (%v), want *schema.RemoteMigrateGateError after retries", err, err)
 			}
@@ -82,7 +82,7 @@ func TestInitSchemaOnDBWithRetryAndGate_GateErrorClassification(t *testing.T) {
 			calls++
 			return &schema.RemoteMigrateGateError{CurrentVersion: 1, LatestVersion: 2, Pending: 1}
 		}
-		_, err := initSchemaOnDBWithRetryAndGate(ctx, db, gate)
+		_, err := initSchemaOnDBWithRetryAndGate(ctx, db, gate, defaultPoolReadTimeout)
 		if !schema.IsRemoteMigrateGateError(err) {
 			t.Fatalf("err = %T (%v), want *schema.RemoteMigrateGateError", err, err)
 		}
@@ -97,7 +97,7 @@ func TestInitSchemaOnDBWithRetryAndGate_GateErrorClassification(t *testing.T) {
 			calls++
 			return errors.New("remote-migrate gate: read remotes: syntax error")
 		}
-		_, err := initSchemaOnDBWithRetryAndGate(ctx, db, gate)
+		_, err := initSchemaOnDBWithRetryAndGate(ctx, db, gate, defaultPoolReadTimeout)
 		if err == nil || schema.IsRemoteMigrateGateError(err) {
 			t.Fatalf("err = %v, want plain permanent error", err)
 		}
@@ -113,7 +113,7 @@ func TestInitSchemaOnDBWithRetryAndGate_GateErrorClassification(t *testing.T) {
 			return fmt.Errorf("remote-migrate gate: probe schema: %w",
 				&mysql.MySQLError{Number: 1105, Message: "connection lost while validating commit"})
 		}
-		_, err := initSchemaOnDBWithRetryAndGate(ctx, db, gate)
+		_, err := initSchemaOnDBWithRetryAndGate(ctx, db, gate, defaultPoolReadTimeout)
 		if err == nil || schema.IsRemoteMigrateGateError(err) {
 			t.Fatalf("err = %v, want plain permanent error", err)
 		}

--- a/internal/storage/dolt/initschema_multiprocess_test.go
+++ b/internal/storage/dolt/initschema_multiprocess_test.go
@@ -75,7 +75,7 @@ func TestHelperSchemaInit(t *testing.T) {
 	// with N processes on one fresh database, N-1 of them are supposed to lose
 	// the lock and come back. #5880 made the same change in this file's
 	// TestMultiProcessSchemaInit_DoltVerify and missed this subprocess helper.
-	_, err = initSchemaOnDBWithRetry(ctx, db)
+	_, err = initSchemaOnDBWithRetry(ctx, db, defaultPoolReadTimeout)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: initSchemaOnDBWithRetry: %v\n", err)
 		os.Exit(1)
@@ -301,7 +301,7 @@ func TestMultiProcessSchemaInit_DoltVerify(t *testing.T) {
 			// retry wrapper (store.go's initSchema), which exists precisely so
 			// contended GET_LOCK attempts converge instead of one unlucky
 			// waiter failing outright.
-			_, err = initSchemaOnDBWithRetry(egCtx, db)
+			_, err = initSchemaOnDBWithRetry(egCtx, db, defaultPoolReadTimeout)
 			return err
 		})
 	}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -609,6 +609,50 @@ func newServerRetryBackoff() backoff.BackOff {
 	return bo
 }
 
+// looksLikeClientReadTimeout reports whether err is the go-sql-driver's
+// deadline kill rather than a server/network failure. The driver surfaces BOTH
+// as "invalid connection" / "driver: bad connection", so the string alone
+// cannot distinguish them — but a deadline kill lands at the deadline, and a
+// server disappearing does not care what our timeout is. elapsed is measured
+// around the failing call, and deadline is the read deadline the failing
+// connection was actually built with (DoltStore.poolReadDeadline) — never a
+// second copy of it, or the blame names a deadline that never fired.
+//
+// Why this matters (ga-2xwhcz, 2026-08-31): under load, real gc/bd reads
+// exceeded the 10s pool deadline and reported "invalid connection" / "failed
+// to generate issue ID: bad connection". That reads as a broken transport and
+// sent responders at connectivity while the actual fault was a slow server —
+// a misdiagnosis that cost hours across two incident windows.
+func looksLikeClientReadTimeout(err error, elapsed, deadline time.Duration) bool {
+	// deadline <= 0 means the connection carries no read deadline at all
+	// (openMigrationDB, embedded mode), so no deadline kill is possible.
+	if err == nil || deadline <= 0 {
+		return false
+	}
+	// Allow a small margin: the deadline fires slightly after it expires.
+	if elapsed < deadline-(500*time.Millisecond) {
+		return false
+	}
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "invalid connection") ||
+		strings.Contains(errStr, "driver: bad connection")
+}
+
+// explainClientReadTimeout rewrites a deadline kill into an error that names
+// the real cause. It deliberately does NOT change retry classification —
+// changing failure semantics under load is a separate, measured decision — it
+// only stops the error from lying about which subsystem is at fault.
+func explainClientReadTimeout(err error, elapsed, deadline time.Duration, what string) error {
+	if !looksLikeClientReadTimeout(err, elapsed, deadline) {
+		return err
+	}
+	return fmt.Errorf(
+		"%s exceeded the %s client read deadline after %s: the server is SLOW, not the connection broken "+
+			"(the MySQL driver reports a deadline kill as \"invalid connection\"); "+
+			"check complex-query health, not connectivity: %w",
+		what, deadline, elapsed.Round(time.Millisecond), err)
+}
+
 // isRetryableError returns true if the error is a transient connection error
 // that should be retried in server mode.
 func isRetryableError(err error) bool {
@@ -2197,6 +2241,32 @@ func isExternalServerHost(host string) bool {
 	return true
 }
 
+// poolReadDeadline reports the read deadline this store's pooled connections
+// were actually built with, read back off the DSN buildServerDSN produced. It
+// is the discriminator the client-timeout classifier uses (ga-2xwhcz): the
+// MySQL driver reports a deadline kill as "invalid connection",
+// indistinguishable by string from a server that genuinely went away, so
+// elapsed-vs-this-value is what tells them apart. Reading it back off the DSN
+// keeps the classifier and the DSN on ONE value — a second copy is how the two
+// silently drift, and a hard-coded 10s blames a deadline a rig running
+// dolt.pool-read-timeout=60s never had. It also picks up
+// Config.PoolReadTimeoutFallback for free, because buildServerDSN has already
+// resolved the whole precedence chain into the DSN by the time it is read
+// back. Returns 0 when the connection carries no read deadline, which the
+// classifier treats as "no deadline kill possible".
+//
+// No production caller yet, by design: the only site that classifies today runs
+// over openMigrationDB's deadline-less pool and passes 0. This is the contract
+// the pooled-path adoption (ga-yma80p) stands on, and the DSN-coherence test
+// TestPoolReadTimeoutIsTheDSNValue keeps it honest until then.
+func (s *DoltStore) poolReadDeadline() time.Duration {
+	parsed, err := mysql.ParseDSN(s.connStr)
+	if err != nil {
+		return defaultPoolReadTimeout
+	}
+	return parsed.ReadTimeout
+}
+
 // buildServerDSN constructs a MySQL DSN for connecting to a Dolt server.
 // If database is empty, connects without selecting a database (for init operations).
 // Adds ReadTimeout/WriteTimeout for long-lived connection pools.
@@ -2624,8 +2694,11 @@ func initSchemaOnDBWithBootstrapHeal(
 	return applied, nil
 }
 
-func initSchemaOnDBWithRetry(ctx context.Context, db *sql.DB) (int, error) {
-	return initSchemaOnDBWithRetryAndGate(ctx, db, nil)
+// readDeadline is the caller's pool read deadline, used only to name a client
+// deadline kill for what it is (see explainClientReadTimeout); pass 0 when the
+// connection carries no read deadline.
+func initSchemaOnDBWithRetry(ctx context.Context, db *sql.DB, readDeadline time.Duration) (int, error) {
+	return initSchemaOnDBWithRetryAndGate(ctx, db, nil, readDeadline)
 }
 
 // initSchemaOnDBWithRetryAndGate is initSchemaOnDBWithRetry with an optional
@@ -2634,8 +2707,8 @@ func initSchemaOnDBWithRetry(ctx context.Context, db *sql.DB) (int, error) {
 // startup/catalog races the migration retry absorbs, so gate probe errors are
 // retried with them instead of failing the open fast (bd-6dnrw.30); a
 // *schema.RemoteMigrateGateError refusal stays permanent.
-func initSchemaOnDBWithRetryAndGate(ctx context.Context, db *sql.DB, gate func(context.Context, *sql.DB) error) (int, error) {
-	return initSchemaOnDBWithRetryAndGateBootstrapHeal(ctx, db, gate, nil, "")
+func initSchemaOnDBWithRetryAndGate(ctx context.Context, db *sql.DB, gate func(context.Context, *sql.DB) error, readDeadline time.Duration) (int, error) {
+	return initSchemaOnDBWithRetryAndGateBootstrapHeal(ctx, db, gate, nil, "", readDeadline)
 }
 
 // initSchemaOnDBWithRetryAndGateBootstrapHeal shares one capability across the
@@ -2646,6 +2719,7 @@ func initSchemaOnDBWithRetryAndGateBootstrapHeal(
 	gate func(context.Context, *sql.DB) error,
 	bootstrapHeal *schema.FreshBootstrapHealCapability,
 	endpoint string,
+	readDeadline time.Duration,
 ) (int, error) {
 	// Schema initialization for server mode is idempotent. Retry transient
 	// Dolt startup/catalog races and contended migration-lock attempts so
@@ -2666,7 +2740,12 @@ func initSchemaOnDBWithRetryAndGateBootstrapHeal(
 			}
 		}
 		var schemaErr error
+		attemptStart := time.Now()
 		applied, schemaErr = initSchemaOnDBWithBootstrapHeal(ctx, db, bootstrapHeal, endpoint)
+		// Name a deadline kill for what it is before it propagates. Retry
+		// classification is unchanged — this only stops the surfaced error from
+		// blaming the transport for a slow server (ga-2xwhcz).
+		schemaErr = explainClientReadTimeout(schemaErr, time.Since(attemptStart), readDeadline, "schema init")
 		if schemaErr != nil && isRetryableError(schemaErr) {
 			return schemaErr
 		}
@@ -2729,7 +2808,16 @@ func (s *DoltStore) initSchema(ctx context.Context, bootstrapHeal *schema.FreshB
 	gate := func(ctx context.Context, db *sql.DB) error {
 		return schema.CheckRemoteMigrateGateForRemoteWithRemoteCheckAndAdopt(ctx, db, s.remote, s.hasPersistedCLIRemote, adopt)
 	}
-	applied, err := initSchemaOnDBWithRetryAndGateBootstrapHeal(ctx, migDB, gate, bootstrapHeal, s.serverEndpoint)
+	// Read deadline 0, deliberately: openMigrationDB builds its pool with
+	// ReadTimeout=0 so a long migration is never killed mid-flight, which makes
+	// a client deadline kill IMPOSSIBLE on this path. Passing the pooled
+	// deadline here would blame a deadline this connection never had — the same
+	// lie the classifier exists to stop, just at a different number. The
+	// deadline<=0 guard in looksLikeClientReadTimeout keeps the explainer
+	// correctly silent. Adopting it on the pooled path, where the ga-2xwhcz
+	// incident actually spoke ("failed to generate issue ID: bad connection"),
+	// is tracked as ga-yma80p — this silence is intentional, not an oversight.
+	applied, err := initSchemaOnDBWithRetryAndGateBootstrapHeal(ctx, migDB, gate, bootstrapHeal, s.serverEndpoint, 0)
 	return applied, err
 }
 
@@ -2742,7 +2830,10 @@ func (s *DoltStore) ApplySchemaMigrations(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	defer migDB.Close()
-	return initSchemaOnDBWithRetry(ctx, migDB)
+	// Read deadline 0 for the same reason as initSchema: this runs over
+	// openMigrationDB's ReadTimeout=0 pool, so no client deadline kill can
+	// occur and naming one would misattribute the failure (ga-yma80p).
+	return initSchemaOnDBWithRetry(ctx, migDB, 0)
 }
 
 // openMigrationDB opens a one-off connection pool for schema migrations with no


### PR DESCRIPTION
Fixes #6219.

## Problem

The go-sql-driver reports its **own** read-deadline kill as `invalid connection` / `driver: bad connection` — the same strings a genuinely dead server produces. `buildServerDSN` puts a per-I/O `ReadTimeout` on pooled connections (the `dolt.pool-read-timeout` / `BEADS_DOLT_POOL_READ_TIMEOUT` knob, default 10s), so under load a legitimate read can be killed by the driver at that deadline while the server is merely slow. The surfaced string cannot separate "slow server" from "broken transport," so diagnosis chases connectivity instead of load. In production (ga-2xwhcz, 2026-08-31) this cost hours across two incident windows.

`#4355` widened the server-mode write-tx retry predicate to `isRetryableError`, which covers precisely these two strings (later reconciled by `#4462`) — so the blame is *sticky*: each retry exceeds the deadline again and re-reports a broken transport.

## Fix

Add the discriminator the string lacks: **elapsed vs the read deadline the failing connection was actually built with**. A deadline kill lands at the deadline; a vanished server does not wait for our timeout.

- `looksLikeClientReadTimeout(err, elapsed, deadline)` — true only when the error matches those driver strings **and** `elapsed >= deadline - 500ms` **and** `deadline > 0`.
- `explainClientReadTimeout(...)` — rewrites such an error to name the real cause ("the server is SLOW, not the connection broken … check complex-query health, not connectivity"), wrapping the original with `%w`.
- `DoltStore.poolReadDeadline()` — reads `ReadTimeout` back off the store's own DSN (`mysql.ParseDSN`), so the classifier and the DSN share one value and cannot drift. Every input `buildServerDSN` already resolved — the pool-read-timeout knob and `Config.PoolReadTimeoutFallback` — reaches the blame text for free; a second hard-coded 10s would blame a rig running at 60s for a deadline it never had.

The one site that classifies today is the schema-init retry loop; the attempt is timed and its error passed through `explainClientReadTimeout` before `isRetryableError` sees it. Both production callers of that chain run over `openMigrationDB`'s `ReadTimeout=0` pool and pass `0` deliberately (naming a deadline that connection never had would be the same lie at a different number). Adopting the classifier on the pooled path — where the incident actually spoke — is tracked separately as ga-yma80p.

## Retry classification is deliberately unchanged

`isRetryableError` is untouched (byte-identical to `main`), and the rewrite wraps the original with `%w`, so the substring match and `errors.Is`/`errors.As` all see exactly what they saw before — a deadline kill stays retryable. Making deadline kills non-retryable would turn recoverable blips into hard failures: a separate decision that deserves measurement, not a side effect of a message fix.

## Tests

- New `client_timeout_test.go`: the classifier's boundary cases (below/at/past the deadline, the margin, `deadline<=0`, both driver strings vs unrelated errors), that `explainClientReadTimeout` names the cause while `errors.Is(got, orig)` and `isRetryableError(got)` both still hold, and `TestPoolReadTimeoutIsTheDSNValue` (the classifier value == the DSN value, across the built-in default, `PoolReadTimeoutFallback`, and an explicit `PoolReadTimeout`).
- `go test ./internal/storage/dolt/ -run 'ClientReadTimeout|PoolReadTimeout'` passes.

## Note

Two pre-existing failures in this package (`TestDoltNew_ReadOnly_ForwardDrift_ReturnsSchemaSkewError`, `TestCheckForwardDrift_ForwardDrift_ReturnsSchemaSkewError`) fail identically on `main` — a forward schema-drift fixture at v67 vs a v66 binary — and are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)