### PR TITLE
feat(count): accept --has-metadata-key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`bd count` accepts `--has-metadata-key`**
+  ([#6160](https://github.com/gastownhall/beads/issues/6160)), closing the last
+  metadata-filter gap against `bd list`, `bd ready` and `bd search`. A caller
+  counting rows that merely carry a key no longer has to list them and measure
+  the page.
+
 - **`bd count` supports repeatable `--metadata-field key=value` filters**
   ([#6023](https://github.com/gastownhall/beads/issues/6023)), so callers can
   count the same metadata-scoped set `bd list` returns without fetching every

--- a/cmd/bd/count.go
+++ b/cmd/bd/count.go
@@ -121,6 +121,12 @@ func parseCountRequest(cmd *cobra.Command) (issueops.CountRequest, issueops.Coun
 			request.MetadataFields[k] = v
 		}
 	}
+	if k, _ := cmd.Flags().GetString("has-metadata-key"); k != "" {
+		if err := storage.ValidateMetadataKey(k); err != nil {
+			return issueops.CountRequest{}, "", HandleErrorRespectJSON("invalid --has-metadata-key: %v", err)
+		}
+		request.HasMetadataKey = k
+	}
 
 	if cmd.Flags().Changed("priority") {
 		priority, _ := cmd.Flags().GetInt("priority")
@@ -279,6 +285,7 @@ func registerCountFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("no-assignee", false, "Filter issues with no assignee")
 	cmd.Flags().Bool("no-labels", false, "Filter issues with no labels")
 	cmd.Flags().StringArray("metadata-field", nil, "Filter by metadata field (key=value, repeatable)")
+	cmd.Flags().String("has-metadata-key", "", "Filter issues that have this metadata key set")
 
 	// Priority ranges
 	cmd.Flags().Int("priority-min", 0, "Filter by minimum priority (inclusive)")

--- a/cmd/bd/count_embedded_test.go
+++ b/cmd/bd/count_embedded_test.go
@@ -90,12 +90,16 @@ func TestEmbeddedCount(t *testing.T) {
 	bdCreate(t, bd, dir, "Count labeled two", "--type", "task", "--label", "backend")
 	bdCreate(t, bd, dir, "Count notes issue", "--type", "task", "--description", "notes keyword here")
 	bdCreate(t, bd, dir, "Count metadata issue", "--type", "task", "--metadata", `{"count_scope":"matching"}`)
+	// The same key with a different value: --has-metadata-key matches both
+	// fixtures where --metadata-field matches one, so the two filters cannot
+	// pass by answering the same number.
+	bdCreate(t, bd, dir, "Count metadata key issue", "--type", "task", "--metadata", `{"count_scope":"other"}`)
 
 	// ===== Basic count =====
 
 	t.Run("basic_count_no_filters", func(t *testing.T) {
 		out := strings.TrimSpace(bdCount(t, bd, dir))
-		// Should return a number >= 9 (we created 9 issues)
+		// Should return a number >= 10 (we created 10 issues)
 		if out == "0" {
 			t.Error("expected non-zero count")
 		}
@@ -176,6 +180,14 @@ func TestEmbeddedCount(t *testing.T) {
 		want := len(bdListJSON(t, bd, dir, "--all", "--limit", "0", "--metadata-field", "count_scope=matching"))
 		if got != want || got != 1 {
 			t.Errorf("count --metadata-field = %d, want list cardinality %d and fixture count 1", got, want)
+		}
+	})
+
+	t.Run("filter_by_has_metadata_key", func(t *testing.T) {
+		got := int(bdCountJSON(t, bd, dir, "--has-metadata-key", "count_scope")["count"].(float64))
+		want := len(bdListJSON(t, bd, dir, "--all", "--limit", "0", "--has-metadata-key", "count_scope"))
+		if got != want || got != 2 {
+			t.Errorf("count --has-metadata-key = %d, want list cardinality %d and fixture count 2", got, want)
 		}
 	})
 

--- a/cmd/bd/count_filter_test.go
+++ b/cmd/bd/count_filter_test.go
@@ -65,6 +65,7 @@ func TestParseCountRequestCarriesEveryFilterFlag(t *testing.T) {
 		"no-assignee":       "true",
 		"no-labels":         "true",
 		"metadata-field":    "team=platform",
+		"has-metadata-key":  "audit_ref",
 		"priority":          "1",
 		"priority-min":      "0",
 		"priority-max":      "4",
@@ -118,6 +119,7 @@ func TestParseCountRequestCarriesEveryFilterFlag(t *testing.T) {
 		NoAssignee:     true,
 		NoLabels:       true,
 		MetadataFields: map[string]string{"team": "platform"},
+		HasMetadataKey: "audit_ref",
 		IncludeInfra:   true,
 	}
 	if !reflect.DeepEqual(request, want) {
@@ -136,6 +138,16 @@ func TestParseCountRequestRejectsInvalidMetadataField(t *testing.T) {
 				t.Fatalf("parseCountRequest accepted --metadata-field %q", value)
 			}
 		})
+	}
+}
+
+func TestParseCountRequestRejectsInvalidHasMetadataKey(t *testing.T) {
+	flags := newCountFlagSet(t)
+	if err := flags.Flags().Set("has-metadata-key", "1bad"); err != nil {
+		t.Fatalf("set --has-metadata-key: %v", err)
+	}
+	if _, _, err := parseCountRequest(flags); err == nil {
+		t.Fatal("parseCountRequest accepted --has-metadata-key 1bad")
 	}
 }
 

--- a/cmd/bd/count_proxied_integration_test.go
+++ b/cmd/bd/count_proxied_integration_test.go
@@ -31,6 +31,9 @@ func TestProxiedServerCount(t *testing.T) {
 	bdProxiedCreate(t, bd, p.dir, "Count labeled two", "--type", "task", "--label", "backend")
 	bdProxiedCreate(t, bd, p.dir, "Count notes issue", "--type", "task", "--description", "notes keyword here")
 	bdProxiedCreate(t, bd, p.dir, "Count metadata issue", "--type", "task", "--metadata", `{"count_scope":"matching"}`)
+	// The same key with a different value, so --has-metadata-key and
+	// --metadata-field cannot pass by answering the same number.
+	bdProxiedCreate(t, bd, p.dir, "Count metadata key issue", "--type", "task", "--metadata", `{"count_scope":"other"}`)
 
 	// countInt runs "count <args>" and parses the plain integer stdout.
 	countInt := func(t *testing.T, args ...string) int {
@@ -126,6 +129,13 @@ func TestProxiedServerCount(t *testing.T) {
 		got := countJSONInt(t, "--metadata-field", "count_scope=matching")
 		if want := listCount("--metadata-field", "count_scope=matching"); got != want || got != 1 {
 			t.Errorf("count --metadata-field = %d, want list cardinality %d and fixture count 1", got, want)
+		}
+	})
+
+	t.Run("filter_by_has_metadata_key", func(t *testing.T) {
+		got := countJSONInt(t, "--has-metadata-key", "count_scope")
+		if want := listCount("--has-metadata-key", "count_scope"); got != want || got != 2 {
+			t.Errorf("count --has-metadata-key = %d, want list cardinality %d and fixture count 2", got, want)
 		}
 	})
 

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -2350,6 +2350,9 @@ type CountIssuesParams struct {
 	// MetadataField Top-level metadata equality filter as `key=value`, split on the first `=`. Repeatable. An invalid key is a 400.
 	MetadataField *[]string `form:"metadata_field,omitempty" json:"metadata_field,omitempty"`
 
+	// HasMetadataKey Only issues carrying this top-level metadata key.
+	HasMetadataKey *string `form:"has_metadata_key,omitempty" json:"has_metadata_key,omitempty"`
+
 	// IncludeInfra Count the cardinality of `bd list --include-infra --all` instead of the durable plane. IT CHANGES FOUR THINGS AT ONCE, and they are listed rather than summarized because a caller reading "include infra" would expect one:
 	//
 	// the ephemeral wisps tier is MERGED IN, picking up both wisps and the `no_history` beads that are durable work stored in that tier; template molecules are EXCLUDED, which a default count includes; gate beads are EXCLUDED unless `type=gate` asks for them by name; and a `type` this workspace calls infra ROUTES the count to the ephemeral tier instead of the durable one.

--- a/internal/httpapi/count_test.go
+++ b/internal/httpapi/count_test.go
@@ -114,6 +114,7 @@ func TestCountForwardsEveryDocumentedParameter(t *testing.T) {
 		"no_assignee":       {"true"},
 		"no_labels":         {"true"},
 		"metadata_field":    {"team=platform", "env=prod"},
+		"has_metadata_key":  {"audit_ref"},
 		"include_infra":     {"true"},
 	}.Encode())
 	if resp.StatusCode != http.StatusOK {
@@ -163,6 +164,7 @@ func TestCountForwardsEveryDocumentedParameter(t *testing.T) {
 		NoAssignee:     true,
 		NoLabels:       true,
 		MetadataFields: map[string]string{"team": "platform", "env": "prod"},
+		HasMetadataKey: "audit_ref",
 
 		IncludeInfra: true,
 	}
@@ -540,9 +542,10 @@ func TestCountParametersMatchTheHandler(t *testing.T) {
 // It also keeps the role's group refusal unreachable from the wire: the
 // handler refuses an unknown group at the edge. Metadata validation is a
 // separate path. An invalid key reaches BuildCountFilter, whose role refusal
-// failReadErr classifies as a 400 on `metadata_field`. This test guards only the
-// group vocabulary; if that enum and the role's constants diverged, a value the
-// server accepted and the role refused would arrive as an unclassified 500.
+// failReadErr classifies as a 400 on `metadata_field` or `has_metadata_key`.
+// This test guards only the group vocabulary; if that enum and the role's
+// constants diverged, a value the server accepted and the role refused would
+// arrive as an unclassified 500.
 func TestCountGroupEnumMatchesTheRolesVocabulary(t *testing.T) {
 	doc := loadSpec(t)
 	so := specOps(t, doc)["countIssues"]
@@ -568,7 +571,7 @@ func TestCountGroupEnumMatchesTheRolesVocabulary(t *testing.T) {
 // The other two are already mechanical: TestCountParametersMatchTheHandler ties
 // the parameter names to the DOCUMENT, and TestCountForwardsEveryDocumentedParameter
 // ties each parameter's VALUE to the field it lands in. Neither can see a role
-// field that no parameter reaches — a 24th filter added to CountRequest and left
+// field that no parameter reaches — a 25th filter added to CountRequest and left
 // unpublished turns nothing red, and the wire silently stops being able to ask
 // a question the role can answer. That is the failure this map closes, and it is
 // the one that matters for an HTTP-backed store: it is how the wire becomes
@@ -600,11 +603,12 @@ var countFieldForParameter = map[string]string{
 	"no_assignee":       "NoAssignee",
 	"no_labels":         "NoLabels",
 	"metadata_field":    "MetadataFields",
+	"has_metadata_key":  "HasMetadataKey",
 	"include_infra":     "IncludeInfra",
 }
 
-// TestEveryCountRequestFieldIsPublished: the role publishes 24 filters and the
-// wire publishes all 24. A field added to issueops.CountRequest fails here and
+// TestEveryCountRequestFieldIsPublished: the role publishes 25 filters and the
+// wire publishes all 25. A field added to issueops.CountRequest fails here and
 // NAMES itself, so the choice is made deliberately — publish it, or record why
 // it is withheld — rather than by nobody noticing.
 //

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -719,9 +719,10 @@ var operationCodes = map[string][]Code{
 	// malformed values, repeated single-valued parameters and a `group_by`
 	// outside the closed set. countGroupOf stops that last case at the edge.
 	// The role has exactly one reachable refusal: BuildCountFilter rejects an
-	// invalid metadata key. failReadErr classifies it through invalidFilterParam
-	// as a 400 on `metadata_field`. An unrecognized status or type is not a
-	// refusal; the role promises it matches nothing and answers 0.
+	// invalid metadata key, from `metadata_field` or `has_metadata_key`.
+	// failReadErr classifies it through invalidFilterParam as a 400 naming the
+	// parameter it came from. An unrecognized status or type is not a refusal;
+	// the role promises it matches nothing and answers 0.
 	OpCountIssues: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The listing's vocabulary minus the cursor: this operation has none, so
 	// invalid_cursor cannot arise. An unparseable EXPRESSION is an

--- a/internal/httpapi/reads.go
+++ b/internal/httpapi/reads.go
@@ -217,6 +217,7 @@ func countFilters(q *query) issueops.CountRequest {
 		NoAssignee:     q.boolean("no_assignee"),
 		NoLabels:       q.boolean("no_labels"),
 		MetadataFields: q.metadataFields("metadata_field"),
+		HasMetadataKey: q.str("has_metadata_key"),
 
 		// The plane switch, forwarded as the boolean the caller sent. What it
 		// MEANS — merge the wisps tier, drop templates, drop gates, and route an

--- a/internal/httpapi/reads_test.go
+++ b/internal/httpapi/reads_test.go
@@ -160,6 +160,7 @@ func TestABuilderRefusalIsTheDocumentedBadRequest(t *testing.T) {
 		{"a metadata field key on the ready surface", "/v0/beads/ready?metadata_field=1bad=x", "metadata_field"},
 		{"a has-metadata key on the ready surface", "/v0/beads/ready?has_metadata_key=1bad", "has_metadata_key"},
 		{"a metadata field key on the count surface", "/v0/beads/issues:count?metadata_field=1bad=x", "metadata_field"},
+		{"a has-metadata key on the count surface", "/v0/beads/issues:count?has_metadata_key=1bad", "has_metadata_key"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ts, _ := newReadServer(t, Config{})

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -1956,6 +1956,11 @@ paths:
             type: array
             items:
               type: string
+        - name: has_metadata_key
+          in: query
+          description: Only issues carrying this top-level metadata key.
+          schema:
+            type: string
         - name: include_infra
           in: query
           description: >-
@@ -2029,9 +2034,9 @@ paths:
             A malformed `metadata_field` shape and an unknown `group_by` are
             transport refusals. An invalid metadata key passes query decoding,
             then `BuildCountFilter` rejects it and `failReadErr` classifies the
-            role's error as a `400` on `metadata_field`. An unrecognized
-            `status` or `type` is not a refusal; it matches nothing and answers
-            `0`.
+            role's error as a `400` naming the parameter it came from —
+            `metadata_field` or `has_metadata_key`. An unrecognized `status` or
+            `type` is not a refusal; it matches nothing and answers `0`.
           x-bd-codes: [invalid_argument]
           content:
             application/problem+json:

--- a/internal/workapi/count.go
+++ b/internal/workapi/count.go
@@ -67,7 +67,10 @@ func BuildCountFilter(in issueops.CountRequest, cfg ListConfig) (types.IssueFilt
 	if len(in.MetadataFields) > 0 {
 		filter.MetadataFields = in.MetadataFields
 	}
-	if err := ValidateMetadataFilters(in.MetadataFields, ""); err != nil {
+	if in.HasMetadataKey != "" {
+		filter.HasMetadataKey = in.HasMetadataKey
+	}
+	if err := ValidateMetadataFilters(in.MetadataFields, in.HasMetadataKey); err != nil {
 		return types.IssueFilter{}, err
 	}
 

--- a/internal/workapi/count_test.go
+++ b/internal/workapi/count_test.go
@@ -173,6 +173,20 @@ func TestBuildCountFilterCarriesMetadataFields(t *testing.T) {
 	}
 }
 
+func TestBuildCountFilterCarriesHasMetadataKey(t *testing.T) {
+	got, err := BuildCountFilter(issueops.CountRequest{HasMetadataKey: "audit_ref"}, ListConfig{})
+	if err != nil {
+		t.Fatalf("BuildCountFilter: %v", err)
+	}
+	if got.HasMetadataKey != "audit_ref" {
+		t.Errorf("HasMetadataKey = %q, want %q", got.HasMetadataKey, "audit_ref")
+	}
+
+	if _, err := BuildCountFilter(issueops.CountRequest{HasMetadataKey: "1bad"}, ListConfig{}); err == nil {
+		t.Fatal("BuildCountFilter accepted an invalid has-metadata key")
+	}
+}
+
 // TestBuildCountFilterTakesStatusAndTypeAsWritten pins the deliberate absence
 // of validation: an unrecognized status or type reaches the filter as written
 // and matches nothing, rather than failing. A scripted caller counting a

--- a/issueops/counter.go
+++ b/issueops/counter.go
@@ -92,8 +92,11 @@ type CountRequest struct {
 	TitleContains string
 	DescContains  string
 	NotesContains string
-	// MetadataFields requires equality for every top-level key/value pair.
+	// MetadataFields requires equality for every top-level key/value pair and
+	// HasMetadataKey is a top-level key-presence filter, spelled as
+	// ListRequest and ReadyRequest spell them. Keys are validated inside.
 	MetadataFields map[string]string
+	HasMetadataKey string
 
 	CreatedAfter  *time.Time
 	CreatedBefore *time.Time


### PR DESCRIPTION
## What

`bd count` now accepts `--has-metadata-key`, the key-presence filter `bd list`, `bd ready` and `bd search` already take. Parsing, validation and the error wording match `list_input.go` and `ready_input.go`. The HTTP surface gains the matching `has_metadata_key` query parameter on `GET /v0/beads/issues:count`.

## Why

Fixes #6160.

Counting the rows that merely carry a metadata key meant listing them and measuring the page. This was the last metadata-filter gap between `count` and the listings, and follow-on to #6024, which added `--metadata-field`.

One PR rather than a stack, because the storage layer already carries the filter: `types.IssueFilter.HasMetadataKey` exists and `sqlbuild.AppendMetadataClauses` already consumes it. Two other pieces were also already in place, which is why the diff is small. `workapi.ValidateMetadataFilters(fields, hasKey)` already accepted the key, and `BuildCountFilter` was passing `""` into it, so wiring the key through is what makes the role's existing refusal reachable from the count surface. `invalidFilterParam` already maps that refusal to the `has_metadata_key` parameter, so the 400 lands on the right name with no new classification code.

`apigen/types.gen.go` is regenerated from the spec with the repo's own `go:generate` directive, not hand edited. The pinned CLI docs under `docs/` are untouched, per `docs/cli-docs.pin`.

## Verification

Red first, per layer, by reverting the wiring in `cmd/bd/count.go`, `internal/workapi/count.go` and `internal/httpapi/reads.go` while keeping the struct field so the tree still compiled:

- `count_filter_test.go:75: set --has-metadata-key=audit_ref: no such flag -has-metadata-key`
- `count_test.go:182: HasMetadataKey = "", want "audit_ref"`
- `TestCountParametersMatchTheHandler`: `the document publishes parameters this handler never reads ... [has_metadata_key]`
- `TestABuilderRefusalIsTheDocumentedBadRequest/a_has-metadata_key_on_the_count_surface`: reason `unknown_parameter` instead of `invalid_value`

Then green:

```
go build -tags gms_pure_go ./...
./scripts/test.sh ./cmd/bd/...
./scripts/test.sh ./internal/httpapi/... ./internal/workapi/...
make test
BEADS_TEST_EMBEDDED_DOLT=1 ./scripts/test.sh -run '^TestEmbeddedCount$' ./cmd/bd/
BEADS_TEST_ENV_RUN_DOLT=1 BEADS_TEST_PROXIED_SERVER=1 ./scripts/test.sh -count=1 -run '^TestProxiedServerCount$' ./cmd/bd/
```

Both integration tests are opt-in and skip silently without those variables, so they were run with them set. `filter_by_has_metadata_key` passes on the embedded route and against a real `dolt-sql-server` on the proxied route. Its fixture adds a second bead carrying the same key with a different value, so `--has-metadata-key count_scope` answers 2 where `--metadata-field count_scope=matching` answers 1. Without that, key-presence and equality could both pass by returning the same number.

Docs gates, neither of which regenerates the pinned reference:

```
./scripts/check-cli-docs-drift.sh --base main    # PASS: generated CLI docs are fresh
./scripts/check-doc-flags.sh                     # PASSED
```

Lint at CI's scope, 0 issues:

```
golangci-lint run --config=.golangci.yml --build-tags=gms_pure_go --new-from-merge-base=main ./...
```

One note on `make ci-pr-lint`: its gofmt step is already red on `main` for `internal/storage/{dolt,embeddeddolt,uow}/role_fixture_kit_test.go`. Confirmed pre-existing with `git show main:<file> | gofmt -l`; this branch touches none of them.

Manual check against a scratch workspace, three beads, two of which carry `audit_ref`:

```
bd count --has-metadata-key audit_ref --json      -> {"count": 2}
bd count --metadata-field audit_ref=a1 --json     -> {"count": 1}
bd count --has-metadata-key nosuchkey --json      -> {"count": 0}
bd count --has-metadata-key 1bad --json           -> error, exit 1
```

`bd list --has-metadata-key audit_ref --all --limit 0 --json` returns the same 2 rows the count reports. An unknown key answers 0 rather than refusing, which is the promise `CountRequest` already makes for an unrecognized status or type.
