### PR TITLE
fix(lint): suppress two darwin-only gosec findings and cross-lint the darwin build in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -445,8 +445,8 @@ jobs:
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
       # No BD_LINT_NEW_FROM_MERGE_BASE here: the push lane sweeps the whole
-      # tree, including the GOOS=windows cross-lint. pr.yml scopes the same
-      # wrapper to the PR's own diff.
+      # tree, including the GOOS=windows and GOOS=darwin cross-lints. pr.yml
+      # scopes the same wrapper to the PR's own diff.
       - name: Run PR lint wrapper
         run: make ci-pr-lint
 

--- a/engdocs/CI_CLEANUP_PLAN.md
+++ b/engdocs/CI_CLEANUP_PLAN.md
@@ -1,6 +1,6 @@
 # CI Cleanup Plan
 
-Last reviewed: 2026-08-10
+Last reviewed: 2026-09-03
 
 Freshness source: `engdocs/CI_TEST_SURFACE_AUDIT.md`, `.github/workflows/*.yml`,
 `.buildflags`, `.golangci.yml`, `scripts/ci/pr-lint.sh`, `Makefile`, package test
@@ -167,8 +167,11 @@ easy to identify and rerun. It includes:
   downloads, a five-minute timeout, and the `gms_pure_go` build tag.
 - A second non-CGO Windows cross-lint pass when the native target does not
   already cover that build tuple.
+- A third non-CGO darwin (arm64) cross-lint pass under the same rule. Both
+  cross-lints are compile-only passes on the Linux runner; they add no macOS or
+  Windows runner and do not change the platform column above.
 
-Both passes are SCOPED BY LANE. On a PR the wrapper takes
+All three passes are SCOPED BY LANE. On a PR the wrapper takes
 `BD_LINT_NEW_FROM_MERGE_BASE` and reports only the findings that PR introduces,
 matching the `only-new-issues` setting on the sibling `lint` job; on a push to
 `main`, and for anyone running `make ci-pr-lint` by hand, it is unset and the

--- a/engdocs/LINTING.md
+++ b/engdocs/LINTING.md
@@ -1,6 +1,6 @@
 # Linting Policy
 
-Last reviewed: 2026-08-10
+Last reviewed: 2026-09-03
 
 Freshness source: `.golangci.yml`, `scripts/ci/pr-lint.sh`, `Makefile`,
 `.github/workflows/pr.yml`, and `.github/workflows/main.yml`.

--- a/engdocs/LINTING.md
+++ b/engdocs/LINTING.md
@@ -42,7 +42,9 @@ The wrapper runs:
   timeout, the `gms_pure_go` build tag, and `--new-from-merge-base` when
   `BD_LINT_NEW_FROM_MERGE_BASE` names a ref; and
 - a second non-CGO Windows cross-lint pass, on the same scope, when the native
-  host does not already cover that target.
+  host does not already cover that target; and
+- a third non-CGO darwin (arm64) cross-lint pass, on the same scope, under the
+  same rule, so `//go:build darwin` files are linted from the Linux runner.
 
 ## Policy
 

--- a/internal/config/permissions_open_nonlinux.go
+++ b/internal/config/permissions_open_nonlinux.go
@@ -8,5 +8,6 @@ import "os"
 // caller's descriptor identity check prevents chmod unless it still refers to
 // the directory inspected with Lstat.
 func openBeadsDirHandle(path string) (beadsDirHandle, error) {
+	//nolint:gosec // G304: path is the .beads directory fixBeadsDirPermissions just inspected with Lstat; its descriptor identity check gates the chmod.
 	return os.Open(path)
 }

