### PR TITLE
fix(hooks): don't report foreign hooks as installed

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -526,11 +526,15 @@ func CheckGitHooks() []HookStatus {
 			Name: hookName,
 		}
 
-		// Check if hook exists
+		// Check if hook exists and is a beads-managed hook (GH#6084).
+		// getHookVersion returns (hookVersionInfo{}, nil) — no error — when the
+		// file is readable but contains no beads markers. Only set Installed=true
+		// when the file is actually a beads hook; a foreign file that beads never
+		// touched must not be reported as installed.
 		hookPath := filepath.Join(hooksDir, hookName)
 		versionInfo, err := getHookVersion(hookPath)
-		if err != nil {
-			// Hook doesn't exist or couldn't be read
+		if err != nil || !versionInfo.IsBdHook {
+			// Hook doesn't exist, couldn't be read, or is not a beads hook
 			status.Installed = false
 		} else {
 			status.Installed = true
@@ -539,7 +543,7 @@ func CheckGitHooks() []HookStatus {
 
 			// Thin shims are never outdated (they delegate to bd)
 			// bd hooks are outdated if version is missing (legacy inline) or differs
-			if !versionInfo.IsShim && versionInfo.IsBdHook && versionInfo.Version != Version {
+			if !versionInfo.IsShim && versionInfo.Version != Version {
 				status.Outdated = true
 			}
 		}

--- a/cmd/bd/init_hooks_test.go
+++ b/cmd/bd/init_hooks_test.go
@@ -1368,3 +1368,103 @@ func TestFixHuskyHookLayout_NoHusky(t *testing.T) {
 		t.Error("h should not exist")
 	}
 }
+
+// TestCheckGitHooks_ForeignHookNotInstalled reproduces GH#6084.
+// A hook file that beads never wrote must not be reported as installed by
+// bd hooks list. Previously CheckGitHooks set Installed=true whenever
+// getHookVersion returned without error, but getHookVersion returns a zero-
+// value hookVersionInfo (IsBdHook=false) with a nil error when the file is
+// readable but contains no beads markers.
+func TestCheckGitHooks_ForeignHookNotInstalled(t *testing.T) {
+	tmpDir := newGitRepo(t)
+	runInDir(t, tmpDir, func() {
+		hooksDir := filepath.Join(tmpDir, ".git", "hooks")
+		if err := os.MkdirAll(hooksDir, 0750); err != nil {
+			t.Fatalf("failed to create hooks dir: %v", err)
+		}
+
+		// Write a hook that contains no beads markers whatsoever — exactly
+		// the script from the issue report.
+		foreignHook := "#!/bin/sh\necho hello\nexit 0\n"
+		hookPath := filepath.Join(hooksDir, "pre-commit")
+		if err := os.WriteFile(hookPath, []byte(foreignHook), 0755); err != nil {
+			t.Fatalf("failed to write foreign hook: %v", err)
+		}
+
+		statuses := CheckGitHooks()
+
+		for _, s := range statuses {
+			if s.Name != "pre-commit" {
+				continue
+			}
+			if s.Installed {
+				t.Errorf("pre-commit: got Installed=true for a foreign hook file that beads never wrote; want Installed=false (GH#6084)")
+			}
+			return
+		}
+		t.Error("pre-commit hook status not found in CheckGitHooks result")
+	})
+}
+
+// TestCheckGitHooks_BeadsHookIsInstalled verifies that the IsBdHook gate added
+// in GH#6084 does not regress recognition of genuine beads-managed hooks.
+// Each variant that getHookVersion can recognise must produce Installed=true.
+func TestCheckGitHooks_BeadsHookIsInstalled(t *testing.T) {
+	cases := []struct {
+		name          string
+		body          string
+		wantInstalled bool
+	}{
+		{
+			name: "section-marker",
+			// Minimal hook with a BEGIN BEADS INTEGRATION section marker.
+			body:          "#!/bin/sh\n" + hookSectionBeginPrefix + " v" + Version + " ---\nbd hooks run pre-commit \"$@\"\n" + hookSectionEndPrefix + " v" + Version + " ---\n",
+			wantInstalled: true,
+		},
+		{
+			name:          "legacy-version-marker",
+			body:          "#!/bin/sh\n" + hookVersionPrefix + Version + "\n# bd (beads) pre-commit hook\nbd sync --flush-only\n",
+			wantInstalled: true,
+		},
+		{
+			name:          "shim-marker",
+			body:          "#!/bin/sh\n" + shimVersionPrefix + Version + "\nexec bd hooks run pre-commit \"$@\"\n",
+			wantInstalled: true,
+		},
+		{
+			name: "inline-marker",
+			// Old bd init style: no version line, just the inline comment.
+			body:          "#!/bin/sh\n# bd (beads) pre-commit hook\nbd sync --flush-only\n",
+			wantInstalled: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := newGitRepo(t)
+			runInDir(t, tmpDir, func() {
+				hooksDir := filepath.Join(tmpDir, ".git", "hooks")
+				if err := os.MkdirAll(hooksDir, 0750); err != nil {
+					t.Fatalf("failed to create hooks dir: %v", err)
+				}
+				hookPath := filepath.Join(hooksDir, "pre-commit")
+				if err := os.WriteFile(hookPath, []byte(tc.body), 0755); err != nil {
+					t.Fatalf("failed to write hook: %v", err)
+				}
+
+				statuses := CheckGitHooks()
+
+				for _, s := range statuses {
+					if s.Name != "pre-commit" {
+						continue
+					}
+					if s.Installed != tc.wantInstalled {
+						t.Errorf("pre-commit (%s): got Installed=%v, want %v", tc.name, s.Installed, tc.wantInstalled)
+					}
+					return
+				}
+				t.Error("pre-commit hook status not found in CheckGitHooks result")
+			})
+		})
+	}
+}


### PR DESCRIPTION
## hooks: don't report foreign hooks as installed (GH#6084)

Fixes #6084.

### Problem

`bd hooks list` printed `✓ pre-commit: installed (version )` for hook
files that beads never wrote — for example a plain `#!/bin/sh` script
created by another tool or manually by the user.

Root cause: `CheckGitHooks` called `getHookVersion` and treated any
`nil` error as proof that beads installed the hook. `getHookVersion`
returns `hookVersionInfo{}` (with `IsBdHook=false`) and a `nil` error
when the file is readable but contains no beads markers. The nil-error
path then unconditionally set `status.Installed = true`.

`CheckGitHooks` also feeds `bd config drift` (cmd/bd/config_drift.go:110)
and the hook warning printed at the end of `bd info` (cmd/bd/info.go:175),
so a foreign hook now surfaces there as `hooks.missing` drift and as the
`Git hooks not installed (N missing)` warning instead of being counted as installed.

### Fix

Gate `status.Installed = true` on `versionInfo.IsBdHook`.

The inner `Outdated` check previously had a redundant `versionInfo.IsBdHook &&`
guard (because the else block is only reached when `IsBdHook` is true).
That guard is removed for clarity.

<details>
<summary>Diff excerpt, tests, and checklist</summary>

```go
// before
if err != nil {
    status.Installed = false
} else {
    status.Installed = true
    ...
}

// after
if err != nil || !versionInfo.IsBdHook {
    status.Installed = false
} else {
    status.Installed = true
    ...
}
```

### Tests

- **`TestCheckGitHooks_ForeignHookNotInstalled`** — regression: a
  foreign hook with no beads markers must produce `Installed=false`.
- **`TestCheckGitHooks_BeadsHookIsInstalled`** — positive coverage for
  all four marker variants that `getHookVersion` recognises:
  `section-marker`, `legacy-version-marker`, `shim-marker`, and
  `inline-marker`; each must produce `Installed=true`.

### Checklist

- [x] Minimal, focused change (2 files, `cmd/bd/hooks.go` + `cmd/bd/init_hooks_test.go`)
- [x] Regression test added
- [x] Positive coverage for all recognised beads marker variants
- [x] `gofmt` clean
- [x] `git diff --check` clean
- [x] Focused tests pass (`go test -tags=gms_pure_go ./cmd/bd/... -run TestCheckGitHooks`)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
