### PR TITLE
fix(test): reap dolt sql-servers leaked by killed test runs

### DIFF
--- a/cmd/bd/test_repo_beads_guard_test.go
+++ b/cmd/bd/test_repo_beads_guard_test.go
@@ -50,9 +50,13 @@ type testRunner interface {
 
 func runTestsAndSweep(m testRunner) int {
 	code := m.Run()
-	doltserver.SweepOrphanedTestServers(testTempRoot)
-	return code
+	swept := doltserver.SweepOrphanedTestServers(testTempRoot)
+	return doltserver.ApplyLeakPolicy("cmd/bd", code, swept)
 }
+
+// suiteRootPrefix is testMainInner's os.MkdirTemp pattern without its random
+// tail. It is what SweepDeadSuiteRoots globs for, so the two must not drift.
+const suiteRootPrefix = "beads-bd-tests-"
 
 // Guardrail: ensure the cmd/bd test suite does not touch the real repo .beads state.
 // Disable with BEADS_TEST_GUARD_DISABLE=1 (useful when running tests while actively using beads).
@@ -68,12 +72,26 @@ func testMainInner(m *testing.M) int {
 	// Many tests expect default config values; running from within this repo would
 	// cause config.Initialize() to walk up from CWD and load `.beads/config.yaml`,
 	// which may set non-default config values and makes tests assert the wrong behavior.
-	tmp, err := os.MkdirTemp("", "beads-bd-tests-*")
+	// Before claiming a root of our own, clear out the roots of EARLIER runs
+	// of this suite whose process is gone — a `go test -timeout` panic skips
+	// both the defer below and the post-Run sweep, so the servers those runs
+	// started outlive every cleanup this process installs, and nothing else
+	// ever looks at a dead run's tree again (wy-j2zc8q). Roots with no owner
+	// marker, and roots whose owner is still running, are left untouched.
+	doltserver.SweepDeadSuiteRoots(os.TempDir(), suiteRootPrefix)
+
+	tmp, err := os.MkdirTemp("", suiteRootPrefix+"*")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
 		return 1
 	}
 	defer func() { _ = forceRemoveAll(tmp) }()
+
+	// Claim the root for this process so the NEXT run can tell our debris
+	// from a concurrent run's live tree.
+	if err := doltserver.WriteSuiteOwnerMarker(tmp); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not claim suite temp root %s: %v\n", tmp, err)
+	}
 
 	// Anchor package-level sync.Once builders (test binaries, isolated
 	// HOMEs) under this directory so the defer above sweeps them up too.

