### PR TITLE
fix(cli): stop eleven subcommands shadowing the root --json flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`bd restore --json`, `bd admin compact --json`, `bd repo <add|remove|list|sync>
+  --json` and `bd migrate [sync|hooks|schema] --json` honor the flag again.**
+  Each of those commands registered its own local `--json` bound to the same
+  variable as the root persistent flag. pflag keeps the local flag and drops
+  the inherited one, so the root flag never read as "changed" and the pre-run
+  reset the output mode from config — the commands printed text unless
+  `json: true` was configured. The local registrations are gone (`bd preflight`
+  drops its unbound local copy too, so it now follows the configured default
+  like every other command), `--json` moves to the Global Flags section of
+  those commands' `--help`, and a guard test fails the build if a command
+  shadows the root flag again.
+
 - **`bd prime` says when it could NOT read the memory plane**
   ([#5877](https://github.com/gastownhall/beads/issues/5877)). A broken or
   unreachable store made prime omit the memory section entirely, so a session

--- a/cmd/bd/compact.go
+++ b/cmd/bd/compact.go
@@ -950,7 +950,6 @@ func init() {
 	compactCmd.Flags().IntVar(&compactBatch, "batch-size", 10, "Issues per batch")
 	compactCmd.Flags().IntVar(&compactWorkers, "workers", 5, "Parallel workers")
 	compactCmd.Flags().BoolVar(&compactStats, "stats", false, "Show compaction statistics")
-	compactCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSON format")
 
 	// New mode flags
 	compactCmd.Flags().BoolVar(&compactAnalyze, "analyze", false, "Analyze mode: export candidates for agent review")

--- a/cmd/bd/compact_test.go
+++ b/cmd/bd/compact_test.go
@@ -345,9 +345,9 @@ func TestCompactInitCommand(t *testing.T) {
 		t.Error("compactCmd should have Long description")
 	}
 
-	// Verify --json flag exists
-	jsonFlag := compactCmd.Flags().Lookup("json")
-	if jsonFlag == nil {
-		t.Error("compact command should have --json flag")
+	// --json is inherited from rootCmd as a persistent flag; a local copy
+	// would shadow it (see TestNoSubcommandShadowsRootJSONFlag).
+	if compactCmd.InheritedFlags().Lookup("json") == nil {
+		t.Error("compact command should inherit --json flag from rootCmd")
 	}
 }

--- a/cmd/bd/compact_test.go
+++ b/cmd/bd/compact_test.go
@@ -347,7 +347,7 @@ func TestCompactInitCommand(t *testing.T) {
 
 	// --json is inherited from rootCmd as a persistent flag; a local copy
 	// would shadow it (see TestNoSubcommandShadowsRootJSONFlag).
-	if compactCmd.InheritedFlags().Lookup("json") == nil {
-		t.Error("compact command should inherit --json flag from rootCmd")
+	if f := compactCmd.Flags().Lookup("json"); f != nil && f != rootCmd.PersistentFlags().Lookup("json") {
+		t.Error("compact command must not register a local --json; it inherits the root flag")
 	}
 }

--- a/cmd/bd/json_flag_shadow_test.go
+++ b/cmd/bd/json_flag_shadow_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestNoSubcommandShadowsRootJSONFlag guards the root --json contract.
+//
+// --json is a persistent flag on rootCmd. When a subcommand registers its own
+// --json (local or persistent), pflag keeps that one and drops the inherited
+// one, so rootCmd.PersistentFlags().Changed("json") stays false for that
+// command. The PersistentPreRun then treats the flag as unset and overwrites
+// jsonOutput with the configured default, and `bd <cmd> --json` prints text
+// unless the config also says json. Every command must inherit the root flag
+// instead.
+func TestNoSubcommandShadowsRootJSONFlag(t *testing.T) {
+	var offenders []string
+	var walk func(cmd *cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		for _, sub := range cmd.Commands() {
+			if sub.LocalNonPersistentFlags().Lookup("json") != nil || sub.PersistentFlags().Lookup("json") != nil {
+				offenders = append(offenders, sub.CommandPath())
+			}
+			walk(sub)
+		}
+	}
+	walk(rootCmd)
+
+	for _, path := range offenders {
+		t.Errorf("%q registers a local --json flag that shadows the root persistent flag", path)
+	}
+}

--- a/cmd/bd/json_flag_shadow_test.go
+++ b/cmd/bd/json_flag_shadow_test.go
@@ -15,12 +15,23 @@ import (
 // jsonOutput with the configured default, and `bd <cmd> --json` prints text
 // unless the config also says json. Every command must inherit the root flag
 // instead.
+//
+// The check reads Flags() and PersistentFlags() only. LocalNonPersistentFlags()
+// and InheritedFlags() call mergePersistentFlags, which copies every root
+// persistent flag into the command's Flags() for the rest of the process and
+// breaks tests that pin a command's exact flag set (TestServeFlags).
 func TestNoSubcommandShadowsRootJSONFlag(t *testing.T) {
+	rootJSON := rootCmd.PersistentFlags().Lookup("json")
+	if rootJSON == nil {
+		t.Fatal("root command must register persistent --json")
+	}
+
 	var offenders []string
 	var walk func(cmd *cobra.Command)
 	walk = func(cmd *cobra.Command) {
 		for _, sub := range cmd.Commands() {
-			if sub.LocalNonPersistentFlags().Lookup("json") != nil || sub.PersistentFlags().Lookup("json") != nil {
+			local := sub.Flags().Lookup("json")
+			if (local != nil && local != rootJSON) || sub.PersistentFlags().Lookup("json") != nil {
 				offenders = append(offenders, sub.CommandPath())
 			}
 			walk(sub)

--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -840,22 +840,18 @@ func init() {
 	migrateCmd.Flags().Bool("dry-run", false, "Show what would be done without making changes")
 	migrateCmd.Flags().Bool("update-repo-id", false, "Update repository ID (use after changing git remote)")
 	migrateCmd.Flags().Bool("inspect", false, "Show migration plan and database state for AI agent analysis")
-	migrateCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output migration statistics in JSON format")
 	// --force bypasses the remote-migrate gate (#4259) as the single designated
 	// migrator. No -f shorthand: deliberate typing for a fork-risk bypass.
 	migrateCmd.Flags().Bool("force", false, "Bypass the remote-migrate gate as the single designated migrator (equivalent to BD_ALLOW_REMOTE_MIGRATE=1)")
 
 	migrateSyncCmd.Flags().Bool("dry-run", false, "Show what would be done without making changes")
-	migrateSyncCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	migrateCmd.AddCommand(migrateSyncCmd)
 
 	migrateHooksCmd.Flags().Bool("dry-run", false, "Show what would be done without making changes")
 	migrateHooksCmd.Flags().Bool("apply", false, "Apply planned hook migration changes")
 	migrateHooksCmd.Flags().Bool("yes", false, "Skip confirmation prompt for --apply")
-	migrateHooksCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	migrateCmd.AddCommand(migrateHooksCmd)
 
-	migrateSchemaCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	// --force on migrate schema mirrors the parent command's flag; both trip the
 	// same isForcedMigrate check in main.go's PersistentPreRunE.
 	migrateSchemaCmd.Flags().Bool("force", false, "Bypass the remote-migrate gate as the single designated migrator (equivalent to BD_ALLOW_REMOTE_MIGRATE=1)")

--- a/cmd/bd/migrate_test.go
+++ b/cmd/bd/migrate_test.go
@@ -17,18 +17,19 @@ import (
 // TestFormatDBList removed: formatDBList and dbInfo types were removed.
 
 func TestMigrateSchemaFlagBoundaries(t *testing.T) {
-	// Registration only: strict subprocess tests use the unique root persistent
-	// --format=json alias because duplicate local --json registration can shadow
-	// whether PersistentPreRunE sees the root flag as explicitly set.
-	for _, name := range []string{"inspect", "dry-run"} {
-		if flag := migrateSchemaCmd.Flags().Lookup(name); flag != nil {
+	// Registration only. --json must come from the root persistent flag: a
+	// local duplicate shadows it, so PersistentPreRunE never sees the root
+	// flag as explicitly set and resets jsonOutput from config.
+	for _, name := range []string{"inspect", "dry-run", "json"} {
+		if flag := migrateSchemaCmd.LocalNonPersistentFlags().Lookup(name); flag != nil {
 			t.Errorf("migrate schema unexpectedly registers local --%s", name)
 		}
 	}
-	for _, name := range []string{"json", "force"} {
-		if flag := migrateSchemaCmd.Flags().Lookup(name); flag == nil {
-			t.Errorf("migrate schema must register local --%s", name)
-		}
+	if flag := migrateSchemaCmd.Flags().Lookup("force"); flag == nil {
+		t.Error("migrate schema must register local --force")
+	}
+	if flag := migrateSchemaCmd.InheritedFlags().Lookup("json"); flag == nil {
+		t.Error("migrate schema must inherit --json from the root command")
 	}
 	if flag := rootCmd.PersistentFlags().Lookup("json"); flag == nil {
 		t.Error("root command must register persistent --json")

--- a/cmd/bd/migrate_test.go
+++ b/cmd/bd/migrate_test.go
@@ -20,16 +20,16 @@ func TestMigrateSchemaFlagBoundaries(t *testing.T) {
 	// Registration only. --json must come from the root persistent flag: a
 	// local duplicate shadows it, so PersistentPreRunE never sees the root
 	// flag as explicitly set and resets jsonOutput from config.
-	for _, name := range []string{"inspect", "dry-run", "json"} {
-		if flag := migrateSchemaCmd.LocalNonPersistentFlags().Lookup(name); flag != nil {
+	for _, name := range []string{"inspect", "dry-run"} {
+		if flag := migrateSchemaCmd.Flags().Lookup(name); flag != nil {
 			t.Errorf("migrate schema unexpectedly registers local --%s", name)
 		}
 	}
+	if f := migrateSchemaCmd.Flags().Lookup("json"); f != nil && f != rootCmd.PersistentFlags().Lookup("json") {
+		t.Error("migrate schema must not register a local --json; it inherits the root flag")
+	}
 	if flag := migrateSchemaCmd.Flags().Lookup("force"); flag == nil {
 		t.Error("migrate schema must register local --force")
-	}
-	if flag := migrateSchemaCmd.InheritedFlags().Lookup("json"); flag == nil {
-		t.Error("migrate schema must inherit --json from the root command")
 	}
 	if flag := rootCmd.PersistentFlags().Lookup("json"); flag == nil {
 		t.Error("root command must register persistent --json")

--- a/cmd/bd/preflight.go
+++ b/cmd/bd/preflight.go
@@ -78,7 +78,6 @@ func runPreflight(cmd *cobra.Command, args []string) error {
 
 	check, _ := cmd.Flags().GetBool("check")
 	fix, _ := cmd.Flags().GetBool("fix")
-	jsonOutput, _ := cmd.Flags().GetBool("json")
 	skipLint, _ := cmd.Flags().GetBool("skip-lint")
 
 	if fix {

--- a/cmd/bd/preflight.go
+++ b/cmd/bd/preflight.go
@@ -63,7 +63,6 @@ Examples:
 func init() {
 	preflightCmd.Flags().Bool("check", false, "Run checks automatically")
 	preflightCmd.Flags().Bool("fix", false, "Auto-fix issues where possible (vendorHash, version sync)")
-	preflightCmd.Flags().Bool("json", false, "Output results as JSON")
 	preflightCmd.Flags().Bool("skip-lint", false, "Skip lint check explicitly")
 
 	rootCmd.AddCommand(preflightCmd)

--- a/cmd/bd/repo.go
+++ b/cmd/bd/repo.go
@@ -476,10 +476,6 @@ func init() {
 	repoCmd.AddCommand(repoListCmd)
 	repoCmd.AddCommand(repoSyncCmd)
 
-	repoAddCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSON")
-	repoRemoveCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSON")
-	repoListCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSON")
-	repoSyncCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSON")
 	repoSyncCmd.Flags().Bool("verbose", false, "Show detailed sync progress")
 
 	rootCmd.AddCommand(repoCmd)

--- a/cmd/bd/restore.go
+++ b/cmd/bd/restore.go
@@ -176,7 +176,6 @@ func issueContentSize(issue *types.Issue) int {
 }
 
 func init() {
-	restoreCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output restore results in JSON format")
 	restoreCmd.Flags().BoolVar(&restoreApply, "apply", false, "Write the restored content back into the issue (default: display only)")
 	rootCmd.AddCommand(restoreCmd)
 }

--- a/cmd/bd/restore_embedded_test.go
+++ b/cmd/bd/restore_embedded_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // bdRestore runs "bd restore" with extra args. Returns combined output.
@@ -145,12 +147,16 @@ func TestEmbeddedRestore(t *testing.T) {
 		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "rstjs")
 		id := simulateCompaction(t, bd, dir, beadsDir, "rstjs")
 
-		// NOTE: bd restore has a known issue where its local --json flag
-		// conflicts with the root command's --json persistent flag.
-		// Just verify the command runs successfully.
-		out := bdRestore(t, bd, dir, id)
-		if !strings.Contains(out, "long description") {
-			t.Errorf("expected restored description in output, got: %s", out)
+		out := bdRestore(t, bd, dir, id, "--json")
+		var restored types.Issue
+		if err := json.Unmarshal([]byte(out), &restored); err != nil {
+			t.Fatalf("bd restore --json must print a JSON issue, got error %v:\n%s", err, out)
+		}
+		if restored.ID != id {
+			t.Errorf("expected restored issue %s, got %q", id, restored.ID)
+		}
+		if !strings.Contains(restored.Description, "long description") {
+			t.Errorf("expected restored description in JSON, got: %q", restored.Description)
 		}
 	})
 }


### PR DESCRIPTION
## What

`bd restore --json`, `bd admin compact --json`, `bd repo <add|remove|list|sync> --json` and `bd migrate [sync|hooks|schema] --json` print text unless the config also says `json: true`. This removes the local `--json` registrations that caused it, adds a guard test so it cannot come back, and restores the assertion that `restore_embedded_test.go` had weakened to work around the bug.

## Why

`--json` is a persistent flag on `rootCmd` bound to `jsonOutput` (`cmd/bd/main.go:762`). Ten subcommands also registered a *local* `--json` bound to the same variable (`restore.go`, `compact.go`, `repo.go` ×4, `migrate.go` ×4). cobra merges inherited flags with pflag's `AddFlagSet`, which skips a flag whose name already exists locally, so the local flag wins the parse and `rootCmd.PersistentFlags().Changed("json")` stays false. `PersistentPreRunE` (`main.go:977`) and `refreshBoundCommandConfig` (`main.go:636`) then treat the flag as unset and overwrite `jsonOutput = config.GetBool("json")`. The repo already knew: `restore_embedded_test.go` said "bd restore has a known issue where its local --json flag conflicts with the root command's --json persistent flag. Just verify the command runs successfully."

`bd preflight` is the eleventh: it registered an unbound local `Bool("json")` and read it via `GetBool`, so it was not hit by the config reset, but it shadowed the root flag the same way and ignored a configured `json` default. It now reads the inherited root flag like `status`, `update` and the proxied close/reopen routes already do. **Behavior change to note:** `bd preflight` in a workspace with `json: true` configured now emits JSON like every other command.

Riskiest thing in the diff: `--json` moves from each of those commands' *Flags* section to *Global Flags* in `--help`, with the root description ("Output in JSON format") replacing the per-command wording. `docs/cli-reference/*.md` is generated from the release pin (`docs/cli-docs.pin`), so it is unchanged here and picks this up at the next regeneration. Anyone scraping `--help` placement is affected.

Related open issue, not addressed here: #6206 (test hygiene sweep of raw `jsonOutput = true` assignments).

## Verification

```
$ source .buildflags
$ go test ./cmd/bd -run 'TestNoSubcommandShadowsRootJSONFlag|TestCompactInitCommand|TestMigrateSchemaFlagBoundaries|TestHelpAll' -count=1
ok      github.com/steveyegge/beads/cmd/bd
$ BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd -run '^TestEmbeddedRestore$' -count=1 -v
    --- PASS: TestEmbeddedRestore/restore_json (4.62s)
--- PASS: TestEmbeddedRestore (31.04s)
$ go test ./cmd/bd -count=1          # full package, default lane
ok      github.com/steveyegge/beads/cmd/bd      279.852s   (via ./scripts/test.sh ./cmd/bd/...)
$ golangci-lint run --config=.golangci.yml --build-tags=gms_pure_go ./cmd/bd/...
0 issues.
$ go build -o /tmp/bd ./cmd/bd && /tmp/bd restore --help | grep -n json
   --json   Output in JSON format      # under Global Flags; the Flags section lists only --apply
```

The guard test fails on `main` with all eleven command paths listed (`bd admin compact`, `bd migrate`, `bd migrate hooks`, `bd migrate schema`, `bd migrate sync`, `bd preflight`, `bd repo add`, `bd repo list`, `bd repo remove`, `bd repo sync`, `bd restore`) and passes on this branch.

Only `restore` has an end-to-end `--json` test; the other commands are covered by the registration-shape guard and share the same root-flag path.
