### PR TITLE
perf(issueops): batched is_blocked mark/unmark decide membership through the batch-scoped should-be-blocked union

### DIFF
--- a/internal/storage/dolt/blocked_full_repair_test.go
+++ b/internal/storage/dolt/blocked_full_repair_test.go
@@ -1,10 +1,9 @@
 package dolt
 
-// Differential coverage for the full is_blocked repair (bd-t9ypt): the
-// full-repair SQL must agree with the scoped per-write templates on EVERY
-// leg of the should-be-blocked disjunction — issue blockers, wisp blockers,
-// issue parents, wisp parents, and the waits-for gate in all its metadata
-// modes (default all-children, any-children, also_blocks,
+// Coverage for the full is_blocked repair (bd-t9ypt) across EVERY leg of the
+// should-be-blocked disjunction — issue blockers, wisp blockers, issue
+// parents, wisp parents, and the waits-for gate in all its metadata modes
+// (default all-children, any-children, also_blocks,
 // also_blocks-over-any-children) — on both the issues table and the wisps
 // table.
 //
@@ -15,6 +14,18 @@ package dolt
 // tests in blocked_consistency_test.go pin legs 1 and 3 (issue blocker,
 // issue parent) with exact corrected-row counts; this test pins the
 // remaining legs, which would otherwise have no full-repair coverage.