--- a/internal/utils/path_case_darwin.go
+++ b/internal/utils/path_case_darwin.go
@@ -52,7 +52,8 @@ func canonicalCaseFast(path string) (string, error) {
 	buf := make([]byte, unix.PathMax)
 	// F_GETPATH has no typed wrapper in x/sys/unix: it writes a NUL-terminated
 	// path of up to MAXPATHLEN bytes into the buffer named by the third arg.
-	_, _, errno := unix.Syscall( // nolint:gosec // buf is a live []byte of PathMax bytes, the exact contract F_GETPATH requires
+	//nolint:gosec // G103: buf is a live []byte of PathMax bytes, the exact contract F_GETPATH requires.
+	_, _, errno := unix.Syscall(
 		unix.SYS_FCNTL,
 		uintptr(fd),
 		uintptr(unix.F_GETPATH),

--- a/scripts/ci/pr-lint.sh
+++ b/scripts/ci/pr-lint.sh
@@ -39,3 +39,15 @@ if [[ "$native_goos" != "windows" || "$native_cgo_enabled" != "0" ]]; then
                 --timeout=5m --build-tags=gms_pure_go \
                 ${lint_scope[@]+"${lint_scope[@]}"} ./...
 fi
+
+# Files guarded by //go:build darwin (and the !windows && !linux fallbacks)
+# are invisible to the Linux runner too. Cross-lint the non-CGO darwin build
+# from the same runner so a darwin-only finding fails the PR instead of the
+# next maintainer's laptop, unless the native target above already matches it.
+if [[ "$native_goos" != "darwin" || "$native_cgo_enabled" != "0" ]]; then
+    ci_time "golangci-lint (darwin)" -- \
+        env GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 GOWORK=off \
+            golangci-lint run --config=.golangci.yml --modules-download-mode=readonly \
+                --timeout=5m --build-tags=gms_pure_go \
+                ${lint_scope[@]+"${lint_scope[@]}"} ./...
+fi


### PR DESCRIPTION
## What

Two gosec findings only appear when linting the darwin build, and CI never lints that build. This adds the two missing `//nolint:gosec` directives and a `GOOS=darwin GOARCH=arm64 CGO_ENABLED=0` cross-lint pass to `scripts/ci/pr-lint.sh`, mirroring the existing windows pass. The three docs/comments that described the wrapper as two passes are updated (`engdocs/LINTING.md`, `engdocs/CI_CLEANUP_PLAN.md`, the comment in `.github/workflows/main.yml`).

## Why

`pr-lint.sh` runs golangci-lint natively (ubuntu in CI) plus one windows cross-lint, so `//go:build darwin` files and the `!windows && !linux` fallbacks are never linted in CI. Against `main` (`c0d8da42d`):

```
$ GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 GOWORK=off golangci-lint run --config=.golangci.yml --build-tags=gms_pure_go ./...
internal/config/permissions_open_nonlinux.go:11:9: G304: Potential file inclusion via variable (gosec)
internal/utils/path_case_darwin.go:59:11: G103: Use of unsafe calls should be audited (gosec)
2 issues
```

- `permissions_open_nonlinux.go`: the file comment already explains why the `os.Open` is safe (`fixBeadsDirPermissions` re-checks descriptor identity with `os.SameFile` before `Chmod`, `internal/config/permissions.go:74-79`); it just had no directive.
- `path_case_darwin.go`: a `nolint:gosec` existed but was a trailing comment on the first line of the multi-line `unix.Syscall(` call, while gosec reports the `unsafe.Pointer` argument line. It never covered the finding. It now sits on its own line above the statement, the placement `cmd/bd/nocow_linux.go` already uses (and which lints clean on linux).

The riskiest part of this diff is the new CI pass, not the annotations: on the `main` push lane it sweeps the whole tree unscoped, so any future darwin-only finding blocks `main` instead of surfacing on a maintainer's laptop. That is the intent. Verified the whole tree is clean under the new pass today.

This is a cross-compile lint on the existing Linux runner. It adds no macOS runner and does not change the `pr-lint` platform column in `engdocs/CI_CLEANUP_PLAN.md`, so it stays inside the "no macOS checks on PRs by default" non-goal the same way the windows cross-lint does.

Known limits, same as the windows pass: `CGO_ENABLED=0`, so darwin+cgo code (embedded Dolt) is outside its reach; `arm64` only.

## Verification

On a darwin/arm64 host with golangci-lint v2.10.1 (the pinned version):

```
$ ./scripts/ci/pr-lint.sh
==> gofmt check            ... succeeded
==> golangci-lint          0 issues.
==> golangci-lint (windows) 0 issues.
==> golangci-lint (darwin)  0 issues.
$ GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 GOWORK=off golangci-lint run --config=.golangci.yml --modules-download-mode=readonly --timeout=10m --build-tags=gms_pure_go ./...
0 issues.
$ GOOS=linux GOARCH=amd64 CGO_ENABLED=0 golangci-lint run --config=.golangci.yml --build-tags=gms_pure_go ./...
0 issues.
$ ./scripts/check-doc-freshness.sh
PASSED
$ bash -n scripts/ci/pr-lint.sh
```

Lint-only change; no Go behavior changes, no tests added. `shellcheck` was not available on the host, so that check is left to CI.
