### PR TITLE
fix(create): report a failed commit instead of printing success

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -647,7 +647,24 @@ var createCmd = &cobra.Command{
 				Command:  "create",
 				IssueIDs: []string{created.ID},
 			}); err != nil {
-				debug.Logf("warning: failed to commit routed repo: %v", err)
+				// A failed commit here USED TO be swallowed into debug.Logf, after
+				// which this function went on to print "✓ Created issue: <id>" and
+				// return nil. The row exists only in the working set at that point,
+				// so the caller is told the issue was created and is given an ID
+				// that does not survive a working-set reset.
+				//
+				// That is not hypothetical. A Gas Town patrol reported creating
+				// three beads on 2026-09-02 and none of them existed afterwards; a
+				// byte copy of the store taken 6.5 hours later contained none of
+				// the three, while every issue the SAME session UPDATED was present
+				// in that same copy. The split is explained exactly here: of the 23
+				// commitPendingIfEmbedded call sites, 16 return the error and this
+				// was the only one that discarded it.
+				//
+				// Report it the way `bd update` does. The issue may still be
+				// recoverable with `bd dolt commit`, which the caller can only do
+				// if they are told.
+				return HandleErrorRespectJSON("created %s but failed to commit it: %v\nThe issue exists in the working set only — run 'bd dolt commit' to persist it.", created.ID, err)
 			}
 		}
 


### PR DESCRIPTION
## `bd create` could print success over a write that never persisted

`bd create --repo <rig>` prints `✓ Created issue: <id>` and exits 0 while the row exists **only in the Dolt working set**, because the commit error is discarded into `debug.Logf` and execution continues to the success print.

```go
// cmd/bd/create.go:646  (before)
if err := commitPendingIfEmbedded(ctx, targetStore, actor, ...); err != nil {
    debug.Logf("warning: failed to commit routed repo: %v", err)   // swallowed
}
...
debug.PrintNormal("%s Created issue: %s\n", ...)                   // success anyway
```

## Found by a census of every call site — which is what makes it conclusive

Of the **23** `commitPendingIfEmbedded` call sites in `cmd/bd`, **16 return the error** — `update.go`, `tag.go`, `reclaim.go`, `ready.go`, `priority.go`, `note.go` and others — and **`create.go:646` was the only one that discarded it.**

That single outlier predicts the exact symptom seen downstream.

## The downstream symptom it explains

A Gas Town patrol reported creating three issues on 2026-09-02. None existed afterwards — while **every issue the same session UPDATED survived**. That split looked mysterious and is simply this asymmetry: `bd update` surfaces a failed commit, `bd create` printed success over it.

The evidence for *never persisted* rather than *persisted then destroyed* is physical. A byte copy (`cp -a`) of the store taken **6.5 hours after** those creates contains none of the three, and contains the same session's updates. Compaction is excluded too: that copy pre-dates any compaction of the store, and a history squash cannot drop rows since it preserves final table state.

## The change

Report it the way `update.go` already does:

```go
return HandleErrorRespectJSON(
    "created %s but failed to commit it: %v\n"+
    "The issue exists in the working set only — run 'bd dolt commit' to persist it.",
    created.ID, err)
```

The message names the ID and the recovery, because the caller can only recover what they're told about. **Failing here rather than warning keeps this consistent with the other 16 sites instead of inventing a third behaviour** — and the row is still in the working set, so `bd dolt commit` recovers it without a duplicate.

`cmd/bd` `TestCreate` suite passes; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxzPCaz7gDX8d9BmDdFrG5