### PR TITLE
fix(create): refuse an ambiguous --repo before the existence check, not after (be-flg)

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -428,12 +428,7 @@ var createCmd = &cobra.Command{
 				targetBeadsDir := routing.ExpandPath(repoPath)
 				debug.Logf("DEBUG: Routing to target repo: %s\n", targetBeadsDir)
 
-				// Auto-routed paths (routing.mode: auto, routing.default)
-				// come from config, not caller input, so they're always
-				// allowed to auto-vivify as before; only an explicit --repo
-				// flag value can be ambiguous.
-				allowCreate := !isAmbiguousRepoTarget(cmd.Flags().Changed("repo"), repoOverride)
-				if err := ensureBeadsDirForPath(rootCtx, targetBeadsDir, store, allowCreate); err != nil {
+				if err := ensureBeadsDirForPath(rootCtx, targetBeadsDir, store, cmd.Flags().Changed("repo"), repoOverride); err != nil {
 					return HandleError("failed to initialize target repo: %v", err)
 				}
 
@@ -467,7 +462,7 @@ var createCmd = &cobra.Command{
 		parentLookupStore := store
 		if dryRun && repoPath != "." {
 			var err error
-			parentLookupStore, err = openDryRunTargetStore(rootCtx, repoPath)
+			parentLookupStore, err = openDryRunTargetStore(rootCtx, repoPath, cmd.Flags().Changed("repo"), repoOverride)
 			if err != nil {
 				return HandleError("%v", err)
 			}
@@ -965,7 +960,12 @@ func formatTimeForRPC(t *time.Time) string {
 // newPreviewStoreFromConfig is the non-mutating factory for a foreign
 // project (bd-6dnrw.32), relaxed for previews exactly as the root pre-run
 // relaxes the command's own store.
-func openDryRunTargetStore(ctx context.Context, repoPath string) (storage.DoltStorage, error) {
+func openDryRunTargetStore(ctx context.Context, repoPath string, repoFlagChanged bool, repoOverride string) (storage.DoltStorage, error) {
+	if isAmbiguousRepoTarget(repoFlagChanged, repoOverride) {
+		// Same misresolution as the write path (be-flg / gt-rlwo): a preview
+		// read against a phantom store is a preview of the wrong repo.
+		return nil, ambiguousRepoTargetError(repoOverride, routing.ExpandPath(repoPath))
+	}
 	if remotecache.IsRemoteURL(repoPath) {
 		cache, err := remotecache.DefaultCache()
 		if err != nil {
@@ -1007,13 +1007,31 @@ func isAmbiguousRepoTarget(repoFlagChanged bool, repoOverride string) bool {
 	return repoFlagChanged && !filepath.IsAbs(repoOverride) && !strings.HasPrefix(repoOverride, "~/")
 }
 
+// ambiguousRepoTargetError explains a refused --repo value. It names the
+// resolved path because that is the one thing that makes the refusal
+// comprehensible: the caller typed a name and got a directory under their
+// cwd. It deliberately does not claim the workspace is missing — the
+// resolved target may well exist, and using it is exactly the bug (be-flg).
+func ambiguousRepoTargetError(repoOverride, resolvedPath string) error {
+	return fmt.Errorf("--repo %q is a relative/bare path, so it resolved against the current directory to %s; bd has no registry of repo names, so that is almost certainly not the workspace you meant. Pass an absolute or \"~/\"-prefixed --repo path instead", repoOverride, resolvedPath)
+}
+
 // ensureBeadsDirForPath ensures a beads directory exists at the target path.
 // If the .beads directory doesn't exist, it creates it and initializes with
 // the same prefix as the source store (T010, T012: prefix inheritance).
 //
-// When allowCreate is false, a target with no existing workspace is refused
-// instead of fabricated — see isAmbiguousRepoTarget.
-func ensureBeadsDirForPath(ctx context.Context, targetPath string, sourceStore storage.DoltStorage, allowCreate bool) error {
+// An ambiguous explicit --repo value (see isAmbiguousRepoTarget) is refused
+// outright, BEFORE the existence check: the misresolved path is just as wrong
+// when a workspace happens to sit there already, and using one silently is
+// worse than fabricating one, because nothing is left behind to notice
+// (be-flg / gt-rlwo). Auto-routed paths (routing.mode: auto, routing.default)
+// come from config rather than caller input, so repoFlagChanged is false for
+// them and they keep auto-vivifying as before.
+func ensureBeadsDirForPath(ctx context.Context, targetPath string, sourceStore storage.DoltStorage, repoFlagChanged bool, repoOverride string) error {
+	if isAmbiguousRepoTarget(repoFlagChanged, repoOverride) {
+		return ambiguousRepoTargetError(repoOverride, targetPath)
+	}
+
 	beadsDir := filepath.Join(targetPath, ".beads")
 	metadataPath := filepath.Join(beadsDir, "metadata.json")
 
@@ -1021,10 +1039,6 @@ func ensureBeadsDirForPath(ctx context.Context, targetPath string, sourceStore s
 	// metadata.json is the canonical marker for an initialized beads dir.
 	if _, err := os.Stat(metadataPath); err == nil {
 		return nil
-	}
-
-	if !allowCreate {
-		return fmt.Errorf("no beads workspace found at %s and --repo's value is a relative/bare path, so it won't be auto-created here (this is likely not the target you intended). Pass an absolute or \"~/\"-prefixed --repo path to an existing workspace instead", targetPath)
 	}
 
 	// Create .beads directory

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -961,11 +961,11 @@ func formatTimeForRPC(t *time.Time) string {
 // project (bd-6dnrw.32), relaxed for previews exactly as the root pre-run
 // relaxes the command's own store.
 func openDryRunTargetStore(ctx context.Context, repoPath string, repoFlagChanged bool, repoOverride string) (storage.DoltStorage, error) {
-	if isAmbiguousRepoTarget(repoFlagChanged, repoOverride) {
-		// Same misresolution as the write path (be-flg / gt-rlwo): a preview
-		// read against a phantom store is a preview of the wrong repo.
-		return nil, ambiguousRepoTargetError(repoOverride, routing.ExpandPath(repoPath))
-	}
+	// Remote URLs are resolved before the ambiguity guard, because a remote URL
+	// is not a filesystem path and filepath.IsAbs is false for every supported
+	// scheme -- so isAmbiguousRepoTarget would refuse all of them. The write
+	// path orders these the same way (its IsRemoteURL branch runs before
+	// ensureBeadsDirForPath); this is the read side of that same ordering.
 	if remotecache.IsRemoteURL(repoPath) {
 		cache, err := remotecache.DefaultCache()
 		if err != nil {
@@ -978,6 +978,12 @@ func openDryRunTargetStore(ctx context.Context, repoPath string, repoFlagChanged
 			return nil, fmt.Errorf("dry-run parent lookup requires an existing cached remote store for %s: %w", repoPath, err)
 		}
 		return store, nil
+	}
+
+	if isAmbiguousRepoTarget(repoFlagChanged, repoOverride) {
+		// Same misresolution as the write path (be-flg / gt-rlwo): a preview
+		// read against a phantom store is a preview of the wrong repo.
+		return nil, ambiguousRepoTargetError(repoOverride, routing.ExpandPath(repoPath))
 	}
 
 	targetPath := routing.ExpandPath(repoPath)

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -1151,12 +1151,21 @@ func TestEmbeddedCreateRepoRelativeUninitRefused(t *testing.T) {
 	}
 }
 
-// TestEmbeddedCreateRepoRelativeExistingWorkspaceUnaffected verifies the
-// bd-8d3f gate only blocks *fabricating* a new workspace: a relative --repo
-// value that already has an initialized workspace at the resolved path must
-// keep working exactly as before, since ensureBeadsDirForPath's existing
-// os.Stat(metadata.json) check returns early before the new gate runs.
-func TestEmbeddedCreateRepoRelativeExistingWorkspaceUnaffected(t *testing.T) {
+// TestEmbeddedCreateRepoRelativeExistingWorkspaceRefused is the regression
+// test for be-flg / gt-rlwo, and it is the case that was broken: the bd-8d3f
+// gate was computed correctly and then bypassed, because
+// ensureBeadsDirForPath returned early whenever the misresolved target
+// already had a metadata.json. So the guard refused to CREATE a stray
+// workspace and happily USED one that existed — and the first such call, made
+// before the guard shipped, is what fabricates it. Ten real beads were
+// written into two phantom stores that way, four of them lost with nobody
+// noticing, because bd printed "✓ Created issue" and exited 0 every time.
+//
+// A bare/relative --repo must therefore be refused whether or not the
+// resolved path happens to hold a workspace. Contrast with
+// TestEmbeddedCreateCrossRepoUninit (absolute --repo, must still work) and
+// TestEmbeddedCreateRepoTildeExistingWorkspaceAllowed.
+func TestEmbeddedCreateRepoRelativeExistingWorkspaceRefused(t *testing.T) {
 	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
 		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
 	}
@@ -1179,12 +1188,122 @@ func TestEmbeddedCreateRepoRelativeExistingWorkspaceUnaffected(t *testing.T) {
 		t.Fatal("expected issue ID for absolute --repo seed create")
 	}
 
-	// A relative --repo pointing at that SAME, now-initialized workspace
-	// must succeed unaffected by the bd-8d3f gate: the gate only blocks
-	// fabricating a workspace that doesn't exist yet.
-	second := bdCreate(t, bd, dir, "Should land in the pre-existing workspace", "--repo", relTarget)
-	if second.ID == "" {
-		t.Fatal("expected issue ID for relative --repo pointing at an existing workspace")
+	out, err := bdRunWithFlockRetry(t, bd, dir, "create", "--json", "Should not land anywhere", "--repo", relTarget)
+	if err == nil {
+		t.Fatalf("expected bd create --repo %q to fail even though a workspace exists at the resolved path, got success: %s", relTarget, out)
+	}
+	if !strings.Contains(string(out), "absolute") {
+		t.Errorf("expected error to explain the absolute/~-prefixed path requirement, got: %s", out)
+	}
+	// The resolved path is what makes the refusal comprehensible: the caller
+	// typed a name and got a directory under their cwd.
+	if !strings.Contains(string(out), absTarget) {
+		t.Errorf("expected error to name the resolved path %s, got: %s", absTarget, out)
+	}
+
+	// The refused create must not have written anything into the target.
+	issues := bdListJSONAllowError(t, bd, absTarget, "--all", "--limit", "0")
+	if issues == nil {
+		t.Fatal("bd list in the target workspace failed")
+	}
+	for _, issue := range issues {
+		if issue.Title == "Should not land anywhere" {
+			t.Fatalf("refused create still landed in the target workspace as %s", issue.ID)
+		}
+	}
+	if len(issues) != 1 {
+		t.Errorf("target workspace has %d issues, want only the seed issue", len(issues))
+	}
+}
+
+// TestEmbeddedCreateRepoTildeExistingWorkspaceAllowed is the negative control
+// for the be-flg refusal: "~/"-prefixed --repo values are unambiguous (they
+// resolve against $HOME, not the cwd), so they must keep working. bdEnv sets
+// HOME to the test dir, and no shell is involved, so "~/..." reaches bd
+// literally and routing.ExpandPath does the expansion.
+func TestEmbeddedCreateRepoTildeExistingWorkspaceAllowed(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "src")
+
+	name := "tilde-target"
+	absTarget := filepath.Join(dir, name)
+	if err := os.MkdirAll(absTarget, 0750); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoAt(t, absTarget)
+
+	issue := bdCreate(t, bd, dir, "Landed via tilde repo", "--repo", "~/"+name)
+	if issue.ID == "" {
+		t.Fatal("expected issue ID for ~/-prefixed --repo create")
+	}
+
+	issues := bdListJSONAllowError(t, bd, absTarget, "--all", "--limit", "0")
+	if issues == nil {
+		t.Fatal("bd list in the target workspace failed")
+	}
+	var found bool
+	for _, got := range issues {
+		if got.ID == issue.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("issue %s not found in the ~/-resolved target workspace", issue.ID)
+	}
+}
+
+// TestEmbeddedCreateAutoRoutedRelativeStillVivifies guards the other side of
+// the be-flg reorder. The refusal keys on the --repo FLAG, not on the shape
+// of the path, because auto-routed targets (routing.mode / routing.default)
+// come from config rather than caller input and have always been allowed to
+// auto-vivify. routing.default is deliberately set to a bare relative name
+// here — the exact shape that is refused when it arrives via --repo — so a
+// refusal moved up to cover every relative path would fail this test.
+func TestEmbeddedCreateAutoRoutedRelativeStillVivifies(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "src")
+
+	name := "auto-routed-target"
+	absTarget := filepath.Join(dir, name)
+
+	cfg := exec.Command(bd, "config", "set", "routing.default", name)
+	cfg.Dir = dir
+	cfg.Env = bdEnv(dir)
+	if out, err := cfg.CombinedOutput(); err != nil {
+		t.Fatalf("bd config set routing.default failed: %v\n%s", err, out)
+	}
+
+	issue := bdCreate(t, bd, dir, "Auto-routed into a fresh workspace")
+	if issue.ID == "" {
+		t.Fatal("expected issue ID for auto-routed create")
+	}
+
+	if _, err := os.Stat(filepath.Join(absTarget, ".beads", "metadata.json")); err != nil {
+		t.Fatalf("auto-routed create did not vivify %s: %v", absTarget, err)
+	}
+
+	issues := bdListJSONAllowError(t, bd, absTarget, "--all", "--limit", "0")
+	if issues == nil {
+		t.Fatal("bd list in the auto-routed workspace failed")
+	}
+	var found bool
+	for _, got := range issues {
+		if got.ID == issue.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("issue %s not found in the auto-routed workspace", issue.ID)
 	}
 }
 

--- a/cmd/bd/create_input_test.go
+++ b/cmd/bd/create_input_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -10,6 +11,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/steveyegge/beads/internal/remotecache"
 )
 
 func TestCreateCommandRejectsExtraPositionalArguments(t *testing.T) {
@@ -270,6 +273,62 @@ func TestIsAmbiguousRepoTarget(t *testing.T) {
 			got := isAmbiguousRepoTarget(tt.flagChanged, tt.repoOverride)
 			if got != tt.wantAmbiguous {
 				t.Errorf("isAmbiguousRepoTarget(%v, %q) = %v, want %v", tt.flagChanged, tt.repoOverride, got, tt.wantAmbiguous)
+			}
+		})
+	}
+}
+
+// TestRemoteURLsAreNotRefusedAsAmbiguousRepoTargets pins the ORDERING that
+// makes the --repo ambiguity guard safe, rather than any single call site.
+//
+// isAmbiguousRepoTarget answers a filesystem question (is this value absolute
+// or "~/"-prefixed?). A remote URL is not a filesystem path, and filepath.IsAbs
+// is false for every supported scheme, so the predicate classifies ALL of them
+// as ambiguous. That is not a bug in the predicate — it is why every caller
+// must resolve remote URLs BEFORE consulting it.
+//
+// The write path has always done this (its remotecache.IsRemoteURL branch runs
+// before ensureBeadsDirForPath). The dry-run path did not, which made
+// `bd create --dry-run --parent ... --repo <remote URL>` fail for every remote
+// while the identical non-dry-run create succeeded.
+func TestRemoteURLsAreNotRefusedAsAmbiguousRepoTargets(t *testing.T) {
+	remotes := []string{
+		"https://github.com/owner/repo.git",
+		"http://example.com/owner/repo.git",
+		"ssh://git@github.com/owner/repo.git",
+		"git@github.com:owner/repo.git",
+		"dolthub://org/db",
+		"file:///srv/beads/repo",
+		"s3://bucket/prefix",
+		"gs://bucket/prefix",
+	}
+
+	for _, u := range remotes {
+		t.Run(u, func(t *testing.T) {
+			if !remotecache.IsRemoteURL(u) {
+				t.Fatalf("test premise broken: %q is not recognised as a remote URL", u)
+			}
+			// The predicate refuses it. This assertion is the point of the
+			// test: it documents that the guard is unsafe to run first, so a
+			// future reordering fails here with an explanation instead of
+			// silently breaking every remote.
+			if !isAmbiguousRepoTarget(true, u) {
+				t.Fatalf("premise changed: isAmbiguousRepoTarget no longer refuses %q; "+
+					"if the predicate now understands remote URLs, this test and the "+
+					"call-site ordering it protects should be revisited", u)
+			}
+
+			// Contain any cache directory the lookup may create.
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+			_, err := openDryRunTargetStore(context.Background(), u, true, u)
+			if err == nil {
+				return // resolved a cached remote; certainly not refused
+			}
+			if strings.Contains(err.Error(), "is a relative/bare path") {
+				t.Fatalf("remote URL %q was refused by the ambiguity guard: %v\n"+
+					"the guard must run AFTER remote URLs are resolved", u, err)
 			}
 		})
 	}

--- a/cmd/bd/create_input_test.go
+++ b/cmd/bd/create_input_test.go
@@ -238,9 +238,11 @@ func newCreateFlagsCommand(t *testing.T, args ...string) *cobra.Command {
 	return cmd
 }
 
-// TestIsAmbiguousRepoTarget covers bd-8d3f: an explicit relative/bare --repo
-// value with no existing workspace must be refused rather than silently
-// auto-vivified. Table-tested at the pure-function level since the embedded
+// TestIsAmbiguousRepoTarget covers bd-8d3f and be-flg: an explicit
+// relative/bare --repo value must be refused rather than resolved against the
+// cwd — whether that resolves onto nothing (bd-8d3f, silently auto-vivified a
+// phantom workspace) or onto a workspace that already exists (be-flg, silently
+// wrote into it). Table-tested at the pure-function level since the embedded
 // dolt round trip is ~15s per case.
 func TestIsAmbiguousRepoTarget(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## The defect

`bd create --repo <bare-name>` silently wrote the issue into a phantom database
resolved against the **current directory**, printed `✓ Created issue: <id>`, and
exited 0.

```
$ bd create -p 3 -t task "probe A no-repo"
  ✓ Created issue: gt-1x0j       ->  bd show gt-1x0j   PERSISTED
$ bd create --repo gastown -p 3 -t task "probe B with-repo"
  ✓ Created issue: gt-c9g        ->  bd show gt-c9g    "no issue found"
```

Both printed success. Both exited 0. Only the first exists.

The guard that should have stopped this (bd-8d3f) **already existed and was
computed correctly** — it was bypassed by an early return:

```go
func ensureBeadsDirForPath(ctx, targetPath, sourceStore, allowCreate) error {
    if _, err := os.Stat(metadataPath); err == nil {
        return nil                      // <-- EARLY RETURN, guard never consulted
    }
    if !allowCreate {
        return fmt.Errorf("no beads workspace found at %s ...")
    }
```

So the guard refused to **create** a stray workspace and happily **used** one
that already existed. The first such call — made before the guard shipped —
fabricates `<cwd>/<name>/.beads`. From that moment the guard is permanently
bypassed for that path, and every later `--repo <name>` from that directory
writes silently into the orphan.

## The fix

Refuse an ambiguous explicit `--repo` **before** the existence check, in both
call sites that resolve a `--repo` target:

- `ensureBeadsDirForPath` (the write path)
- `openDryRunTargetStore` (the parent-lookup dry-run read path — a preview read
  against a phantom store is a preview of the wrong repo)

The refusal keys on the `--repo` **flag**, not on the shape of the path, so
auto-routed targets (`routing.mode`, `routing.default`) still come from config
rather than caller input and keep auto-vivifying exactly as before.

Remote URLs are resolved **before** the guard on both paths. `isAmbiguousRepoTarget`
answers a filesystem question, and `filepath.IsAbs` is false for every supported
scheme, so running the guard first would refuse every remote. The write path
always ordered it this way; the dry-run path did not, which is the second commit
here.

The error message was reworded too. `no beads workspace found at X` is wrong when
the workspace *does* exist, and the resolved path is the one thing that makes the
refusal comprehensible — the caller typed a name and got a directory under their cwd:

```
--repo "gastown" is a relative/bare path, so it resolved against the current
directory to /home/user/gt/deacon/gastown; bd has no registry of repo names, so
that is almost certainly not the workspace you meant. Pass an absolute or
"~/"-prefixed --repo path instead
```

## Tests

All five cases from the report, plus an ordering test:

| test | case |
|---|---|
| `TestEmbeddedCreateRepoRelativeExistingWorkspaceRefused` | **the regression test** — bare `--repo` onto an existing workspace |
| `TestEmbeddedCreateRepoRelativeUninitRefused` | bare `--repo` onto nothing (bd-8d3f, unchanged) |
| `TestEmbeddedCreateRepoTildeExistingWorkspaceAllowed` | negative control — `~/` still works |
| `TestEmbeddedCreateCrossRepoUninit` | negative control — absolute `--repo` still works |
| `TestEmbeddedCreateAutoRoutedRelativeStillVivifies` | `routing.default` set to a bare relative name still vivifies |
| `TestRemoteURLsAreNotRefusedAsAmbiguousRepoTargets` | pins the remote-URL-before-guard ordering, 8 schemes |
| `TestIsAmbiguousRepoTarget` | 7 table cases on the predicate |

`TestEmbeddedCreateRepoRelativeExistingWorkspaceUnaffected` is renamed and its
assertion inverted, deliberately: it asserted the behaviour this PR fixes.

**Positive control — the thing that licenses the fix.** With `cmd/bd/create.go`
reverted to its pre-fix state and the new tests kept,
`TestEmbeddedCreateRepoRelativeExistingWorkspaceRefused` **fails**, reproducing
the reported symptom exactly:

```
FAIL — got success: {"id": "src-83n", "title": "Should not land anywhere" ...}
```

With the fix restored it passes. A regression test that has never been seen to
fail proves nothing; this one has.

## Verification

Toolchain: **go1.26.5**, the version `go.mod` pins and CI resolves via
`go-version-file: go.mod`.

- `make ci-pr-lint` with `BD_LINT_NEW_FROM_MERGE_BASE=origin/main` — **rc=0**
  (gofmt clean, golangci-lint v2.10.1 0 issues, windows cross-lint 0 issues)
- `make build` rc=0 · `go vet ./...` rc=0
- `BEADS_TEST_EMBEDDED_DOLT=1` — all 5 embedded cases pass; `TestIsAmbiguousRepoTarget`
  7/7; `TestRemoteURLsAreNotRefusedAsAmbiguousRepoTargets` 8/8
- `codex exec review --base main` — no findings
- **A/B failure-set comparison against a clean `origin/main` worktree.**
  `go test ./cmd/bd/` fails 4 tests on **both** sides, and the failing test-name
  **sets are identical** (compared as sets, so a swap cannot hide inside a count):
  `TestConfigValidateReadOnlyIsHermetic`,
  `TestInitNonInteractiveAutoExportDefaultOffAndOptIn`,
  `TestPrepareSelectedCommandContext_DoesNotMergeCallerConfigForUnsetKeys`,
  `TestPrepareSelectedCommandContext_RebindsTargetConfig`.
  These are pre-existing and environment-induced (the harness's ambient actor
  identity leaks into the assertions); this branch changes neither the set nor
  the messages.

## Relationship to PR #5553 — not a duplicate, and it does not cover this

Re-verified at the time of writing: #5553 is still OPEN, `DIRTY` /
`CONFLICTING`, `CHANGES_REQUESTED`, last updated 2026-08-10, and touches the
same two files.

It **deletes** `ensureBeadsDirForPath` and replaces it with
`requireInitializedRepoPath`, refusing auto-vivification for *every* `--repo`
target including absolute ones — a broader policy change. But
`requireInitializedRepoPath` still `return nil`s when `metadata.json` exists, so
a bare `--repo` resolving onto an already-existing phantom store is still
accepted under #5553. **It prevents new phantoms from being born; it does not
stop writes into the ones that exist.** Its base also predates the bd-8d3f guard
(its diff shows the 3-arg `ensureBeadsDirForPath` with no `allowCreate`).

Nothing here supersedes or closes it. **If #5553 lands, the ambiguity refusal
must be carried into `requireInitializedRepoPath` or this hole reopens.**

## Scope notes, stated rather than silently omitted

- The early return at `create.go:407` (`dryRun && parentID == ""`) fires before
  any `--repo` handling, so a bare `--repo` on a *parentless* dry run is still
  not refused. It performs no write and opens no target store, so it is not this
  defect. The parent-lookup dry-run path **is** guarded, because that one really
  does open the phantom store to read from it.
- Both call sites of the guard in the tree are covered; `grep` for
  `ensureBeadsDirForPath|isAmbiguousRepoTarget` finds no others.
- Discovered, filed not fixed: `bd repo add <bare-name>` persists a cwd-relative
  path into `config.yaml` and re-resolves it against a different cwd later
  (`cmd/bd/repo.go:67-93`) — same class, one layer along.

## Why the priority

10 real beads were written into two phantom stores and lost: 3 P0, 4 P1, 2 P2,
1 P3. All 10 were later recovered with their original ids. Two had been reported
as destroyed; **four were lost with nobody ever noticing.**

The sharpest cost: a bug report filed 2026-09-02 vanished this way. The identical
defect was rediscovered from scratch two days later, re-diagnosed, re-filed,
dispatched to a worker and shipped as a separate PR. A silently misfiled bug
report does not merely go missing — it gets found again later at full price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X65kwNLsmtbePfHqtC6WjB
