### PR TITLE
fix(list): describe the piped and agent-mode --limit defaults in --help

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -409,7 +409,7 @@ func init() {
 	listCmd.Flags().String("title", "", "Filter by title text (case-insensitive substring match)")
 	listCmd.Flags().String("spec", "", "Filter by spec_id prefix")
 	listCmd.Flags().String("id", "", "Filter by specific issue IDs (comma-separated, e.g., bd-1,bd-5,bd-10)")
-	listCmd.Flags().IntP("limit", "n", workapi.DefaultListLimit, "Limit results (default 50, use 0 for unlimited)")
+	listCmd.Flags().IntP("limit", "n", workapi.DefaultListLimit, "Limit results (an explicit --limit always wins, 0 meaning unlimited; otherwise --all is unlimited; otherwise a configured list.limit applies; otherwise unlimited when piped, else 20 in agent mode at a terminal, else 50)")
 	listCmd.Flags().Int("offset", 0, "Skip the first N matching results (0-based). Only supported under --proxied-server.")
 	listCmd.Flags().String("format", "", "Output format: 'digraph' (for golang.org/x/tools/cmd/digraph), 'dot' (Graphviz), or Go template")
 	listCmd.Flags().Bool("all", false, "Show all issues including closed (overrides default filter)")

--- a/cmd/bd/list_limit_policy_test.go
+++ b/cmd/bd/list_limit_policy_test.go
@@ -91,3 +91,62 @@ func TestListLimitPolicyIsResolvedBeforeTheRequest(t *testing.T) {
 		})
 	}
 }
