### PR TITLE
fix(prime): document all three PRIME.md fallback tiers in --help

### DIFF
--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -106,7 +106,14 @@ Config options:
   See docs/getting-started/ide-setup.md#policy-profiles for what each profile means.
 
 	Workflow customization:
-	- Place a .beads/PRIME.md file in the local clone or resolved workspace to override the default workflow text. Persistent memories (from bd remember) are still appended so memory injection keeps working under a custom template.
+	- Place a PRIME.md file to override the default workflow text. Checked in this
+	  order, once bd resolves a workspace (outside one, prime emits no content):
+	  (1) .beads/PRIME.md relative to the current directory;
+	  (2) PRIME.md in the .beads directory bd resolves for this workspace
+	      (honors $BEADS_DIR; a redirected .beads is followed);
+	  (3) the global ~/.config/beads/PRIME.md (or OS equivalent config dir).
+	- Persistent memories (from bd remember) are still appended so memory
+	  injection keeps working under a custom template.
 	- Use --export to dump the default content for customization.
 	- Use --memories-only for hook contexts that should inject only persistent memories; this returns only the memories section even when a custom PRIME.md is present.
 	- Use --no-memories to omit the persistent memories section (useful when the memories section is large and would dominate a context budget). --memories-only takes precedence if both are set.

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -111,7 +111,10 @@ Config options:
 	  (1) .beads/PRIME.md relative to the current directory;
 	  (2) PRIME.md in the .beads directory bd resolves for this workspace
 	      (honors $BEADS_DIR; a redirected .beads is followed);
-	  (3) the global ~/.config/beads/PRIME.md (or OS equivalent config dir).
+	  (3) the global PRIME.md in bd's user config dir:
+	      ~/.config/beads/ on Linux ($XDG_CONFIG_HOME/beads/ if set),
+	      ~/Library/Application Support/beads/ on macOS,
+	      %AppData%\beads\ on Windows.
 	- Persistent memories (from bd remember) are still appended so memory
 	  injection keeps working under a custom template.
 	- Use --export to dump the default content for customization.

--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -812,3 +812,30 @@ func TestPrime_RawMarkdown_NotJSON_WithoutFlag(t *testing.T) {
 		t.Fatal("prime output without --hook-json should not be valid JSON (regression guard)")
 	}
 }
+
+// GH#6095: bd prime --help must document all three PRIME.md resolution
+// tiers (current-directory, resolved workspace .beads, global config) in
+// their actual lookup order, not just the first tier.
+func TestPrimeHelpMentionsAllFallbackTiers(t *testing.T) {
+	needles := []string{
+		".beads/PRIME.md relative to the current directory",
+		".beads directory bd resolves for this workspace",
+		"~/.config/beads/PRIME.md",
+	}
+	positions := make([]int, len(needles))
+	for i, needle := range needles {
+		pos := strings.Index(primeCmd.Long, needle)
+		if pos == -1 {
+			t.Errorf("prime help missing %q", needle)
+		}
+		positions[i] = pos
+	}
+	for i := 1; i < len(positions); i++ {
+		if positions[i-1] == -1 || positions[i] == -1 {
+			continue
+		}
+		if positions[i] <= positions[i-1] {
+			t.Errorf("prime help documents fallback tiers out of order: %q at %d should come before %q at %d", needles[i-1], positions[i-1], needles[i], positions[i])
+		}
+	}
+}

