### PR TITLE
ci(pr-core): bound the wrapper's per-package deadline at 25m

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,6 +32,11 @@ The broad Go wrappers also cap package and test parallelism to `4` by default
 (`GO_TEST_PKG_PARALLEL` and `GO_TEST_PARALLEL`). This avoids turning high-core
 shared hosts into a different test topology than GitHub Actions.
 
+They also pass an explicit `-timeout` (`TEST_TIMEOUT`, default `25m`) rather
+than riding `go test`'s 10m default. That deadline is a hang backstop, not a
+performance budget — it costs nothing while packages pass — and the floor is
+set by `cmd/bd`, which exceeds 10m on a loaded runner even under `-short`.
+
 `make ci-pr-policy` includes `scripts/check-testing-short.sh`, which enforces
 that `testing.Short()` is only used for runtime, stress, or large-fixture skips.
 Use build tags, environment checks, or named wrappers for integration/e2e/API

--- a/scripts/ci/pr-core.sh
+++ b/scripts/ci/pr-core.sh
@@ -17,8 +17,18 @@ cd "$REPO_ROOT"
 
 beads_test_env_enter
 
+# TIMEOUT is go test's PER-PACKAGE deadline — a hang backstop, not a
+# performance budget: it costs nothing while packages pass. Without it this
+# wrapper rode go test's 10m default, and cmd/bd has outgrown that even under
+# -short: passing runs measure 414-441s, so a slow runner crosses 600s and
+# panics with `test timed out` while naming whichever test was merely in
+# flight and zero `--- FAIL` lines — a package-wide crawl, not a hang. Use the
+# same 25m the repo already applies to this package's deadline in
+# scripts/test.sh and main.yml's test matrix (wy-5b5fbl) rather than adding a
+# third number to keep in step. Raise via TEST_TIMEOUT.
+TIMEOUT="${TEST_TIMEOUT:-25m}"
 GO_TEST_PKG_PARALLEL="${GO_TEST_PKG_PARALLEL:-4}"
 GO_TEST_PARALLEL="${GO_TEST_PARALLEL:-4}"
 
 ci_time "pr-core go test" -- \
-    go test -p "$GO_TEST_PKG_PARALLEL" -parallel "$GO_TEST_PARALLEL" -race -short -skip '^TestEmbedded' ./...
+    go test -p "$GO_TEST_PKG_PARALLEL" -parallel "$GO_TEST_PARALLEL" -timeout "$TIMEOUT" -race -short -skip '^TestEmbedded' ./...


### PR DESCRIPTION
`scripts/ci/pr-core.sh` runs `go test -race -short -skip '^TestEmbedded' ./...` with no `-timeout`, so every package rides Go's 10m default. `cmd/bd` has outgrown that even under `-short`.

## Measured, not assumed

In the wrapper's exact environment (`gms_pure_go`, prebuilt `bd`, `BEADS_TEST_SKIP=dolt`): **447s, PASS, 1876 tests run, 495 skipped.** Our CI's passing runs sit at 414–441s; a slow runner crosses 600s and Go panics with `test timed out`, naming whichever test was merely in flight, with zero `--- FAIL` lines. Three unrelated PRs hit it on one day; every rerun passed.

| Bucket | Tests | Sum | Share |
| --- | --- | --- | --- |
| ≥10s | 14 | 199.8s | 44.9% |
| 5–10s | 25 | 177.9s | 40.0% |
| 0.1–5s | 112 | 58.8s | 13.2% |
| <0.1s | **1725** | 8.2s | 1.8% |

**39 tests (2%) are 85% of the package; the slowest single one is 20s.** No hot spot, no hang. They are CLI subprocess tests doing `git init` + `bd init` (an embedded-Dolt bootstrap) plus several `bd` calls at 2–5s each, and none call `t.Parallel()` — summed test time ≈ wall time, so `-parallel 4` buys nothing.

Ruled out: per-test binary builds (already a `sync.Once` behind `findPrebuiltBDBinary()`, and the job exports the prebuilt artifact), an expensive `TestMain`, `time.Sleep`.

## Why only the deadline

- Gating those 39 under `-short` is blocked by `scripts/check-testing-short.sh`, which reserves `testing.Short()` for runtime/stress/large-fixture skips and points integration tests at build tags or env checks instead. That would be a policy change.
- Making them cheaper is real but large: they mutate the global `store`, `chdir` and env, so sharing a store or parallelising is a refactor.

So: `-timeout "${TEST_TIMEOUT:-25m}"` — the **same value and the same knob** this repo already applies to this package in `scripts/test.sh:45` and `main.yml`'s test matrix (wy-5b5fbl). No third number to keep in step. A per-package deadline is a hang backstop, not a performance budget; it costs nothing while packages pass. Runtime is unchanged by construction — this is headroom, not a speedup.

## Verification

```
bash -n scripts/ci/pr-core.sh              rc=0
bash scripts/check-testing-short.sh        rc=0
go test ./scripts/                         ok
composed command, by dry run:
  go test -p 4 -parallel 4 -timeout 25m -race -short -skip ^TestEmbedded ./...
```

On our fork, the first `PR Core` run under the new deadline finished `cmd/bd` in 422.7s.

**Not changed, flagged:** `pr.yml`'s `test-macos` leg has the identical exposure (`ci_workflow_test.go:301` pins a command with no `-timeout`). Left for a separate, deliberate change since that test pins the YAML.
