### PR TITLE
feat(migrate): make the MIGRATION-FREEZE stand-down reachable outside Gas Town

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,20 +65,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   checks in embedded, server, and proxied-server command paths; the legacy
   `<rig>:<bead-id>` await value remains accepted for compatibility.
 
-- **Write commands now refuse to run while a MIGRATION-FREEZE sentinel sits
-  at the town root** (dc-6jaq), mirroring the gate the gt CLI already applies
-  to `gt mail send`/`nudge`/`sling`/`assign`. `bd create`/`update`/`close`/
-  `remember`/`import` and every other command gated by `CheckReadonly`
-  (~120 call sites, `bd q` included) now print `⛔ town is frozen for
-  migration (by <operator>)` and exit 1 instead of writing to a store mid-
-  migration. The check runs twice: once early in the root command, before
+- **Write commands now refuse to run while a MIGRATION-FREEZE sentinel is
+  present** (dc-6jaq), mirroring the gate the gt CLI already applies to
+  `gt mail send`/`nudge`/`sling`/`assign`. The sentinel is read from the Gas
+  Town root when there is one, and otherwise from the workspace's `.beads`
+  directory, so the stand-down is available to every beads workspace and not
+  only to a town. `bd create`/`update`/`close`/`remember`/`import` and every
+  other command gated by `CheckReadonly` (~120 call sites, `bd q` included)
+  now print `⛔ town is frozen for migration (by <operator>)` — or
+  `⛔ workspace is frozen …` outside a town — and exit 1 instead of writing to
+  a store mid-migration. The check runs twice: once early in the root command, before
   version-bump auto-migration or JSONL auto-import can touch the store, and
   again at each write command's own chokepoint. Read commands (`list`,
   `show`, `ready`, …) keep working during a freeze — the same early check
   also skips version tracking and auto-migration for them, so a frozen store
   is never rewritten just because someone ran a read. `--dry-run`/`--inspect`
   previews are blocked at the per-command chokepoint instead, same as strict
-  `--readonly` already blocks them. Clear the freeze with `gt migrate thaw`.
+  `--readonly` already blocks them. Clear a town freeze with `gt migrate thaw`;
+  outside a town, remove the `.beads/MIGRATION-FREEZE` file, which the refusal
+  names by path. The sentinel is in the `.beads/.gitignore` template and in
+  `bd doctor`'s untrack list, so it is neither committed by a new workspace nor
+  left tracked in one that committed it before those landed — a committed
+  sentinel would freeze every clone that pulled it.
 
 - **`bd dep add` names the implicit `type=blocks` default, but only to an
   interactive operator** (#5854). Creating an edge with no `-t/--type` silently

--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -73,6 +73,11 @@ dolt-pprof/
 # Corrupt backup directories (created by bd doctor --fix recovery)
 *.corrupt.backup/
 
+# Migration freeze sentinel (internal/migration): a live operational stand-down
+# for THIS clone. Committing it would freeze every clone that pulls it, with a
+# refusal message naming a local path.
+MIGRATION-FREEZE
+
 # Backup data (auto-exported JSONL, local-only)
 backup/
 
@@ -138,6 +143,10 @@ var requiredPatterns = []string{
 	"proxied_server_client_info.json",
 	".local_version",
 	"backup/",
+	// A live sentinel is per-clone operational state; committed, it would
+	// freeze every clone that pulls it. In the template AND here, so bd doctor
+	// carries it to workspaces initialized before it was added.
+	"MIGRATION-FREEZE",
 }
 
 // CheckGitignore checks if .beads/.gitignore is up to date.

--- a/cmd/bd/doctor/gitignore_test.go
+++ b/cmd/bd/doctor/gitignore_test.go
@@ -2828,3 +2828,52 @@ func TestCheckNoVestigialSyncWorktrees_VestigialDetected(t *testing.T) {
 		t.Errorf("Message = %q, want it to contain 'Vestigial'", check.Message)
 	}
 }