--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -817,10 +817,12 @@ func TestPrime_RawMarkdown_NotJSON_WithoutFlag(t *testing.T) {
 // tiers (current-directory, resolved workspace .beads, global config) in
 // their actual lookup order, not just the first tier.
 func TestPrimeHelpMentionsAllFallbackTiers(t *testing.T) {
+	// Each needle carries its (N) label so that swapping only the labels,
+	// not the descriptions, still fails the ordering check below.
 	needles := []string{
-		".beads/PRIME.md relative to the current directory",
-		".beads directory bd resolves for this workspace",
-		"~/.config/beads/PRIME.md",
+		"(1) .beads/PRIME.md relative to the current directory",
+		"(2) PRIME.md in the .beads directory bd resolves for this workspace",
+		"(3) the global PRIME.md in bd's user config dir",
 	}
 	positions := make([]int, len(needles))
 	for i, needle := range needles {
@@ -836,6 +838,20 @@ func TestPrimeHelpMentionsAllFallbackTiers(t *testing.T) {
 		}
 		if positions[i] <= positions[i-1] {
 			t.Errorf("prime help documents fallback tiers out of order: %q at %d should come before %q at %d", needles[i-1], positions[i-1], needles[i], positions[i])
+		}
+	}
+
+	// Tier (3) resolves via os.UserConfigDir(), whose location differs per
+	// platform. The help text is static, so it must spell out every OS's
+	// path rather than pinning one platform's spelling as if it were
+	// universal.
+	for _, configDirPath := range []string{
+		"~/.config/beads/",
+		"~/Library/Application Support/beads/",
+		`%AppData%\beads\`,
+	} {
+		if !strings.Contains(primeCmd.Long, configDirPath) {
+			t.Errorf("prime help tier (3) missing user config dir path %q", configDirPath)
 		}
 	}
 }


### PR DESCRIPTION
# fix(prime): document all three PRIME.md fallback tiers in --help

## What

`bd prime --help` now lists all three `PRIME.md` override locations that `readCustomPrimeContent` (cmd/bd/prime.go) checks, in lookup order, and notes that the lookup runs only once bd resolves a workspace. The single long help line becomes a short bullet list. A new test, `TestPrimeHelpMentionsAllFallbackTiers`, guards the help text. No behavior change to the resolution logic itself.

| File | What it does now |
|---|---|
| cmd/bd/prime.go | `Workflow customization:` section of `primeCmd.Long` enumerates tiers (1) `.beads/PRIME.md` relative to the current directory, (2) `PRIME.md` in the `.beads` directory bd resolves for this workspace, (3) the global `PRIME.md` in bd's user config dir, spelled out per OS (`~/.config/beads/` on Linux, `~/Library/Application Support/beads/` on macOS, `%AppData%\beads\` on Windows, i.e. what `os.UserConfigDir()` returns); the lead-in notes the lookup runs only once bd resolves a workspace |
| cmd/bd/prime_test.go | `TestPrimeHelpMentionsAllFallbackTiers` asserts all three tiers, with their literal `(1)`/`(2)`/`(3)` labels, appear in `primeCmd.Long` in that order (`strings.Index` positions, not just substring presence), and that all three per-OS config-dir spellings are present |

## Why

Fixes gastownhall/beads#6095
Reported by @seanmartinsmith, who has since confirmed on this PR that they had not started a change of their own.

Type: docs · Risk: low — the diff touches only the `primeCmd.Long` string literal and appends one test.

The help text named a single path ("the local clone or resolved workspace"), which conflates tiers 1 and 2 and omits the global fallback entirely. As @seanmartinsmith notes in the issue, the global tier is the one a multi-project user most wants, yet it was the least discoverable from the CLI: because resolution is silent and ordered, someone who creates `~/.config/beads/PRIME.md` and still sees default output cannot learn from `--help` that a stray `.beads/PRIME.md` is shadowing it.

Tier 2 is described by outcome rather than by mechanism because `FindBeadsDir` has several resolution paths (`$BEADS_DIR`, an ancestor walk, git-worktree and jj-workspace fallbacks), most of which follow a `.beads/redirect` file. The lead-in carries an explicit precondition ("once bd resolves a workspace (outside one, prime emits no content)") because `runPrime` returns before any tier is consulted when no workspace resolves, so a `PRIME.md` alone, including the global one, never produces content.

## Verification

- The edited help block (prime.go:108-117) is ten lines, none longer than 79 characters.
- `TestPrimeHelpMentionsAllFallbackTiers` (prime_test.go:819-857) asserts that each tier's literal `(N)` needle is present (needles at `:823-825`, checked at `:831`), that the three appear in that order by `strings.Index` position (`:835-842`), and that each of the three per-OS config-dir spellings appears in `primeCmd.Long` (`:848-856`). The `(1)`/`(2)`/`(3)` labels are inside the needles and each spelling is asserted separately, so swapping only the labels, or dropping only the macOS path, fails the test.
- The checks for this change are `gofmt -l cmd/bd`, `CGO_ENABLED=0 go vet -tags gms_pure_go ./cmd/bd/`, and the `Prime` test run; the exact commands are below. No test output is quoted here — they are reproduction steps, not a transcript of a recorded run.

<details><summary>Provenance and verification</summary>

Out of scope: `resolveGlobalPrimePath` (cmd/bd/prime.go:73) uses `os.UserConfigDir()` (`~/Library/Application Support` on macOS, `%AppData%` on Windows; `$XDG_CONFIG_HOME` is not consulted on macOS), while internal/configfile (credentials.go:25, central_config.go:30) builds `~/.config/beads` literally, so on macOS PRIME.md and credentials live in different directories. The help now names the directory `os.UserConfigDir()` actually returns on each OS; aligning the two spellings is a behavior change left for its own issue.

### Tier history

`git log --oneline -S'redirectedPrimePath' -- cmd/bd/prime.go` names a single commit,
4021f4944 (`feat(prime): add PRIME.md override for workflow customization (GH#876)`); the
same search for `resolveGlobalPrimePath` names 3a2d351ea (`feat: support global
~/.config/beads/PRIME.md fallback (GH#2330)`).

Tiers 1 and 2 (`localPrimePath`, `redirectedPrimePath`) were introduced together in GH#876; tier 3 (`resolveGlobalPrimePath`, via `os.UserConfigDir()`) was added for GH#2330.

### Redirect handling in FindBeadsDir

internal/beads/beads.go `FindBeadsDir`: the `$BEADS_DIR` path (`FollowRedirect` at :763), the ancestor walk (:833), the per-worktree redirect (3a, :855, via `worktreeRedirectTarget`, which stats `.beads/redirect` at :1103 and calls `FollowRedirect` at :1106), the worktree shared-`.beads` fallback (:900), the jj primary fallback (:943) and the extended walk (:974) follow a `.beads/redirect`. The worktree's own `.beads` (3b, :879/:892) and the jj secondary's own `.beads` (3'b, :923/:934) do not: both are separate-DB branches reached only when no redirect applies. Hence "most of which", not "each".

### Workspace precondition

cmd/bd/prime.go:152-160: `runPrime` calls `beads.FindBeadsDir()` first and returns (printing nothing, or an empty `--hook-json` envelope) when it is empty; `readCustomPrimeContent` at :197 is only reached after that. So every tier, including the global one, is consulted only inside a resolvable workspace, which is why the precondition sits in the lead-in rather than on tier 3.

### Docs

The generated CLI docs (docs/cli-reference/prime.md, docs/CLI_REFERENCE.md) are built from the release tag pinned in docs/cli-docs.pin (v1.2.2), not from main, so they are intentionally untouched here.

### Test pattern

The new test follows the existing help-contract pattern in cmd/bd/dolt_help_auth_test.go (`TestDoltHelpMentionsRemoteAuth`).

### Reproducing the checks

```
gofmt -l cmd/bd
CGO_ENABLED=0 go vet -tags gms_pure_go ./cmd/bd/
BEADS_TEST_SKIP=dolt CGO_ENABLED=0 go test -tags gms_pure_go -timeout 10m ./cmd/bd/ -run 'Prime' -count=1 -v

# negative control: run the new test against the pre-change help text
cp cmd/bd/prime.go /tmp/prime-head.go
git show e05000d64:cmd/bd/prime.go > cmd/bd/prime.go
BEADS_TEST_SKIP=dolt CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd/ -run 'TestPrimeHelpMentionsAllFallbackTiers' -count=1
cp /tmp/prime-head.go cmd/bd/prime.go
```

Line lengths in the edited block, read from the file at this commit: lines 108-117 measure
24, 79, 77, 57, 70, 60, 51, 66, 53 and 35 characters, so none exceeds 79. Re-derive with
`awk 'FNR>=108 && FNR<=117 {print FNR": "length($0)}' cmd/bd/prime.go`.

The help text as it now reads in `primeCmd.Long` (cmd/bd/prime.go:108-120):

```
	Workflow customization:
	- Place a PRIME.md file to override the default workflow text. Checked in this
	  order, once bd resolves a workspace (outside one, prime emits no content):
	  (1) .beads/PRIME.md relative to the current directory;
	  (2) PRIME.md in the .beads directory bd resolves for this workspace
	      (honors $BEADS_DIR; a redirected .beads is followed);
	  (3) the global PRIME.md in bd's user config dir:
	      ~/.config/beads/ on Linux ($XDG_CONFIG_HOME/beads/ if set),
	      ~/Library/Application Support/beads/ on macOS,
	      %AppData%\beads\ on Windows.
	- Persistent memories (from bd remember) are still appended so memory
	  injection keeps working under a custom template.
	- Use --export to dump the default content for customization.
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
