### PR TITLE
fix(wisp): never GC a wisp carrying a protected label

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -973,7 +973,7 @@ var recognizedConfigPrefixes = []string{
 	"status.", "types.", "doctor.suppress.", "routing.", "sync.", "git.",
 	"directory.", "repos.", "external_projects.", "validation.",
 	"lint.", "hierarchy.", "ai.", "backup.", "federation.", "metrics.",
-	"agent.", "claim.", "storage-class.",
+	"agent.", "claim.", "storage-class.", "wisp.",
 }
 
 // validateStorageClassConfig validates a storage-class.<type> per-type

--- a/cmd/bd/config_validate_key_test.go
+++ b/cmd/bd/config_validate_key_test.go
@@ -13,7 +13,7 @@ func TestIsRecognizedConfigKey(t *testing.T) {
 		"doctor.suppress.git-hooks", "no-git-ops", "beads.role",
 		"status.custom", "types.custom", "types.infra", "ai.model",
 		"backup.enabled", "import.path", "dolt.local-only", "agent.profile",
-		"claim.pools",
+		"claim.pools", "wisp.protected_labels",
 		// Tracker namespaces are derived from the registry (GH#4427); cover
 		// ado (the original bug) plus the others removed from the static list.
 		"ado.org", "ado.project", "github.token", "linear.api-key",

--- a/cmd/bd/mol_port.go
+++ b/cmd/bd/mol_port.go
@@ -156,10 +156,18 @@ func (r uowMolReader) GetIssuesByIDs(ctx context.Context, ids []string) ([]*type
 	if err != nil {
 		return nil, err
 	}
-	if labelMap, err := r.uw.LabelUseCase().GetLabelsForIssues(ctx, ids); err == nil { //nolint:forbidigo // in-transaction port read; see GetIssue above
-		for _, issue := range issues {
-			issue.Labels = labelMap[issue.ID]
-		}
+	// A dropped label error is NOT a display defect here. `bd mol wisp gc`
+	// consults Labels to decide what it must not delete (isProtectedWisp), and
+	// a swallowed error leaves every issue looking unlabeled — which reads as
+	// "carries no protected label" and licenses the delete. Silence in a guard
+	// that gates a destructive command is the failure mode, so both label reads
+	// propagate.
+	labelMap, err := r.uw.LabelUseCase().GetLabelsForIssues(ctx, ids) //nolint:forbidigo // in-transaction port read; see GetIssue above
+	if err != nil {
+		return nil, fmt.Errorf("loading labels for %d issue(s): %w", len(ids), err)
+	}
+	for _, issue := range issues {
+		issue.Labels = labelMap[issue.ID]
 	}
 
 	wisps, err := r.uw.IssueUseCase().GetWispsByIDs(ctx, ids)
@@ -167,10 +175,15 @@ func (r uowMolReader) GetIssuesByIDs(ctx context.Context, ids []string) ([]*type
 		wisps = nil //nolint:staticcheck // wisps table may not exist; issues result still valid
 	}
 	if len(wisps) > 0 {
-		if labelMap, err := r.uw.LabelUseCase().GetLabelsForWisps(ctx, ids); err == nil { //nolint:forbidigo // in-transaction port read; see GetIssue above
-			for _, wisp := range wisps {
-				wisp.Labels = labelMap[wisp.ID]
-			}
+		// Reached only when the wisps table exists and returned rows, so
+		// wisp_labels exists too: an error here is a real read failure, not the
+		// optional-table case the branch above tolerates.
+		wispLabels, err := r.uw.LabelUseCase().GetLabelsForWisps(ctx, ids) //nolint:forbidigo // in-transaction port read; see GetIssue above
+		if err != nil {
+			return nil, fmt.Errorf("loading labels for %d wisp(s): %w", len(wisps), err)
+		}
+		for _, wisp := range wisps {
+			wisp.Labels = wispLabels[wisp.ID]
 		}
 	}
 

--- a/cmd/bd/mol_port_labels_test.go
+++ b/cmd/bd/mol_port_labels_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// labelFailIssueUC answers the two ID lookups uowMolReader.GetIssuesByIDs
+// makes; every other method is a nil call, which is the assertion that this
+// path touches nothing else.
+type labelFailIssueUC struct {
+	domain.IssueUseCase
+	issues []*types.Issue
+	wisps  []*types.Issue
+}
+
+func (s labelFailIssueUC) GetIssuesByIDs(context.Context, []string) ([]*types.Issue, error) {
+	return s.issues, nil
+}
+
+func (s labelFailIssueUC) GetWispsByIDs(context.Context, []string) ([]*types.Issue, error) {
+	return s.wisps, nil
+}
+
+// labelFailLabelUC fails whichever of the two label reads is selected.
+type labelFailLabelUC struct {
+	domain.LabelUseCase
+	issueErr error
+	wispErr  error
+}
+
+func (s labelFailLabelUC) GetLabelsForIssues(context.Context, []string) (map[string][]string, error) {
+	if s.issueErr != nil {
+		return nil, s.issueErr
+	}
+	return map[string][]string{}, nil
+}
+
+func (s labelFailLabelUC) GetLabelsForWisps(context.Context, []string) (map[string][]string, error) {
+	if s.wispErr != nil {
+		return nil, s.wispErr
+	}
+	return map[string][]string{}, nil
+}
+
+type labelFailUOW struct {
+	uow.UnitOfWork
+	issues domain.IssueUseCase
+	labels domain.LabelUseCase
+}
+
+func (u labelFailUOW) Close(context.Context)             {}
+func (u labelFailUOW) IssueUseCase() domain.IssueUseCase { return u.issues }
+func (u labelFailUOW) LabelUseCase() domain.LabelUseCase { return u.labels }
+
+// TestUOWMolReaderGetIssuesByIDsPropagatesLabelErrors pins the fail-closed
+// contract the wisp GC guard depends on.
+//
+// This port used to swallow both label reads (`if labelMap, err := …; err ==
+// nil`), which left every returned issue with nil Labels. For a renderer that
+// is a cosmetic defect. For isProtectedWisp it is a licence to delete: an
+// unlabeled issue reads as "carries no protected label", so a transient label
+// read failure during cascade expansion would have made `bd mol wisp gc` reclaim
+// exactly the records wisp.protected_labels promises it never will — silently,
+// with no error anywhere for an operator to notice.
+func TestUOWMolReaderGetIssuesByIDsPropagatesLabelErrors(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("label table read failed")
+
+	for _, tc := range []struct {
+		name   string
+		reader uowMolReader
+	}{
+		{
+			name: "issue label read failure",
+			reader: uowMolReader{uw: labelFailUOW{
+				issues: labelFailIssueUC{issues: []*types.Issue{{ID: "bd-1"}}},
+				labels: labelFailLabelUC{issueErr: boom},
+			}},
+		},
+		{
+			name: "wisp label read failure",
+			reader: uowMolReader{uw: labelFailUOW{
+				issues: labelFailIssueUC{wisps: []*types.Issue{{ID: "bd-wisp-1"}}},
+				labels: labelFailLabelUC{wispErr: boom},
+			}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tc.reader.GetIssuesByIDs(t.Context(), []string{"bd-1", "bd-wisp-1"})
+			if err == nil {
+				t.Fatalf("a failed label read must surface as an error, got issues=%v and nil error", got)
+			}
+			if !errors.Is(err, boom) {
+				t.Errorf("error should wrap the underlying failure; got %v", err)
+			}
+			if got != nil {
+				t.Errorf("no partial result may escape a failed label read; got %v", got)
+			}
+		})
+	}
+}

--- a/cmd/bd/wisp.go
+++ b/cmd/bd/wisp.go
@@ -9,11 +9,13 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/formula"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/utils"
 )
 
 // Wisp commands - manage ephemeral molecules
@@ -619,6 +621,19 @@ A wisp is considered abandoned if:
     configured category, so only plain open (active) and closed (done) steps
     are age-reclaimable. If the blocked set or the custom-status list cannot be
     read, the GC aborts rather than risk reclaiming live steps.
+  - AND it carries no protected label.
+
+Protected labels (wisp.protected_labels, default "bd:protected") are never
+reclaimed, in ANY mode of this command — not by age, not by --all, not by
+--closed. Status protection cannot cover a write-once record such as a message
+or an escalation: an unread one sits in plain open status, which is
+age-reclaimable by design, so the longer it went unread the more certainly it
+was deleted. Label such records instead:
+
+  bd config set wisp.protected_labels bd:protected,my:message
+
+A configured value REPLACES the default (same rule as types.infra);
+--exclude-label ADDS to whatever is configured.
 
 Abandoned wisps are deleted without creating a digest. Use 'bd mol squash'
 if you want to preserve a summary before garbage collection.
@@ -639,7 +654,8 @@ Examples:
   bd mol wisp gc --closed --force                   # Delete all closed wisps
   bd mol wisp gc --closed --dry-run                 # Explicit dry-run (same as no --force)
   bd mol wisp gc --exclude-type agent,rig           # Protect agent and rig wisps from GC
-  bd mol wisp gc --closed --force --exclude-type mol # Delete closed wisps except mol type`,
+  bd mol wisp gc --closed --force --exclude-type mol # Delete closed wisps except mol type
+  bd mol wisp gc --exclude-label my:message         # Also protect wisps labeled my:message`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE:          runWispGC,
@@ -696,25 +712,112 @@ func protectedWispStatuses(ctx context.Context, r molReader) (map[types.Status]b
 	return protected, nil
 }
 
-// isProtectedWisp reports whether a wisp is live work that age-based GC must
-// never reclaim. A wisp is protected if it is explicitly pinned, if it is
-// blocked on an open dependency (blockedSet, derived from is_blocked), or if
-// its status falls in a protected category. Reclaiming any of these
-// mid-execution destroys active molecules (GH#4394).
+// protectedWispLabelsKey is the config key holding the labels that make a wisp
+// unreclaimable by `bd mol wisp gc`.
+const protectedWispLabelsKey = "wisp.protected_labels"
+
+// defaultProtectedWispLabels is the label set honored when nothing is
+// configured. It is deliberately a beads-native label rather than any
+// particular orchestrator's: which of an orchestration layer's records are
+// irreplaceable is that layer's policy, and the charter keeps that policy out
+// of core (engdocs/PROJECT_CHARTER.md, Orchestration Boundary). Core's job is
+// to provide the extension point and to fail closed on it.
+var defaultProtectedWispLabels = []string{"bd:protected"}
+
+// protectedWispLabels resolves the labels that make a wisp unreclaimable by
+// `bd mol wisp gc`, with the same precedence the infra-type set uses: the DB
+// config key wisp.protected_labels, then config.yaml, then the built-in
+// default. A configured value REPLACES the default rather than extending it,
+// matching types.infra.
+//
+// extra carries --exclude-label, which is additive: a caller naming a label on
+// the command line is asking for more protection than the workspace
+// configures, never less.
+//
+// Reading the config is required, not best-effort. This command deletes, so an
+// unreadable guard must abort it rather than silently under-protect — the same
+// contract protectedWispStatuses holds.
+func protectedWispLabels(ctx context.Context, r molReader, extra []string) (map[string]bool, error) {
+	value, err := r.GetConfig(ctx, protectedWispLabelsKey)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s for wisp gc: %w", protectedWispLabelsKey, err)
+	}
+	return resolveProtectedWispLabels(value, config.GetProtectedWispLabelsFromYAML(), extra), nil
+}
+
+// resolveProtectedWispLabels is protectedWispLabels' precedence rule with the
+// three sources already read, so it can be tested without a store: dbValue is
+// the raw comma-separated wisp.protected_labels config value, yaml is the
+// config.yaml fallback, and extra is --exclude-label.
+func resolveProtectedWispLabels(dbValue string, yaml, extra []string) map[string]bool {
+	labels := utils.NormalizeLabels(strings.Split(dbValue, ","))
+	if len(labels) == 0 {
+		labels = utils.NormalizeLabels(yaml)
+	}
+	if len(labels) == 0 {
+		labels = defaultProtectedWispLabels
+	}
+	set := make(map[string]bool, len(labels)+len(extra))
+	for _, l := range utils.NormalizeLabels(append(append([]string{}, labels...), extra...)) {
+		set[l] = true
+	}
+	return set
+}
+
+// wispGuard is everything `bd mol wisp gc` must consult before deleting a wisp.
+// It is a struct rather than three parameters so that adding a fourth kind of
+// protection cannot silently miss one of the call sites that filters candidates
+// (the age sweep, its cascade expansion, and the closed purge).
+type wispGuard struct {
+	blocked  map[string]bool
+	statuses map[types.Status]bool
+	labels   map[string]bool
+}
+
+// hasProtectedLabel reports whether the issue carries any protected label.
+func (g wispGuard) hasProtectedLabel(issue *types.Issue) bool {
+	for _, l := range issue.Labels {
+		if g.labels[l] {
+			return true
+		}
+	}
+	return false
+}
+
+// isProtectedWisp reports whether a wisp is live work or an irreplaceable
+// record that GC must never reclaim. A wisp is protected if it is explicitly
+// pinned, if it is blocked on an open dependency (blocked, derived from
+// is_blocked), if its status falls in a protected category, or if it carries a
+// protected label. Reclaiming any of the first three mid-execution destroys
+// active molecules (GH#4394).
+//
+// The label check exists because status protection cannot reach the records
+// that matter most. An orchestration layer that stores mail, escalations or
+// any other write-once record as an ephemeral bead leaves it in plain `open`
+// status for exactly as long as nobody has read it — and open is CategoryActive,
+// which is reclaimable by design. So the longer such a record went unread, the
+// more certainly age GC deleted it, and there is no status the layer could set
+// instead without lying about the record's state. A label is the only handle
+// that survives that, and it must be consulted on every candidate rather than
+// pushed into the search filter, because the cascade expansion below reaches
+// wisps the filter never saw.
 //
 // Named isProtectedWisp rather than isActiveWisp to avoid confusion with
 // (*DoltStore).isActiveWisp in internal/storage/dolt, which is in this same
 // delete path but means only "a row for this ID exists in the wisps table".
-func isProtectedWisp(issue *types.Issue, blockedSet map[string]bool, protectedStatuses map[types.Status]bool) bool {
+func isProtectedWisp(issue *types.Issue, g wispGuard) bool {
 	// The pinned flag is independent of the pinned status; the closed-purge
 	// branch of this same command already honors it (see runWispPurgeClosed).
 	if issue.Pinned {
 		return true
 	}
-	if blockedSet[issue.ID] {
+	if g.blocked[issue.ID] {
 		return true
 	}
-	return protectedStatuses[issue.Status]
+	if g.statuses[issue.Status] {
+		return true
+	}
+	return g.hasProtectedLabel(issue)
 }
 
 func runWispGC(cmd *cobra.Command, args []string) error {
@@ -735,6 +838,7 @@ func runWispGC(cmd *cobra.Command, args []string) error {
 	closedMode, _ := cmd.Flags().GetBool("closed")
 	force, _ := cmd.Flags().GetBool("force")
 	excludeTypeStrs, _ := cmd.Flags().GetStringSlice("exclude-type")
+	excludeLabels, _ := cmd.Flags().GetStringSlice("exclude-label")
 
 	ageThreshold := time.Hour
 	if ageStr != "" {
@@ -751,7 +855,7 @@ func runWispGC(cmd *cobra.Command, args []string) error {
 	}
 
 	if usesProxiedServer() {
-		return runWispGCProxiedServer(rootCtx, dryRun, ageThreshold, cleanAll, closedMode, force, excludeTypes)
+		return runWispGCProxiedServer(rootCtx, dryRun, ageThreshold, cleanAll, closedMode, force, excludeTypes, excludeLabels)
 	}
 
 	if store == nil {
@@ -759,10 +863,10 @@ func runWispGC(cmd *cobra.Command, args []string) error {
 	}
 
 	if closedMode {
-		return runWispPurgeClosed(ctx, dryRun, force, excludeTypes)
+		return runWispPurgeClosed(ctx, dryRun, force, excludeTypes, excludeLabels)
 	}
 
-	abandoned, err := findAbandonedWisps(ctx, store, cleanAll, ageThreshold, excludeTypes)
+	abandoned, err := findAbandonedWisps(ctx, store, cleanAll, ageThreshold, excludeTypes, excludeLabels)
 	if err != nil && abandoned == nil {
 		return HandleError("%v", err)
 	}
@@ -821,8 +925,11 @@ func runWispGC(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func findAbandonedWisps(ctx context.Context, r molReader, cleanAll bool, ageThreshold time.Duration, excludeTypes []types.IssueType) ([]*types.Issue, error) {
+func findAbandonedWisps(ctx context.Context, r molReader, cleanAll bool, ageThreshold time.Duration, excludeTypes []types.IssueType, excludeLabels []string) ([]*types.Issue, error) {
 	ephemeralFlag := true
+	// SkipLabels stays unset deliberately: the guard below reads issue.Labels,
+	// and a lite/label-skipping projection would make every wisp look unlabeled
+	// — a silent, total loss of label protection with no error to notice.
 	filter := types.IssueFilter{
 		Ephemeral:    &ephemeralFlag,
 		ExcludeTypes: excludeTypes,
@@ -847,6 +954,13 @@ func findAbandonedWisps(ctx context.Context, r molReader, cleanAll bool, ageThre
 		return nil, err
 	}
 
+	protectedLabels, err := protectedWispLabels(ctx, r, excludeLabels)
+	if err != nil {
+		return nil, err
+	}
+
+	guard := wispGuard{blocked: blockedSet, statuses: protectedStatuses, labels: protectedLabels}
+
 	now := time.Now()
 	var abandoned []*types.Issue
 	for _, issue := range issues {
@@ -856,7 +970,7 @@ func findAbandonedWisps(ctx context.Context, r molReader, cleanAll bool, ageThre
 		if issue.Status == types.StatusClosed && !cleanAll {
 			continue
 		}
-		if isProtectedWisp(issue, blockedSet, protectedStatuses) {
+		if isProtectedWisp(issue, guard) {
 			continue
 		}
 		if now.Sub(issue.UpdatedAt) > ageThreshold {
@@ -891,7 +1005,7 @@ func findAbandonedWisps(ctx context.Context, r molReader, cleanAll bool, ageThre
 				if r.IsInfraTypeCtx(ctx, child.IssueType) {
 					continue
 				}
-				if isProtectedWisp(child, blockedSet, protectedStatuses) {
+				if isProtectedWisp(child, guard) {
 					continue
 				}
 				abandoned = append(abandoned, child)
@@ -901,7 +1015,68 @@ func findAbandonedWisps(ctx context.Context, r molReader, cleanAll bool, ageThre
 	return abandoned, cascadeErr
 }
 
-func runWispPurgeClosed(ctx context.Context, dryRun bool, force bool, excludeTypes []types.IssueType) error {
+// infraTypeReader is the one thing filterClosedPurgeCandidates needs from a
+// store. Narrowing the parameter keeps the filter testable without standing up
+// the whole molReader surface.
+type infraTypeReader interface {
+	IsInfraTypeCtx(ctx context.Context, t types.IssueType) bool
+}
+
+// closedPurgeSkips counts the closed wisps a purge declined to delete, by
+// reason. It is reported rather than merely applied: a guard that silently
+// removes rows is indistinguishable from having had nothing to delete, and the
+// operator needs to know that the purge left something behind and why.
+type closedPurgeSkips struct {
+	pinned  int
+	infra   int
+	labeled int
+}
+
+func (c closedPurgeSkips) report() {
+	if c.pinned > 0 {
+		fmt.Printf("Skipping %d pinned issue(s) (protected from cleanup)\n", c.pinned)
+	}
+	if c.infra > 0 {
+		fmt.Printf("Skipping %d configured infra issue(s) protected from GC\n", c.infra)
+	}
+	if c.labeled > 0 {
+		fmt.Printf("Skipping %d wisp(s) carrying a protected label (%s)\n", c.labeled, protectedWispLabelsKey)
+	}
+}
+
+// filterClosedPurgeCandidates removes from a closed-wisp purge everything the
+// purge must not delete. It is shared by the direct and proxied-server paths so
+// the two cannot drift on which protections they honor — they already had two
+// hand-copied versions of the pinned/infra filter.
+//
+// Label protection applies here as well as to the age sweep on purpose: the
+// rule a caller has to remember is "wisp gc never reclaims a wisp carrying a
+// protected label", with no mode in which it does. A record whose whole point
+// is that it outlives the run that produced it is not made disposable by having
+// been closed, and `bd delete` remains available for deleting one on purpose.
+func filterClosedPurgeCandidates(ctx context.Context, r infraTypeReader, issues []*types.Issue, protectedLabels map[string]bool) ([]*types.Issue, closedPurgeSkips) {
+	guard := wispGuard{labels: protectedLabels}
+	var skips closedPurgeSkips
+	filtered := make([]*types.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if issue.Pinned {
+			skips.pinned++
+			continue
+		}
+		if r.IsInfraTypeCtx(ctx, issue.IssueType) {
+			skips.infra++
+			continue
+		}
+		if guard.hasProtectedLabel(issue) {
+			skips.labeled++
+			continue
+		}
+		filtered = append(filtered, issue)
+	}
+	return filtered, skips
+}
+
+func runWispPurgeClosed(ctx context.Context, dryRun bool, force bool, excludeTypes []types.IssueType, excludeLabels []string) error {
 	statusClosed := types.StatusClosed
 	ephemeralTrue := true
 	filter := types.IssueFilter{
@@ -916,28 +1091,14 @@ func runWispPurgeClosed(ctx context.Context, dryRun bool, force bool, excludeTyp
 		return HandleError("listing closed wisps: %v", err)
 	}
 
-	// Filter out pinned and infra issues (protected from cleanup)
-	pinnedCount := 0
-	infraCount := 0
-	filtered := make([]*types.Issue, 0, len(closedIssues))
-	for _, issue := range closedIssues {
-		if issue.Pinned {
-			pinnedCount++
-			continue
-		}
-		if store.IsInfraTypeCtx(ctx, issue.IssueType) {
-			infraCount++
-			continue
-		}
-		filtered = append(filtered, issue)
+	protectedLabels, err := protectedWispLabels(ctx, store, excludeLabels)
+	if err != nil {
+		return HandleError("%v", err)
 	}
-	closedIssues = filtered
 
-	if pinnedCount > 0 && !jsonOutput {
-		fmt.Printf("Skipping %d pinned issue(s) (protected from cleanup)\n", pinnedCount)
-	}
-	if infraCount > 0 && !jsonOutput {
-		fmt.Printf("Skipping %d configured infra issue(s) protected from GC\n", infraCount)
+	closedIssues, skips := filterClosedPurgeCandidates(ctx, store, closedIssues, protectedLabels)
+	if !jsonOutput {
+		skips.report()
 	}
 
 	if len(closedIssues) == 0 {
@@ -1015,6 +1176,7 @@ func init() {
 	wispGCCmd.Flags().Bool("closed", false, "Delete all closed wisps (ignores --age threshold)")
 	wispGCCmd.Flags().BoolP("force", "f", false, "Actually delete (default: preview only)")
 	wispGCCmd.Flags().StringSlice("exclude-type", nil, "Exclude wisps of these types from GC (comma-separated, e.g., agent,rig)")
+	wispGCCmd.Flags().StringSlice("exclude-label", nil, "Additionally protect wisps carrying these labels (comma-separated); adds to wisp.protected_labels")
 
 	wispCmd.AddCommand(wispCreateCmd)
 	wispCmd.AddCommand(wispListCmd)

--- a/cmd/bd/wisp_gc_protected_label_embedded_test.go
+++ b/cmd/bd/wisp_gc_protected_label_embedded_test.go
@@ -1,0 +1,154 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestWispGCProtectsLabeledWisps is the regression test for the data loss that
+// motivated the label guard: `bd mol wisp gc --age` deleted unread mail and
+// open escalations that an orchestration layer had stored as ephemeral beads.
+//
+// Nothing else in the predicate could have saved them. Such a record sits in
+// plain `open` status for exactly as long as nobody has acted on it, and open is
+// CategoryActive — age-reclaimable by design — so the longer a message went
+// unread, the more certainly GC deleted it. --exclude-type could not help
+// either: these records are ordinary `task`-typed beads, so excluding their
+// type excludes nearly the whole store.
+//
+// The assertions run against a throwaway store created by bdInit, never a live
+// one; this command deletes, and deletes without a digest.
+func TestWispGCProtectsLabeledWisps(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "gcl")
+
+	// A configured value REPLACES the built-in default, so name every label
+	// this store wants protected.
+	bdCommand(t, bd, dir, "config", "set", "wisp.protected_labels", "gt:message,gt:escalation")
+
+	// Ordering matters for the same reason as in TestWispGCProtectsActiveWisps:
+	// wisps expected to be RECLAIMED are created first, so the age predicate
+	// cannot mistake the most recently touched bead for not-yet-stale if the DB
+	// clock runs ahead of the test process. Protected wisps are excluded
+	// regardless of age.
+	idle := bdCreate(t, bd, dir, "idle wisp", "--ephemeral").ID
+	otherLabel := bdCreate(t, bd, dir, "unrelated label", "--ephemeral", "--label", "gt:thread").ID
+
+	// The two classes that were actually destroyed. Both are plain open tasks.
+	unreadMail := bdCreate(t, bd, dir, "unread mail", "--ephemeral", "--label", "gt:message").ID
+	escalation := bdCreate(t, bd, dir, "open escalation", "--ephemeral", "--label", "gt:escalation").ID
+
+	// Protection is per-label, not per-bead: a record carrying a protected
+	// label alongside unprotected ones is still protected.
+	mixed := bdCreate(t, bd, dir, "mail in a thread", "--ephemeral", "--label", "gt:thread,gt:message").ID
+
+	// An ad-hoc label named only on the command line adds to the configured set.
+	adHoc := bdCreate(t, bd, dir, "ad-hoc protected", "--ephemeral", "--label", "keep:me").ID
+
+	candidates := wispGCCandidates(t, bd, dir, "--age", "1ms", "--dry-run", "--exclude-label", "keep:me")
+
+	for _, tc := range []struct {
+		id   string
+		what string
+	}{
+		{unreadMail, "unread mail"},
+		{escalation, "open escalation"},
+		{mixed, "mail carrying an extra unprotected label"},
+		{adHoc, "wisp protected by --exclude-label"},
+	} {
+		if candidates[tc.id] {
+			t.Errorf("%s wisp %s must NOT be reclaimed by age; candidates=%v", tc.what, tc.id, keys(candidates))
+		}
+	}
+
+	// The guard must not degenerate into "protect everything": a wisp with no
+	// label, and a wisp whose only label is unprotected, stay reclaimable.
+	for _, tc := range []struct {
+		id   string
+		what string
+	}{
+		{idle, "unlabeled idle"},
+		{otherLabel, "unprotected-label"},
+	} {
+		if !candidates[tc.id] {
+			t.Errorf("%s wisp %s should stay a GC candidate (guard must not over-protect); candidates=%v", tc.what, tc.id, keys(candidates))
+		}
+	}
+}
+
+// TestWispGCClosedPurgeProtectsLabeledWisps pins the other half of the rule:
+// `wisp gc` never reclaims a protected label in ANY mode. Closing a record does
+// not make it disposable — a read message and a resolved escalation are exactly
+// the ones worth keeping — and --closed selects purely by status, so without
+// this the age guard would just move the deletion to a different flag.
+func TestWispGCClosedPurgeProtectsLabeledWisps(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "gcc")
+
+	bdCommand(t, bd, dir, "config", "set", "wisp.protected_labels", "gt:message")
+
+	readMail := bdCreate(t, bd, dir, "read mail", "--ephemeral", "--label", "gt:message").ID
+	spent := bdCreate(t, bd, dir, "spent wisp", "--ephemeral").ID
+	bdCommand(t, bd, dir, "close", readMail)
+	bdCommand(t, bd, dir, "close", spent)
+
+	out := bdCommand(t, bd, dir, "mol", "wisp", "gc", "--closed", "--dry-run")
+
+	if !strings.Contains(out, "Found 1 closed wisp(s)") {
+		t.Errorf("closed purge should have exactly one candidate (%s), got:\n%s", spent, out)
+	}
+	if !strings.Contains(out, "protected label") {
+		t.Errorf("closed purge must report the wisp it skipped and why; got:\n%s", out)
+	}
+
+	// The labeled wisp must still be there afterwards; the unlabeled one is the
+	// purge's business.
+	if !strings.Contains(bdCommand(t, bd, dir, "show", readMail), readMail) {
+		t.Errorf("closed wisp %s carrying a protected label must survive --closed", readMail)
+	}
+}
+
+// wispGCCandidates runs `bd mol wisp gc --json` and returns the candidate IDs
+// as a set.
+func wispGCCandidates(t *testing.T, bd, dir string, args ...string) map[string]bool {
+	t.Helper()
+	out := bdCommand(t, bd, dir, append([]string{"mol", "wisp", "gc", "--json"}, args...)...)
+
+	start := strings.Index(out, "{")
+	if start < 0 {
+		t.Fatalf("gc --json produced no JSON object\nraw:\n%s", out)
+	}
+	var res struct {
+		CleanedIDs []string `json:"cleaned_ids"`
+	}
+	if err := json.NewDecoder(strings.NewReader(out[start:])).Decode(&res); err != nil {
+		t.Fatalf("parse gc --json output: %v\nraw:\n%s", err, out)
+	}
+	candidates := make(map[string]bool, len(res.CleanedIDs))
+	for _, id := range res.CleanedIDs {
+		candidates[id] = true
+	}
+	return candidates
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/cmd/bd/wisp_gc_protected_labels_test.go
+++ b/cmd/bd/wisp_gc_protected_labels_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// noInfraReader is an infraTypeReader for which no type is infrastructure, so
+// the closed-purge filter's other branches are what the assertions measure.
+type noInfraReader struct{}
+
+func (noInfraReader) IsInfraTypeCtx(context.Context, types.IssueType) bool { return false }
+
+// TestResolveProtectedWispLabels pins the precedence rule: a configured value
+// REPLACES the built-in default (matching types.infra), config.yaml is consulted
+// only when the DB value is unset, and --exclude-label always ADDS. Getting the
+// precedence backwards would silently widen or narrow what a destructive
+// command refuses to delete.
+func TestResolveProtectedWispLabels(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		dbValue string
+		yaml    []string
+		extra   []string
+		want    []string
+		absent  []string
+	}{
+		{
+			name:   "unset everywhere falls back to the built-in default",
+			want:   []string{"bd:protected"},
+			absent: []string{"gt:message"},
+		},
+		{
+			name:    "configured value replaces the default, it does not extend it",
+			dbValue: "gt:message,gt:escalation",
+			want:    []string{"gt:message", "gt:escalation"},
+			absent:  []string{"bd:protected"},
+		},
+		{
+			name:    "whitespace around a configured label is trimmed",
+			dbValue: " gt:message ,  gt:escalation ",
+			want:    []string{"gt:message", "gt:escalation"},
+		},
+		{
+			name:   "config.yaml is the fallback when the DB value is unset",
+			yaml:   []string{"yaml:keep"},
+			want:   []string{"yaml:keep"},
+			absent: []string{"bd:protected"},
+		},
+		{
+			name:    "the DB value wins over config.yaml",
+			dbValue: "db:keep",
+			yaml:    []string{"yaml:keep"},
+			want:    []string{"db:keep"},
+			absent:  []string{"yaml:keep"},
+		},
+		{
+			name:    "--exclude-label adds to the configured set",
+			dbValue: "gt:message",
+			extra:   []string{"ad:hoc"},
+			want:    []string{"gt:message", "ad:hoc"},
+		},
+		{
+			name:  "--exclude-label adds to the default set",
+			extra: []string{"ad:hoc"},
+			want:  []string{"bd:protected", "ad:hoc"},
+		},
+		{
+			name:    "an all-whitespace config value reads as unset, not as no protection",
+			dbValue: "  ,  ",
+			want:    []string{"bd:protected"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveProtectedWispLabels(tc.dbValue, tc.yaml, tc.extra)
+			for _, l := range tc.want {
+				if !got[l] {
+					t.Errorf("label %q should be protected; got set %v", l, got)
+				}
+			}
+			for _, l := range tc.absent {
+				if got[l] {
+					t.Errorf("label %q should NOT be protected; got set %v", l, got)
+				}
+			}
+		})
+	}
+}
+
+// TestIsProtectedWispLabels is the unit-level regression for the hole this
+// guard closes: an unread message or escalation stored as an ephemeral bead
+// sits in plain open status, which every other protection in this predicate
+// treats as reclaimable. Before the label check it was deleted by age alone.
+func TestIsProtectedWispLabels(t *testing.T) {
+	t.Parallel()
+
+	guard := wispGuard{
+		blocked:  map[string]bool{},
+		statuses: map[types.Status]bool{types.StatusInProgress: true},
+		labels:   map[string]bool{"gt:message": true},
+	}
+
+	unreadMail := &types.Issue{
+		ID:     "gt-wisp-mail",
+		Status: types.StatusOpen,
+		Labels: []string{"gt:message", "gt:thread"},
+	}
+	if !isProtectedWisp(unreadMail, guard) {
+		t.Error("an open wisp carrying a protected label must not be reclaimable by age")
+	}
+
+	// The guard must not degenerate into "protect everything": an ordinary
+	// open wisp with unrelated labels stays a candidate.
+	ordinary := &types.Issue{
+		ID:     "gt-wisp-idle",
+		Status: types.StatusOpen,
+		Labels: []string{"gt:thread"},
+	}
+	if isProtectedWisp(ordinary, guard) {
+		t.Error("an open wisp with no protected label must stay reclaimable")
+	}
+
+	// Label protection is independent of status protection: it must hold for a
+	// closed wisp too, because --closed purges by status alone.
+	closedMail := &types.Issue{
+		ID:     "gt-wisp-read",
+		Status: types.StatusClosed,
+		Labels: []string{"gt:message"},
+	}
+	if !isProtectedWisp(closedMail, guard) {
+		t.Error("a closed wisp carrying a protected label must not be reclaimable")
+	}
+
+	// A wisp with no labels at all must not panic or protect.
+	if isProtectedWisp(&types.Issue{ID: "gt-wisp-bare", Status: types.StatusOpen}, guard) {
+		t.Error("an unlabeled open wisp must stay reclaimable")
+	}
+}
+
+// TestFilterClosedPurgeCandidatesCountsWhatItSkipped pins the reporting half:
+// a guard that silently drops rows is indistinguishable from having had
+// nothing to delete, so the purge must count each reason separately.
+func TestFilterClosedPurgeCandidatesCountsWhatItSkipped(t *testing.T) {
+	t.Parallel()
+
+	issues := []*types.Issue{
+		{ID: "keep-1", Status: types.StatusClosed},
+		{ID: "pinned-1", Status: types.StatusClosed, Pinned: true},
+		{ID: "labeled-1", Status: types.StatusClosed, Labels: []string{"gt:message"}},
+		{ID: "labeled-2", Status: types.StatusClosed, Labels: []string{"other", "gt:message"}},
+		{ID: "keep-2", Status: types.StatusClosed, Labels: []string{"other"}},
+	}
+
+	kept, skips := filterClosedPurgeCandidates(t.Context(), noInfraReader{}, issues, map[string]bool{"gt:message": true})
+
+	var keptIDs []string
+	for _, i := range kept {
+		keptIDs = append(keptIDs, i.ID)
+	}
+	if len(kept) != 2 || keptIDs[0] != "keep-1" || keptIDs[1] != "keep-2" {
+		t.Errorf("kept = %v, want [keep-1 keep-2]", keptIDs)
+	}
+	if skips.pinned != 1 {
+		t.Errorf("skips.pinned = %d, want 1", skips.pinned)
+	}
+	if skips.labeled != 2 {
+		t.Errorf("skips.labeled = %d, want 2", skips.labeled)
+	}
+	if skips.infra != 0 {
+		t.Errorf("skips.infra = %d, want 0", skips.infra)
+	}
+}

--- a/cmd/bd/wisp_proxied_server.go
+++ b/cmd/bd/wisp_proxied_server.go
@@ -118,7 +118,7 @@ func runWispListProxiedServer(ctx context.Context, showAll bool, typeFilter stri
 	return renderWispListResult(buildWispListResult(issues, showAll))
 }
 
-func runWispGCProxiedServer(ctx context.Context, dryRun bool, ageThreshold time.Duration, cleanAll, closedMode, force bool, excludeTypes []types.IssueType) error {
+func runWispGCProxiedServer(ctx context.Context, dryRun bool, ageThreshold time.Duration, cleanAll, closedMode, force bool, excludeTypes []types.IssueType, excludeLabels []string) error {
 	CheckReadonly("wisp gc")
 
 	if uowProvider == nil {
@@ -126,7 +126,7 @@ func runWispGCProxiedServer(ctx context.Context, dryRun bool, ageThreshold time.
 	}
 
 	if closedMode {
-		return runWispPurgeClosedProxiedServer(ctx, dryRun, force, excludeTypes)
+		return runWispPurgeClosedProxiedServer(ctx, dryRun, force, excludeTypes, excludeLabels)
 	}
 
 	uw, err := proxiedOpenReadUOW(ctx)
@@ -134,7 +134,7 @@ func runWispGCProxiedServer(ctx context.Context, dryRun bool, ageThreshold time.
 		return err
 	}
 	r := uowMolReader{uw: uw}
-	abandoned, err := findAbandonedWisps(ctx, r, cleanAll, ageThreshold, excludeTypes)
+	abandoned, err := findAbandonedWisps(ctx, r, cleanAll, ageThreshold, excludeTypes, excludeLabels)
 	uw.Close(ctx)
 	if err != nil && abandoned == nil {
 		return HandleError("%v", err)
@@ -219,7 +219,7 @@ func renderWispGCDeleteResult(ids []string, res domain.DeleteIssuesResult) error
 	return nil
 }
 
-func runWispPurgeClosedProxiedServer(ctx context.Context, dryRun, force bool, excludeTypes []types.IssueType) error {
+func runWispPurgeClosedProxiedServer(ctx context.Context, dryRun, force bool, excludeTypes []types.IssueType, excludeLabels []string) error {
 	uw, err := proxiedOpenReadUOW(ctx)
 	if err != nil {
 		return err
@@ -240,28 +240,17 @@ func runWispPurgeClosedProxiedServer(ctx context.Context, dryRun, force bool, ex
 		return HandleError("listing closed wisps: %v", err)
 	}
 
-	pinnedCount := 0
-	infraCount := 0
-	filtered := make([]*types.Issue, 0, len(closedIssues))
-	for _, issue := range closedIssues {
-		if issue.Pinned {
-			pinnedCount++
-			continue
-		}
-		if r.IsInfraTypeCtx(ctx, issue.IssueType) {
-			infraCount++
-			continue
-		}
-		filtered = append(filtered, issue)
+	protectedLabels, err := protectedWispLabels(ctx, r, excludeLabels)
+	if err != nil {
+		uw.Close(ctx)
+		return HandleError("%v", err)
 	}
-	closedIssues = filtered
+
+	closedIssues, skips := filterClosedPurgeCandidates(ctx, r, closedIssues, protectedLabels)
 	uw.Close(ctx)
 
-	if pinnedCount > 0 && !jsonOutput {
-		fmt.Printf("Skipping %d pinned issue(s) (protected from cleanup)\n", pinnedCount)
-	}
-	if infraCount > 0 && !jsonOutput {
-		fmt.Printf("Skipping %d configured infra issue(s) protected from GC\n", infraCount)
+	if !jsonOutput {
+		skips.report()
 	}
 
 	if len(closedIssues) == 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1094,6 +1094,14 @@ func GetInfraTypesFromYAML() []string {
 	return getConfigList("types.infra")
 }
 
+// GetProtectedWispLabelsFromYAML retrieves the labels that make a wisp
+// unreclaimable by `bd mol wisp gc`, from config.yaml. Used as a fallback when
+// the database has no wisp.protected_labels value (caller should fall through
+// to the built-in default). Returns nil if the key is unset.
+func GetProtectedWispLabelsFromYAML() []string {
+	return getConfigList("wisp.protected_labels")
+}
+
 // GetCustomStatusesFromYAML retrieves custom statuses from config.yaml.
 // This is used as a fallback when the database doesn't have status.custom set yet
 // or when the database connection is temporarily unavailable.


### PR DESCRIPTION
## The defect

`bd mol wisp gc --age` deletes unread mail and open escalations that an orchestration layer has stored as ephemeral beads. Three escalation wisps were destroyed by a single `--age 1h --force` run. This is measured, not theoretical.

Nothing in the existing predicate could have saved them. `isProtectedWisp` covered `Pinned`, blocked, and the WIP/Frozen status categories — but a write-once record sits in plain `open` status for exactly as long as nobody has acted on it, and `open` is `CategoryActive`, which is age-reclaimable by design. **The longer a message went unread, the more certainly GC deleted it**, and there is no status the layer could set instead without lying about the record's state.

`--exclude-type` was no escape either: these are ordinary `task` beads, so excluding their type excludes nearly the whole store.

A label is the only handle that survives that, and there was no label-aware code anywhere on this delete path. This adds the first.

## What changed

**`wisp.protected_labels` config key** — DB config, then `config.yaml`, then a built-in default, with the same REPLACES-not-extends semantics `types.infra` uses. The default is `bd:protected` rather than any particular orchestrator's label: which records are irreplaceable is orchestration policy, which `engdocs/PROJECT_CHARTER.md` keeps out of core. Core ships the extension point and fails closed on it.

```bash
bd config set wisp.protected_labels bd:protected,my:message
```

**One rule, no modes.** A wisp carrying a protected label is never reclaimed by `wisp gc` — not by `--age`, not by `--all`, not by `--closed`, on either the direct or the proxied-server path. Closing a record does not make it disposable; `bd delete` still deletes one on purpose. A mode-dependent guard is a guard someone forgets.

**`wispGuard{blocked, statuses, labels}`** replaces the loose parameter pair, so a future fourth protection cannot silently miss one of the three sites that filter candidates: the age sweep, its cascade expansion (which reaches wisps the search filter never saw), and the closed purge.

**`--exclude-label`**, additive to whatever the workspace configures.

**Skips are counted and reported per reason.** A guard that silently drops rows reads identically to having had nothing to delete.

**Fail closed.** An unreadable config aborts the GC, the same contract `protectedWispStatuses` already held.

The two hand-copied pinned/infra filters in the closed-purge paths are now one shared `filterClosedPurgeCandidates`, so they cannot drift on which protections they honor.

## Two findings from codex review, both fixed here

- **`uowMolReader.GetIssuesByIDs` swallowed both of its label reads** (`if labelMap, err := ...; err == nil`), leaving every issue with nil `Labels` on failure. For a renderer that is cosmetic. For this guard it is a licence to delete — an unlabeled issue reads as "carries no protected label" — so a transient label read failure during cascade expansion would have reclaimed exactly the records the feature promises to keep, silently. Both reads now propagate. The wisp branch still tolerates a missing `wisps` table; its label read is reached only when that table exists and returned rows.
- **`bd config set wisp.protected_labels` warned that the key was unrecognized** and suggested `custom.*`, while GC read it perfectly well. A setup command that reports itself as unsupported is one people do not finish — which on this path means the guard stays unarmed. The `wisp.` namespace is now registered.

## Tests

All three new test files fail before their respective change, verified by neutralizing the code under test and re-running:

| file | covers |
|---|---|
| `cmd/bd/wisp_gc_protected_labels_test.go` | config precedence, the predicate, skip accounting |
| `cmd/bd/wisp_gc_protected_label_embedded_test.go` | end-to-end through the real gc path, age **and** `--closed` |
| `cmd/bd/mol_port_labels_test.go` | a failed label read surfaces as an error, no partial result |

Every test asserts **both directions** — labeled records survive, and unlabeled or unrelated-label wisps stay reclaimable — so the guard cannot degenerate into protecting everything. The embedded tests run against a throwaway `bdInit` store, never a live one; this command deletes, and deletes without a digest.

## Validation

- `go build ./...`, `go vet`, `gofmt` clean; `golangci-lint` reports 0 issues.
- `make check-docs` passes.
- `scripts/ci/pr-core.sh`: the failure **set** is identical to a clean worktree at `c0d8da42d`. `TestPrepareSelectedCommandContext_RebindsTargetConfig` and `TestInitNonInteractiveAutoExportDefaultOffAndOptIn` fail on baseline too — both assert on actor identity and this environment's actor is not the one they expect. Verified set-wise against a detached baseline worktree, not by count.
- `codex exec review --base main` run three times; the final round is clean.

## Docs deliberately not touched

`docs/cli-docs.pin` pins the docs corpus to release `v1.2.2`, and the house rule is to document the pinned release rather than main. The help text in `cmd/bd/wisp.go` is the source and flows into `docs/cli-reference/mol.md` at the next pin bump and regeneration.

## Notes for the reviewer

- **Overlaps external PR #5219** (`fix(wisp gc): apply the --age test to cascade children`) on `cmd/bd/wisp.go` and `cmd/bd/wisp_proxied_server.go`. Different defect, and I have not touched that PR. It is already `DIRTY` against main independently of this branch. Whichever lands second will need a small rebase inside `findAbandonedWisps`; the two changes are complementary, not competing.
- **`bd purge --force` still has this hole** and is presented in the docs as `wisp gc`'s interchangeable sibling: it protects only pinned beads and does not honor `wisp.protected_labels`. Not fixed here because its skip accounting lives in the storage layer (`PurgeResult.Skipped`), which is a wider change wanting its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LrvF6W2PDpu6ocxKvXg29