+//
+// What the differential half proves narrowed in gastownhall/beads#6291: both
+// sides — the ground-truth producer (batched templates) and the system under
+// test (full repair) — now render from the one shouldBeBlockedIDsUnionSQL
+// builder, so write-path-vs-full-repair agreement no longer cross-checks two
+// independently written SQL forms. It validates scope-splicing (the batched
+// legs' `AND d.issue_id IN (batch)`) and the waits-for DISTINCT barrier, which
+// the two sides do not share. Per-leg semantics are instead pinned by the
+// absolute fixture expectations in the "Sanity-pin the interesting
+// expectations" block below — hardcoded ids covering all five legs and both
+// tables, on the write path. Those pins are what makes a shared-builder leg
+// bug fail here: do not drop them as redundant with the differential compare.
 
 import (
 	"context"

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -4557,12 +4557,12 @@ func (s *DoltStore) RecomputeAllBlocked(ctx context.Context) (int, error) {
 }
 
 func (s *DoltStore) recomputeAllBlocked(ctx context.Context) (int, error) {
-	// The full pass's batched UPDATEs carry five correlated EXISTS subqueries
-	// each; on a loaded shared server a single batch can outlive the pool's
-	// per-I/O deadline (default 10s, see buildServerDSN), killing the repair
-	// with "i/o timeout" — and the retry dies the same way, so the owed
-	// recompute never lands (bd-bn8jo). Run it on a dedicated long-timeout
-	// connection like the other known-long maintenance ops.
+	// The full pass runs unbatched whole-table semi-join UPDATEs, looped until
+	// the fixpoint converges; on a loaded shared server a single one can
+	// outlive the pool's per-I/O deadline (default 10s, see buildServerDSN),
+	// killing the repair with "i/o timeout" — and the retry dies the same way,
+	// so the owed recompute never lands (bd-bn8jo). Run it on a dedicated
+	// long-timeout connection like the other known-long maintenance ops.
 	db, err := s.openLongTimeoutConn()
 	if err != nil {
 		return 0, err

--- a/internal/storage/issueops/blocked_consistency.go
+++ b/internal/storage/issueops/blocked_consistency.go
@@ -265,12 +265,14 @@ func RecomputeAllIsBlockedInTx(ctx context.Context, tx DBTX) (int64, error) {
 //
 // Unlike the scoped passes, the full repair runs UNBATCHED semi-join statements
 // (markAllBlockedSQL/unmarkAllBlockedSQL): the id lists here cover every row by
-// construction, so an IN-batch adds nothing but statement count, and the
-// batched templates' OR-of-correlated-EXISTS shape cannot be decorrelated by
-// the engine — per-outer-row subquery execution made the full repair cost
-// ~80+ statement-seconds on fast hardware and >600s on small cloud CPUs
-// (bd-t9ypt). The id lists are still captured for the journal snapshot, and
-// len(wispIDs) doubles as the "wisps table exists and has rows" signal.
+// construction, so an IN-batch adds nothing but statement count. This was the
+// first home of the decorrelated union — the batched templates' original
+// OR-of-correlated-EXISTS shape ran per outer row and made the full repair
+// cost ~80+ statement-seconds on fast hardware and >600s on small cloud CPUs
+// (bd-t9ypt); the batched templates now use the same union scoped to their
+// batch (gastownhall/beads#6288). The id lists are still captured for the
+// journal snapshot, and len(wispIDs) doubles as the "wisps table exists and
+// has rows" signal.
 func recomputeIsBlockedCounting(ctx context.Context, tx DBTX, issueIDs, wispIDs []string) (int64, error) {
 	if len(issueIDs) == 0 && len(wispIDs) == 0 {
 		return 0, nil
@@ -365,47 +367,76 @@ func unmarkAllBlockedSQL(table, alias, depTable string) string {
 
 // shouldBeBlockedIDsUnionSQL selects, UNCORRELATED with any outer row, every
 // depTable issue_id that currently has a reason to be blocked: one UNION leg
-// per branch of the correlated disjunction inside the batched mark/unmark
-// templates in blocked_state.go, in the same order. Semantically,
-// `<alias>.id IN (this select)` ≡ that disjunction: every branch
-// of the disjunction correlates with the outer row ONLY through
-// d.issue_id = <alias>.id, so membership of the outer id in the union of each
-// branch's issue_ids is the same predicate — but the engine evaluates this
-// form once as hash lookups instead of per outer row (bd-t9ypt). The lockstep
-// test pins the two forms to each other.
+// per reason — an open blocks/conditional-blocks target (issue or wisp), a
+// blocked parent-child parent (issue or wisp), a blocking waits-for gate.
+// Semantically, `<alias>.id IN (this select)` ≡ the disjunction of those
+// reasons correlated on d.issue_id = <alias>.id, which is what the batched
+// mark/unmark templates in blocked_state.go once spelled out as five
+// correlated EXISTS — but the engine evaluates this form once as hash
+// lookups instead of per outer row (bd-t9ypt). Full repair, doctor count and
+// the batched templates (scoped, see below) now share this one definition.
 //
 //nolint:gosec // G201: depTable is constant; waitsForGateBlockedSQL is a constant template.
 func shouldBeBlockedIDsUnionSQL(depTable string) string {
+	return shouldBeBlockedIDsUnionScopedSQL(depTable, "")
+}
+
+// shouldBeBlockedIDsUnionScopedSQL is shouldBeBlockedIDsUnionSQL with an
+// extra predicate on the dependency row appended to every leg's WHERE — "" for
+// the whole table (full repair, doctor count), batchScopeSQL for the batched
+// mark/unmark templates in blocked_state.go, which confine each leg to
+// d.issue_id IN (batch) so the union stays index-sized per statement. scope is
+// spliced verbatim: a %s inside it survives this Sprintf for the batch runner.
+//
+// The waits-for leg wraps its dependency rows in a DISTINCT derived table
+// BEFORE the gate predicate (waitsForGateBlockedSQL, six correlated EXISTS
+// over the parent-child children and the spawner) is applied, so the engine
+// narrows to the leg's few waits-for rows first and evaluates the gate only
+// per surviving row. Written flat, dolt 2.1.8's planner pushed the gate's
+// correlated subqueries ahead of the type filter and re-ran them against the
+// whole overlay for every candidate row — over a 19k-row uncommitted working
+// set the flat leg took 436 s while returning zero rows; behind the derived
+// table, 0.01 s (gastownhall/beads#6288, wy-pyrus4). The DISTINCT is
+// semantically free (the leg feeds a UNION, and the gate depends only on the
+// projected columns) and is what makes the barrier structural: a plain
+// single-table derived table is the mergeable shape MySQL-dialect planners
+// fold back into the outer query; a DISTINCT one is materialized.
+//
+//nolint:gosec // G201: depTable and scope are constants; waitsForGateBlockedSQL is a constant template.
+func shouldBeBlockedIDsUnionScopedSQL(depTable, scope string) string {
 	return fmt.Sprintf(`
 		SELECT d.issue_id FROM %[1]s d
 		JOIN issues t ON t.id = d.depends_on_issue_id
-		WHERE d.issue_id IS NOT NULL
+		WHERE d.issue_id IS NOT NULL %[3]s
 		  AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
 		  AND t.status <> 'closed' AND t.status <> 'pinned'
 		UNION
 		SELECT d.issue_id FROM %[1]s d
 		JOIN wisps t ON t.id = d.depends_on_wisp_id
-		WHERE d.issue_id IS NOT NULL
+		WHERE d.issue_id IS NOT NULL %[3]s
 		  AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
 		  AND t.status <> 'closed' AND t.status <> 'pinned'
 		UNION
 		SELECT d.issue_id FROM %[1]s d
 		JOIN issues p ON p.id = d.depends_on_issue_id
-		WHERE d.issue_id IS NOT NULL
+		WHERE d.issue_id IS NOT NULL %[3]s
 		  AND d.type = 'parent-child'
 		  AND p.is_blocked = 1
 		UNION
 		SELECT d.issue_id FROM %[1]s d
 		JOIN wisps p ON p.id = d.depends_on_wisp_id
-		WHERE d.issue_id IS NOT NULL
+		WHERE d.issue_id IS NOT NULL %[3]s
 		  AND d.type = 'parent-child'
 		  AND p.is_blocked = 1
 		UNION
-		SELECT d.issue_id FROM %[1]s d
-		WHERE d.issue_id IS NOT NULL
-		  AND d.type = 'waits-for'
-		  AND (%[2]s)
-	`, depTable, waitsForGateBlockedSQL)
+		SELECT d.issue_id FROM (
+		  SELECT DISTINCT d.issue_id, d.depends_on_issue_id, d.depends_on_wisp_id, d.metadata
+		  FROM %[1]s d
+		  WHERE d.issue_id IS NOT NULL %[3]s
+		    AND d.type = 'waits-for'
+		) d
+		WHERE (%[2]s)
+	`, depTable, waitsForGateBlockedSQL, scope)
 }
 
 // CountIsBlockedInconsistenciesInTx reports how many issue and wisp rows carry a

--- a/internal/storage/issueops/blocked_consistency.go
+++ b/internal/storage/issueops/blocked_consistency.go
@@ -444,7 +444,8 @@ func shouldBeBlockedIDsUnionScopedSQL(depTable, scope string) string {
 // detection behind the bd doctor "Blocked State" check (bd-6dnrw.37); the
 // repair is RecomputeAllIsBlockedInTx.
 //
-// The two share no SQL but are pinned together by the blocked-consistency
+// Both derive their membership test from the one shouldBeBlockedIDsUnionSQL
+// builder above, and they are pinned together by the blocked-consistency
 // lockstep test: a converged database counts 0, and any row this counts is one
 // a recompute pass changes. The count is a single-pass lower bound — a
 // corrupted parent's children are only counted on the pass after the parent is

--- a/internal/storage/issueops/blocked_state.go
+++ b/internal/storage/issueops/blocked_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -203,97 +204,96 @@ func markIsBlockedPassForIssuesInTx(ctx context.Context, tx DBTX, ids []string) 
 // clones that recomputed the same flip at different times, bd-578h9.19) and
 // makes stale-guard/conflict-guard consumers treat the row as user-edited.
 // An explicit assignment suppresses the ON UPDATE clause.
+//
+// Both templates decide membership through shouldBeBlockedIDsUnionScopedSQL,
+// the same uncorrelated union the full repair and the doctor count use
+// (blocked_consistency.go), scoped to the batch: one derived blocked set per
+// batch, computed once and probed by hash. The previous shape — five
+// correlated EXISTS per outer row — was re-executed per row by the engine:
+// ~4 s per 200-id batch on committed, indexed data, and unbounded (>69 min
+// observed on dolt 2.1.8) over a large uncommitted working set, where every
+// probe re-read the uncommitted overlay (gastownhall/beads#6288).
+//
+// The batch IN-list therefore appears more than once per statement — the
+// outer row filter plus one per union leg; expandBatchTemplate repeats the
+// placeholders and the bound ids to match.
+
+// batchScopeSQL is the per-leg predicate that confines the should-be-blocked
+// union to the batch (see shouldBeBlockedIDsUnionScopedSQL); its %s is filled
+// with the batch placeholders by expandBatchTemplate, never by fmt here.
+const batchScopeSQL = "AND d.issue_id IN (%s)"
+
 func markBlockedTemplateForIssues() string {
-	return fmt.Sprintf(`
-		UPDATE issues i SET i.is_blocked = 1, i.updated_at = i.updated_at
-		WHERE i.id IN (%%s)
-		  AND i.is_blocked = 0
-		  AND i.status <> 'closed' AND i.status <> 'pinned'
-		  AND (
-		    EXISTS (
-		      SELECT 1 FROM dependencies d
-		      JOIN issues t ON t.id = d.depends_on_issue_id
-		      WHERE d.issue_id = i.id
-		        AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
-		        AND t.status <> 'closed' AND t.status <> 'pinned'
-		    )
-		    OR EXISTS (
-		      SELECT 1 FROM dependencies d
-		      JOIN wisps t ON t.id = d.depends_on_wisp_id
-		      WHERE d.issue_id = i.id
-		        AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
-		        AND t.status <> 'closed' AND t.status <> 'pinned'
-		    )
-		    OR EXISTS (
-		      SELECT 1 FROM dependencies d
-		      JOIN issues p ON p.id = d.depends_on_issue_id
-		      WHERE d.issue_id = i.id
-		        AND d.type = 'parent-child'
-		        AND p.is_blocked = 1
-		    )
-		    OR EXISTS (
-		      SELECT 1 FROM dependencies d
-		      JOIN wisps p ON p.id = d.depends_on_wisp_id
-		      WHERE d.issue_id = i.id
-		        AND d.type = 'parent-child'
-		        AND p.is_blocked = 1
-		    )
-		    OR EXISTS (
-		      SELECT 1 FROM dependencies d
-		      WHERE d.issue_id = i.id AND d.type = 'waits-for'
-		        AND (%s)
-		    )
-		  )
-	`, waitsForGateBlockedSQL)
+	return markBlockedTemplate("issues", "i", "dependencies")
 }
 
 func unmarkBlockedTemplateForIssues() string {
-	return fmt.Sprintf(`
-		UPDATE issues i SET i.is_blocked = 0, i.updated_at = i.updated_at
-		WHERE i.id IN (%%s)
-		  AND i.is_blocked = 1
-		  AND (
-		    i.status = 'closed' OR i.status = 'pinned'
-		    OR (
-		      NOT EXISTS (
-		        SELECT 1 FROM dependencies d
-		        JOIN issues t ON t.id = d.depends_on_issue_id
-		        WHERE d.issue_id = i.id
-		          AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
-		          AND t.status <> 'closed' AND t.status <> 'pinned'
-		      )
-		      AND NOT EXISTS (
-		        SELECT 1 FROM dependencies d
-		        JOIN wisps t ON t.id = d.depends_on_wisp_id
-		        WHERE d.issue_id = i.id
-		          AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
-		          AND t.status <> 'closed' AND t.status <> 'pinned'
-		      )
-		      AND NOT EXISTS (
-		        SELECT 1 FROM dependencies d
-		        JOIN issues p ON p.id = d.depends_on_issue_id
-		        WHERE d.issue_id = i.id
-		          AND d.type = 'parent-child'
-		          AND p.is_blocked = 1
-		      )
-		      AND NOT EXISTS (
-		        SELECT 1 FROM dependencies d
-		        JOIN wisps p ON p.id = d.depends_on_wisp_id
-		        WHERE d.issue_id = i.id
-		          AND d.type = 'parent-child'
-		          AND p.is_blocked = 1
-		      )
-		      AND NOT EXISTS (
-		        SELECT 1 FROM dependencies d
-		        WHERE d.issue_id = i.id AND d.type = 'waits-for'
-		          AND (%s)
-		      )
-		    )
-		  )
-	`, waitsForGateBlockedSQL)
+	return unmarkBlockedTemplate("issues", "i", "dependencies")
 }
 
-//nolint:gosec // G201: SQL templates are constant; only IN-clause placeholders are formatted in.
+func markBlockedTemplateForWisps() string {
+	return markBlockedTemplate("wisps", "w", "wisp_dependencies")
+}
+
+func unmarkBlockedTemplateForWisps() string {
+	return unmarkBlockedTemplate("wisps", "w", "wisp_dependencies")
+}
+
+// markBlockedTemplate is the batched mark statement for one table: the
+// batch-scoped analog of markAllBlockedSQL. The union is confined to the
+// batch's own dependency rows, so `<alias>.id IN (union)` is exactly the
+// old correlated disjunction for every id in the batch.
+//
+//nolint:gosec // G201: table, alias, and depTable are constants from the four callers above.
+func markBlockedTemplate(table, alias, depTable string) string {
+	return fmt.Sprintf(`
+		UPDATE %[1]s %[2]s SET %[2]s.is_blocked = 1, %[2]s.updated_at = %[2]s.updated_at
+		WHERE %[2]s.id IN (%%s)
+		  AND %[2]s.is_blocked = 0
+		  AND %[2]s.status <> 'closed' AND %[2]s.status <> 'pinned'
+		  AND %[2]s.id IN (%[3]s)
+	`, table, alias, shouldBeBlockedIDsUnionScopedSQL(depTable, batchScopeSQL))
+}
+
+// unmarkBlockedTemplate is the batched unmark statement for one table: the
+// batch-scoped analog of unmarkAllBlockedSQL. NOT IN is null-hostile; the
+// union's d.issue_id IS NOT NULL guards keep it total.
+//
+//nolint:gosec // G201: table, alias, and depTable are constants from the four callers above.
+func unmarkBlockedTemplate(table, alias, depTable string) string {
+	return fmt.Sprintf(`
+		UPDATE %[1]s %[2]s SET %[2]s.is_blocked = 0, %[2]s.updated_at = %[2]s.updated_at
+		WHERE %[2]s.id IN (%%s)
+		  AND %[2]s.is_blocked = 1
+		  AND ( %[2]s.status = 'closed' OR %[2]s.status = 'pinned'
+		        OR %[2]s.id NOT IN (%[3]s) )
+	`, table, alias, shouldBeBlockedIDsUnionScopedSQL(depTable, batchScopeSQL))
+}
+
+// expandBatchTemplate fills every %s in a batched template with the same
+// IN-list placeholders and repeats the bound ids once per occurrence, in
+// order. Templates carry the batch list in the outer row filter and in each
+// leg of the scoped union (six occurrences today); a template with a single
+// %s degrades to the plain Sprintf it always was. The count is textual, so a
+// template must contain no other percent sign (no LIKE 'x%' pattern, no %%)
+// and at least one %s — a template with none is a programmer error that
+// surfaces as an %!(EXTRA …) syntax error at exec.
+//
+//nolint:gosec // G201: tmpl is a constant template; only IN-clause placeholders are formatted in.
+func expandBatchTemplate(tmpl, placeholders string, args []interface{}) (string, []interface{}) {
+	n := strings.Count(tmpl, "%s")
+	if n <= 1 {
+		return fmt.Sprintf(tmpl, placeholders), args
+	}
+	fills := make([]interface{}, n)
+	expanded := make([]interface{}, 0, n*len(args))
+	for k := range fills {
+		fills[k] = placeholders
+		expanded = append(expanded, args...)
+	}
+	return fmt.Sprintf(tmpl, fills...), expanded
+}
+
 func recomputeIsBlockedPassForWispsInTx(ctx context.Context, tx DBTX, ids []string) (int64, error) {
 	if len(ids) == 0 {
 		return 0, nil
@@ -309,97 +309,6 @@ func markIsBlockedPassForWispsInTx(ctx context.Context, tx DBTX, ids []string) (
 	return runMarkBatchedInTx(ctx, tx, markBlockedTemplateForWisps(), ids)
 }
 
-func markBlockedTemplateForWisps() string {
-	return fmt.Sprintf(`
-		UPDATE wisps w SET w.is_blocked = 1, w.updated_at = w.updated_at
-		WHERE w.id IN (%%s)
-		  AND w.is_blocked = 0
-		  AND w.status <> 'closed' AND w.status <> 'pinned'
-		  AND (
-		    EXISTS (
-		      SELECT 1 FROM wisp_dependencies d
-		      JOIN issues t ON t.id = d.depends_on_issue_id
-		      WHERE d.issue_id = w.id
-		        AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
-		        AND t.status <> 'closed' AND t.status <> 'pinned'
-		    )
-		    OR EXISTS (
-		      SELECT 1 FROM wisp_dependencies d
-		      JOIN wisps t ON t.id = d.depends_on_wisp_id
-		      WHERE d.issue_id = w.id
-		        AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
-		        AND t.status <> 'closed' AND t.status <> 'pinned'
-		    )
-		    OR EXISTS (
-		      SELECT 1 FROM wisp_dependencies d
-		      JOIN issues p ON p.id = d.depends_on_issue_id
-		      WHERE d.issue_id = w.id
-		        AND d.type = 'parent-child'
-		        AND p.is_blocked = 1
-		    )
-		    OR EXISTS (
-		      SELECT 1 FROM wisp_dependencies d
-		      JOIN wisps p ON p.id = d.depends_on_wisp_id
-		      WHERE d.issue_id = w.id
-		        AND d.type = 'parent-child'
-		        AND p.is_blocked = 1
-		    )
-		    OR EXISTS (
-		      SELECT 1 FROM wisp_dependencies d
-		      WHERE d.issue_id = w.id AND d.type = 'waits-for'
-		        AND (%s)
-		    )
-		  )
-	`, waitsForGateBlockedSQL)
-}
-
-func unmarkBlockedTemplateForWisps() string {
-	return fmt.Sprintf(`
-		UPDATE wisps w SET w.is_blocked = 0, w.updated_at = w.updated_at
-		WHERE w.id IN (%%s)
-		  AND w.is_blocked = 1
-		  AND (
-		    w.status = 'closed' OR w.status = 'pinned'
-		    OR (
-		      NOT EXISTS (
-		        SELECT 1 FROM wisp_dependencies d
-		        JOIN issues t ON t.id = d.depends_on_issue_id
-		        WHERE d.issue_id = w.id
-		          AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
-		          AND t.status <> 'closed' AND t.status <> 'pinned'
-		      )
-		      AND NOT EXISTS (
-		        SELECT 1 FROM wisp_dependencies d
-		        JOIN wisps t ON t.id = d.depends_on_wisp_id
-		        WHERE d.issue_id = w.id
-		          AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
-		          AND t.status <> 'closed' AND t.status <> 'pinned'
-		      )
-		      AND NOT EXISTS (
-		        SELECT 1 FROM wisp_dependencies d
-		        JOIN issues p ON p.id = d.depends_on_issue_id
-		        WHERE d.issue_id = w.id
-		          AND d.type = 'parent-child'
-		          AND p.is_blocked = 1
-		      )
-		      AND NOT EXISTS (
-		        SELECT 1 FROM wisp_dependencies d
-		        JOIN wisps p ON p.id = d.depends_on_wisp_id
-		        WHERE d.issue_id = w.id
-		          AND d.type = 'parent-child'
-		          AND p.is_blocked = 1
-		      )
-		      AND NOT EXISTS (
-		        SELECT 1 FROM wisp_dependencies d
-		        WHERE d.issue_id = w.id AND d.type = 'waits-for'
-		          AND (%s)
-		      )
-		    )
-		  )
-	`, waitsForGateBlockedSQL)
-}
-
-//nolint:gosec // G201: callers pass constant templates; only IN-clause placeholders are formatted in.
 func runMarkUnmarkBatchedInTx(ctx context.Context, tx DBTX, markTmpl, unmarkTmpl string, ids []string) (int64, error) {
 	var changed int64
 	for start := 0; start < len(ids); start += queryBatchSize {
@@ -409,7 +318,8 @@ func runMarkUnmarkBatchedInTx(ctx context.Context, tx DBTX, markTmpl, unmarkTmpl
 		}
 		placeholders, args := buildSQLInClause(ids[start:end])
 
-		res, err := tx.ExecContext(ctx, fmt.Sprintf(markTmpl, placeholders), args...)
+		stmt, stmtArgs := expandBatchTemplate(markTmpl, placeholders, args)
+		res, err := tx.ExecContext(ctx, stmt, stmtArgs...)
 		if err != nil {
 			return changed, fmt.Errorf("recompute is_blocked (mark): %w", err)
 		}
@@ -419,7 +329,8 @@ func runMarkUnmarkBatchedInTx(ctx context.Context, tx DBTX, markTmpl, unmarkTmpl
 		}
 		changed += n
 
-		res, err = tx.ExecContext(ctx, fmt.Sprintf(unmarkTmpl, placeholders), args...)
+		stmt, stmtArgs = expandBatchTemplate(unmarkTmpl, placeholders, args)
+		res, err = tx.ExecContext(ctx, stmt, stmtArgs...)
 		if err != nil {
 			return changed, fmt.Errorf("recompute is_blocked (unmark): %w", err)
 		}
@@ -432,7 +343,6 @@ func runMarkUnmarkBatchedInTx(ctx context.Context, tx DBTX, markTmpl, unmarkTmpl
 	return changed, nil
 }
 
-//nolint:gosec // G201: callers pass constant templates; only IN-clause placeholders are formatted in.
 func runMarkBatchedInTx(ctx context.Context, tx DBTX, markTmpl string, ids []string) (int64, error) {
 	var changed int64
 	for start := 0; start < len(ids); start += queryBatchSize {
@@ -442,7 +352,8 @@ func runMarkBatchedInTx(ctx context.Context, tx DBTX, markTmpl string, ids []str
 		}
 		placeholders, args := buildSQLInClause(ids[start:end])
 
-		res, err := tx.ExecContext(ctx, fmt.Sprintf(markTmpl, placeholders), args...)
+		stmt, stmtArgs := expandBatchTemplate(markTmpl, placeholders, args)
+		res, err := tx.ExecContext(ctx, stmt, stmtArgs...)
 		if err != nil {
 			return changed, fmt.Errorf("mark is_blocked: %w", err)
 		}

--- a/internal/storage/issueops/blocked_state_template_test.go
+++ b/internal/storage/issueops/blocked_state_template_test.go
@@ -1,0 +1,95 @@
+package issueops
+
+import (
+	"strings"
+	"testing"
+)
+
+// The batched mark/unmark templates reach the engine through
+// expandBatchTemplate, which decides how many IN-lists to splice by counting
+// "%s" textually. Two things are therefore load-bearing and invisible to the
+// sqlmock suite next door — its expectations match an unanchored statement
+// prefix and never assert bound args, so it stays green against a miscounted
+// template: the occurrence count itself, and the absence of any other percent
+// sign in the finished template (a future LIKE 'x%' or %d in a union leg would
+// shift the count or corrupt the statement). Today a break surfaces only in the
+// container-backed dolt suite; these tests pin it at the fast tier
+// (gastownhall/beads#6291).
+
+// batchTemplateOccurrences is the number of IN-lists a batched template
+// carries: the outer row filter, plus one per leg of the scoped
+// should-be-blocked union.
+const batchTemplateOccurrences = 6
+
+func batchedTemplates() map[string]string {
+	return map[string]string{
+		"markBlockedTemplateForIssues":   markBlockedTemplateForIssues(),
+		"unmarkBlockedTemplateForIssues": unmarkBlockedTemplateForIssues(),
+		"markBlockedTemplateForWisps":    markBlockedTemplateForWisps(),
+		"unmarkBlockedTemplateForWisps":  unmarkBlockedTemplateForWisps(),
+	}
+}
+
+func TestBatchedTemplatePercentBudget(t *testing.T) {
+	for name, tmpl := range batchedTemplates() {
+		t.Run(name, func(t *testing.T) {
+			if got := strings.Count(tmpl, "%s"); got != batchTemplateOccurrences {
+				t.Errorf("%%s count = %d, want %d — expandBatchTemplate binds one id group per occurrence, so a changed count must be a deliberate edit here", got, batchTemplateOccurrences)
+			}
+			// The stray-percent guard: every percent sign in the finished
+			// template must belong to one of the %s verbs counted above.
+			if got := strings.Count(tmpl, "%"); got != batchTemplateOccurrences {
+				t.Errorf("total %% count = %d, want %d — a percent sign outside a %%s (LIKE 'x%%', %%d, %%%%) miscounts the template or corrupts the statement", got, batchTemplateOccurrences)
+			}
+		})
+	}
+}
+
+func TestWaitsForGateBlockedSQLCarriesNoPercent(t *testing.T) {
+	// The gate is spliced into every template as a resolved constant, so any
+	// percent sign it grew would land in the counted text above.
+	if got := strings.Count(waitsForGateBlockedSQL, "%"); got != 0 {
+		t.Errorf("waitsForGateBlockedSQL %% count = %d, want 0", got)
+	}
+}
+
+func TestExpandBatchTemplateFillsEveryOccurrence(t *testing.T) {
+	placeholders, args := buildSQLInClause([]string{"issue-1", "issue-2"})
+	wantArgs := batchTemplateOccurrences * len(args)
+
+	for name, tmpl := range batchedTemplates() {
+		t.Run(name, func(t *testing.T) {
+			stmt, stmtArgs := expandBatchTemplate(tmpl, placeholders, args)
+
+			if strings.ContainsAny(stmt, "%") {
+				t.Errorf("expanded statement still contains %%: %s", stmt)
+			}
+			if got := strings.Count(stmt, "?"); got != wantArgs {
+				t.Errorf("placeholder count = %d, want %d", got, wantArgs)
+			}
+			if got := len(stmtArgs); got != wantArgs {
+				t.Fatalf("arg count = %d, want %d — placeholders and args must stay in lockstep", got, wantArgs)
+			}
+			// Each occurrence gets the same group, repeated in order.
+			for i, arg := range stmtArgs {
+				if want := args[i%len(args)]; arg != want {
+					t.Errorf("arg %d = %v, want %v", i, arg, want)
+				}
+			}
+		})
+	}
+}
+
+func TestExpandBatchTemplateSingleOccurrenceDegrades(t *testing.T) {
+	// A template with one %s is the plain Sprintf it always was: the args pass
+	// through untouched rather than being repeated.
+	placeholders, args := buildSQLInClause([]string{"issue-1", "issue-2"})
+	stmt, stmtArgs := expandBatchTemplate("SELECT id FROM issues WHERE id IN (%s)", placeholders, args)
+
+	if want := "SELECT id FROM issues WHERE id IN (?,?)"; stmt != want {
+		t.Errorf("stmt = %q, want %q", stmt, want)
+	}
+	if len(stmtArgs) != len(args) {
+		t.Errorf("arg count = %d, want %d", len(stmtArgs), len(args))
+	}
+}


### PR DESCRIPTION
Fixes #6288.

## Problem

The batched `is_blocked` mark/unmark templates in `issueops/blocked_state.go` decided membership with five correlated `EXISTS` per outer row (blocks/conditional-blocks target open, parent-child parent blocked, waits-for gate). The engine re-executed them per candidate row: ~1.5–4.7 s per 200-id batch on committed, indexed data, and unbounded over a large **uncommitted** working set, where every probe re-reads the overlay. A proxied-server import of a 19k-issue database was observed at >69 min for a single 200-id batch on dolt 2.1.8 (2.3.1 does the same statement in 1.8 s, so this is partly a planner regression, but the shape is what makes it possible).

## Change

1. The four batched templates (issues/wisps × mark/unmark) now decide membership through the **same uncorrelated should-be-blocked union** the full repair and the doctor count already use (`shouldBeBlockedIDsUnionSQL`, bd-t9ypt), scoped to the batch: `shouldBeBlockedIDsUnionScopedSQL(depTable, scope)` splices `AND d.issue_id IN (batch)` into every leg's WHERE. One derived blocked set per batch, computed once and probed by hash. `expandBatchTemplate` repeats the IN-list placeholders and the bound ids for every `%s` (outer row filter + 5 legs: 200 ids → 1200 args).
2. The waits-for leg wraps its dependency rows in a **derived table before the gate predicate** is applied. Flat, the planner pushed the gate's four correlated `EXISTS` ahead of the `type = 'waits-for'` filter and evaluated them against the whole overlay for every candidate row — 436 s on the overlay while returning zero rows. Behind the barrier the leg narrows to the batch's (usually zero) waits-for rows first: 0.01 s. The derived projection is `SELECT DISTINCT` — semantically free here (the leg feeds a `UNION` and the gate depends only on the projected columns) and what makes the barrier structural rather than a planner-version observation: a plain single-table derived table is the mergeable shape MySQL-dialect planners fold back into the outer query, a DISTINCT one is materialized. Since the full repair and doctor count share the builder, they get the barrier too.

Statement prefixes are unchanged (the sqlmock expectations match untouched), the fixpoint loop in `RecomputeIsBlockedInTx` and the `updated_at = updated_at` self-assignment are untouched, error strings are verbatim.

## Numbers (dolt 2.1.8, real 19k-issue / 10k-dependency database, one 200-id batch)

| data set | old (correlated) | union, flat gate leg | union, barriered (this PR) |
|---|---|---|---|
| committed | 1.5–4.7 s | 0.22 s | **0.04–0.08 s** |
| uncommitted overlay (whole db inserted in the txn) | >24.6 min, killed | 367 s | **3–8 s** (box-load dependent; 3.2 s quiet, 7.1 s with a container test suite running alongside) |

## Proof

- `go test ./internal/storage/issueops/` (sqlmock) — green untouched.
- Container-backed `go test ./internal/storage/dolt/ -run 'Blocked|IsBlocked'` — green (the blocked-consistency lockstep tests pin the batched path, the full repair and the doctor count to each other).
- `golangci-lint run ./internal/storage/issueops/` clean.
- Mutation pass against the container-backed Blocked suite, 8/8 killed: parent-child leg dead, unmark `NOT IN`→`IN`, batch args not repeated, scope on the wrong column, closed blocker still blocks, barrier without the waits-for type filter, barrier losing `metadata`, barrier swapping the spawner columns.
