### PR TITLE
fix(dolt): report Unix-socket server topology truthfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`bd dolt status` and `bd info` report externally managed Unix-socket
+  topology truthfully** ([#6017](https://github.com/gastownhall/beads/issues/6017)).
+  Status now probes the configured socket and database instead of treating a
+  missing repo-local PID file (and port zero) as proof that the server is down.
+  Info labels direct CLI access separately from Dolt mode and transport, so a
+  shared server is no longer presented ambiguously as merely `Mode: direct`.
+
 - **`bd prime` says when it could NOT read the memory plane**
   ([#5877](https://github.com/gastownhall/beads/issues/5877)). A broken or
   unreachable store made prime omit the memory section entirely, so a session

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -1200,6 +1200,13 @@ func shouldUseExternalDoltStatus(cfg *configfile.Config, autoStartDisabled, shar
 	if sharedServerMode && !cfg.IsDoltProxiedServerMode() {
 		return true
 	}
+	// A configured Unix socket is an endpoint owned outside the repo-local
+	// PID-file lifecycle. Treat it like every other externally-managed server:
+	// probe the configured endpoint instead of claiming that a missing local
+	// PID file means the server is down (GH#6017).
+	if cfg.IsDoltServerMode() && cfg.GetDoltServerSocket() != "" {
+		return true
+	}
 	if !cfg.IsDoltServerMode() {
 		return false
 	}
@@ -1229,6 +1236,7 @@ func isLocalHost(host string) bool {
 // user-relevant signals.
 func runExternalDoltStatus(beadsDir string, cfg *configfile.Config) {
 	host := cfg.GetDoltServerHost()
+	socket := cfg.GetDoltServerSocket()
 	port := doltserver.DefaultConfig(beadsDir).Port
 	user := cfg.GetDoltServerUser()
 	database := cfg.GetDoltDatabase()
@@ -1237,6 +1245,7 @@ func runExternalDoltStatus(beadsDir string, cfg *configfile.Config) {
 
 	dsn := doltutil.ServerDSN{
 		Host:     host,
+		Socket:   socket,
 		Port:     port,
 		User:     user,
 		Password: password,
@@ -1251,6 +1260,14 @@ func runExternalDoltStatus(beadsDir string, cfg *configfile.Config) {
 		"user":     user,
 		"database": database,
 		"tls":      tls,
+	}
+	if socket != "" {
+		result["transport"] = "unix_socket"
+		result["socket"] = socket
+		delete(result, "host")
+		delete(result, "port")
+	} else {
+		result["transport"] = "tcp"
 	}
 
 	db, openErr := sql.Open("mysql", dsn)
@@ -1293,8 +1310,12 @@ func runExternalDoltStatus(beadsDir string, cfg *configfile.Config) {
 	} else {
 		fmt.Println("Dolt server: not reachable (external)")
 	}
-	fmt.Printf("  Host:     %s\n", host)
-	fmt.Printf("  Port:     %d\n", port)
+	if socket != "" {
+		fmt.Printf("  Socket:   %s\n", socket)
+	} else {
+		fmt.Printf("  Host:     %s\n", host)
+		fmt.Printf("  Port:     %d\n", port)
+	}
 	fmt.Printf("  Database: %s\n", database)
 	fmt.Printf("  User:     %s\n", user)
 	fmt.Printf("  TLS:      %t\n", tls)

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -1546,6 +1546,41 @@ func TestRunExternalDoltStatus_Unreachable(t *testing.T) {
 	})
 }
 
+func TestRunExternalDoltStatus_UnreachableUnixSocket(t *testing.T) {
+	beadsDir := t.TempDir()
+	socket := filepath.Join(beadsDir, "missing.sock")
+	cfg := &configfile.Config{
+		DoltMode:         "server",
+		DoltServerSocket: socket,
+		DoltServerUser:   "root",
+		DoltDatabase:     "beads_socket",
+	}
+
+	orig := jsonOutput
+	defer func() { jsonOutput = orig }()
+	jsonOutput = false
+	out := captureStdout(t, func() error { runExternalDoltStatus(beadsDir, cfg); return nil })
+	if !strings.Contains(out, "Socket:   "+socket) {
+		t.Fatalf("expected configured socket in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "Expected port:") || strings.Contains(out, "Host:") {
+		t.Fatalf("socket status must not fall back to PID/TCP output, got:\n%s", out)
+	}
+
+	jsonOutput = true
+	out = captureStdout(t, func() error { runExternalDoltStatus(beadsDir, cfg); return nil })
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("expected valid JSON, got %v: %s", err, out)
+	}
+	if result["transport"] != "unix_socket" || result["socket"] != socket {
+		t.Fatalf("expected unix socket topology, got: %#v", result)
+	}
+	if _, ok := result["port"]; ok {
+		t.Fatalf("socket topology must not publish a misleading port: %#v", result)
+	}
+}
+
 // TestShouldUseExternalDoltStatus covers the routing predicate for
 // `bd dolt status`. The predicate decides whether to ping the configured
 // SQL endpoint (externally-managed server) or read the local PID file
@@ -1576,6 +1611,17 @@ func TestShouldUseExternalDoltStatus(t *testing.T) {
 			},
 			autoStartDisabled: true, // even with auto-start off
 			want:              false,
+		},
+		{
+			name: "server mode + configured Unix socket routes to external (GH#6017)",
+			cfg: &configfile.Config{
+				Backend:          "dolt",
+				DoltMode:         "server",
+				DoltServerSocket: "/tmp/dolt.sock",
+			},
+			autoStartDisabled: false,
+			sharedServerMode:  false,
+			want:              true,
 		},
 		{
 			name: "server mode + remote host always uses external status",

--- a/cmd/bd/info.go
+++ b/cmd/bd/info.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/workapi"
@@ -58,11 +59,12 @@ Examples:
 		}
 
 		absDBPath := absoluteDBPath()
-
-		info := map[string]interface{}{
-			"database_path": absDBPath,
-			"mode":          "direct",
+		beadsDir := selectedDoltBeadsDir()
+		cfg, err := loadDoltBackendConfig(beadsDir)
+		if err != nil {
+			return HandleError("cannot resolve database topology for bd info: %v", err)
 		}
+		info := buildDirectInfo(absDBPath, cfg)
 
 		if store != nil {
 			ctx := rootCtx
@@ -100,6 +102,34 @@ Examples:
 
 		return renderInfo(info, schemaFlag, absDBPath)
 	},
+}
+
+func buildDirectInfo(absDBPath string, cfg *configfile.Config) map[string]interface{} {
+	info := map[string]interface{}{
+		"database_path": absDBPath,
+		// Keep mode for JSON compatibility; it describes CLI access, not the
+		// Dolt deployment topology. New consumers should use access_mode.
+		"mode":        "direct",
+		"access_mode": "direct",
+	}
+	if cfg == nil || cfg.GetBackend() != configfile.BackendDolt {
+		return info
+	}
+
+	doltMode := cfg.GetDoltMode()
+	info["dolt_mode"] = doltMode
+	switch {
+	case doltMode == configfile.DoltModeEmbedded:
+		info["transport"] = "embedded"
+	case cfg.GetDoltServerSocket() != "":
+		info["transport"] = "unix_socket"
+		info["socket"] = cfg.GetDoltServerSocket()
+	default:
+		info["transport"] = "tcp"
+		info["host"] = cfg.GetDoltServerHost()
+		info["port"] = cfg.GetDoltServerPort()
+	}
+	return info
 }
 
 func absoluteDBPath() string {
@@ -145,12 +175,24 @@ func renderInfo(info map[string]interface{}, schemaFlag bool, absDBPath string) 
 		return outputJSON(info)
 	}
 
-	mode, _ := info["mode"].(string)
+	accessMode, _ := info["access_mode"].(string)
+	if accessMode == "" {
+		accessMode, _ = info["mode"].(string)
+	}
 
 	fmt.Println("\nBeads Database Information")
 	fmt.Println("===========================")
 	fmt.Printf("Database: %s\n", absDBPath)
-	fmt.Printf("Mode: %s\n", mode)
+	fmt.Printf("Access mode: %s\n", accessMode)
+	if doltMode, ok := info["dolt_mode"].(string); ok && doltMode != "" {
+		fmt.Printf("Dolt mode: %s\n", doltMode)
+	}
+	if transport, ok := info["transport"].(string); ok && transport != "" {
+		fmt.Printf("Transport: %s\n", transport)
+	}
+	if socket, ok := info["socket"].(string); ok && socket != "" {
+		fmt.Printf("Socket: %s\n", socket)
+	}
 
 	if count, ok := info["issue_count"].(int); ok {
 		fmt.Printf("\nIssue Count: %d\n", count)

--- a/cmd/bd/info_kv_exclusion_test.go
+++ b/cmd/bd/info_kv_exclusion_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage/kvkeys"
 	"github.com/steveyegge/beads/internal/workapi"
 )
@@ -43,5 +44,34 @@ func TestInfoConfigExcludesTheKVPlane(t *testing.T) {
 		if _, ok := got[want]; !ok {
 			t.Errorf("%q was dropped; only keys under %q may be", want, kvkeys.Prefix)
 		}
+	}
+}
+
+func TestBuildDirectInfoSeparatesAccessFromDoltTopology(t *testing.T) {
+	socket := "/tmp/shared-dolt.sock"
+	got := buildDirectInfo("/repo/.beads/dolt", &configfile.Config{
+		Backend:          configfile.BackendDolt,
+		DoltMode:         configfile.DoltModeServer,
+		DoltServerSocket: socket,
+	})
+
+	if got["access_mode"] != "direct" {
+		t.Fatalf("access_mode = %v, want direct", got["access_mode"])
+	}
+	if got["dolt_mode"] != configfile.DoltModeServer {
+		t.Fatalf("dolt_mode = %v, want server", got["dolt_mode"])
+	}
+	if got["transport"] != "unix_socket" || got["socket"] != socket {
+		t.Fatalf("expected Unix-socket topology, got %#v", got)
+	}
+
+	out := captureStdout(t, func() error { return renderInfo(got, false, "/repo/.beads/dolt") })
+	for _, want := range []string{"Access mode: direct", "Dolt mode: server", "Transport: unix_socket", "Socket: " + socket} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "\nMode: direct") {
+		t.Fatalf("ambiguous topology label remains in output:\n%s", out)
 	}
 }


### PR DESCRIPTION
Fixes #6017.

## Summary

- `bd dolt status` now probes a configured Unix socket and database instead of
  falling through to repo-local PID bookkeeping and `Expected port: 0`.
- `bd info` separates direct CLI access from Dolt mode and transport.
- JSON output adds `access_mode`, `dolt_mode`, `transport`, and `socket`, while
  retaining the existing `mode` field for compatibility.

## Root cause

The external-status predicate covered remote TCP hosts, disabled auto-start,
and the separate shared-server flag, but not an explicit Unix socket in
server-mode metadata. Its SQL probe also omitted that socket from the DSN.
Separately, `bd info` hard-coded `mode: direct` and rendered it as an
unqualified `Mode`, conflating access routing with deployment topology.

## Poka-yoke

The command boundary now makes diagnostic topology explicit and testable:
status probes the exact configured endpoint/database, while info exposes
access mode, Dolt mode, and transport separately. PID state remains available
for bd-managed local servers.

The stronger rule—discard PID state and use connectivity alone—is rejected:
PID/log/lock details remain useful lifecycle evidence for managed servers, and
an arbitrary listener does not prove the configured database is usable.

## Verification

- Focused Go tests for the changed status and info surfaces pass.
- A Darwin/arm64 binary built from this branch reports a live externally
  supervised Unix-socket server as `running (external)` with its configured
  database and Dolt version.
- `bd --readonly info` against the same server reports `Access mode: direct`,
  `Dolt mode: server`, and `Transport: unix_socket`.
- The broader short package suite reached two pre-existing
  permission-assumption failures under a root Docker container; neither
  failure touches these changes. The focused tests passed in that container.
