### PR TITLE
test(proxied): un-skip the two bd list subtests that waited for bd dep add proxied support

### DIFF
--- a/cmd/bd/list_proxied_integration_test.go
+++ b/cmd/bd/list_proxied_integration_test.go
@@ -228,16 +228,43 @@ func TestProxiedServerList(t *testing.T) {
 	})
 
 	t.Run("ready_parent_tree_excludes_blocked_descendants", func(t *testing.T) {
-		// TODO: re-enable once `bd dep add` is ported to proxied mode.
-		// Currently bd dep add fails with "storage is nil" under proxied
-		// since the dep subcommand has no usesProxiedServer() dispatch.
-		t.Skip("requires bd dep add proxied support")
+		parent := bdProxiedCreate(t, bd, p.dir, "Ready parent tree", "--type", "epic")
+		readyChild := bdProxiedCreate(t, bd, p.dir, "Ready child in tree", "--type", "task", "--parent", parent.ID)
+		blockedChild := bdProxiedCreate(t, bd, p.dir, "Blocked child in tree", "--type", "task", "--parent", parent.ID)
+		blocker := bdProxiedCreate(t, bd, p.dir, "Tree child blocker", "--type", "task")
+		bdProxiedDep(t, bd, p.dir, "add", blockedChild.ID, blocker.ID)
+
+		out := bdProxiedList(t, bd, p, "--ready", "--parent", parent.ID, "--no-pager")
+		if !strings.Contains(out, readyChild.ID) {
+			t.Errorf("ready child %s should appear in ready parent tree:\n%s", readyChild.ID, out)
+		}
+		if strings.Contains(out, blockedChild.ID) {
+			t.Errorf("blocked child %s should not appear in ready parent tree:\n%s", blockedChild.ID, out)
+		}
 	})
 
 	// Regression for gastownhall/beads#3936: relates-to between two epics
-	// must not nest them, and bidirectional relates-to must not drop them.
+	// must not nest them in `bd list` tree mode, and a bidirectional
+	// relates-to must not silently drop both epics from the output.
 	t.Run("tree_relates_to_does_not_nest_or_drop_epics", func(t *testing.T) {
-		t.Skip("requires bd dep add proxied support")
+		epicA := bdProxiedCreate(t, bd, p.dir, "Relates Epic A", "--type", "epic", "--priority", "2")
+		epicB := bdProxiedCreate(t, bd, p.dir, "Relates Epic B", "--type", "epic", "--priority", "2")
+
+		bdProxiedDep(t, bd, p.dir, "add", epicA.ID, epicB.ID, "--type", "relates-to")
+		out := bdProxiedList(t, bd, p, "--no-pager", "--type", "epic")
+		if !strings.Contains(out, epicA.ID) || !strings.Contains(out, epicB.ID) {
+			t.Fatalf("one-direction relates-to should keep both epics visible:\n%s", out)
+		}
+		if strings.Contains(out, "└── "+epicA.ID) || strings.Contains(out, "└── "+epicB.ID) ||
+			strings.Contains(out, "├── "+epicA.ID) || strings.Contains(out, "├── "+epicB.ID) {
+			t.Fatalf("relates-to must not nest epics under each other:\n%s", out)
+		}
+
+		bdProxiedDep(t, bd, p.dir, "add", epicB.ID, epicA.ID, "--type", "relates-to")
+		out = bdProxiedList(t, bd, p, "--no-pager", "--type", "epic")
+		if !strings.Contains(out, epicA.ID) || !strings.Contains(out, epicB.ID) {
+			t.Fatalf("bidirectional relates-to must not drop epics from tree output:\n%s", out)
+		}
 	})
 
 	t.Run("ready_parent_filter_includes_grandchildren", func(t *testing.T) {


### PR DESCRIPTION
## What

Removes two stale `t.Skip("requires bd dep add proxied support")` in `cmd/bd/list_proxied_integration_test.go` and ports the subtest bodies from their embedded twins in `cmd/bd/list_embedded_test.go`:

- `ready_parent_tree_excludes_blocked_descendants`
- `tree_relates_to_does_not_nest_or_drop_epics` (the gastownhall/beads#3936 regression)

Test-only change, one file, +33/-6.

## Why

The skip's TODO said `bd dep add` fails with "storage is nil" under proxied mode because the `dep` subcommand had no `usesProxiedServer()` dispatch. That is no longer true: `cmd/bd/dep.go` routes `dep add` to `runDepAddProxiedServer` (`cmd/bd/dep_proxied_server.go`), which accepts `--type relates-to`. The skips were only hiding coverage on the proxied path, which is exactly the "direct path tested, proxied path not" gap review keeps flagging.

The bodies are the embedded versions with helper substitutions only (`bdCreate` → `bdProxiedCreate`, `bdDepAdd`/`bdDep` → `bdProxiedDep`, `bdList` → `bdProxiedList`). Same assertions, same `--no-pager` / `--priority 2` flags, same `Fatalf`/`Errorf` choices and messages. Nothing weakened.

Both subtests add beads to the shared `lst` project, like the existing `ready_parent_filter_includes_grandchildren` subtest does. The pagination siblings (`limit_N_matches_first_N`, `page_walk_reconstructs_full_result`, etc.) re-snapshot `--all --limit 0` inside each subtest and assert only `>=` floors, and `empty_database` / `concurrent_create_and_list` build their own projects, so the extra rows do not disturb them.

## Verification

Requires Docker for the shared Dolt test container.

```
$ source .buildflags
$ BEADS_TEST_PROXIED_SERVER=1 go test ./cmd/bd -run '^TestProxiedServerList$' -count=1 -v
    --- PASS: TestProxiedServerList/ready_parent_tree_excludes_blocked_descendants (0.60s)
    --- PASS: TestProxiedServerList/tree_relates_to_does_not_nest_or_drop_epics (0.44s)
--- PASS: TestProxiedServerList (40.55s)
ok      github.com/steveyegge/beads/cmd/bd      42.428s
$ gofmt -l cmd/bd        # clean
$ go vet ./cmd/bd/       # clean
$ ./scripts/ci/fmt-check.sh   # All Go files are properly formatted
```

Note: in the default (non-proxied) CI lane these subtests compile but skip with the rest of `TestProxiedServerList`; the `pr-risk.yml` / `main.yml` proxied lanes run them.