--- a/internal/doltserver/sweep.go
+++ b/internal/doltserver/sweep.go
@@ -1,6 +1,8 @@
 package doltserver
 
 import (
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -24,10 +26,9 @@ type serverCandidate struct {
 // reap as leaked test debris. A candidate qualifies only when its cmdline
 // names a dolt sql-server AND either:
 //
-//   - its working directory has been deleted (the temp dir it was serving
-//     no longer exists — this is the signature of a SIGKILLed test run
-//     whose t.TempDir() cleanup ran on top of a still-live server), or
-//   - its working directory sits under one of suiteRoots.
+//   - its working directory sits under one of suiteRoots, or
+//   - its working directory has been deleted AND the path it used to name
+//     sits under one of tempRoots.
 //
 // suiteRoots MUST be directories owned by the calling test suite alone
 // (e.g. that suite's own testTempRoot) — never a shared/global temp dir
@@ -38,28 +39,95 @@ type serverCandidate struct {
 // data dirs live somewhere under os.TempDir() too. Passing a global root
 // here would turn this safety net into a cross-suite server killer.
 //
+// tempRoots (see tempDirRoots) bounds the deleted-cwd arm to throwaway
+// directories. A deleted working directory is a strong leak signal — a
+// t.TempDir() cleanup ran on top of a still-live detached server — but it is
+// NOT by itself proof of a TEST server: a production server is spawned with
+// cmd.Dir = <workspace>/.beads/dolt, so a developer who moved or deleted that
+// workspace, or whose external volume was unmounted, would have their live
+// server reaped by any test run on the box. Requiring the deleted path to
+// have been under a temp dir keeps the arm pointed at test debris only.
+//
 // This is intentionally conservative in the "never kill production" sense:
-// a real shared server's data directory is a persistent, non-temp path that
-// still exists and is never one of a test suite's own scoped roots, so it
-// matches neither condition and is left alone.
-func selectOrphanTestServerPIDs(candidates []serverCandidate, suiteRoots []string) []int {
+// a real shared server's data directory is a persistent, non-temp path, so it
+// is neither under a suite's scoped roots nor — deleted or not — under a temp
+// root, and matches neither condition.
+func selectOrphanTestServerPIDs(candidates []serverCandidate, suiteRoots, tempRoots []string) []int {
+	return selectCandidatePIDs(candidates, func(c serverCandidate) bool {
+		if underAnyRoot(c.cwd, suiteRoots) {
+			return true
+		}
+		return c.cwdDeleted && underAnyRoot(c.cwd, tempRoots)
+	})
+}
+
+// selectServersUnderRoots returns the PIDs of candidates whose working
+// directory sits under one of roots, and nothing else. It is the strictly
+// root-scoped selection: no deleted-cwd arm, so it can never reach a process
+// outside the caller's own trees.
+//
+// SweepDeadSuiteRoots uses it because that sweep runs at suite START, while
+// sibling packages (go test -p N) are mid-run: whatever it reaps must be
+// provably inside the one dead root it is cleaning up, never merely
+// "somewhere temporary".
+func selectServersUnderRoots(candidates []serverCandidate, roots []string) []int {
+	return selectCandidatePIDs(candidates, func(c serverCandidate) bool {
+		return underAnyRoot(c.cwd, roots)
+	})
+}
+
+// selectCandidatePIDs applies want to every candidate that is a dolt
+// sql-server with a known working directory. A candidate whose cwd could not
+// be resolved is always skipped: unknown is not provably debris.
+func selectCandidatePIDs(candidates []serverCandidate, want func(serverCandidate) bool) []int {
 	var pids []int
 	for _, c := range candidates {
-		if !isDoltServerCmdline(c.cmdline) {
+		if !isDoltServerCmdline(c.cmdline) || c.cwd == "" {
 			continue
 		}
-		if c.cwdDeleted {
-			pids = append(pids, c.pid)
-			continue
-		}
-		if c.cwd == "" {
-			continue
-		}
-		if underAnyRoot(c.cwd, suiteRoots) {
+		if want(c) {
 			pids = append(pids, c.pid)
 		}
 	}
 	return pids
+}
+
+// tempDirRoots is the set of directories under which a deleted working
+// directory is credible evidence of leaked TEST debris rather than a moved
+// production workspace: the process temp dir (honoring TMPDIR, which the
+// suites pin to their own root) and /tmp, which os.MkdirTemp uses when TMPDIR
+// is unset and which several suites hardcode.
+func tempDirRoots() []string {
+	return canonicalRoots([]string{os.TempDir(), "/tmp"})
+}
+
+// canonicalRoots expands each non-empty root into every form a process's
+// working directory may be reported in: the path as given and, when it
+// differs, its symlink-resolved form. macOS is why — os.MkdirTemp hands back
+// /var/folders/… while lsof reports the /private/var/folders/… that symlink
+// points at — but /tmp is a symlink to /private/tmp there too, and on Linux
+// /tmp can be a symlink as well. Roots that cannot be resolved are kept
+// as-is; duplicates are dropped.
+func canonicalRoots(roots []string) []string {
+	var out []string
+	seen := make(map[string]bool, len(roots)*2)
+	add := func(path string) {
+		if path == "" || seen[path] {
+			return
+		}
+		seen[path] = true
+		out = append(out, path)
+	}
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		add(root)
+		if resolved, err := filepath.EvalSymlinks(root); err == nil {
+			add(resolved)
+		}
+	}
+	return out
 }
 
 // isDoltServerCmdline reports whether cmdline looks like a dolt sql-server

--- a/internal/doltserver/sweep.go
+++ b/internal/doltserver/sweep.go
@@ -126,6 +126,15 @@ func tempDirRoots() []string {
 // The home test doubles as the breadth test: a directory holding the user's
 // home holds their workspaces too, so a deleted .beads/dolt under it would
 // again look like test debris.
+//
+// The one home that anchors no workspaces is a SANDBOX home: CI harnesses
+// (scripts/ci/lib/test-env.sh) export HOME under a mktemp -d root so a test
+// can never read or write the runner's real dotfiles. That home lives under
+// /tmp, and without this carve-out it would disqualify /tmp itself, leaving
+// tempDirRoots empty and the deleted-cwd arm silently disabled on exactly the
+// boxes whose killed runs it exists to clean up after. A root that merely
+// contains a sandbox home stays credible; a root that IS the home does not,
+// whatever the home looks like.
 func isCredibleTempRoot(root, home string) bool {
 	cleaned := filepath.Clean(root)
 	if cleaned == "" || cleaned == "." || cleaned == string(filepath.Separator) {
@@ -138,11 +147,24 @@ func isCredibleTempRoot(root, home string) bool {
 		return true
 	}
 	for _, h := range canonicalRoots([]string{home}) {
-		if isUnderDir(filepath.Clean(h), cleaned) {
+		h = filepath.Clean(h)
+		if h == cleaned {
+			return false
+		}
+		if isUnderDir(h, cleaned) && !isSandboxHome(h) {
 			return false
 		}
 	}
 	return true
+}
+
+// isSandboxHome reports whether home lives inside the fixed /tmp fallback —
+// the shape a test harness's throwaway HOME takes. It is judged against the
+// hardcoded fallback, never os.TempDir(), so TMPDIR cannot vote on its own
+// credibility: TMPDIR=/home with HOME=/home/runner must still read as a real
+// home under an overbroad root.
+func isSandboxHome(home string) bool {
+	return underAnyRoot(home, canonicalRoots([]string{"/tmp"}))
 }
 
 // canonicalRoots expands each non-empty root into every form a process's

--- a/internal/doltserver/sweep.go
+++ b/internal/doltserver/sweep.go
@@ -97,8 +97,52 @@ func selectCandidatePIDs(candidates []serverCandidate, want func(serverCandidate
 // production workspace: the process temp dir (honoring TMPDIR, which the
 // suites pin to their own root) and /tmp, which os.MkdirTemp uses when TMPDIR
 // is unset and which several suites hardcode.
+//
+// Roots too broad to be evidence of anything are dropped — see
+// isCredibleTempRoot. TMPDIR is an environment variable, so "/" or a home
+// directory can land here, and a root that broad would restore exactly the
+// unbounded deleted-cwd arm this bound exists to remove.
 func tempDirRoots() []string {
-	return canonicalRoots([]string{os.TempDir(), "/tmp"})
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
+	var roots []string
+	for _, root := range canonicalRoots([]string{os.TempDir(), "/tmp"}) {
+		if !isCredibleTempRoot(root, home) {
+			continue
+		}
+		roots = append(roots, root)
+	}
+	return roots
+}
+
+// isCredibleTempRoot reports whether root is narrow enough to bound the
+// deleted-cwd arm. It rejects the filesystem root, a relative or empty path,
+// and any directory that IS the user's home or contains it — "/", "/Users",
+// "/home", $HOME itself. Everything a real temp dir looks like (/tmp,
+// /private/tmp, /var/folders/xx/yy/T, a pinned suite root) passes.
+//
+// The home test doubles as the breadth test: a directory holding the user's
+// home holds their workspaces too, so a deleted .beads/dolt under it would
+// again look like test debris.
+func isCredibleTempRoot(root, home string) bool {
+	cleaned := filepath.Clean(root)
+	if cleaned == "" || cleaned == "." || cleaned == string(filepath.Separator) {
+		return false
+	}
+	if !filepath.IsAbs(cleaned) {
+		return false
+	}
+	if home == "" {
+		return true
+	}
+	for _, h := range canonicalRoots([]string{home}) {
+		if isUnderDir(filepath.Clean(h), cleaned) {
+			return false
+		}
+	}
+	return true
 }
 
 // canonicalRoots expands each non-empty root into every form a process's

--- a/internal/doltserver/sweep_darwin.go
+++ b/internal/doltserver/sweep_darwin.go
@@ -97,6 +97,10 @@ func isDoltServerProcess(pid int) bool {
 	return isDoltServerCmdline(strings.TrimSpace(string(out)))
 }
 
+// statFunc matches os.Stat. parseDarwinCwd takes one so its
+// deleted-directory probe can be exercised without a live process.
+type statFunc func(string) (os.FileInfo, error)
+
 // readDarwinCwd resolves pid's cwd from lsof's machine-readable field output.
 // lsof emits the name as an `n` field after selecting descriptor `cwd`.
 func readDarwinCwd(pid int) (cwd string, deleted bool, ok bool) {
@@ -106,7 +110,27 @@ func readDarwinCwd(pid int) (cwd string, deleted bool, ok bool) {
 	if err != nil {
 		return "", false, false
 	}
-	for _, line := range strings.Split(string(out), "\n") {
+	return parseDarwinCwd(out, os.Stat)
+}
+
+// parseDarwinCwd extracts the working directory from `lsof -Fn` output and
+// decides whether that directory still exists.
+//
+// Unlike Linux's /proc/<pid>/cwd symlink, macOS lsof does NOT append a
+// " (deleted)" marker when the directory a process is sitting in has been
+// unlinked — it prints the bare, now-dangling path. The suffix is still
+// honored (harmless, and it keeps this parser shaped like readProcCwd), but
+// when it is absent the path is stat'ed and ENOENT is the deletion signal.
+// Without that probe the deleted-cwd arm of selectOrphanTestServerPIDs could
+// never fire on darwin, so a `go test -timeout` panic — which skips every
+// t.Cleanup and TestMain defer — left its dolt sql-server running forever
+// even though the temp tree it served was long gone (wy-j2zc8q).
+//
+// Any other stat error (a permission wall, an unreadable parent) is treated
+// as "not deleted": this sweep only ever escalates on positive proof, never
+// on a failed read.
+func parseDarwinCwd(lsofOutput []byte, stat statFunc) (cwd string, deleted bool, ok bool) {
+	for _, line := range strings.Split(string(lsofOutput), "\n") {
 		if !strings.HasPrefix(line, "n") {
 			continue
 		}
@@ -115,9 +139,13 @@ func readDarwinCwd(pid int) (cwd string, deleted bool, ok bool) {
 		if strings.HasSuffix(cwd, deletedSuffix) {
 			return strings.TrimSuffix(cwd, deletedSuffix), true, true
 		}
-		if cwd != "" {
-			return cwd, false, true
+		if cwd == "" {
+			continue
 		}
+		if _, err := stat(cwd); err != nil && os.IsNotExist(err) {
+			return cwd, true, true
+		}
+		return cwd, false, true
 	}
 	return "", false, false
 }

--- a/internal/doltserver/sweep_darwin.go
+++ b/internal/doltserver/sweep_darwin.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -25,8 +24,28 @@ import (
 // Returns the PIDs it sent a kill signal to.
 func SweepOrphanedTestServers(suiteTempRoots ...string) []int {
 	candidates := gatherDoltServerCandidates()
-	pids := selectOrphanTestServerPIDs(candidates, canonicalDarwinRoots(suiteTempRoots))
+	pids := selectOrphanTestServerPIDs(candidates, canonicalRoots(suiteTempRoots), tempDirRoots())
+	return reapServerPIDs(pids)
+}
 
+// sweepServersUnderRoots reaps only the dolt sql-servers whose working
+// directory sits under one of suiteTempRoots. It is SweepOrphanedTestServers
+// without the deleted-cwd arm, for callers that must not reach outside the
+// trees they name — see selectServersUnderRoots.
+//
+// Returns the PIDs it sent a kill signal to.
+func sweepServersUnderRoots(suiteTempRoots ...string) []int {
+	candidates := gatherDoltServerCandidates()
+	pids := selectServersUnderRoots(candidates, canonicalRoots(suiteTempRoots))
+	return reapServerPIDs(pids)
+}
+
+// reapServerPIDs SIGTERMs each selected PID, then SIGKILLs whatever is still
+// alive a moment later, revalidating the process identity immediately before
+// each signal so a PID recycled since selection cannot be targeted.
+//
+// Returns the PIDs it sent a kill signal to.
+func reapServerPIDs(pids []int) []int {
 	self := os.Getpid()
 	var killed []int
 	for _, pid := range pids {
@@ -60,25 +79,6 @@ func SweepOrphanedTestServers(suiteTempRoots ...string) []int {
 	}
 
 	return killed
-}
-
-// canonicalDarwinRoots makes caller roots comparable with lsof output. macOS
-// commonly reports a cwd below /private/var while os.MkdirTemp returned the
-// equivalent /var path.
-func canonicalDarwinRoots(roots []string) []string {
-	canonical := make([]string, 0, len(roots))
-	for _, root := range roots {
-		if root == "" {
-			continue
-		}
-		resolved, err := filepath.EvalSymlinks(root)
-		if err != nil {
-			canonical = append(canonical, root)
-			continue
-		}
-		canonical = append(canonical, resolved)
-	}
-	return canonical
 }
 
 func gatherDoltServerCandidates() []serverCandidate {

--- a/internal/doltserver/sweep_darwin.go
+++ b/internal/doltserver/sweep_darwin.go
@@ -3,13 +3,10 @@
 package doltserver
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
-	"syscall"
-	"time"
 )
 
 // SweepOrphanedTestServers reaps `dolt sql-server` processes that are
@@ -25,7 +22,7 @@ import (
 func SweepOrphanedTestServers(suiteTempRoots ...string) []int {
 	candidates := gatherDoltServerCandidates()
 	pids := selectOrphanTestServerPIDs(candidates, canonicalRoots(suiteTempRoots), tempDirRoots())
-	return reapServerPIDs(pids)
+	return reapServerPIDs(pids, isDoltServerProcess)
 }
 
 // sweepServersUnderRoots reaps only the dolt sql-servers whose working
@@ -37,48 +34,7 @@ func SweepOrphanedTestServers(suiteTempRoots ...string) []int {
 func sweepServersUnderRoots(suiteTempRoots ...string) []int {
 	candidates := gatherDoltServerCandidates()
 	pids := selectServersUnderRoots(candidates, canonicalRoots(suiteTempRoots))
-	return reapServerPIDs(pids)
-}
-
-// reapServerPIDs SIGTERMs each selected PID, then SIGKILLs whatever is still
-// alive a moment later, revalidating the process identity immediately before
-// each signal so a PID recycled since selection cannot be targeted.
-//
-// Returns the PIDs it sent a kill signal to.
-func reapServerPIDs(pids []int) []int {
-	self := os.Getpid()
-	var killed []int
-	for _, pid := range pids {
-		if pid == self {
-			continue
-		}
-		// Re-read the process command immediately before signaling so a PID
-		// recycled since candidate collection cannot target an unrelated
-		// process.
-		if !isDoltServerProcess(pid) {
-			continue
-		}
-		if err := syscall.Kill(pid, syscall.SIGTERM); err == nil {
-			killed = append(killed, pid)
-		}
-	}
-
-	if len(killed) == 0 {
-		return killed
-	}
-
-	fmt.Fprintf(os.Stderr, "Info: swept %d orphaned test dolt sql-server process(es): %v\n", len(killed), killed)
-
-	time.Sleep(300 * time.Millisecond)
-	for _, pid := range killed {
-		// Revalidate again before escalation for the same PID-reuse reason.
-		if !isDoltServerProcess(pid) {
-			continue
-		}
-		_ = syscall.Kill(pid, syscall.SIGKILL)
-	}
-
-	return killed
+	return reapServerPIDs(pids, isDoltServerProcess)
 }
 
 func gatherDoltServerCandidates() []serverCandidate {

--- a/internal/doltserver/sweep_darwin_test.go
+++ b/internal/doltserver/sweep_darwin_test.go
@@ -76,7 +76,7 @@ func TestParseDarwinCwdOrphanDetection(t *testing.T) {
 			wantOK:     false,
 		},
 		{
-			name:       "an empty n field is skipped in favour of the next one",
+			name:       "an empty n field is skipped in favor of the next one",
 			lsofOutput: "p123\nn\nn" + livePath + "\n",
 			stat:       statLive,
 			wantCwd:    livePath,

--- a/internal/doltserver/sweep_darwin_test.go
+++ b/internal/doltserver/sweep_darwin_test.go
@@ -1,0 +1,120 @@
+//go:build darwin
+
+package doltserver
+
+import (
+	"io/fs"
+	"os"
+	"testing"
+)
+
+// TestParseDarwinCwdOrphanDetection pins the darwin-only half of the
+// deleted-cwd signal. macOS lsof prints the bare path of a working directory
+// that has since been removed — no " (deleted)" suffix, unlike Linux's
+// /proc/<pid>/cwd — so the stat probe is the only thing that lets
+// selectOrphanTestServerPIDs recognize a leaked test server on this platform
+// (wy-j2zc8q).
+func TestParseDarwinCwdOrphanDetection(t *testing.T) {
+	const livePath = "/private/var/folders/xx/T/some-suite/002"
+	const gonePath = "/private/var/folders/xx/T/TestUOWDependencyEditorContract1/002"
+
+	statLive := func(string) (os.FileInfo, error) { return nil, nil }
+	statGone := func(string) (os.FileInfo, error) {
+		return nil, &fs.PathError{Op: "stat", Path: gonePath, Err: fs.ErrNotExist}
+	}
+	statDenied := func(string) (os.FileInfo, error) {
+		return nil, &fs.PathError{Op: "stat", Path: livePath, Err: fs.ErrPermission}
+	}
+	statPanics := func(string) (os.FileInfo, error) {
+		t.Helper()
+		t.Fatal("stat must not be called when lsof already reported the directory deleted")
+		return nil, nil
+	}
+
+	cases := []struct {
+		name        string
+		lsofOutput  string
+		stat        statFunc
+		wantCwd     string
+		wantDeleted bool
+		wantOK      bool
+	}{
+		{
+			name:       "existing directory is live",
+			lsofOutput: "p123\nn" + livePath + "\n",
+			stat:       statLive,
+			wantCwd:    livePath,
+			wantOK:     true,
+		},
+		{
+			name:        "missing directory is the leak signature even with no suffix",
+			lsofOutput:  "p123\nn" + gonePath + "\n",
+			stat:        statGone,
+			wantCwd:     gonePath,
+			wantDeleted: true,
+			wantOK:      true,
+		},
+		{
+			name:        "explicit (deleted) suffix still wins without touching the filesystem",
+			lsofOutput:  "p123\nn" + gonePath + " (deleted)\n",
+			stat:        statPanics,
+			wantCwd:     gonePath,
+			wantDeleted: true,
+			wantOK:      true,
+		},
+		{
+			name:       "a stat error that is not ENOENT is never read as deleted",
+			lsofOutput: "p123\nn" + livePath + "\n",
+			stat:       statDenied,
+			wantCwd:    livePath,
+			wantOK:     true,
+		},
+		{
+			name:       "no n field at all is unknown, not deleted",
+			lsofOutput: "p123\nfcwd\n",
+			stat:       statPanics,
+			wantOK:     false,
+		},
+		{
+			name:       "an empty n field is skipped in favour of the next one",
+			lsofOutput: "p123\nn\nn" + livePath + "\n",
+			stat:       statLive,
+			wantCwd:    livePath,
+			wantOK:     true,
+		},
+		{
+			name:       "empty output is unknown",
+			lsofOutput: "",
+			stat:       statPanics,
+			wantOK:     false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cwd, deleted, ok := parseDarwinCwd([]byte(tc.lsofOutput), tc.stat)
+			if cwd != tc.wantCwd || deleted != tc.wantDeleted || ok != tc.wantOK {
+				t.Errorf("parseDarwinCwd() = (%q, %v, %v), want (%q, %v, %v)",
+					cwd, deleted, ok, tc.wantCwd, tc.wantDeleted, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestParseDarwinCwdAgainstRealFilesystem exercises the same path with the
+// real os.Stat, so the ENOENT classification is checked against the kernel
+// rather than a hand-written error value.
+func TestParseDarwinCwdAgainstRealFilesystem(t *testing.T) {
+	live := t.TempDir()
+	gone := t.TempDir()
+	if err := os.RemoveAll(gone); err != nil {
+		t.Fatalf("RemoveAll(%s): %v", gone, err)
+	}
+
+	if _, deleted, ok := parseDarwinCwd([]byte("n"+live+"\n"), os.Stat); !ok || deleted {
+		t.Errorf("live dir %s: deleted=%v ok=%v, want deleted=false ok=true", live, deleted, ok)
+	}
+	if cwd, deleted, ok := parseDarwinCwd([]byte("n"+gone+"\n"), os.Stat); !ok || !deleted || cwd != gone {
+		t.Errorf("removed dir %s: cwd=%q deleted=%v ok=%v, want cwd=%s deleted=true ok=true", gone, cwd, deleted, ok, gone)
+	}
+}

--- a/internal/doltserver/sweep_linux.go
+++ b/internal/doltserver/sweep_linux.go
@@ -30,10 +30,13 @@ import (
 // caller vouches for as its own.
 //
 // A server whose working directory has been deleted (cwdDeleted, see
-// readProcCwd) is reaped unconditionally regardless of suiteTempRoots —
-// that is the unambiguous leak signature (a t.TempDir() cleanup ran out
-// from under a still-live detached server) and cannot occur for any
-// server, from any suite, that is still legitimately in use.
+// readProcCwd) is reaped regardless of suiteTempRoots, but only when the
+// path it used to name was under a temp dir (tempDirRoots). A deleted cwd
+// is the leak signature — a t.TempDir() cleanup ran out from under a
+// still-live detached server — yet on its own it does not distinguish a
+// test server from a production one whose workspace was moved, deleted, or
+// unmounted (a production server is spawned with cmd.Dir = the workspace's
+// .beads/dolt). The temp-dir bound keeps that arm on test debris.
 //
 // Safety is the whole point: this must never touch a developer's real
 // shared server. It only reads /proc (no killing) to build the candidate
@@ -46,8 +49,28 @@ import (
 // Returns the PIDs it sent a kill signal to.
 func SweepOrphanedTestServers(suiteTempRoots ...string) []int {
 	candidates := gatherDoltServerCandidates()
-	pids := selectOrphanTestServerPIDs(candidates, suiteTempRoots)
+	pids := selectOrphanTestServerPIDs(candidates, canonicalRoots(suiteTempRoots), tempDirRoots())
+	return reapServerPIDs(pids)
+}
 
+// sweepServersUnderRoots reaps only the dolt sql-servers whose working
+// directory sits under one of suiteTempRoots. It is SweepOrphanedTestServers
+// without the deleted-cwd arm, for callers that must not reach outside the
+// trees they name — see selectServersUnderRoots.
+//
+// Returns the PIDs it sent a kill signal to.
+func sweepServersUnderRoots(suiteTempRoots ...string) []int {
+	candidates := gatherDoltServerCandidates()
+	pids := selectServersUnderRoots(candidates, canonicalRoots(suiteTempRoots))
+	return reapServerPIDs(pids)
+}
+
+// reapServerPIDs SIGTERMs each selected PID, then SIGKILLs whatever is still
+// alive a moment later, revalidating the process identity immediately before
+// each signal so a PID recycled since selection cannot be targeted.
+//
+// Returns the PIDs it sent a kill signal to.
+func reapServerPIDs(pids []int) []int {
 	self := os.Getpid()
 	var killed []int
 	for _, pid := range pids {

--- a/internal/doltserver/sweep_linux.go
+++ b/internal/doltserver/sweep_linux.go
@@ -3,13 +3,10 @@
 package doltserver
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
-	"time"
 )
 
 // SweepOrphanedTestServers reaps `dolt sql-server` processes that are
@@ -50,7 +47,7 @@ import (
 func SweepOrphanedTestServers(suiteTempRoots ...string) []int {
 	candidates := gatherDoltServerCandidates()
 	pids := selectOrphanTestServerPIDs(candidates, canonicalRoots(suiteTempRoots), tempDirRoots())
-	return reapServerPIDs(pids)
+	return reapServerPIDs(pids, isDoltServerProcess)
 }
 
 // sweepServersUnderRoots reaps only the dolt sql-servers whose working
@@ -62,58 +59,7 @@ func SweepOrphanedTestServers(suiteTempRoots ...string) []int {
 func sweepServersUnderRoots(suiteTempRoots ...string) []int {
 	candidates := gatherDoltServerCandidates()
 	pids := selectServersUnderRoots(candidates, canonicalRoots(suiteTempRoots))
-	return reapServerPIDs(pids)
-}
-
-// reapServerPIDs SIGTERMs each selected PID, then SIGKILLs whatever is still
-// alive a moment later, revalidating the process identity immediately before
-// each signal so a PID recycled since selection cannot be targeted.
-//
-// Returns the PIDs it sent a kill signal to.
-func reapServerPIDs(pids []int) []int {
-	self := os.Getpid()
-	var killed []int
-	for _, pid := range pids {
-		if pid == self {
-			continue
-		}
-		// Revalidate identity right before signaling: candidate selection
-		// above already did its own /proc read, and in a PID-reuse window
-		// the kernel could have recycled this PID to an unrelated process
-		// in between. isDoltServerProcess re-reads /proc/<pid>/cmdline so
-		// we only ever signal something that still looks like the
-		// dolt sql-server we selected.
-		if !isDoltServerProcess(pid) {
-			continue
-		}
-		if err := syscall.Kill(pid, syscall.SIGTERM); err == nil {
-			killed = append(killed, pid)
-		}
-	}
-
-	if len(killed) == 0 {
-		return killed
-	}
-
-	fmt.Fprintf(os.Stderr, "Info: swept %d orphaned test dolt sql-server process(es): %v\n", len(killed), killed)
-
-	// Give SIGTERM a moment, then force anything still alive. This runs at
-	// suite exit, so a short bounded wait here is acceptable.
-	time.Sleep(300 * time.Millisecond)
-	for _, pid := range killed {
-		// Revalidate again before escalating to SIGKILL: the original
-		// server may have exited cleanly during the grace period, and in
-		// a PID-reuse window (the kernel cycling the whole PID space
-		// within 300ms) this PID could now belong to an unrelated
-		// process. Recheck it still looks like a dolt sql-server before
-		// force-killing it.
-		if !isDoltServerProcess(pid) {
-			continue
-		}
-		_ = syscall.Kill(pid, syscall.SIGKILL)
-	}
-
-	return killed
+	return reapServerPIDs(pids, isDoltServerProcess)
 }
 
 // isDoltServerProcess re-reads /proc/<pid>/cmdline and reports whether pid

--- a/internal/doltserver/sweep_other.go
+++ b/internal/doltserver/sweep_other.go
@@ -8,3 +8,9 @@ package doltserver
 func SweepOrphanedTestServers(_ ...string) []int {
 	return nil
 }
+
+// sweepServersUnderRoots is the root-scoped sibling of
+// SweepOrphanedTestServers and is a no-op here for the same reason.
+func sweepServersUnderRoots(_ ...string) []int {
+	return nil
+}

--- a/internal/doltserver/sweep_reap_unix.go
+++ b/internal/doltserver/sweep_reap_unix.go
@@ -1,0 +1,57 @@
+//go:build darwin || linux
+
+package doltserver
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+// reapServerPIDs SIGTERMs each selected PID, then SIGKILLs whatever is still
+// alive a moment later. isServer re-reads the process's identity and reports
+// whether it still looks like a dolt sql-server; it is consulted immediately
+// before EVERY signal, because the kernel could have recycled the PID onto an
+// unrelated process since the candidate list was built (and again during the
+// grace period below). The caller passes its platform's probe — /proc on
+// linux, ps on darwin.
+//
+// This lives in a darwin||linux file rather than the portable sweep.go
+// because the signaling itself is POSIX; the selection logic that decides
+// WHICH pids get here is in sweep.go and is platform-independent.
+//
+// Returns the PIDs it sent a kill signal to.
+func reapServerPIDs(pids []int, isServer func(int) bool) []int {
+	self := os.Getpid()
+	var killed []int
+	for _, pid := range pids {
+		if pid == self {
+			continue
+		}
+		if !isServer(pid) {
+			continue
+		}
+		if err := syscall.Kill(pid, syscall.SIGTERM); err == nil {
+			killed = append(killed, pid)
+		}
+	}
+
+	if len(killed) == 0 {
+		return killed
+	}
+
+	fmt.Fprintf(os.Stderr, "Info: swept %d orphaned test dolt sql-server process(es): %v\n", len(killed), killed)
+
+	// Give SIGTERM a moment, then force anything still alive. This runs at a
+	// suite boundary, so a short bounded wait here is acceptable.
+	time.Sleep(300 * time.Millisecond)
+	for _, pid := range killed {
+		if !isServer(pid) {
+			continue
+		}
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+	}
+
+	return killed
+}

--- a/internal/doltserver/sweep_suite.go
+++ b/internal/doltserver/sweep_suite.go
@@ -1,0 +1,176 @@
+package doltserver
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// SuiteOwnerMarkerName is the file a test suite's TestMain writes at the root
+// of the temp tree it owns, recording the PID of the process that created it.
+//
+// It exists so a LATER run can tell two indistinguishable-looking leftovers
+// apart: the temp root of a sibling run that is alive right now (a parallel
+// package under scripts/test.sh -p N, or a second `go test` in another
+// terminal), and the temp root of a run whose process is gone — killed by
+// `go test -timeout`, a CI cancel, or Ctrl-C — which skipped every defer and
+// left its dolt sql-server behind (wy-j2zc8q).
+const SuiteOwnerMarkerName = "testmain.pid"
+
+// FailOnLeakEnv turns a post-run sweep that actually reaped something from a
+// warning into a suite failure. It is opt-in on purpose: a single leaky test
+// would otherwise redden a whole package for everyone, so the default is a
+// loud line on stderr and the code the tests themselves produced.
+const FailOnLeakEnv = "BEADS_TEST_FAIL_ON_LEAK"
+
+// WriteSuiteOwnerMarker records this process as the owner of root by writing
+// SuiteOwnerMarkerName inside it. Call it from TestMain immediately after
+// creating the suite's temp root; SweepDeadSuiteRoots in a later run reads it.
+//
+// A root with no marker is never swept, so failing to write one only costs
+// the next run its chance to clean up — it is never unsafe.
+func WriteSuiteOwnerMarker(root string) error {
+	if root == "" {
+		return fmt.Errorf("doltserver: WriteSuiteOwnerMarker: empty root")
+	}
+	path := filepath.Join(root, SuiteOwnerMarkerName)
+	return os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o600)
+}
+
+// readSuiteOwnerMarker returns the PID recorded in root's owner marker.
+// ok is false when the marker is absent, unreadable, or does not hold a
+// plausible PID — all of which mean "owner unknown", never "owner dead".
+func readSuiteOwnerMarker(root string) (pid int, ok bool) {
+	// #nosec G304 -- the path is this package's own constant joined to a
+	// temp root the caller vouches for; nothing here comes from user input.
+	data, err := os.ReadFile(filepath.Join(root, SuiteOwnerMarkerName))
+	if err != nil {
+		return 0, false
+	}
+	pid, err = strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}
+
+// suiteRootAction is what SweepDeadSuiteRoots does with one candidate root.
+type suiteRootAction int
+
+const (
+	// leaveSuiteRoot means the root is not provably debris: either nobody
+	// claimed it (a pre-marker leftover, or another tool's directory that
+	// merely shares the prefix) or its owning process is still running.
+	leaveSuiteRoot suiteRootAction = iota
+	// sweepSuiteRoot means a run claimed this root and that run is gone, so
+	// anything still alive under it is leaked debris.
+	sweepSuiteRoot
+)
+
+// decideSuiteRoot is the whole safety judgment of SweepDeadSuiteRoots,
+// isolated from the filesystem and from process signaling so it can be
+// tabled in a unit test.
+//
+// Only one combination reaps: a marker exists AND the PID it names is gone.
+// "No marker" deliberately does NOT reap — a directory nobody claimed cannot
+// be proven to be ours, and deleting it (plus SIGTERMing servers under it)
+// on a guess is exactly the cross-suite killer sweep.go's contract forbids.
+func decideSuiteRoot(hasMarker, ownerAlive bool) suiteRootAction {
+	if !hasMarker || ownerAlive {
+		return leaveSuiteRoot
+	}
+	return sweepSuiteRoot
+}
+
+// SweepDeadSuiteRoots reaps the temp roots left behind by earlier runs of the
+// calling suite whose owning process is dead: it kills the dolt sql-servers
+// still running under each such root and removes the tree.
+//
+// parentDir is where the suite creates its roots (os.TempDir() at call time)
+// and prefix is the suite's own os.MkdirTemp pattern minus the random tail
+// (e.g. "beads-bd-tests-"). Both must be non-empty; an empty prefix would
+// glob the entire temp directory and is refused.
+//
+// Call it from TestMain BEFORE creating this run's own root. It is
+// best-effort and returns the roots it removed.
+//
+// Safety rests entirely on decideSuiteRoot: a root is only ever touched when
+// it carries this suite's own owner marker and that owner is gone. Live
+// sibling runs (marker + live PID) and unclaimed leftovers (no marker) are
+// both left exactly as they are. The per-root SweepOrphanedTestServers call
+// therefore honors that function's contract — a caller-vouched suite root,
+// never a shared temp dir.
+func SweepDeadSuiteRoots(parentDir, prefix string) []string {
+	return sweepDeadSuiteRoots(parentDir, prefix, processAlive, SweepOrphanedTestServers, os.RemoveAll)
+}
+
+// sweepDeadSuiteRoots is SweepDeadSuiteRoots with its three effects injected:
+// the liveness probe, the orphan-server reaper, and the tree removal.
+func sweepDeadSuiteRoots(
+	parentDir, prefix string,
+	alive func(int) bool,
+	sweepServers func(...string) []int,
+	removeAll func(string) error,
+) []string {
+	if parentDir == "" || prefix == "" {
+		return nil
+	}
+	matches, err := filepath.Glob(filepath.Join(parentDir, prefix+"*"))
+	if err != nil {
+		return nil
+	}
+
+	var swept []string
+	for _, root := range matches {
+		// Lstat, not Stat: a symlink that happens to match the prefix must
+		// not be followed out of parentDir and removed.
+		info, err := os.Lstat(root)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		pid, hasMarker := readSuiteOwnerMarker(root)
+		if decideSuiteRoot(hasMarker, hasMarker && alive(pid)) != sweepSuiteRoot {
+			continue
+		}
+		sweepServers(root)
+		if err := removeAll(root); err != nil {
+			continue
+		}
+		swept = append(swept, root)
+	}
+
+	if len(swept) > 0 {
+		fmt.Fprintf(os.Stderr, "Info: swept %d dead test-suite temp root(s): %v\n", len(swept), swept)
+	}
+	return swept
+}
+
+// ApplyLeakPolicy folds the result of a post-run SweepOrphanedTestServers
+// call into the suite's exit code. suite names the package for the log line.
+//
+// A non-empty sweep means the suite leaked a dolt sql-server: the tests
+// finished, but a server survived every t.Cleanup and TestMain defer. That is
+// always reported loudly on stderr; it only fails the run when
+// FailOnLeakEnv is set to "1", so one flaky test cannot redden a package for
+// everyone who did not opt in. A code the tests already failed with is
+// preserved, never downgraded.
+func ApplyLeakPolicy(suite string, code int, swept []int) int {
+	if len(swept) == 0 {
+		return code
+	}
+	if os.Getenv(FailOnLeakEnv) == "1" {
+		fmt.Fprintf(os.Stderr,
+			"FAIL: %s leaked %d dolt sql-server process(es) %v; swept them, and %s=1 makes that a failure\n",
+			suite, len(swept), swept, FailOnLeakEnv)
+		if code == 0 {
+			return 1
+		}
+		return code
+	}
+	fmt.Fprintf(os.Stderr,
+		"Warning: %d leaked dolt sql-server(s) swept after %s: %v (set %s=1 to fail the run on this)\n",
+		len(swept), suite, swept, FailOnLeakEnv)
+	return code
+}

--- a/internal/doltserver/sweep_suite.go
+++ b/internal/doltserver/sweep_suite.go
@@ -32,11 +32,18 @@ const FailOnLeakEnv = "BEADS_TEST_FAIL_ON_LEAK"
 // A root with no marker is never swept, so failing to write one only costs
 // the next run its chance to clean up — it is never unsafe.
 func WriteSuiteOwnerMarker(root string) error {
+	return writeSuiteOwnerMarkerPID(root, os.Getpid())
+}
+
+// writeSuiteOwnerMarkerPID writes an owner marker naming an arbitrary PID.
+// SweepDeadSuiteRoots uses it to put a marker BACK, naming the same dead
+// owner, when it could not finish removing a root.
+func writeSuiteOwnerMarkerPID(root string, pid int) error {
 	if root == "" {
 		return fmt.Errorf("doltserver: WriteSuiteOwnerMarker: empty root")
 	}
 	path := filepath.Join(root, SuiteOwnerMarkerName)
-	return os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o600)
+	return os.WriteFile(path, []byte(strconv.Itoa(pid)+"\n"), 0o600)
 }
 
 // readSuiteOwnerMarker returns the PID recorded in root's owner marker.
@@ -97,13 +104,40 @@ func decideSuiteRoot(hasMarker, ownerAlive bool) suiteRootAction {
 // best-effort and returns the roots it removed.
 //
 // Safety rests entirely on decideSuiteRoot: a root is only ever touched when
-// it carries this suite's own owner marker and that owner is gone. Live
-// sibling runs (marker + live PID) and unclaimed leftovers (no marker) are
-// both left exactly as they are. The per-root SweepOrphanedTestServers call
-// therefore honors that function's contract — a caller-vouched suite root,
-// never a shared temp dir.
+// it is owned by the current user, carries this suite's own owner marker, and
+// that owner is gone. Live sibling runs (marker + live PID) and unclaimed
+// leftovers (no marker) are both left exactly as they are.
+//
+// The per-root reap is sweepServersUnderRoots, NOT SweepOrphanedTestServers:
+// this runs at suite START, while sibling packages (go test -p N) are mid-run,
+// so it must only ever reach processes provably inside the dead root it is
+// cleaning up. SweepOrphanedTestServers' extra deleted-cwd arm spans every
+// temp dir on the box and belongs only at end-of-run, where the suite is the
+// last thing standing.
 func SweepDeadSuiteRoots(parentDir, prefix string) []string {
-	return sweepDeadSuiteRoots(parentDir, prefix, processAlive, SweepOrphanedTestServers, os.RemoveAll)
+	return sweepDeadSuiteRoots(parentDir, prefix, processAlive, sweepServersUnderRoots, removeSuiteRoot)
+}
+
+// removeSuiteRoot removes a suite temp root, making unwritable directories
+// writable first. cmd/bd's root doubles as an isolated $HOME, so it can hold
+// read-only Go module cache entries that plain os.RemoveAll refuses; this
+// mirrors forceRemoveAll in cmd/bd's TestMain.
+func removeSuiteRoot(root string) error {
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() && info.Mode()&0o200 == 0 {
+			// #nosec G122 -- filepath.Walk lstats, so this only ever fires on
+			// a real directory (never a symlink), inside a root the caller
+			// already proved is owned by this user and abandoned by a dead
+			// process. Widening its owner-write bit is also the least
+			// consequential thing that could be done to a swapped path.
+			_ = os.Chmod(path, info.Mode()|0o200)
+		}
+		return nil
+	})
+	return os.RemoveAll(root)
 }
 
 // sweepDeadSuiteRoots is SweepDeadSuiteRoots with its three effects injected:
@@ -130,12 +164,30 @@ func sweepDeadSuiteRoots(
 		if err != nil || !info.IsDir() {
 			continue
 		}
+		// On a shared /tmp anyone can plant a directory with this prefix and
+		// a marker naming a dead PID. Only trust a root this user owns.
+		if !rootOwnedBySelf(info) {
+			continue
+		}
 		pid, hasMarker := readSuiteOwnerMarker(root)
 		if decideSuiteRoot(hasMarker, hasMarker && alive(pid)) != sweepSuiteRoot {
 			continue
 		}
 		sweepServers(root)
 		if err := removeAll(root); err != nil {
+			// Removal is not atomic: the marker is usually among the first
+			// entries deleted, so a partial failure would leave an unclaimed
+			// root that no later run may ever touch again. Put the marker
+			// back, naming the same dead owner, so the next run retries.
+			if writeErr := writeSuiteOwnerMarkerPID(root, pid); writeErr != nil {
+				fmt.Fprintf(os.Stderr,
+					"Warning: could not remove dead test-suite root %s (%v) and could not restore its owner marker (%v); it will not be retried\n",
+					root, err, writeErr)
+			} else {
+				fmt.Fprintf(os.Stderr,
+					"Warning: could not remove dead test-suite root %s: %v (marker restored; the next run retries)\n",
+					root, err)
+			}
 			continue
 		}
 		swept = append(swept, root)

--- a/internal/doltserver/sweep_suite_other.go
+++ b/internal/doltserver/sweep_suite_other.go
@@ -2,6 +2,13 @@
 
 package doltserver
 
+import "os"
+
+// rootOwnedBySelf accepts every root on platforms with no POSIX ownership in
+// os.FileInfo.Sys(). It costs nothing: processAlive below reports every owner
+// alive here, so SweepDeadSuiteRoots never removes anything anyway.
+func rootOwnedBySelf(_ os.FileInfo) bool { return true }
+
 // processAlive reports every owner as alive on platforms where this package
 // has no liveness probe, which makes SweepDeadSuiteRoots a no-op there: it
 // can never conclude a root's owner is dead, so it never removes anything.

--- a/internal/doltserver/sweep_suite_other.go
+++ b/internal/doltserver/sweep_suite_other.go
@@ -1,0 +1,11 @@
+//go:build !linux && !darwin
+
+package doltserver
+
+// processAlive reports every owner as alive on platforms where this package
+// has no liveness probe, which makes SweepDeadSuiteRoots a no-op there: it
+// can never conclude a root's owner is dead, so it never removes anything.
+// Same posture as SweepOrphanedTestServers in sweep_other.go — the stub keeps
+// callers (test TestMains) portable without giving them a destructive
+// best-guess.
+func processAlive(_ int) bool { return true }

--- a/internal/doltserver/sweep_suite_test.go
+++ b/internal/doltserver/sweep_suite_test.go
@@ -1,0 +1,219 @@
+package doltserver
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+// TestDecideSuiteRoot pins the safety judgment behind SweepDeadSuiteRoots:
+// exactly one of the four states — claimed by a process that is gone — is
+// debris. In particular an UNCLAIMED root is left alone, because a directory
+// that merely matches the suite's prefix cannot be proven to be this suite's,
+// and reaping it would resurrect the cross-suite killer that
+// selectOrphanTestServerPIDs' contract exists to prevent (wy-j2zc8q).
+func TestDecideSuiteRoot(t *testing.T) {
+	cases := []struct {
+		name       string
+		hasMarker  bool
+		ownerAlive bool
+		want       suiteRootAction
+	}{
+		{"claimed by a dead owner is debris", true, false, sweepSuiteRoot},
+		{"claimed by a live owner is a concurrent run", true, true, leaveSuiteRoot},
+		{"unclaimed root is never provably ours", false, false, leaveSuiteRoot},
+		{"unclaimed root stays unclaimed even if some pid is alive", false, true, leaveSuiteRoot},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := decideSuiteRoot(tc.hasMarker, tc.ownerAlive); got != tc.want {
+				t.Errorf("decideSuiteRoot(%v, %v) = %v, want %v", tc.hasMarker, tc.ownerAlive, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSuiteOwnerMarkerRoundTrip covers the marker read/write pair, including
+// every way a read can be inconclusive — each of which must report "owner
+// unknown" (ok=false), never "owner dead".
+func TestSuiteOwnerMarkerRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	if err := WriteSuiteOwnerMarker(root); err != nil {
+		t.Fatalf("WriteSuiteOwnerMarker: %v", err)
+	}
+	pid, ok := readSuiteOwnerMarker(root)
+	if !ok || pid != os.Getpid() {
+		t.Errorf("readSuiteOwnerMarker() = (%d, %v), want (%d, true)", pid, ok, os.Getpid())
+	}
+
+	if err := WriteSuiteOwnerMarker(""); err == nil {
+		t.Error("WriteSuiteOwnerMarker(\"\") = nil, want an error")
+	}
+
+	if _, ok := readSuiteOwnerMarker(t.TempDir()); ok {
+		t.Error("readSuiteOwnerMarker() on a root with no marker reported ok=true")
+	}
+
+	for _, body := range []string{"", "not-a-pid", "0", "-1"} {
+		bad := t.TempDir()
+		if err := os.WriteFile(filepath.Join(bad, SuiteOwnerMarkerName), []byte(body), 0o600); err != nil {
+			t.Fatalf("write marker: %v", err)
+		}
+		if _, ok := readSuiteOwnerMarker(bad); ok {
+			t.Errorf("readSuiteOwnerMarker() on marker %q reported ok=true, want unknown", body)
+		}
+	}
+}
+
+// TestSweepDeadSuiteRootsSelection walks a synthetic temp directory holding
+// one of every case and asserts both halves of the outcome: which roots were
+// removed, and which roots SweepOrphanedTestServers was vouched for. Nothing
+// here signals a real process — the liveness probe and the reaper are
+// injected.
+func TestSweepDeadSuiteRootsSelection(t *testing.T) {
+	parent := t.TempDir()
+	const prefix = "beads-bd-tests-"
+
+	mkRoot := func(name string, markerPID int) string {
+		dir := filepath.Join(parent, name)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		if markerPID != 0 {
+			body := []byte(strconv.Itoa(markerPID) + "\n")
+			if err := os.WriteFile(filepath.Join(dir, SuiteOwnerMarkerName), body, 0o600); err != nil {
+				t.Fatalf("write marker in %s: %v", dir, err)
+			}
+		}
+		return dir
+	}
+
+	const deadPID, livePID = 4242, 4243
+	dead := mkRoot(prefix+"dead", deadPID)
+	live := mkRoot(prefix+"live", livePID)
+	unclaimed := mkRoot(prefix+"unclaimed", 0)
+	otherSuite := mkRoot("beads-storage-dolt-tests-dead", deadPID)
+
+	// A plain file and a symlink that both match the prefix: neither is a
+	// directory this suite created, and neither may be removed.
+	stray := filepath.Join(parent, prefix+"stray-file")
+	if err := os.WriteFile(stray, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write stray file: %v", err)
+	}
+	elsewhere := t.TempDir()
+	link := filepath.Join(parent, prefix+"symlink")
+	if err := os.Symlink(elsewhere, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	var vouched []string
+	swept := sweepDeadSuiteRoots(
+		parent, prefix,
+		func(pid int) bool { return pid == livePID },
+		func(roots ...string) []int {
+			vouched = append(vouched, roots...)
+			return nil
+		},
+		os.RemoveAll,
+	)
+
+	if want := []string{dead}; !reflect.DeepEqual(swept, want) {
+		t.Errorf("sweepDeadSuiteRoots() = %v, want %v", swept, want)
+	}
+	if want := []string{dead}; !reflect.DeepEqual(vouched, want) {
+		t.Errorf("SweepOrphanedTestServers vouched for %v, want %v", vouched, want)
+	}
+	if _, err := os.Stat(dead); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("dead-owner root %s still present: %v", dead, err)
+	}
+	for _, keep := range []string{live, unclaimed, otherSuite, stray, link, elsewhere} {
+		if _, err := os.Lstat(keep); err != nil {
+			t.Errorf("%s must have been left alone: %v", keep, err)
+		}
+	}
+}
+
+// TestSweepDeadSuiteRootsRefusesUnboundedGlob guards the one input that would
+// turn this helper into a temp-directory shredder.
+func TestSweepDeadSuiteRootsRefusesUnboundedGlob(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "anything")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, SuiteOwnerMarkerName), []byte("4242\n"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	dead := func(int) bool { return false }
+	fatalSweep := func(roots ...string) []int {
+		t.Errorf("SweepOrphanedTestServers must not be called: %v", roots)
+		return nil
+	}
+	fatalRemove := func(path string) error {
+		t.Errorf("removeAll must not be called: %s", path)
+		return nil
+	}
+
+	if got := sweepDeadSuiteRoots(parent, "", dead, fatalSweep, fatalRemove); got != nil {
+		t.Errorf("empty prefix swept %v, want nothing", got)
+	}
+	if got := sweepDeadSuiteRoots("", "beads-bd-tests-", dead, fatalSweep, fatalRemove); got != nil {
+		t.Errorf("empty parent dir swept %v, want nothing", got)
+	}
+}
+
+// TestSweepDeadSuiteRootsSkipsSelf is the belt-and-braces check that the
+// running process's own root survives, since TestMain writes its marker into
+// a directory the very same glob will match on the next call.
+func TestSweepDeadSuiteRootsSkipsSelf(t *testing.T) {
+	parent := t.TempDir()
+	const prefix = "beads-self-tests-"
+	mine := filepath.Join(parent, prefix+"mine")
+	if err := os.MkdirAll(mine, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := WriteSuiteOwnerMarker(mine); err != nil {
+		t.Fatalf("WriteSuiteOwnerMarker: %v", err)
+	}
+
+	// Real liveness probe this time: our own PID must read as alive.
+	swept := sweepDeadSuiteRoots(parent, prefix, processAlive, SweepOrphanedTestServers, os.RemoveAll)
+	if len(swept) != 0 {
+		t.Fatalf("sweepDeadSuiteRoots removed %v, including this process's own root", swept)
+	}
+	if _, err := os.Stat(mine); err != nil {
+		t.Errorf("own root %s was removed: %v", mine, err)
+	}
+}
+
+// TestApplyLeakPolicyForSuite covers the exit-code arithmetic of the
+// env-gated leak-as-failure rule.
+func TestApplyLeakPolicyForSuite(t *testing.T) {
+	cases := []struct {
+		name  string
+		env   string
+		code  int
+		swept []int
+		want  int
+	}{
+		{name: "no leak, passing suite", code: 0, swept: nil, want: 0},
+		{name: "no leak, failing suite", code: 2, swept: nil, want: 2},
+		{name: "leak warns but does not fail by default", code: 0, swept: []int{101}, want: 0},
+		{name: "leak fails a passing suite when opted in", env: "1", code: 0, swept: []int{101}, want: 1},
+		{name: "leak never downgrades an existing failure", env: "1", code: 2, swept: []int{101}, want: 2},
+		{name: "any value other than 1 stays advisory", env: "true", code: 0, swept: []int{101}, want: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(FailOnLeakEnv, tc.env)
+			if got := ApplyLeakPolicy("internal/doltserver", tc.code, tc.swept); got != tc.want {
+				t.Errorf("ApplyLeakPolicy(%d, %v) with %s=%q = %d, want %d",
+					tc.code, tc.swept, FailOnLeakEnv, tc.env, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/doltserver/sweep_suite_test.go
+++ b/internal/doltserver/sweep_suite_test.go
@@ -70,9 +70,8 @@ func TestSuiteOwnerMarkerRoundTrip(t *testing.T) {
 
 // TestSweepDeadSuiteRootsSelection walks a synthetic temp directory holding
 // one of every case and asserts both halves of the outcome: which roots were
-// removed, and which roots SweepOrphanedTestServers was vouched for. Nothing
-// here signals a real process — the liveness probe and the reaper are
-// injected.
+// removed, and which roots the server reaper was vouched for. Nothing here
+// signals a real process — the liveness probe and the reaper are injected.
 func TestSweepDeadSuiteRootsSelection(t *testing.T) {
 	parent := t.TempDir()
 	const prefix = "beads-bd-tests-"
@@ -106,7 +105,10 @@ func TestSweepDeadSuiteRootsSelection(t *testing.T) {
 	elsewhere := t.TempDir()
 	link := filepath.Join(parent, prefix+"symlink")
 	if err := os.Symlink(elsewhere, link); err != nil {
-		t.Fatalf("symlink: %v", err)
+		// Windows without the create-symlink privilege; the rest of the
+		// case still carries its weight.
+		t.Logf("skipping the symlink leg: %v", err)
+		link = ""
 	}
 
 	var vouched []string
@@ -124,15 +126,95 @@ func TestSweepDeadSuiteRootsSelection(t *testing.T) {
 		t.Errorf("sweepDeadSuiteRoots() = %v, want %v", swept, want)
 	}
 	if want := []string{dead}; !reflect.DeepEqual(vouched, want) {
-		t.Errorf("SweepOrphanedTestServers vouched for %v, want %v", vouched, want)
+		t.Errorf("the server reaper was vouched for %v, want %v", vouched, want)
 	}
 	if _, err := os.Stat(dead); !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("dead-owner root %s still present: %v", dead, err)
 	}
 	for _, keep := range []string{live, unclaimed, otherSuite, stray, link, elsewhere} {
+		if keep == "" {
+			continue
+		}
 		if _, err := os.Lstat(keep); err != nil {
 			t.Errorf("%s must have been left alone: %v", keep, err)
 		}
+	}
+}
+
+// TestSweepDeadSuiteRootsRestoresMarkerOnPartialRemoval covers the recovery
+// path for a removal that fails halfway. os.RemoveAll is not atomic and the
+// marker is an early casualty, so without the rewrite a root that could not
+// be fully deleted (a read-only Go module cache entry under cmd/bd's isolated
+// $HOME, say) would come back UNCLAIMED — and an unclaimed root is never
+// swept again, by design. The marker must go back naming the same dead owner.
+func TestSweepDeadSuiteRootsRestoresMarkerOnPartialRemoval(t *testing.T) {
+	parent := t.TempDir()
+	const prefix = "beads-partial-tests-"
+	const deadPID = 4242
+
+	root := filepath.Join(parent, prefix+"stuck")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := writeSuiteOwnerMarkerPID(root, deadPID); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	// Stand in for a partial os.RemoveAll: the marker is gone, the root is
+	// not, and an error comes back.
+	stubbornRemove := func(path string) error {
+		if err := os.Remove(filepath.Join(path, SuiteOwnerMarkerName)); err != nil {
+			t.Fatalf("simulate partial removal: %v", err)
+		}
+		return errors.New("permission denied")
+	}
+
+	swept := sweepDeadSuiteRoots(parent, prefix, func(int) bool { return false }, func(...string) []int { return nil }, stubbornRemove)
+	if len(swept) != 0 {
+		t.Errorf("sweepDeadSuiteRoots() = %v, want nothing reported as removed", swept)
+	}
+	if _, err := os.Stat(root); err != nil {
+		t.Fatalf("root should still be there: %v", err)
+	}
+	pid, ok := readSuiteOwnerMarker(root)
+	if !ok || pid != deadPID {
+		t.Fatalf("marker after a failed removal = (%d, %v), want (%d, true) so the next run retries", pid, ok, deadPID)
+	}
+
+	// And the next run, with removal working, finishes the job.
+	swept = sweepDeadSuiteRoots(parent, prefix, func(int) bool { return false }, func(...string) []int { return nil }, removeSuiteRoot)
+	if want := []string{root}; !reflect.DeepEqual(swept, want) {
+		t.Errorf("retry swept %v, want %v", swept, want)
+	}
+}
+
+// TestSweepDeadSuiteRootsRemovesReadOnlyDirs pins removeSuiteRoot's chmod
+// walk: cmd/bd's suite root doubles as an isolated $HOME and can hold
+// read-only Go module cache directories, which plain os.RemoveAll refuses.
+func TestSweepDeadSuiteRootsRemovesReadOnlyDirs(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root")
+	nested := filepath.Join(root, "pkg", "mod", "readonly")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "file"), []byte("x"), 0o400); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Chmod(nested, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	// Restore write permission whatever happens, so the test's own temp
+	// cleanup cannot fail.
+	t.Cleanup(func() { _ = os.Chmod(nested, 0o700) })
+
+	if err := os.RemoveAll(root); err == nil {
+		t.Skip("this platform's os.RemoveAll already handles read-only directories")
+	}
+	if err := removeSuiteRoot(root); err != nil {
+		t.Fatalf("removeSuiteRoot: %v", err)
+	}
+	if _, err := os.Stat(root); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("root still present after removeSuiteRoot: %v", err)
 	}
 }
 
@@ -181,7 +263,7 @@ func TestSweepDeadSuiteRootsSkipsSelf(t *testing.T) {
 	}
 
 	// Real liveness probe this time: our own PID must read as alive.
-	swept := sweepDeadSuiteRoots(parent, prefix, processAlive, SweepOrphanedTestServers, os.RemoveAll)
+	swept := sweepDeadSuiteRoots(parent, prefix, processAlive, sweepServersUnderRoots, removeSuiteRoot)
 	if len(swept) != 0 {
 		t.Fatalf("sweepDeadSuiteRoots removed %v, including this process's own root", swept)
 	}

--- a/internal/doltserver/sweep_suite_unix.go
+++ b/internal/doltserver/sweep_suite_unix.go
@@ -1,0 +1,27 @@
+//go:build darwin || linux
+
+package doltserver
+
+import (
+	"errors"
+	"syscall"
+)
+
+// processAlive reports whether pid still names a running process, using the
+// signal-0 probe (kill(2) performs its permission and existence checks but
+// delivers nothing).
+//
+// Only ESRCH — "no such process" — counts as dead. EPERM means the process
+// exists and belongs to another user, and any other errno means the probe
+// itself failed; both report alive, so SweepDeadSuiteRoots leaves the root
+// untouched rather than deleting a tree on an inconclusive read.
+func processAlive(pid int) bool {
+	// kill(0, sig) signals the caller's whole process group and kill(-1, …)
+	// every process it may signal, so a nonsensical PID must never reach the
+	// syscall. Report it alive: an unusable marker is not proof of death.
+	if pid <= 0 {
+		return true
+	}
+	err := syscall.Kill(pid, 0)
+	return !errors.Is(err, syscall.ESRCH)
+}

--- a/internal/doltserver/sweep_suite_unix.go
+++ b/internal/doltserver/sweep_suite_unix.go
@@ -4,8 +4,26 @@ package doltserver
 
 import (
 	"errors"
+	"os"
 	"syscall"
 )
+
+// rootOwnedBySelf reports whether the directory info describes is owned by
+// the user running this process.
+//
+// SweepDeadSuiteRoots globs a world-writable temp directory, so on a shared
+// box (/tmp, a CI runner with several users) anyone could plant a directory
+// carrying this suite's prefix and an owner marker naming a PID that is not
+// running, and have the sweep delete a tree of their choosing under the
+// caller's identity. Ownership is the cheap check that closes it. An
+// unreadable or unexpected stat shape reports false — not ours, leave it.
+func rootOwnedBySelf(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	return int(stat.Uid) == os.Getuid()
+}
 
 // processAlive reports whether pid still names a running process, using the
 // signal-0 probe (kill(2) performs its permission and existence checks but

--- a/internal/doltserver/sweep_test.go
+++ b/internal/doltserver/sweep_test.go
@@ -344,10 +344,12 @@ func TestTempDirRootsBoundTheOrphanArm(t *testing.T) {
 // inside the deleted-cwd arm, which is precisely what tempDirRoots exists to
 // prevent. /tmp and the real per-user temp dir must survive that filter.
 func TestTempDirRootsRejectsOverbroadTMPDIR(t *testing.T) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skipf("no home directory to test against: %v", err)
-	}
+	// A real, non-temp home. The ambient one cannot be trusted for these
+	// expectations: CI (scripts/ci/lib/test-env.sh) runs the suite with HOME
+	// under /tmp, where "a workspace under the home directory" and "a path
+	// under /tmp" are the same path.
+	const home = "/home/beads-fixture"
+	t.Setenv("HOME", home)
 
 	t.Run("normal TMPDIR keeps a usable root", func(t *testing.T) {
 		roots := tempDirRoots()
@@ -392,6 +394,36 @@ func TestTempDirRootsRejectsOverbroadTMPDIR(t *testing.T) {
 			t.Errorf("tempDirRoots() = %v, want /tmp still covered", roots)
 		}
 	})
+
+	// The CI shape: HOME is a throwaway directory under /tmp. /tmp contains
+	// it, and must survive anyway — this is the case that emptied
+	// tempDirRoots on every Linux runner and disabled the arm there.
+	t.Run("sandbox HOME under /tmp keeps /tmp", func(t *testing.T) {
+		sandbox := "/tmp/beads-test-env-abc123/home"
+		t.Setenv("HOME", sandbox)
+		roots := tempDirRoots()
+		if !underAnyRoot("/tmp/beads-bd-tests-xyz/.beads/dolt", roots) {
+			t.Errorf("tempDirRoots() = %v with HOME=%s, want /tmp still covered", roots, sandbox)
+		}
+		for _, root := range roots {
+			if filepath.Clean(root) == string(filepath.Separator) {
+				t.Errorf("tempDirRoots() = %v, which includes the filesystem root", roots)
+			}
+		}
+	})
+
+	// TMPDIR=$HOME with a sandbox home: the root IS the home, so it is
+	// dropped even though a sandbox home is otherwise ignored.
+	t.Run("TMPDIR=sandbox HOME is dropped", func(t *testing.T) {
+		sandbox := "/tmp/beads-test-env-abc123/home"
+		t.Setenv("HOME", sandbox)
+		t.Setenv("TMPDIR", sandbox)
+		for _, root := range tempDirRoots() {
+			if filepath.Clean(root) == sandbox {
+				t.Errorf("tempDirRoots() kept %q, the sandbox home itself", root)
+			}
+		}
+	})
 }
 
 // TestIsCredibleTempRoot tables the predicate directly, including the shapes
@@ -420,6 +452,28 @@ func TestIsCredibleTempRoot(t *testing.T) {
 	for _, tc := range cases {
 		if got := isCredibleTempRoot(tc.root, home); got != tc.want {
 			t.Errorf("isCredibleTempRoot(%q, %q) = %v, want %v", tc.root, home, got, tc.want)
+		}
+	}
+
+	// A sandbox home (CI's HOME under /tmp) does not disqualify the roots
+	// that contain it; the root that IS the home is still out, and a real
+	// home under an overbroad TMPDIR still rejects that TMPDIR.
+	const sandbox = "/tmp/beads-test-env-abc123/home"
+	sandboxCases := []struct {
+		root, home string
+		want       bool
+	}{
+		{"/tmp", sandbox, true},
+		{"/tmp/beads-test-env-abc123", sandbox, true},
+		{sandbox, sandbox, false},
+		{sandbox + "/", sandbox, false},
+		{"/", sandbox, false},
+		{"/home", "/home/runner", false},
+		{"/tmp", "/tmp", false},
+	}
+	for _, tc := range sandboxCases {
+		if got := isCredibleTempRoot(tc.root, tc.home); got != tc.want {
+			t.Errorf("isCredibleTempRoot(%q, %q) = %v, want %v", tc.root, tc.home, got, tc.want)
 		}
 	}
 

--- a/internal/doltserver/sweep_test.go
+++ b/internal/doltserver/sweep_test.go
@@ -1,6 +1,8 @@
 package doltserver
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -15,11 +17,18 @@ import (
 // servers all living under os.TempDir(), and only a suite's own scoped
 // root may reap its own debris, not everyone else's (gastownhall/beads
 // mybd-q6cz).
+//
+// The second bound is on the deleted-cwd arm: a deleted working directory
+// only counts as debris when the path it named was under a TEMP root. A
+// production server is spawned with cmd.Dir = <workspace>/.beads/dolt, so
+// without that bound a moved workspace or an unmounted volume would make a
+// developer's live server look exactly like test debris (wy-j2zc8q).
 func TestSelectOrphanTestServerPIDs(t *testing.T) {
 	cases := []struct {
 		name       string
 		candidates []serverCandidate
 		suiteRoots []string
+		tempRoots  []string
 		want       []int
 	}{
 		{
@@ -28,6 +37,7 @@ func TestSelectOrphanTestServerPIDs(t *testing.T) {
 				{pid: 100, cmdline: "dolt sql-server -H 127.0.0.1 -P 12345", cwd: "/tmp/beads-bd-tests-xyz/.beads/dolt", cwdDeleted: true},
 			},
 			suiteRoots: nil,
+			tempRoots:  []string{"/tmp"},
 			want:       []int{100},
 		},
 		{
@@ -36,6 +46,7 @@ func TestSelectOrphanTestServerPIDs(t *testing.T) {
 				{pid: 101, cmdline: "dolt sql-server -H 127.0.0.1 -P 12345", cwd: "/tmp/my-suite-root/.beads/dolt"},
 			},
 			suiteRoots: []string{"/tmp/my-suite-root"},
+			tempRoots:  []string{"/tmp"},
 			want:       []int{101},
 		},
 		{
@@ -44,6 +55,7 @@ func TestSelectOrphanTestServerPIDs(t *testing.T) {
 				{pid: 102, cmdline: "dolt sql-server -H 127.0.0.1 -P 12345", cwd: "/tmp/other-suite-xyz/.beads/dolt"},
 			},
 			suiteRoots: []string{"/tmp/my-suite-root"},
+			tempRoots:  []string{"/tmp"},
 			want:       nil,
 		},
 		{
@@ -52,6 +64,7 @@ func TestSelectOrphanTestServerPIDs(t *testing.T) {
 				{pid: 103, cmdline: "dolt --prof cpu --prof-path /tmp/my-suite-root/dolt-pprof sql-server -H 127.0.0.1 -P 12345", cwd: "/tmp/my-suite-root/.beads/dolt"},
 			},
 			suiteRoots: []string{"/tmp/my-suite-root"},
+			tempRoots:  []string{"/tmp"},
 			want:       []int{103},
 		},
 		{
@@ -60,6 +73,7 @@ func TestSelectOrphanTestServerPIDs(t *testing.T) {
 				{pid: 200, cmdline: "dolt sql-server -H 127.0.0.1 -P 3307", cwd: "/home/dev/project/.beads/dolt"},
 			},
 			suiteRoots: []string{"/tmp/my-suite-root"},
+			tempRoots:  []string{"/tmp"},
 			want:       nil,
 		},
 		{
@@ -68,6 +82,7 @@ func TestSelectOrphanTestServerPIDs(t *testing.T) {
 				{pid: 201, cmdline: "some-other-binary --flag", cwd: "/tmp/my-suite-root/whatever"},
 			},
 			suiteRoots: []string{"/tmp/my-suite-root"},
+			tempRoots:  []string{"/tmp"},
 			want:       nil,
 		},
 		{
@@ -76,6 +91,7 @@ func TestSelectOrphanTestServerPIDs(t *testing.T) {
 				{pid: 202, cmdline: "dolt status", cwd: "/tmp/my-suite-root/whatever"},
 			},
 			suiteRoots: []string{"/tmp/my-suite-root"},
+			tempRoots:  []string{"/tmp"},
 			want:       nil,
 		},
 		{
@@ -84,6 +100,7 @@ func TestSelectOrphanTestServerPIDs(t *testing.T) {
 				{pid: 203, cmdline: "dolt sql-server -H 127.0.0.1 -P 12345", cwd: ""},
 			},
 			suiteRoots: []string{"/tmp/my-suite-root"},
+			tempRoots:  []string{"/tmp"},
 			want:       nil,
 		},
 		{
@@ -92,6 +109,7 @@ func TestSelectOrphanTestServerPIDs(t *testing.T) {
 				{pid: 204, cmdline: "dolt sql-server -H 127.0.0.1 -P 12345", cwd: "/tmp/my-suite-root2/evil"},
 			},
 			suiteRoots: []string{"/tmp/my-suite-root"},
+			tempRoots:  []string{"/tmp"},
 			want:       nil,
 		},
 		{
@@ -100,6 +118,7 @@ func TestSelectOrphanTestServerPIDs(t *testing.T) {
 				{pid: 205, cmdline: "dolt sql-server -H 127.0.0.1 -P 12345", cwd: "/tmp/some-suite/.beads/dolt"},
 			},
 			suiteRoots: nil,
+			tempRoots:  []string{"/tmp"},
 			want:       nil,
 		},
 		{
@@ -111,13 +130,68 @@ func TestSelectOrphanTestServerPIDs(t *testing.T) {
 				{pid: 303, cmdline: "dolt sql-server -P 4", cwdDeleted: true, cwd: "/tmp/whatever-else/.beads/dolt"},
 			},
 			suiteRoots: []string{"/tmp/my-suite-root"},
+			tempRoots:  []string{"/tmp"},
 			want:       []int{302, 303},
+		},
+		{
+			name: "a PRODUCTION server whose workspace was moved or deleted is left alone",
+			candidates: []serverCandidate{
+				{pid: 400, cmdline: "dolt sql-server --config /Users/dev/project/.beads/dolt-server-config.yaml", cwd: "/Users/dev/project/.beads/dolt", cwdDeleted: true},
+			},
+			suiteRoots: []string{"/tmp/my-suite-root"},
+			tempRoots:  []string{"/tmp", "/private/var/folders/c1/xx/T"},
+			want:       nil,
+		},
+		{
+			name: "a production server on an unmounted volume is left alone",
+			candidates: []serverCandidate{
+				{pid: 401, cmdline: "dolt sql-server -P 3307", cwd: "/Volumes/external/work/.beads/dolt", cwdDeleted: true},
+			},
+			suiteRoots: nil,
+			tempRoots:  []string{"/tmp"},
+			want:       nil,
+		},
+		{
+			name: "the observed orphan: deleted cwd under the macOS private temp form is reaped with no suite roots",
+			candidates: []serverCandidate{
+				{pid: 402, cmdline: "dolt sql-server --config /private/var/folders/c1/xx/T/TestUOWDependencyEditorContract1/003/config.yaml", cwd: "/private/var/folders/c1/xx/T/TestUOWDependencyEditorContract1/002", cwdDeleted: true},
+			},
+			suiteRoots: nil,
+			tempRoots:  []string{"/var/folders/c1/xx/T", "/private/var/folders/c1/xx/T"},
+			want:       []int{402},
+		},
+		{
+			name: "the same orphan reported in the unresolved /var form is reaped too",
+			candidates: []serverCandidate{
+				{pid: 403, cmdline: "dolt sql-server -P 1", cwd: "/var/folders/c1/xx/T/TestUOWDependencyEditorContract1/002", cwdDeleted: true},
+			},
+			suiteRoots: nil,
+			tempRoots:  []string{"/var/folders/c1/xx/T", "/private/var/folders/c1/xx/T"},
+			want:       []int{403},
+		},
+		{
+			name: "a deleted cwd inside the caller's own suite root needs no temp root at all",
+			candidates: []serverCandidate{
+				{pid: 404, cmdline: "dolt sql-server -P 1", cwd: "/opt/scratch/my-suite-root/.beads/dolt", cwdDeleted: true},
+			},
+			suiteRoots: []string{"/opt/scratch/my-suite-root"},
+			tempRoots:  nil,
+			want:       []int{404},
+		},
+		{
+			name: "no temp roots at all disables the deleted-cwd arm entirely",
+			candidates: []serverCandidate{
+				{pid: 405, cmdline: "dolt sql-server -P 1", cwd: "/tmp/some-suite/.beads/dolt", cwdDeleted: true},
+			},
+			suiteRoots: []string{"/tmp/my-suite-root"},
+			tempRoots:  nil,
+			want:       nil,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := selectOrphanTestServerPIDs(tc.candidates, tc.suiteRoots)
+			got := selectOrphanTestServerPIDs(tc.candidates, tc.suiteRoots, tc.tempRoots)
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("selectOrphanTestServerPIDs() = %v, want %v", got, tc.want)
 			}
@@ -175,9 +249,91 @@ not-a-pid dolt sql-server
 		t.Fatalf("gatherPSCandidates() = %#v, want %#v", candidates, wantCandidates)
 	}
 
-	gotPIDs := selectOrphanTestServerPIDs(candidates, []string{"/tmp/my-suite"})
+	gotPIDs := selectOrphanTestServerPIDs(candidates, []string{"/tmp/my-suite"}, []string{"/tmp"})
 	wantPIDs := []int{101, 103}
 	if !reflect.DeepEqual(gotPIDs, wantPIDs) {
 		t.Errorf("darwin ps selection path = %v, want %v", gotPIDs, wantPIDs)
+	}
+}
+
+// TestSelectServersUnderSuiteRoots pins the strictly root-scoped selection
+// SweepDeadSuiteRoots relies on. It runs at suite START, with sibling
+// packages mid-run, so it must reap only what is provably inside the roots
+// it was handed: no deleted-cwd arm, no temp-dir reasoning of any kind.
+func TestSelectServersUnderSuiteRoots(t *testing.T) {
+	candidates := []serverCandidate{
+		{pid: 500, cmdline: "dolt sql-server -P 1", cwd: "/tmp/dead-root/.beads/dolt"},
+		{pid: 501, cmdline: "dolt sql-server -P 2", cwd: "/tmp/dead-root/nested/deeper/dolt", cwdDeleted: true},
+		{pid: 502, cmdline: "dolt sql-server -P 3", cwd: "/tmp/live-sibling-root/.beads/dolt"},
+		{pid: 503, cmdline: "dolt sql-server -P 4", cwd: "/tmp/some-other-suite/.beads/dolt", cwdDeleted: true},
+		{pid: 504, cmdline: "dolt sql-server -P 5", cwd: "/Users/dev/project/.beads/dolt", cwdDeleted: true},
+		{pid: 505, cmdline: "not-dolt --flag", cwd: "/tmp/dead-root/whatever"},
+		{pid: 506, cmdline: "dolt sql-server -P 6", cwd: ""},
+	}
+
+	got := selectServersUnderRoots(candidates, []string{"/tmp/dead-root"})
+	want := []int{500, 501}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("selectServersUnderRoots() = %v, want %v", got, want)
+	}
+
+	if got := selectServersUnderRoots(candidates, nil); got != nil {
+		t.Errorf("selectServersUnderRoots() with no roots = %v, want nothing", got)
+	}
+}
+
+// TestCanonicalRootsForSweep covers the path-form expansion that lets a root
+// match however the OS reports a process's cwd.
+func TestCanonicalRootsForSweep(t *testing.T) {
+	if got := canonicalRoots(nil); got != nil {
+		t.Errorf("canonicalRoots(nil) = %v, want nothing", got)
+	}
+	if got := canonicalRoots([]string{"", ""}); got != nil {
+		t.Errorf("canonicalRoots(empties) = %v, want nothing", got)
+	}
+
+	// A path that cannot be resolved is still kept as given.
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if got := canonicalRoots([]string{missing}); !reflect.DeepEqual(got, []string{missing}) {
+		t.Errorf("canonicalRoots(%q) = %v, want just the literal path", missing, got)
+	}
+
+	// A real directory reached through a symlink yields both forms, in that
+	// order, with no duplicates — this is what makes macOS's
+	// /var/folders/… vs /private/var/folders/… pair match.
+	target := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%s): %v", link, err)
+	}
+	got := canonicalRoots([]string{link, link, resolved})
+	want := []string{link, resolved}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("canonicalRoots() = %v, want %v", got, want)
+	}
+}
+
+// TestTempDirRootsBoundTheOrphanArm checks that the deleted-cwd bound
+// actually covers the directory this process's own t.TempDir() lands in —
+// if it did not, the arm would silently never fire.
+func TestTempDirRootsBoundTheOrphanArm(t *testing.T) {
+	roots := tempDirRoots()
+	if len(roots) == 0 {
+		t.Fatal("tempDirRoots() is empty; the deleted-cwd arm could never fire")
+	}
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		resolved = dir
+	}
+	if !underAnyRoot(dir, roots) && !underAnyRoot(resolved, roots) {
+		t.Errorf("t.TempDir() %q (resolved %q) is under none of tempDirRoots() %v", dir, resolved, roots)
+	}
+	if underAnyRoot("/Users/dev/project/.beads/dolt", roots) {
+		t.Errorf("a production workspace path matched tempDirRoots() %v", roots)
 	}
 }

--- a/internal/doltserver/sweep_test.go
+++ b/internal/doltserver/sweep_test.go
@@ -337,3 +337,97 @@ func TestTempDirRootsBoundTheOrphanArm(t *testing.T) {
 		t.Errorf("a production workspace path matched tempDirRoots() %v", roots)
 	}
 }
+
+// TestTempDirRootsRejectsOverbroadTMPDIR covers the bound on the bound.
+// TMPDIR is an ordinary environment variable, so os.TempDir() can be handed
+// "/" or a home directory; either would put every workspace on the box back
+// inside the deleted-cwd arm, which is precisely what tempDirRoots exists to
+// prevent. /tmp and the real per-user temp dir must survive that filter.
+func TestTempDirRootsRejectsOverbroadTMPDIR(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home directory to test against: %v", err)
+	}
+
+	t.Run("normal TMPDIR keeps a usable root", func(t *testing.T) {
+		roots := tempDirRoots()
+		if len(roots) == 0 {
+			t.Fatal("tempDirRoots() is empty for the ambient TMPDIR")
+		}
+		for _, root := range roots {
+			if root == string(filepath.Separator) {
+				t.Errorf("tempDirRoots() = %v, which includes the filesystem root", roots)
+			}
+			if isUnderDir(filepath.Clean(home), root) {
+				t.Errorf("tempDirRoots() root %q contains the home directory %q", root, home)
+			}
+		}
+	})
+
+	t.Run("TMPDIR=/ is dropped", func(t *testing.T) {
+		t.Setenv("TMPDIR", "/")
+		roots := tempDirRoots()
+		for _, root := range roots {
+			if filepath.Clean(root) == string(filepath.Separator) {
+				t.Fatalf("tempDirRoots() = %v, want the filesystem root dropped", roots)
+			}
+		}
+		// The hardcoded /tmp fallback still has to come through, or the
+		// deleted-cwd arm would quietly stop working.
+		if !underAnyRoot("/tmp/beads-bd-tests-xyz/.beads/dolt", roots) {
+			t.Errorf("tempDirRoots() = %v, want /tmp still covered", roots)
+		}
+		if underAnyRoot(filepath.Join(home, "project", ".beads", "dolt"), roots) {
+			t.Errorf("tempDirRoots() = %v still covers a path under the home directory", roots)
+		}
+	})
+
+	t.Run("TMPDIR=$HOME is dropped", func(t *testing.T) {
+		t.Setenv("TMPDIR", home)
+		roots := tempDirRoots()
+		if underAnyRoot(filepath.Join(home, "project", ".beads", "dolt"), roots) {
+			t.Errorf("tempDirRoots() = %v covers a workspace under the home directory", roots)
+		}
+		if !underAnyRoot("/tmp/beads-bd-tests-xyz/.beads/dolt", roots) {
+			t.Errorf("tempDirRoots() = %v, want /tmp still covered", roots)
+		}
+	})
+}
+
+// TestIsCredibleTempRoot tables the predicate directly, including the shapes
+// no environment on this box can produce.
+func TestIsCredibleTempRoot(t *testing.T) {
+	const home = "/Users/dev"
+	cases := []struct {
+		root string
+		want bool
+	}{
+		{"/tmp", true},
+		{"/private/tmp", true},
+		{"/var/folders/c1/xx/T", true},
+		{"/var/folders/c1/xx/T/beads-bd-tests-1", true},
+		{"/", false},
+		{"//", false},
+		{"", false},
+		{".", false},
+		{"relative/tmp", false},
+		{home, false},
+		{home + "/", false},
+		{"/Users", false},
+		{"/Users/dev/tmp", true},
+		{"/Users/other", true},
+	}
+	for _, tc := range cases {
+		if got := isCredibleTempRoot(tc.root, home); got != tc.want {
+			t.Errorf("isCredibleTempRoot(%q, %q) = %v, want %v", tc.root, home, got, tc.want)
+		}
+	}
+
+	// With no home known, only the structural rejections apply.
+	if !isCredibleTempRoot("/Users/dev", "") {
+		t.Error("isCredibleTempRoot with no home should accept an ordinary absolute path")
+	}
+	if isCredibleTempRoot("/", "") {
+		t.Error("isCredibleTempRoot must reject the filesystem root even with no home")
+	}
+}

--- a/internal/storage/dolt/testmain_test.go
+++ b/internal/storage/dolt/testmain_test.go
@@ -75,9 +75,33 @@ func testMainInner(m *testing.M) int {
 		// It returns BEFORE the suite temp root below for the same reason:
 		// eight concurrent helpers would each run the dead-root sweep and each
 		// claim a root of its own, and os.Exit would abandon every one of
-		// them. A helper needs neither — it inherits the parent's live
-		// BEADS_TEST_CIRCUIT_DIR through the BEADS_ allowlist in
-		// integration.FilterEnv, and the parent's root outlives it.
+		// them. A helper needs neither: it starts no server, so it has no
+		// orphans to sweep and nothing for a later run to reap.
+		//
+		// It DOES still need its own circuit-breaker directory. That state is
+		// one file keyed host:port:db, read-modify-written, and the parent's
+		// BEADS_TEST_CIRCUIT_DIR reaches every helper through the BEADS_
+		// allowlist in integration.FilterEnv — so inheriting it would put all
+		// eight of TestMultiProcessSchemaInit's helpers on ONE file at once,
+		// against the same host:port:db. Each helper used to get a fresh
+		// directory under a suite root of its own; this keeps that isolation
+		// without the root, the sweep, or the marker.
+		circuitDir, circuitErr := os.MkdirTemp("", "beads-dolt-helper-circuit-*")
+		if circuitErr != nil {
+			fmt.Fprintf(os.Stderr, "FATAL: failed to isolate helper circuit state: %v\n", circuitErr)
+			return 1
+		}
+		// A helper commonly exits through os.Exit (see above), which skips
+		// this defer. The directory holds a few bytes of circuit state and
+		// never a server, and it carries no owner marker, so no sweep will
+		// ever look at it: the occasional leftover is accepted rather than
+		// given machinery of its own.
+		defer os.RemoveAll(circuitDir)
+		if err := os.Setenv(testCircuitBreakerDirEnv, circuitDir); err != nil {
+			fmt.Fprintf(os.Stderr, "FATAL: failed to isolate helper circuit state: %v\n", err)
+			return 1
+		}
+		defer os.Unsetenv(testCircuitBreakerDirEnv)
 		return m.Run()
 	}
 

--- a/internal/storage/dolt/testmain_test.go
+++ b/internal/storage/dolt/testmain_test.go
@@ -60,12 +60,23 @@ func testMainInner(m *testing.M) int {
 	// Suite-owned root for the orphan-server sweep below. Must never be a
 	// shared/global temp dir (see SweepOrphanedTestServers) — this one is
 	// unique to this test run and removed when it exits.
-	suiteTempRoot, tempRootErr := os.MkdirTemp("", "beads-storage-dolt-tests-*")
+	//
+	// Before claiming one, clear out the roots of earlier runs of this suite
+	// whose process is gone: a `go test -timeout` panic skips both the defer
+	// below and the post-Run sweep, so those runs' servers outlive every
+	// cleanup installed here (wy-j2zc8q). Unclaimed roots, and roots whose
+	// owner is still running, are left untouched.
+	doltserver.SweepDeadSuiteRoots(os.TempDir(), suiteRootPrefix)
+
+	suiteTempRoot, tempRootErr := os.MkdirTemp("", suiteRootPrefix+"*")
 	if tempRootErr != nil {
 		fmt.Fprintf(os.Stderr, "FATAL: failed to create suite temp root: %v\n", tempRootErr)
 		return 1
 	} else {
 		defer os.RemoveAll(suiteTempRoot)
+		if err := doltserver.WriteSuiteOwnerMarker(suiteTempRoot); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not claim suite temp root %s: %v\n", suiteTempRoot, err)
+		}
 		if err := os.Setenv(testCircuitBreakerDirEnv, filepath.Join(suiteTempRoot, "circuit")); err != nil {
 			fmt.Fprintf(os.Stderr, "FATAL: failed to isolate circuit state: %v\n", err)
 			return 1
@@ -129,7 +140,8 @@ func testMainInner(m *testing.M) int {
 	// suite's own temp root (e.g. a SIGKILLed run of the multiprocess
 	// schema init tests, which call doltserver.Start directly) — see
 	// gastownhall/beads mybd-q6cz.
-	doltserver.SweepOrphanedTestServers(suiteTempRoot)
+	swept := doltserver.SweepOrphanedTestServers(suiteTempRoot)
+	code = doltserver.ApplyLeakPolicy("internal/storage/dolt", code, swept)
 
 	testServerPort = 0
 	os.Unsetenv("BEADS_DOLT_PORT")
@@ -137,6 +149,10 @@ func testMainInner(m *testing.M) int {
 	os.Unsetenv("BEADS_TEST_PDEATHSIG")
 	return code
 }
+
+// suiteRootPrefix is testMainInner's os.MkdirTemp pattern without its random
+// tail. It is what SweepDeadSuiteRoots globs for, so the two must not drift.
+const suiteRootPrefix = "beads-storage-dolt-tests-"
 
 // initSharedSchema creates a store on the shared DB, sets config, and commits
 // so that branches inherit the full schema.

--- a/internal/storage/dolt/testmain_test.go
+++ b/internal/storage/dolt/testmain_test.go
@@ -57,6 +57,30 @@ func testMainInner(m *testing.M) int {
 	// separate flag from BEADS_TEST_MODE.
 	os.Setenv("BEADS_TEST_PDEATHSIG", "1")
 
+	// AD-01 (be-c5p): the test/bench harness opens a process-local dolt
+	// sql-server (testcontainer or external port). The new database-name
+	// firewall in dolt.New refuses test-named DBs unless this opt-in is set.
+	os.Setenv("BEADS_TEST_SERVER", "1")
+	if isHelperSubprocess() {
+		// A helper subprocess is handed its server's port by the parent test
+		// and never looks at this suite's own server. Starting one anyway
+		// costs a Dolt container plus a full migration chain per subprocess:
+		// TestMultiProcessSchemaInit spawns 8 at once, so the machine ran 9
+		// Dolt servers to measure a lock race between 8 clients of the
+		// parent's single server. Worse, every helper exits through os.Exit,
+		// which skips the deferred TerminateDoltContainer below and leaks the
+		// container. That load is what pushed the contended GET_LOCK past its
+		// 5s wait in CI shard 3.
+		//
+		// It returns BEFORE the suite temp root below for the same reason:
+		// eight concurrent helpers would each run the dead-root sweep and each
+		// claim a root of its own, and os.Exit would abandon every one of
+		// them. A helper needs neither — it inherits the parent's live
+		// BEADS_TEST_CIRCUIT_DIR through the BEADS_ allowlist in
+		// integration.FilterEnv, and the parent's root outlives it.
+		return m.Run()
+	}
+
 	// Suite-owned root for the orphan-server sweep below. Must never be a
 	// shared/global temp dir (see SweepOrphanedTestServers) — this one is
 	// unique to this test run and removed when it exits.
@@ -82,23 +106,6 @@ func testMainInner(m *testing.M) int {
 			return 1
 		}
 		defer os.Unsetenv(testCircuitBreakerDirEnv)
-	}
-
-	// AD-01 (be-c5p): the test/bench harness opens a process-local dolt
-	// sql-server (testcontainer or external port). The new database-name
-	// firewall in dolt.New refuses test-named DBs unless this opt-in is set.
-	os.Setenv("BEADS_TEST_SERVER", "1")
-	if isHelperSubprocess() {
-		// A helper subprocess is handed its server's port by the parent test
-		// and never looks at this suite's own server. Starting one anyway
-		// costs a Dolt container plus a full migration chain per subprocess:
-		// TestMultiProcessSchemaInit spawns 8 at once, so the machine ran 9
-		// Dolt servers to measure a lock race between 8 clients of the
-		// parent's single server. Worse, every helper exits through os.Exit,
-		// which skips the deferred TerminateDoltContainer below and leaks the
-		// container. That load is what pushed the contended GET_LOCK past its
-		// 5s wait in CI shard 3.
-		return m.Run()
 	}
 	if err := testutil.EnsureDoltContainerForTestMain(); err != nil {
 		fmt.Fprintf(os.Stderr, "WARN: %v, skipping Dolt tests\n", err)

--- a/internal/storage/uow/testmain_test.go
+++ b/internal/storage/uow/testmain_test.go
@@ -1,0 +1,100 @@
+package uow
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/testutil"
+)
+
+// suiteRootPrefix is this suite's os.MkdirTemp pattern without its random
+// tail. SweepDeadSuiteRoots globs for it, so the two must not drift.
+const suiteRootPrefix = "beads-storage-uow-tests-"
+
+// suiteTempRoot is the TestMain-owned temp directory that every t.TempDir()
+// in this package lands under, so SweepOrphanedTestServers has a root it can
+// vouch for when it reaps leaked dolt sql-servers.
+var suiteTempRoot string
+
+// TestMain gives this package the suite-lifecycle it was missing.
+//
+// The integration tests here (newTestUOWProvider) start a real proxied
+// `dolt sql-server` whose data directory is a t.TempDir(). Cleanup was purely
+// per-test — proxy.Shutdown in a t.Cleanup — and there was no TestMain at
+// all, so a run killed by `go test -timeout` (which panics the binary and
+// skips every Cleanup) left the server running with its data directory
+// deleted out from under it, forever. Observed live on a dev box as a
+// TestUOWDependencyEditorContract server still serving a temp dir that had
+// been gone for hours (wy-j2zc8q).
+func TestMain(m *testing.M) {
+	os.Exit(testMainInner(m))
+}
+
+func testMainInner(m *testing.M) int {
+	// Clear out the roots of earlier runs of this suite whose process is
+	// gone, before claiming one of our own. Roots with no owner marker, and
+	// roots whose owner is still running (a parallel package under
+	// scripts/test.sh, a second `go test`), are left untouched.
+	doltserver.SweepDeadSuiteRoots(os.TempDir(), suiteRootPrefix)
+
+	// Pin TMPDIR under a suite-owned root so every t.TempDir() — including
+	// the storeRootDir a provider serves — is nested under something the
+	// post-run sweep may vouch for. Same pattern as cmd/bd/doctor's TestMain.
+	root, pinErr := testutil.PinSuiteTempRoot(suiteRootPrefix + "*")
+	if pinErr != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: suite temp root: %v\n", pinErr)
+		return 1
+	}
+	suiteTempRoot = root
+	defer os.RemoveAll(root)
+
+	// Claim the root for this process so the NEXT run can tell our debris
+	// from a concurrent run's live tree.
+	if err := doltserver.WriteSuiteOwnerMarker(root); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not claim suite temp root %s: %v\n", root, err)
+	}
+
+	code := m.Run()
+
+	// Best-effort reap of any dolt sql-server still running under this run's
+	// own root — the backstop for a test whose Cleanup did not get to run.
+	swept := doltserver.SweepOrphanedTestServers(root)
+	return doltserver.ApplyLeakPolicy("internal/storage/uow", code, swept)
+}
+
+// TestTempDirLandsUnderSuiteSweepRoot guards the pinning above: if t.TempDir()
+// ever stops landing under suiteTempRoot, the post-run sweep silently loses
+// its scope and leaked sql-servers become unreapable again.
+func TestTempDirLandsUnderSuiteSweepRoot(t *testing.T) {
+	if suiteTempRoot == "" {
+		t.Fatal("TestMain did not pin suiteTempRoot; leaked dolt sql-server processes cannot be swept")
+	}
+	dir := t.TempDir()
+	if !pathUnderRoot(dir, suiteTempRoot) {
+		t.Fatalf("t.TempDir() %q is not under suiteTempRoot %q", dir, suiteTempRoot)
+	}
+}
+
+// pathUnderRoot reports whether dir is root or nested under it, comparing
+// symlink-resolved paths (macOS hands out /var paths that resolve to
+// /private/var).
+func pathUnderRoot(dir, root string) bool {
+	dir = evalOrSelf(dir)
+	root = evalOrSelf(root)
+	if dir == root {
+		return true
+	}
+	sep := string(os.PathSeparator)
+	return strings.HasPrefix(dir, strings.TrimRight(root, sep)+sep)
+}
+
+func evalOrSelf(p string) string {
+	if r, err := filepath.EvalSymlinks(p); err == nil {
+		return r
+	}
+	return p
+}

--- a/internal/storage/uow/version_reconcile_integration_test.go
+++ b/internal/storage/uow/version_reconcile_integration_test.go
@@ -2,13 +2,19 @@ package uow
 
 import (
 	"context"
+	"errors"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
 	"github.com/steveyegge/beads/internal/testutil"
 	"github.com/steveyegge/beads/internal/workapi"
 	publicops "github.com/steveyegge/beads/issueops"
@@ -32,9 +38,14 @@ func newTestUOWProvider(t *testing.T) UnitOfWorkProvider {
 	storeRootDir := t.TempDir()
 	shutdownOnInterrupt(t, storeRootDir)
 	t.Cleanup(func() {
+		// Read the backend PID BEFORE shutting down: a successful
+		// proxy.Shutdown removes the pid file, so afterwards there is
+		// nothing left to verify against.
+		pid := backendServerPID(t, storeRootDir)
 		if err := proxy.Shutdown(storeRootDir); err != nil {
 			t.Logf("proxy.Shutdown(%s): %v", storeRootDir, err)
 		}
+		requireBackendExited(t, pid)
 	})
 	cfgPath := writeServerConfig(t, port)
 	logPath := filepath.Join(t.TempDir(), "server.log")
@@ -58,6 +69,78 @@ func newTestUOWProvider(t *testing.T) UnitOfWorkProvider {
 	require.NotNil(t, provider)
 	t.Cleanup(func() { _ = provider.Close(context.Background()) })
 	return provider
+}
+
+const (
+	// backendExitTimeout is how long a test waits for the dolt sql-server to
+	// leave the process table after proxy.Shutdown returned. Shutdown itself
+	// already polls for confirmation, so anything approaching this budget is
+	// a real failure to stop, not slow teardown.
+	backendExitTimeout = 5 * time.Second
+	backendExitPoll    = 50 * time.Millisecond
+)
+
+// backendServerPID returns the PID of the dolt sql-server the proxy started
+// under rootDir, read from the backend pid file the proxy's child manager
+// writes (server.PIDFileName). It returns 0 when there is no usable record —
+// no server was ever started, or it already shut down and removed the file.
+func backendServerPID(t *testing.T, rootDir string) int {
+	t.Helper()
+	pf, err := pidfile.Read(rootDir, server.PIDFileName)
+	if err != nil {
+		t.Logf("read %s in %s: %v", server.PIDFileName, rootDir, err)
+		return 0
+	}
+	if pf == nil || pf.Pid <= 0 {
+		return 0
+	}
+	return pf.Pid
+}
+
+// requireBackendExited fails the test if the dolt sql-server is still running
+// a short while after proxy.Shutdown claimed to have stopped it, then
+// force-kills it so the leak does not outlive the run.
+//
+// This is deliberately a t.Errorf and not a t.Logf: a surviving server holds
+// the temp tree the test is about to delete, which is precisely how this
+// package produced sql-servers still serving directories that had been gone
+// for hours (wy-j2zc8q). A leak must be visible where it is caused, not
+// discovered later by a sweep.
+func requireBackendExited(t *testing.T, pid int) {
+	t.Helper()
+	if pid <= 0 {
+		return
+	}
+	deadline := time.Now().Add(backendExitTimeout)
+	for {
+		if !processRunning(pid) {
+			return
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(backendExitPoll)
+	}
+	if proc, err := os.FindProcess(pid); err == nil {
+		_ = proc.Kill()
+	}
+	t.Errorf("dolt sql-server pid %d survived Shutdown by more than %s (force-killed)", pid, backendExitTimeout)
+}
+
+// processRunning reports whether pid is still in the process table, using the
+// signal-0 probe (the kernel runs its existence and permission checks but
+// delivers nothing). EPERM means the process exists but belongs to someone
+// else, which still counts as running.
+func processRunning(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	return errors.Is(err, syscall.EPERM)
 }
 
 // TestReconcileVersionPersistsAcrossUOW is the one version assertion that

--- a/internal/storage/uow/version_reconcile_integration_test.go
+++ b/internal/storage/uow/version_reconcile_integration_test.go
@@ -2,16 +2,14 @@ package uow
 
 import (
 	"context"
-	"errors"
-	"os"
 	"os/exec"
 	"path/filepath"
-	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/steveyegge/beads/internal/procid"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
@@ -38,14 +36,19 @@ func newTestUOWProvider(t *testing.T) UnitOfWorkProvider {
 	storeRootDir := t.TempDir()
 	shutdownOnInterrupt(t, storeRootDir)
 	t.Cleanup(func() {
-		// Read the backend PID BEFORE shutting down: a successful
+		// Read the backend's record BEFORE shutting down: a successful
 		// proxy.Shutdown removes the pid file, so afterwards there is
 		// nothing left to verify against.
-		pid := backendServerPID(t, storeRootDir)
-		if err := proxy.Shutdown(storeRootDir); err != nil {
-			t.Logf("proxy.Shutdown(%s): %v", storeRootDir, err)
+		record := backendServerRecord(t, storeRootDir)
+		err := proxy.Shutdown(storeRootDir)
+		if err == nil {
+			// Shutdown killed the backend AND confirmed its exit
+			// (waitForRecordedProcessExit) before removing the record.
+			// There is nothing left to check.
+			return
 		}
-		requireBackendExited(t, pid)
+		t.Logf("proxy.Shutdown(%s): %v", storeRootDir, err)
+		requireBackendExited(t, record)
 	})
 	cfgPath := writeServerConfig(t, port)
 	logPath := filepath.Join(t.TempDir(), "server.log")
@@ -73,47 +76,68 @@ func newTestUOWProvider(t *testing.T) UnitOfWorkProvider {
 
 const (
 	// backendExitTimeout is how long a test waits for the dolt sql-server to
-	// leave the process table after proxy.Shutdown returned. Shutdown itself
-	// already polls for confirmation, so anything approaching this budget is
-	// a real failure to stop, not slow teardown.
-	backendExitTimeout = 5 * time.Second
+	// leave the process table after proxy.Shutdown failed. It is generous on
+	// purpose: Shutdown's own budget is already 5s of confirmation plus a 2s
+	// post-kill minimum, and this only runs on the error path, where the
+	// interesting outcome is "still there", not "took a while".
+	backendExitTimeout = 30 * time.Second
 	backendExitPoll    = 50 * time.Millisecond
 )
 
-// backendServerPID returns the PID of the dolt sql-server the proxy started
-// under rootDir, read from the backend pid file the proxy's child manager
-// writes (server.PIDFileName). It returns 0 when there is no usable record —
-// no server was ever started, or it already shut down and removed the file.
-func backendServerPID(t *testing.T, rootDir string) int {
+// backendServerRecord returns the pid file the proxy's child manager wrote
+// for the dolt sql-server under rootDir (server.PIDFileName). nil means there
+// is nothing to verify: no server was started, or it shut down cleanly and
+// removed its record.
+//
+// The whole record is returned, not just the PID: Birth is the process-birth
+// token that makes the PID safe to act on at all.
+func backendServerRecord(t *testing.T, rootDir string) *pidfile.PidFile {
 	t.Helper()
 	pf, err := pidfile.Read(rootDir, server.PIDFileName)
 	if err != nil {
 		t.Logf("read %s in %s: %v", server.PIDFileName, rootDir, err)
-		return 0
+		return nil
 	}
 	if pf == nil || pf.Pid <= 0 {
-		return 0
+		return nil
 	}
-	return pf.Pid
+	return pf
 }
 
-// requireBackendExited fails the test if the dolt sql-server is still running
-// a short while after proxy.Shutdown claimed to have stopped it, then
-// force-kills it so the leak does not outlive the run.
+// requireBackendExited fails the test if the recorded dolt sql-server is
+// still running after proxy.Shutdown returned an ERROR, then force-kills it
+// so the leak does not outlive the run.
 //
-// This is deliberately a t.Errorf and not a t.Logf: a surviving server holds
+// It is deliberately a t.Errorf and not a t.Logf: a surviving server holds
 // the temp tree the test is about to delete, which is precisely how this
 // package produced sql-servers still serving directories that had been gone
 // for hours (wy-j2zc8q). A leak must be visible where it is caused, not
 // discovered later by a sweep.
-func requireBackendExited(t *testing.T, pid int) {
+//
+// Every step is gated on procid birth identity rather than the bare PID. The
+// server is not this process's child, so its PID is reusable the instant it
+// exits, and proxy.Shutdown deliberately REFUSES to signal a record it cannot
+// verify (ErrUnverifiableProcess) — killing that same PID here would defeat
+// the exact protection the package went out of its way to provide. A record
+// with no Birth token, or one whose token no longer matches, is therefore
+// left alone: not the server we recorded, nothing to report.
+func requireBackendExited(t *testing.T, pf *pidfile.PidFile) {
 	t.Helper()
-	if pid <= 0 {
+	if pf == nil || pf.Pid <= 0 || pf.Birth == "" {
 		return
 	}
+	token := procid.Token(pf.Birth)
+
 	deadline := time.Now().Add(backendExitTimeout)
 	for {
-		if !processRunning(pid) {
+		same, err := procid.Verify(pf.Pid, token)
+		if err != nil {
+			t.Logf("procid.Verify(%d): %v", pf.Pid, err)
+			return
+		}
+		if !same {
+			// Either the process is gone, or the PID now belongs to
+			// something else. Either way our server is not running.
 			return
 		}
 		if time.Now().After(deadline) {
@@ -121,26 +145,21 @@ func requireBackendExited(t *testing.T, pid int) {
 		}
 		time.Sleep(backendExitPoll)
 	}
-	if proc, err := os.FindProcess(pid); err == nil {
-		_ = proc.Kill()
-	}
-	t.Errorf("dolt sql-server pid %d survived Shutdown by more than %s (force-killed)", pid, backendExitTimeout)
-}
 
-// processRunning reports whether pid is still in the process table, using the
-// signal-0 probe (the kernel runs its existence and permission checks but
-// delivers nothing). EPERM means the process exists but belongs to someone
-// else, which still counts as running.
-func processRunning(pid int) bool {
-	proc, err := os.FindProcess(pid)
+	handle, err := procid.Open(pf.Pid, token)
 	if err != nil {
-		return false
+		t.Errorf("dolt sql-server pid %d survived Shutdown by more than %s and could not be opened to kill: %v",
+			pf.Pid, backendExitTimeout, err)
+		return
 	}
-	err = proc.Signal(syscall.Signal(0))
-	if err == nil {
-		return true
+	killErr := handle.Kill()
+	_ = handle.Close()
+	if killErr != nil {
+		t.Errorf("dolt sql-server pid %d survived Shutdown by more than %s and could not be killed: %v",
+			pf.Pid, backendExitTimeout, killErr)
+		return
 	}
-	return errors.Is(err, syscall.EPERM)
+	t.Errorf("dolt sql-server pid %d survived Shutdown by more than %s (force-killed)", pf.Pid, backendExitTimeout)
 }
 
 // TestReconcileVersionPersistsAcrossUOW is the one version assertion that

--- a/internal/storage/uow/version_reconcile_integration_test.go
+++ b/internal/storage/uow/version_reconcile_integration_test.go
@@ -123,7 +123,14 @@ func backendServerRecord(t *testing.T, rootDir string) *pidfile.PidFile {
 // left alone: not the server we recorded, nothing to report.
 func requireBackendExited(t *testing.T, pf *pidfile.PidFile) {
 	t.Helper()
-	if pf == nil || pf.Pid <= 0 || pf.Birth == "" {
+	if pf == nil || pf.Pid <= 0 {
+		return
+	}
+	if pf.Birth == "" {
+		// A record from before birth tokens were written. There is no safe
+		// way to ask about that PID, so the check is skipped — say so, rather
+		// than looking like a silent pass.
+		t.Logf("backend record for pid %d carries no birth token; skipping the survived-Shutdown check", pf.Pid)
 		return
 	}
 	token := procid.Token(pf.Birth)
@@ -148,18 +155,44 @@ func requireBackendExited(t *testing.T, pf *pidfile.PidFile) {
 
 	handle, err := procid.Open(pf.Pid, token)
 	if err != nil {
-		t.Errorf("dolt sql-server pid %d survived Shutdown by more than %s and could not be opened to kill: %v",
-			pf.Pid, backendExitTimeout, err)
+		if backendStillRunning(t, pf.Pid, token) {
+			t.Errorf("dolt sql-server pid %d survived Shutdown by more than %s and could not be opened to kill: %v",
+				pf.Pid, backendExitTimeout, err)
+		}
 		return
 	}
 	killErr := handle.Kill()
 	_ = handle.Close()
 	if killErr != nil {
-		t.Errorf("dolt sql-server pid %d survived Shutdown by more than %s and could not be killed: %v",
-			pf.Pid, backendExitTimeout, killErr)
+		if backendStillRunning(t, pf.Pid, token) {
+			t.Errorf("dolt sql-server pid %d survived Shutdown by more than %s and could not be killed: %v",
+				pf.Pid, backendExitTimeout, killErr)
+		}
 		return
 	}
 	t.Errorf("dolt sql-server pid %d survived Shutdown by more than %s (force-killed)", pf.Pid, backendExitTimeout)
+}
+
+// backendStillRunning re-checks birth identity after procid.Open or
+// Handle.Kill failed, and reports whether the recorded server is verifiably
+// still there.
+//
+// Both calls verify the token themselves and return a plain "does not match
+// token" error when it no longer does — which is exactly what a process that
+// exited between the wait loop's last poll and the kill attempt produces, and
+// that error is NOT procid.IsProcessGone. Without this second look, a server
+// that shut down a few milliseconds late would be reported as one that
+// survived Shutdown entirely. A verify that itself errors reports "not
+// running": the run is over, and an inconclusive probe is not evidence of a
+// leak.
+func backendStillRunning(t *testing.T, pid int, token procid.Token) bool {
+	t.Helper()
+	same, err := procid.Verify(pid, token)
+	if err != nil {
+		t.Logf("procid.Verify(%d) after a failed kill attempt: %v", pid, err)
+		return false
+	}
+	return same
 }
 
 // TestReconcileVersionPersistsAcrossUOW is the one version assertion that


### PR DESCRIPTION
## Problem

Killed test runs leave `dolt sql-server` processes behind, and nothing ever notices. Verified on a dev Mac carrying two of them for 1.5 days:

- `internal/storage/uow` boots a real server per provider (`newTestUOWProvider`) and cleans up in `t.Cleanup`. A `go test -timeout` panic skips every cleanup. The package had no `TestMain`, so no end-of-run sweep either.
- `cmd/bd`'s `TestMain` *does* sweep its suite root after `m.Run()` — but the same timeout kill skips both that sweep and the deferred root removal, and nothing on the next run looks at a dead run's root again. The orphan's `beads-bd-tests-*` root was still on disk with `dolt-server.pid` inside.
- On macOS, `lsof` prints no `" (deleted)"` suffix for a deleted cwd, so `SweepOrphanedTestServers`' deleted-cwd arm was dead code on darwin. The uow orphan's cwd was a `t.TempDir()` that no longer existed and the sweep still called it live.

## Fix

1. **Darwin deleted-cwd detection** (`sweep_darwin.go`): `parseDarwinCwd` stats the path lsof reports and treats `ErrNotExist` (only) as deleted.
2. **Deleted-cwd is bounded to temp roots** (`sweep.go`): a deleted cwd counts as debris only under the caller's suite roots or a canonical temp root (`os.TempDir()`, `/tmp`, literal + symlink-resolved forms). A production server whose data dir was moved, or whose volume unmounted, is left alone. `tempDirRoots` rejects `/` and anything containing `$HOME` so a bad `TMPDIR` cannot widen the arm.
3. **Dead-owner sweep at suite start** (`sweep_suite.go`): each `TestMain` writes `testmain.pid` into its suite root. On the next run, `SweepDeadSuiteRoots(os.TempDir(), prefix)` reaps roots whose recorded owner is gone (ESRCH), via a **root-only** reaper with no deleted-cwd arm — it runs while sibling packages are mid-run under `-p 4`. Roots with no marker, a live owner, or a different uid are never touched. Removal does a chmod-u+w walk (mirroring cmd/bd's `forceRemoveAll`) and, on partial failure, rewrites the marker with the same dead pid so the next run retries. Wired into `cmd/bd`, `internal/storage/dolt` (below the helper-subprocess return; helpers keep their own circuit dir) and the new `internal/storage/uow` `TestMain`.
4. **uow provider cleanup** asserts the backend exited: only when `proxy.Shutdown` errors, gated on `procid.Verify(pid, Token(Birth))`, killed through `procid.Open(...).Kill()`, re-verified before any `t.Errorf` so a late exit never false-fails.
5. **Leak policy**: each wired `TestMain` reports post-run sweeps loudly; it fails the package only under `BEADS_TEST_FAIL_ON_LEAK=1`, which no workflow sets yet.

## Verification

- `gofmt`, `go vet` (darwin, `GOOS=linux`, `GOOS=windows`), `golangci-lint` (0 issues), `scripts/check-build-tags.sh` clean.
- `go test ./internal/doltserver/ -run 'Sweep|Orphan|Suite|Darwin|TempDir'`: 53 tests, pass.
- `go test ./internal/storage/uow/ -run TestUOWDependencyEditorContract` and `go test ./cmd/bd/ -run 'TestMain|TestVersion'` pass on the darwin box with a real dolt; the pre-existing deleted-cwd orphan was reaped by the uow suite's post-run sweep, and a live-cwd orphan under an unmarked `beads-bd-tests-*` root plus the production server were untouched, as designed.
- The signalling loop itself (`reapServerPIDs`) is exercised only by that live run; selection logic is table-tested.

Two adversarial review rounds (opus) preceded this PR; their findings — the production-server hazard of an unbounded deleted-cwd arm, the suite-start composition, the blind pid kill, the marker lost to a partial `RemoveAll` — are what rounds 2 and 3 fix.

Refs: wy-j2zc8q (third recurrence of the leak first fixed for wy-9byjk). Follow-ups not in this PR: sweep the ~22 pre-fix unmarked `beads-bd-tests-*` roots once; turn on `BEADS_TEST_FAIL_ON_LEAK=1` for the uow race job after a few green weeks; teach `scripts/clean-test-tmp.sh` the marker and the two new prefixes.
