### PR TITLE
test(metrics): the reap test must wait for the reap, not fail on the first zombie

### DIFF
--- a/internal/metrics/spawn_reap_test.go
+++ b/internal/metrics/spawn_reap_test.go
@@ -49,7 +49,18 @@ func TestStartDetachedReapsExitedChild(t *testing.T) {
 	for time.Now().Before(deadline) {
 		st, alive := unixProcStat(pid)
 		if strings.Contains(st, "Z") {
-			t.Fatalf("child pid %d became a zombie (stat=%q); startDetached did not reap", pid, st)
+			// Exited but not yet wait4'd. That is the reaper's WINDOW, not
+			// its failure: startDetached reaps from a goroutine, and between
+			// the child's exit and that goroutine's Wait returning the
+			// process table legitimately reads Z. Normally microseconds —
+			// but under -race on a loaded runner the goroutine can be
+			// descheduled for longer than one 20ms poll, and failing on the
+			// first sighting turned that scheduling gap into a red build.
+			// A zombie is proof the child ran; keep polling, and a zombie
+			// that is STILL here at the deadline fails below, stat and all.
+			seenLive = true
+			time.Sleep(20 * time.Millisecond)
+			continue
 		}
 		if alive {
 			seenLive = true


### PR DESCRIPTION
`TestStartDetachedReapsExitedChild` (#5933) polls the child's process-table state under a 3s deadline — and `Fatalf`s the **first** time it reads `Z`.

## Why that is a test bug

Between a child's exit and the parent's `wait4`, `Z` is the *correct* state. `startDetached` reaps from a goroutine:

```go
go func() { _ = cmd.Wait() }()
```

Between the exit and that goroutine's `Wait` returning, the process table legitimately shows a zombie. Normally microseconds — but under `-race` on a loaded runner the goroutine can be descheduled for longer than the test's 20ms poll, and failing on first sighting turns a scheduling gap into a red build. Seen on our fork's CI (`go test -race -short ./...`):

```
--- FAIL: TestStartDetachedReapsExitedChild (1.53s)
    spawn_reap_test.go:52: child pid 13162 became a zombie (stat="Zl"); startDetached did not reap
```

The identical package passed on a sibling PR minutes earlier; the failing PR did not touch `internal/metrics`.

## The change

A `Z` sighting now counts as "seen alive, not yet reaped" and the loop keeps polling. The **existing** post-loop assertion — still present at the deadline, stat included — is where a zombie that is genuinely never reaped fails. Twelve lines, all in the test; `spawn.go` is untouched.

## Verification — the test still discriminates

With the reaper goroutine deleted from `startDetached`:

```
--- FAIL: TestStartDetachedReapsExitedChild (3.03s)
    spawn_reap_test.go:80: child pid 98969 still present after 3s (alive=true stat="Z"); startDetached did not reap
```

It still catches a real non-reap — at the deadline, which is when the claim can actually be made. With the reaper in place, on `origin/main` + this commit:

```
ok  internal/metrics   16.316s   (-race -count=10)
```