+
+// GH#6069: the --limit flag help must describe the switch pinned above, in
+// the switch's own order, not claim an unconditional "default 50". The whole
+// usage string is pinned verbatim: a substring check would accept a clause
+// scoped wider than its arm (an earlier draft's "--all is always unlimited"
+// contained every needle and was still false, because an explicit --limit
+// outranks --all). The cases below tie the three claims a reader is most
+// likely to get wrong back to the switch, each with list.limit configured.
+func TestListLimitHelpDescribesPipedBehavior(t *testing.T) {
+	flag := listCmd.Flags().Lookup("limit")
+	if flag == nil {
+		t.Fatal("listCmd has no --limit flag registered")
+	}
+	const want = "Limit results (an explicit --limit always wins, 0 meaning unlimited; otherwise --all is unlimited; otherwise a configured list.limit applies; otherwise unlimited when piped, else 20 in agent mode at a terminal, else 50)"
+	if flag.Usage != want {
+		t.Errorf("--limit help = %q\nwant %q", flag.Usage, want)
+	}
+
+	t.Chdir(t.TempDir())
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+	config.Set("list.limit", 7)
+	if got := config.GetValueSource("list.limit"); got == config.SourceDefault {
+		t.Fatal("precondition: config.Set did not make list.limit count as configured")
+	}
+	for _, tc := range []struct {
+		name      string
+		args      []string
+		want      int
+		needsPipe bool
+	}{
+		// limitChanged is the first arm, so --all does not make an explicit
+		// --limit unlimited. Holds at a terminal or a pipe alike.
+		{"an explicit --limit outranks --all", []string{"--all", "--limit", "5"}, 5, false},
+		// The AllFlag arm precedes listLimitConfigured and !IsTerminal, so
+		// this holds at a terminal too and never needs to skip.
+		{"--all is unlimited even with list.limit configured", []string{"--all"}, 0, false},
+		// listLimitConfigured precedes the !IsTerminal arm. Only a piped
+		// stdout can show that ordering; at a terminal the same 7 would
+		// prove nothing about the piped arm.
+		{"piped output takes a configured list.limit", nil, 7, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.needsPipe && ui.IsTerminal() {
+				t.Skip("this case shows a configured list.limit outranking the piped-stdout arm, so stdout must be a pipe; go test's is, this run's is not")
+			}
+			in, err := gatherListInput(newListLimitCommand(t, tc.args...))
+			if err != nil {
+				t.Fatalf("gatherListInput(%v): %v", tc.args, err)
+			}
+			if in.effectiveLimit != tc.want {
+				t.Errorf("effectiveLimit = %d, want %d", in.effectiveLimit, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# fix(list): correct --limit help for piped-output default

## What

Rewords the `--limit` flag's help in `cmd/bd/list.go` so it states the limit `bd list` actually
applies, in the order `gatherListInput` resolves it (cmd/bd/list_input.go:304-315 on this branch): an explicit
`--limit` first, then `--all`, then a configured `list.limit`, then unlimited when piped, then 20 in
agent mode at a terminal, then 50. Adds a test that pins the new usage string verbatim and checks
three of its claims against the switch.

| File | Change |
|---|---|
| cmd/bd/list.go:412 | `--limit` usage string rewritten; the flag still registers `workapi.DefaultListLimit`, so cobra's `(default 50)` suffix stays (why: under Provenance) |
| cmd/bd/list_limit_policy_test.go | `TestListLimitHelpDescribesPipedBehavior`: usage pinned verbatim; with `list.limit=7`, `--all --limit 5`→5, `--all`→0, piped→7 |

## Why

Fixes gastownhall/beads#6069 (reported by @hwaterer). `bd list --help` said `(default 50, use 0 for unlimited)`, but piped
stdout has resolved to unlimited since #4158 (GH#4094) and agent mode at a terminal resolves to 20,
so a script piping `bd list --json | ...` or an agent at a terminal could not learn its real limit
from `--help`. Help text and test only; `gatherListInput` is unchanged.

Type: docs · Risk: low — one usage string plus a test; no behaviour change.

## Verification

- `gofmt -l cmd/bd` — empty. `CGO_ENABLED=0 go vet -tags gms_pure_go ./cmd/bd/` — exit 0.
- `BEADS_TEST_SKIP=dolt CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd/ -run ListLimit -count=1 -v` — 2 tests, 7 subtests, all PASS: `ok  	github.com/steveyegge/beads/cmd/bd	0.925s`.
- `BEADS_TEST_SKIP=dolt CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd/ -count=1` — 18 failures, all pre-existing under `CGO_ENABLED=0`: each fails at `bd init` with "embedded Dolt requires a CGO build" (Dolt is the default backend; CI runs this package with CGO), none in `list`; counts under Provenance.
- `go run -tags gms_pure_go ./cmd/bd list --help | grep -- --limit` renders the new line (verbatim under Provenance).
- Docs intentionally untouched: `docs/cli-docs.pin` is `v1.2.2`, so `docs/CLI_REFERENCE.md:923` and `docs/cli-reference/list.md:45` regenerate from that tag, not from main.

<details><summary>Provenance and verification</summary>

### The switch the help describes (cmd/bd/list_input.go, this branch)

```
55: 	limit, _ := cmd.Flags().GetInt("limit")
56: 	in.limitChanged = cmd.Flags().Changed("limit")
57: 	listLimitConfigured := false
58: 	if !in.limitChanged {
59: 		listLimitConfigured = config.GetValueSource("list.limit") != config.SourceDefault
60: 		limit = config.GetInt("list.limit")
61: 	}
...
303: 	in.effectiveLimit = limit
304: 	switch {
305: 	case in.limitChanged:
306: 		in.effectiveLimit = limit
307: 	case in.AllFlag:
308: 		in.effectiveLimit = 0
309: 	case listLimitConfigured:
310: 		in.effectiveLimit = limit
311: 	case !ui.IsTerminal():
312: 		in.effectiveLimit = 0 // Piped stdout should not truncate (GH#4094)
313: 	case ui.IsAgentMode():
314: 		in.effectiveLimit = 20
315: 	}
```

Usage-string clause → arm: "an explicit --limit always wins, 0 meaning unlimited" → :305 (so `--all --limit 5` is 5);
"otherwise --all is unlimited" → :307; "otherwise a configured list.limit applies" → :309 (`limit` is
`config.GetInt("list.limit")` from :60); "otherwise unlimited when piped" → :311; "else 20 in agent mode at a
terminal" → :313, reachable only after :311 fails, i.e. at a terminal (`ui.IsAgentMode` = `BD_AGENT_MODE=1` or
`CLAUDE_CODE` set, internal/ui/styles.go:87-96); "else 50" → the fall-through, where `limit` is the config default
50 (internal/config/config.go:346 `v.SetDefault("list.limit", 50)`).

### Why cobra's `(default 50)` suffix stays

The registered default is never consumed at runtime: :55 reads it, :60 overwrites it with
`config.GetInt("list.limit")` whenever the flag is unset, and :305 only uses it when the flag was set. Registering
0 would drop the suffix, but internal/httpapi/apigen/types.gen.go:2170 documents the registration as a CLI/HTTP
parity contract ("The default below is the shared list limit constant (`workapi.DefaultListLimit`, the value
`bd list`'s `--limit` flag registers)"), the existing test helper (cmd/bd/list_limit_policy_test.go:14-20)
mirrors it, and internal/httpapi/spec_parity_test.go:605-627 `TestDefaultsMatchCLIFlags` regex-pins the
`IntP("limit", "n", …)` registration in cmd/bd/list.go to `workapi.DefaultListLimit`, so registering 0 would
fail that test. Changing the default is out of scope for a help-text fix.

### History

```
$ gh pr view 4158 --repo gastownhall/beads --json number,title,state,mergedAt,mergeCommit --jq '"#\(.number) \(.state) merged=\(.mergedAt) sha=\(.mergeCommit.oid[0:9]) \(.title)"'
#4158 MERGED merged=2026-06-19T16:07:03Z sha=1d4dbb5ff fix(list): disable default truncation when stdout is piped (test fix from PR #4114)
$ git show 1d4dbb5ff --stat --format=%h\ %s | head -5
1d4dbb5ff fix(list): disable default truncation when stdout is piped (GH#4094) (#4158)

 cmd/bd/list_embedded_test.go | 9 +++++----
 cmd/bd/list_input.go         | 2 ++
 cmd/bd/list_output.go        | 2 +-
$ git show 1d4dbb5ff -- cmd/bd/list.go | grep -c 'IntP("limit"'
0
$ git log --oneline -S'(default 50, use 0 for unlimited)' e05000d64 -- cmd/bd/list.go
5c1cd2b9f feat: add default limit of 50 to bd list (bd-v5fn, GH#788)
$ gh pr view 5974 --repo gastownhall/beads --json number,title,state --jq '"#\(.number) \(.state) \(.title)"'
#5974 OPEN fix(list,query): emit truncation signals for piped and JSON consumers (#5102)
$ gh pr diff 5974 --repo gastownhall/beads | grep -c 'IntP("limit"'
0
```

So #4158 added the piped arm without touching the flag registration; the `(default 50, use 0 for unlimited)`
string dates from GH#788 (5c1cd2b9f); and the open #5974 changes truncation notices, not this flag line, so the
two do not conflict.

### Docs gate

```
$ tail -1 docs/cli-docs.pin
v1.2.2
$ grep -n -- '-n, --limit' docs/cli-reference/list.md docs/CLI_REFERENCE.md | grep 'Limit results (default 50, use 0 for unlimited)'
docs/cli-reference/list.md:45:  -n, --limit int                    Limit results (default 50, use 0 for unlimited) (default 50)
docs/CLI_REFERENCE.md:923:  -n, --limit int                    Limit results (default 50, use 0 for unlimited) (default 50)
```

Per the pin file's header, the docs pipeline builds `bd` from the pinned release tag, so these two lines pick up
the new string at the next release bump plus `./scripts/generate-cli-docs.sh`; editing them here would be
overwritten.

### Verification (2026-09-04, `go version go1.26.5 darwin/arm64`, run from the branch worktree)

```
$ gofmt -l cmd/bd
$ CGO_ENABLED=0 go vet -tags gms_pure_go ./cmd/bd/
$ BEADS_TEST_SKIP=dolt CGO_ENABLED=0 go test -tags gms_pure_go -timeout 10m ./cmd/bd/ -run 'ListLimit' -count=1 -v 2>&1 | grep -E '^(--- |    --- |ok|FAIL|PASS|SKIP)'
--- PASS: TestListLimitPolicyIsResolvedBeforeTheRequest (0.02s)
    --- PASS: TestListLimitPolicyIsResolvedBeforeTheRequest/an_explicit_limit_wins (0.00s)
    --- PASS: TestListLimitPolicyIsResolvedBeforeTheRequest/an_explicit_zero_stays_unlimited (0.00s)
    --- PASS: TestListLimitPolicyIsResolvedBeforeTheRequest/--all_is_unlimited (0.00s)
    --- PASS: TestListLimitPolicyIsResolvedBeforeTheRequest/piped_stdout_is_unlimited,_not_the_shared_default (0.00s)
--- PASS: TestListLimitHelpDescribesPipedBehavior (0.02s)
    --- PASS: TestListLimitHelpDescribesPipedBehavior/an_explicit_--limit_outranks_--all (0.00s)
    --- PASS: TestListLimitHelpDescribesPipedBehavior/--all_is_unlimited_even_with_list.limit_configured (0.00s)
    --- PASS: TestListLimitHelpDescribesPipedBehavior/piped_output_takes_a_configured_list.limit (0.00s)
PASS
ok  	github.com/steveyegge/beads/cmd/bd	0.925s
$ BEADS_TEST_SKIP=dolt CGO_ENABLED=0 go test -tags gms_pure_go -timeout 10m ./cmd/bd/ -count=1 > full.log 2>&1; tail -3 full.log
FAIL
FAIL	github.com/steveyegge/beads/cmd/bd	64.849s
FAIL
$ grep -c '^--- FAIL' full.log
18
$ grep -c 'embedded Dolt requires a CGO build' full.log
19
$ grep '^--- FAIL' full.log | grep -c -i list
0
$ grep -m1 'embedded Dolt' full.log
        Error: failed to open Dolt store: embedded Dolt requires a CGO build, but this bd binary was built with CGO_ENABLED=0.
$ go run -tags gms_pure_go ./cmd/bd list --help 2>&1 | grep -A1 -- '--limit'
  -n, --limit int                    Limit results (an explicit --limit always wins, 0 meaning unlimited; otherwise --all is unlimited; otherwise a configured list.limit applies; otherwise unlimited when piped, else 20 in agent mode at a terminal, else 50) (default 50)
      --long                         Show detailed multi-line output for each issue
```

The new test fails on the base tree by construction: it compares `listCmd.Flags().Lookup("limit").Usage` for
equality against the full new string, and the base registration is

```
$ git show e05000d64:cmd/bd/list.go | awk 'NR==412 {print NR": "$0}'
412: 	listCmd.Flags().IntP("limit", "n", workapi.DefaultListLimit, "Limit results (default 50, use 0 for unlimited)")
```

Of the three behavioural subtests, only `piped output takes a configured list.limit` skips when `go test` is
run with a terminal stdout (it demonstrates :309 outranking :311, which needs a pipe); the other two hold at a
terminal as well and always run.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