+
+// TestGitignore_ContainsMigrationFreeze pins the MIGRATION-FREEZE sentinel in
+// BOTH lists, for the reason the sibling entries above are pinned: the generic
+// loops iterate requiredPatterns, so they cannot notice its removal.
+//
+// The template covers workspaces bd init creates from now on. requiredPatterns
+// is what bd doctor actually checks, so it is the half that carries the line
+// to workspaces initialized before the sentinel existed — drop it and
+// `bd doctor --fix` silently stops healing them.
+//
+// The stakes: a committed sentinel freezes every clone that pulls it, and the
+// refusal (cmd/bd/errors.go) names a LOCAL path, so the first person to hit it
+// has no reason to suspect it came over the wire.
+func TestGitignore_ContainsMigrationFreeze(t *testing.T) {
+	// Keep in sync with migration.FileName. Not imported here because
+	// cmd/bd/doctor must not depend on that package for a string constant —
+	// the same rule TestGitignore_ContainsDoltServerConfig follows.
+	const pattern = "MIGRATION-FREEZE"
+
+	if !containsGitignorePattern(GitignoreTemplate, pattern) {
+		t.Errorf("GitignoreTemplate should contain %q", pattern)
+	}
+
+	found := false
+	for _, p := range requiredPatterns {
+		if p == pattern {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("requiredPatterns should contain %q, otherwise bd doctor --fix cannot heal an existing .beads/.gitignore", pattern)
+	}
+
+	// And an old .gitignore must be reported as missing it, which is the
+	// behaviour the retrofit depends on.
+	old := "dolt/\nembeddeddolt/\n*.lock\n"
+	missing := missingGitignorePatterns(old)
+	seen := false
+	for _, p := range missing {
+		if p == pattern {
+			seen = true
+			break
+		}
+	}
+	if !seen {
+		t.Errorf("missingGitignorePatterns should report %q missing from a pre-change .gitignore; got %v", pattern, missing)
+	}
+}

--- a/cmd/bd/doctor/tracked_runtime.go
+++ b/cmd/bd/doctor/tracked_runtime.go
@@ -42,6 +42,11 @@ var trackedRuntimePatterns = []string{
 	"sync-state.json",
 	"last-touched",
 	"last_pull", // bd-578h9.6: gitignored since 7ebf4df6a, but gitignore cannot untrack already-committed copies
+	// Same shape, and the stakes are higher: a committed MIGRATION-FREEZE
+	// freezes every clone that pulls it, and the refusal names a local path
+	// so nobody suspects it arrived over the wire. Ignoring it does not
+	// untrack a copy committed before the pattern existed.
+	"MIGRATION-FREEZE",
 	".local_version",
 	"redirect",
 

--- a/cmd/bd/doctor/tracked_runtime.go
+++ b/cmd/bd/doctor/tracked_runtime.go
@@ -46,6 +46,11 @@ var trackedRuntimePatterns = []string{
 	// freezes every clone that pulls it, and the refusal names a local path
 	// so nobody suspects it arrived over the wire. Ignoring it does not
 	// untrack a copy committed before the pattern existed.
+	//
+	// Untracking is not unfreezing: `git rm --cached` leaves the working-tree
+	// file, so this clone stays frozen until the operator removes it — which
+	// is right, because bd cannot know whether the freeze is also live here.
+	// What it stops is the sentinel propagating any further.
 	"MIGRATION-FREEZE",
 	".local_version",
 	"redirect",

--- a/cmd/bd/doctor/tracked_runtime_test.go
+++ b/cmd/bd/doctor/tracked_runtime_test.go
@@ -124,3 +124,17 @@ func TestFixTrackedRuntimeFiles_WorktreeFallbackUsesSharedBeads(t *testing.T) {
 		t.Fatalf("expected runtime file to remain on disk after git rm --cached: %v", err)
 	}
 }
+
+// TestTrackedRuntime_IncludesMigrationFreeze pins the sentinel as a runtime
+// file, which is what makes `bd doctor --fix` untrack a copy committed before
+// the gitignore pattern existed. Ignoring a path does not untrack it — the
+// same gap last_pull is in this list for.
+func TestTrackedRuntime_IncludesMigrationFreeze(t *testing.T) {
+	const pattern = "MIGRATION-FREEZE"
+	for _, p := range trackedRuntimePatterns {
+		if p == pattern {
+			return
+		}
+	}
+	t.Errorf("trackedRuntimePatterns should contain %q: a sentinel committed before .gitignore covered it stays tracked, and freezes every clone that pulls it", pattern)
+}

--- a/cmd/bd/doctor/tracked_runtime_test.go
+++ b/cmd/bd/doctor/tracked_runtime_test.go
@@ -28,6 +28,7 @@ func TestShouldFlagTrackedFile_RuntimeArtifacts(t *testing.T) {
 		flag bool
 	}{
 		{"last_pull", true}, // bd-578h9.6
+		{"MIGRATION-FREEZE", true},
 		{"last-touched", true},
 		{"push-state.json", true},
 		{"sync-state.json", true},

--- a/cmd/bd/doctor_gastown_guard.go
+++ b/cmd/bd/doctor_gastown_guard.go
@@ -89,9 +89,23 @@ func findTownRoot() string {
 // Nothing changes when neither file exists, which is the overwhelmingly common
 // case: this returns a path, and IsFrozen still has to stat a file that is not
 // there.
+//
+// The workspace is the one bd is RUN IN (BEADS_DIR, or the .beads found from
+// the cwd; -C is applied before this runs). --db/--database do not feed it: a
+// command aimed at another workspace's database consults this workspace's
+// sentinel, the same way a town freeze covers whoever runs inside the town.
 func freezeRoot() string {
+	root, _ := freezeRootAndScope()
+	return root
+}
+
+// freezeRootAndScope is freezeRoot plus WHICH kind of root it found, so a
+// caller that words its message by that ("town is frozen" / "workspace is
+// frozen", `gt migrate thaw` / remove the file) cannot disagree with the path
+// it is reporting: one walk, one answer.
+func freezeRootAndScope() (root string, inTown bool) {
 	if townRoot := findTownRoot(); townRoot != "" {
-		return townRoot
+		return townRoot, true
 	}
-	return beads.FindBeadsDir()
+	return beads.FindBeadsDir(), false
 }

--- a/cmd/bd/doctor_gastown_guard.go
+++ b/cmd/bd/doctor_gastown_guard.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/steveyegge/beads/internal/beads"
 )
 
 // isOrchestratorRoot returns true when path looks like a multi-project
@@ -70,4 +72,26 @@ func findTownRoot() string {
 	}
 
 	return ""
+}
+
+// freezeRoot resolves the directory that holds the MIGRATION-FREEZE sentinel.
+//
+// A Gas Town town root wins whenever there is one, so a town-wide freeze keeps
+// behaving exactly as it did: one sentinel, every rig in the town stands down,
+// and `gt migrate thaw` is still the way out.
+//
+// Outside a town — which is every other beads workspace — findTownRoot returns
+// "" and migration.IsFrozen("") is false, so the freeze was UNREACHABLE: bd had
+// a fleet-wide migration stand-down that only Gas Town could arm. The fallback
+// is the .beads directory, the one workspace-scoped location every backend
+// already agrees on and the same directory the freeze exists to protect.
+//
+// Nothing changes when neither file exists, which is the overwhelmingly common
+// case: this returns a path, and IsFrozen still has to stat a file that is not
+// there.
+func freezeRoot() string {
+	if townRoot := findTownRoot(); townRoot != "" {
+		return townRoot
+	}
+	return beads.FindBeadsDir()
 }

--- a/cmd/bd/errors.go
+++ b/cmd/bd/errors.go
@@ -174,12 +174,12 @@ func CheckReadonly(operation string) {
 //     doesn't block it either), so it cannot inherit the freeze check from
 //     caller 1 and needs its own explicit call.
 func CheckMigrationFreeze(operation string) {
-	townRoot := findTownRoot()
-	if !migration.IsFrozen(townRoot) {
+	root := freezeRoot()
+	if !migration.IsFrozen(root) {
 		return
 	}
 
-	info := migration.Read(townRoot)
+	info := migration.Read(root)
 	operator := "unknown"
 	reason := ""
 	if info != nil {
@@ -187,11 +187,22 @@ func CheckMigrationFreeze(operation string) {
 		reason = info.Reason
 	}
 
-	fmt.Fprintf(os.Stderr, "⛔ ERROR: town is frozen for migration (by %s).\n", operator)
+	// The subject and the way out both depend on which sentinel was found. A
+	// town freeze is cleared by gt, which owns it; a workspace freeze is a
+	// file the operator put there by hand and removes the same way. Telling a
+	// non-Gas-Town user to run `gt migrate thaw` would name a binary they do
+	// not have, for a town that does not exist.
+	inTown := findTownRoot() != ""
+	subject, remedy := "workspace", "remove "+migration.FilePath(root)
+	if inTown {
+		subject, remedy = "town", "gt migrate thaw"
+	}
+
+	fmt.Fprintf(os.Stderr, "⛔ ERROR: %s is frozen for migration (by %s).\n", subject, operator)
 	if reason != "" {
 		fmt.Fprintf(os.Stderr, "   Reason: %s\n", reason)
 	}
-	fmt.Fprintf(os.Stderr, "   bd %s is blocked. Clear the freeze: gt migrate thaw\n", operation)
+	fmt.Fprintf(os.Stderr, "   bd %s is blocked. Clear the freeze: %s\n", operation, remedy)
 	metrics.CloseAndFlush()
 	os.Exit(1)
 }

--- a/cmd/bd/errors.go
+++ b/cmd/bd/errors.go
@@ -174,7 +174,7 @@ func CheckReadonly(operation string) {
 //     doesn't block it either), so it cannot inherit the freeze check from
 //     caller 1 and needs its own explicit call.
 func CheckMigrationFreeze(operation string) {
-	root := freezeRoot()
+	root, inTown := freezeRootAndScope()
 	if !migration.IsFrozen(root) {
 		return
 	}
@@ -192,7 +192,6 @@ func CheckMigrationFreeze(operation string) {
 	// file the operator put there by hand and removes the same way. Telling a
 	// non-Gas-Town user to run `gt migrate thaw` would name a binary they do
 	// not have, for a town that does not exist.
-	inTown := findTownRoot() != ""
 	subject, remedy := "workspace", "remove "+migration.FilePath(root)
 	if inTown {
 		subject, remedy = "town", "gt migrate thaw"

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1416,7 +1416,7 @@ var rootCmd = &cobra.Command{
 		// silently rewritten mid-freeze anyway. Skip both calls under an
 		// active freeze without blocking the read itself. Short-circuits on
 		// !policy.runMaintenance (strict --readonly) so the IsFrozen/
-		// findTownRoot filesystem walk isn't paid on that path, where these
+		// freezeRoot walk isn't paid on that path, where these
 		// calls are already skipped for an unrelated reason.
 		frozenForMaintenance := policy.runMaintenance && migration.IsFrozen(freezeRoot())
 

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1418,7 +1418,7 @@ var rootCmd = &cobra.Command{
 		// !policy.runMaintenance (strict --readonly) so the IsFrozen/
 		// findTownRoot filesystem walk isn't paid on that path, where these
 		// calls are already skipped for an unrelated reason.
-		frozenForMaintenance := policy.runMaintenance && migration.IsFrozen(findTownRoot())
+		frozenForMaintenance := policy.runMaintenance && migration.IsFrozen(freezeRoot())
 
 		// Track bd version changes unless strict readonly forbids repository mutation.
 		// Best-effort tracking - failures are silent.

--- a/cmd/bd/migration_freeze_root_test.go
+++ b/cmd/bd/migration_freeze_root_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/migration"
+)
+
+// newTownRoot builds a directory that findTownRoot recognises: the marker it
+// looks for is mayor/town.json and nothing else.
+func newTownRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "mayor"), 0o755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "mayor", "town.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+	// Same symlink reason as newBeadsDir: findTownRoot walks up from the cwd,
+	// which the shell resolves, so the root it reports is the resolved one.
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("resolve town root: %v", err)
+	}
+	return resolved
+}
+
+// newBeadsDir builds a directory FindBeadsDir will accept. It validates that a
+// candidate holds real project files, so an empty directory is not enough.
+func newBeadsDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	// FindBeadsDir canonicalizes the path it returns, and on macOS t.TempDir()
+	// hands back /var/... which is a symlink to /private/var/.... Resolve here
+	// so the comparison is about the DIRECTORY and not about which spelling of
+	// it each side happened to keep.
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("resolve .beads: %v", err)
+	}
+	return resolved
+}
+
+// TestFreezeRootPrefersTheTownRoot pins the half that must not change. A town
+// freeze is town-wide by design — every rig under it stands down from one
+// sentinel — so a .beads directory inside a town must not be able to shadow it
+// with a freeze of its own, and must not be consulted when the town is frozen.
+func TestFreezeRootPrefersTheTownRoot(t *testing.T) {
+	town := newTownRoot(t)
+	t.Setenv("BEADS_DIR", newBeadsDir(t))
+	t.Chdir(town)
+
+	if got := freezeRoot(); got != town {
+		t.Errorf("freezeRoot() = %q, want the town root %q — a town-wide freeze must not be shadowed by a workspace one", got, town)
+	}
+}
+
+// TestFreezeRootFallsBackToTheBeadsDir is the change. Outside a town
+// findTownRoot returns "", IsFrozen("") is false, and the stand-down was
+// unreachable for every workspace that is not Gas Town.
+func TestFreezeRootFallsBackToTheBeadsDir(t *testing.T) {
+	beadsDir := newBeadsDir(t)
+	t.Setenv("BEADS_DIR", beadsDir)
+	// Somewhere with no mayor/town.json above it.
+	t.Chdir(t.TempDir())
+	t.Setenv("GT_TOWN_ROOT", "")
+	t.Setenv("GT_ROOT", "")
+
+	if got := freezeRoot(); got != beadsDir {
+		t.Errorf("freezeRoot() = %q, want the .beads dir %q", got, beadsDir)
+	}
+}
+
+// TestFreezeRootIsFrozenEndToEnd is the composition that matters: a sentinel
+// dropped in the .beads directory must actually read as frozen. freezeRoot
+// returning a path proves nothing on its own if IsFrozen then looks elsewhere.
+func TestFreezeRootIsFrozenEndToEnd(t *testing.T) {
+	beadsDir := newBeadsDir(t)
+	t.Setenv("BEADS_DIR", beadsDir)
+	t.Chdir(t.TempDir())
+	t.Setenv("GT_TOWN_ROOT", "")
+	t.Setenv("GT_ROOT", "")
+
+	if migration.IsFrozen(freezeRoot()) {
+		t.Fatal("must not be frozen before the sentinel exists")
+	}
+
+	sentinel := migration.FilePath(freezeRoot())
+	if err := os.WriteFile(sentinel, []byte("kb\t2026-09-03T10:00:00Z\tschema bump"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	if !migration.IsFrozen(freezeRoot()) {
+		t.Fatalf("a MIGRATION-FREEZE at %s must read as frozen", sentinel)
+	}
+
+	// And the parsed contents reach the caller, so the refusal can name the
+	// operator and the reason rather than just saying no.
+	info := migration.Read(freezeRoot())
+	if info == nil || info.Operator != "kb" || info.Reason != "schema bump" {
+		t.Errorf("Read() = %+v, want operator=kb reason=\"schema bump\"", info)
+	}
+
+	if err := os.Remove(sentinel); err != nil {
+		t.Fatalf("remove sentinel: %v", err)
+	}
+	if migration.IsFrozen(freezeRoot()) {
+		t.Error("removing the sentinel must thaw the workspace")
+	}
+}
+
+// TestFreezeRootWithNoWorkspaceIsNotFrozen pins the no-op case: bd run outside
+// any beads workspace and outside any town must not start refusing writes.
+func TestFreezeRootWithNoWorkspaceIsNotFrozen(t *testing.T) {
+	t.Setenv("BEADS_DIR", "")
+	t.Setenv("GT_TOWN_ROOT", "")
+	t.Setenv("GT_ROOT", "")
+	t.Chdir(t.TempDir())
+
+	if migration.IsFrozen(freezeRoot()) {
+		t.Error("no town and no .beads dir must never read as frozen")
+	}
+}

--- a/cmd/bd/migration_freeze_workspace_embedded_test.go
+++ b/cmd/bd/migration_freeze_workspace_embedded_test.go
@@ -1,0 +1,64 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/migration"
+)
+
+// TestEmbeddedWorkspaceMigrationFreezeRefusesWrites drives the freeze end to
+// end in a workspace that is NOT a Gas Town: no mayor/town.json anywhere above
+// it, so findTownRoot returns "" and, before this change, migration.IsFrozen("")
+// was false and the sentinel was inert no matter where it was placed.
+//
+// The A/B on one file is the whole test: the same command must be refused with
+// the sentinel present and succeed with it gone. Asserting only the refusal
+// would pass against a bd that refused `create` for any reason at all.
+func TestEmbeddedWorkspaceMigrationFreezeRefusesWrites(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "fz")
+
+	sentinel := filepath.Join(dir, ".beads", migration.FileName)
+	if err := os.WriteFile(sentinel, []byte("kb\t2026-09-03T10:00:00Z\tschema bump"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	out, code := bdRunFailCode(t, bd, dir, "create", "blocked by the freeze", "--type", "task")
+	if code != 1 {
+		t.Errorf("bd create under a freeze exited %d, want 1", code)
+	}
+	// The operator and reason come out of the file, so a refusal that printed a
+	// generic message would still fail here — the parse has to reach the caller.
+	for _, want := range []string{"frozen for migration", "kb", "schema bump"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("refusal must mention %q; got:\n%s", want, out)
+		}
+	}
+	// Outside a town the remedy is the file, not `gt migrate thaw` — naming a
+	// binary the user does not have is the failure mode this replaces.
+	if !strings.Contains(out, migration.FileName) {
+		t.Errorf("refusal must name the sentinel to remove; got:\n%s", out)
+	}
+	if strings.Contains(out, "gt migrate thaw") {
+		t.Errorf("outside a town the remedy must not be a gt command; got:\n%s", out)
+	}
+
+	// Thaw: the same command must now work. Without this half, a bd that
+	// refused every create would pass everything above.
+	if err := os.Remove(sentinel); err != nil {
+		t.Fatalf("remove sentinel: %v", err)
+	}
+	if issue := bdCreate(t, bd, dir, "allowed after thaw", "--type", "task"); issue == nil || issue.ID == "" {
+		t.Fatal("bd create must succeed once the sentinel is removed")
+	}
+}

--- a/internal/migration/freeze.go
+++ b/internal/migration/freeze.go
@@ -1,7 +1,13 @@
 // Package migration provides read-side access to the MIGRATION-FREEZE
-// write-freeze sentinel: a file whose presence makes bd refuse writes and skip
-// its own store-touching side effects (version tracking, auto-migration,
-// auto-import) until it is removed.
+// write-freeze sentinel: a file whose presence makes bd refuse write commands
+// and skip the root pre-run's own side effects (version tracking, the
+// version-bump auto-migrate, auto-import) until it is removed.
+//
+// It stops WRITES, not schema migration. A read command is let through so
+// diagnosis keeps working, and its store open still runs schema.MigrateUp —
+// nothing under internal/storage consults this sentinel. A behind database
+// read under an active freeze is migrated by that read. Closing that gap
+// belongs at the MigrateUp chokepoint and is a separate change.
 //
 // It has two homes, resolved by cmd/bd's freezeRoot. In a Gas Town workspace
 // the sentinel sits at the town root and is created and removed by the gt CLI

--- a/internal/migration/freeze.go
+++ b/internal/migration/freeze.go
@@ -1,9 +1,15 @@
-// Package migration provides read-side access to the town-wide
-// MIGRATION-FREEZE write-freeze sentinel used during Gas Town dolt
-// migrations. The sentinel file itself is created and removed by the gt CLI
-// (see gt migrate freeze/thaw, gastownhall/gastown's internal/migration
-// package) — bd only reads it, before a write command runs, to refuse
-// human-typed writes that would bypass the gt-layer gate (dc-6jaq).
+// Package migration provides read-side access to the MIGRATION-FREEZE
+// write-freeze sentinel: a file whose presence makes bd refuse writes and skip
+// its own store-touching side effects (version tracking, auto-migration,
+// auto-import) until it is removed.
+//
+// It has two homes, resolved by cmd/bd's freezeRoot. In a Gas Town workspace
+// the sentinel sits at the town root and is created and removed by the gt CLI
+// (gt migrate freeze/thaw, gastownhall/gastown's internal/migration package);
+// bd only reads it, to refuse human-typed writes that would bypass the
+// gt-layer gate (dc-6jaq). Anywhere else it sits in the .beads directory and
+// the operator manages it directly — same sentinel, same semantics, for the
+// fleets that are not towns.
 package migration
 
 import (


### PR DESCRIPTION
`bd` has a fleet-wide migration stand-down that only Gas Town can arm.

`CheckMigrationFreeze` (dc-6jaq) refuses writes and skips bd's own store-touching side effects while a `MIGRATION-FREEZE` sentinel exists. It finds that sentinel with `findTownRoot()`, which requires `mayor/town.json` (or `GT_TOWN_ROOT`/`GT_ROOT` pointing at one). Every other beads workspace gets `""` back, `migration.IsFrozen("")` is `false`, and the sentinel is inert wherever it is placed.

## The change

One resolver, `freezeRoot()`. The town root wins whenever there is one, so a town-wide freeze behaves exactly as before: one sentinel, every rig under it stands down, `gt migrate thaw` is still the way out, and a rig's own `.beads` directory cannot shadow it. Outside a town it falls back to the `.beads` directory — the one workspace-scoped location every backend already agrees on, and the directory the freeze exists to protect.

Both existing readers use it (`CheckMigrationFreeze`, and the `frozenForMaintenance` gate in `main.go`), so there is one policy rather than two.

The refusal message follows the sentinel: a town freeze is cleared by `gt`, which owns it; a workspace freeze is a file the operator placed and removes the same way. Telling a non-Gas-Town user to run `gt migrate thaw` would name a binary they do not have, for a town that does not exist.

Nothing changes when neither file exists — `freezeRoot` returns a path and `IsFrozen` still stats a file that is not there.

## Known limitation, deliberately left for its own PR

The freeze stops **writes**; it does not yet stop a **migration**. A read is let past the CLI check so diagnosis keeps working, and its store open runs `schema.MigrateUp` unconditionally — measured with the cursor rolled back to 60 against a v66 binary, `bd list` under an active freeze moved it to 66. That is pre-existing and equally true of a town freeze today; nothing in `internal/storage` consults the sentinel. The fix belongs at the `MigrateUp` chokepoint and is a separate change (I'll open it once this lands, so it can be reviewed on its own).

## Verification

```
--- PASS: TestFreezeRootPrefersTheTownRoot
--- PASS: TestFreezeRootFallsBackToTheBeadsDir
--- PASS: TestFreezeRootIsFrozenEndToEnd
--- PASS: TestFreezeRootWithNoWorkspaceIsNotFrozen
--- PASS: TestEmbeddedWorkspaceMigrationFreezeRefusesWrites (14.29s)
ok  cmd/bd              83.4s   (-run 'Freeze|Frozen', BEADS_TEST_EMBEDDED_DOLT=1)
ok  internal/migration
```

All 8 existing `cmd/bd/migration_freeze_gate_test.go` cases pass unchanged, including the town-fixture assertion that the hint is still `gt migrate thaw` there.

The embedded test is an A/B on one file: the same `bd create` must be refused with the sentinel present and succeed with it gone. Asserting only the refusal would pass against a `bd` that refused `create` for any reason. It also asserts the operator and reason reach the message and that the remedy names the file rather than a `gt` command.

`TestFreezeRootPrefersTheTownRoot` guards the half that must not move: a `.beads` directory inside a town must not shadow the town-wide freeze.
