### PR TITLE
fix(ci): resolve gofmt from go.mod's toolchain, not PATH (be-gx8)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -27,8 +27,12 @@ if [ -n "$staged_go_files" ]; then
         exit 1
     fi
 
-    # Auto-format and re-stage
-    echo "$staged_go_files" | xargs gofmt -w
+    # Auto-format and re-stage, through the go.mod-pinned gofmt. A bare PATH
+    # gofmt belongs to the host toolchain, and on a host newer than the go
+    # directive it rewrites and re-stages files into a form CI's gofmt rejects
+    # -- silently, on every Go commit. See scripts/ci/gofmt-bin.sh.
+    gofmt_bin="$(./scripts/ci/gofmt-bin.sh)"
+    echo "$staged_go_files" | xargs "$gofmt_bin" -w
     echo "$staged_go_files" | xargs git add
 
     # Lint changed code with auto-fix; block on remaining issues.

--- a/Makefile
+++ b/Makefile
@@ -345,10 +345,13 @@ endif
 
 install: check-up-to-date
 
-# Format all Go files
+# Format all Go files.
+# Through the go.mod-pinned gofmt, never a bare PATH one: a newer local Go
+# formats differently from CI, so a bare gofmt -w here rewrites files into a
+# form CI's gofmt then rejects. See scripts/ci/gofmt-bin.sh.
 fmt:
 	@echo "Formatting Go files..."
-	@gofmt -w .
+	@gofmt_bin="$$(./scripts/ci/gofmt-bin.sh)" && "$$gofmt_bin" -w .
 	@echo "Done"
 
 # Check that all Go files are properly formatted (for CI)

--- a/scripts/ci/fmt-check.sh
+++ b/scripts/ci/fmt-check.sh
@@ -8,8 +8,27 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 cd "$REPO_ROOT"
 
+# Which gofmt runs decides the verdict, so resolve it from go.mod instead of
+# PATH and report it. Naming the binary here is what makes a toolchain skew
+# legible as a skew, rather than as unformatted files in code no branch
+# touched. See scripts/ci/gofmt-bin.sh.
+GOFMT_BIN="$("$SCRIPT_DIR/gofmt-bin.sh")"
+
+describe_gofmt() {
+    local bin="$1" version=""
+    if command -v go >/dev/null 2>&1; then
+        version="$(go version "$bin" 2>/dev/null | awk '{ print $NF }')"
+    fi
+    if [[ -n "$version" ]]; then
+        printf '%s (%s)' "$version" "$bin"
+    else
+        printf '%s' "$bin"
+    fi
+}
+
 printf 'Checking Go formatting...\n'
-if UNFORMATTED="$(gofmt -l .)"; then
+printf 'Using gofmt %s\n' "$(describe_gofmt "$GOFMT_BIN")"
+if UNFORMATTED="$("$GOFMT_BIN" -l .)"; then
     :
 else
     status=$?

--- a/scripts/ci/gofmt-bin.sh
+++ b/scripts/ci/gofmt-bin.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Resolve the gofmt that matches go.mod's pinned Go toolchain, and print its
+# absolute path on stdout.
+#
+# gofmt's output is not stable across Go releases, so whichever binary runs
+# decides the verdict. A bare `gofmt` on PATH belongs to whatever Go happens to
+# be installed locally, and GOTOOLCHAIN=auto does not correct for that: the
+# toolchain switch only ever moves UP to satisfy go.mod's go directive, never
+# down. CI has no such freedom -- actions/setup-go installs exactly the go.mod
+# version via go-version-file -- so a host running a newer Go formats
+# differently from the gate that judges it.
+#
+# The failure is in the dangerous direction. The gate reds on files no branch
+# touched, which reads as "main's lint is broken", and its own advice ("run
+# make fmt") rewrites those files into a form CI's pinned gofmt then rejects.
+#
+# Every gofmt invocation in this repo goes through here: scripts/ci/fmt-check.sh,
+# the Makefile fmt target, and .githooks/pre-commit. Add call sites to that list
+# rather than reaching for a bare gofmt.
+#
+# Set GOFMT to override the resolution entirely.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+warn() {
+    printf 'gofmt-bin: %s\n' "$*" >&2
+}
+
+# Falling back is safer than failing, but it must be LOUD: a silent fallback to
+# the PATH binary is indistinguishable from a correct resolution, and it
+# reintroduces exactly the skew this script exists to remove.
+fallback() {
+    local reason="$1" path
+    if ! path="$(command -v gofmt 2>/dev/null)"; then
+        warn "$reason, and there is no gofmt on PATH either"
+        return 1
+    fi
+    warn "$reason"
+    warn "falling back to $path, which may format differently from CI"
+    printf '%s\n' "$path"
+}
+
+if [[ -n "${GOFMT:-}" ]]; then
+    printf '%s\n' "$GOFMT"
+    exit 0
+fi
+
+pinned="$(awk '$1 == "go" { print $2; exit }' "$REPO_ROOT/go.mod")"
+if [[ -z "$pinned" ]]; then
+    fallback "no go directive in $REPO_ROOT/go.mod"
+    exit
+fi
+
+# A "go 1.26" directive is legal; GOTOOLCHAIN names need the patch component.
+if [[ "$pinned" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    pinned="$pinned.0"
+fi
+
+if ! command -v go >/dev/null 2>&1; then
+    fallback "go is not on PATH, so go.mod's go$pinned toolchain cannot be resolved"
+    exit
+fi
+
+goroot=""
+if [[ "$(go env GOVERSION 2>/dev/null)" == "go$pinned" ]]; then
+    # The CI case: the host go already is the pinned one. Read GOROOT directly
+    # rather than naming a GOTOOLCHAIN, so nothing is fetched on a machine that
+    # has nothing to fetch.
+    goroot="$(go env GOROOT 2>/dev/null || true)"
+elif ! goroot="$(GOTOOLCHAIN="go$pinned" go env GOROOT 2>/dev/null)"; then
+    goroot=""
+fi
+
+if [[ -z "$goroot" || ! -x "$goroot/bin/gofmt" ]]; then
+    fallback "could not resolve a gofmt from go.mod's go$pinned toolchain"
+    exit
+fi
+
+printf '%s\n' "$goroot/bin/gofmt"

--- a/scripts/prlintmake/gofmtbin_test.go
+++ b/scripts/prlintmake/gofmtbin_test.go
@@ -1,0 +1,146 @@
+package prlintmake
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The regression tests for be-gx8.
+//
+// gofmt's output is not stable across Go releases, and the repo's formatting
+// gate is judged by whichever binary runs. CI installs exactly go.mod's version
+// (actions/setup-go with go-version-file), so any resolution that can land on a
+// different Go silently disagrees with the gate that blocks merges -- and the
+// gate's own advice, "run make fmt", then rewrites files into a form CI
+// rejects.
+//
+// These pin the resolution itself rather than fmt-check.sh's reporting, because
+// the shipped bug was in the resolution: a bare `gofmt` reached PATH, and every
+// output assertion around it stayed green.
+
+func TestGofmtBinMatchesGoModDirective(t *testing.T) {
+	goBin := testGo(t)
+	want := "go" + goModToolchainVersion(t)
+
+	resolved, stderr := runGofmtBin(t, nil, nil)
+
+	output, err := exec.Command(goBin, "version", resolved).CombinedOutput()
+	if err != nil {
+		t.Fatalf("go version %s: %v\n%s\nresolver stderr:\n%s", resolved, err, output, stderr)
+	}
+	fields := strings.Fields(string(output))
+	got := fields[len(fields)-1]
+	if got != want {
+		t.Fatalf("gofmt-bin.sh resolved %s (built with %s), want a %s gofmt.\n"+
+			"CI formats with go.mod's version, so this host's `make fmt` would "+
+			"rewrite files CI then rejects.\nresolver stderr:\n%s",
+			resolved, got, want, stderr)
+	}
+}
+
+func TestGofmtBinIgnoresPathGofmt(t *testing.T) {
+	testGo(t)
+	bash := testBash(t)
+	shimDir := filepath.Join(t.TempDir(), "path shims")
+	if err := os.MkdirAll(shimDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	shim := filepath.Join(shimDir, "gofmt")
+	writeShellExecutable(t, bash, shim, "#!/usr/bin/env bash\nexit 0\n")
+
+	path := shimDir + string(os.PathListSeparator) + os.Getenv("PATH")
+	resolved, stderr := runGofmtBin(t, map[string]string{"PATH": path}, nil)
+
+	if resolved == shellVisiblePath(shim) {
+		t.Fatalf("gofmt-bin.sh returned the PATH shim %s; it must resolve from "+
+			"go.mod's toolchain instead.\nresolver stderr:\n%s", resolved, stderr)
+	}
+}
+
+func TestGofmtBinHonorsGOFMTOverride(t *testing.T) {
+	want := shellVisiblePath(filepath.Join(t.TempDir(), "explicit gofmt"))
+
+	resolved, stderr := runGofmtBin(t, map[string]string{"GOFMT": want}, nil)
+
+	if resolved != want {
+		t.Fatalf("gofmt-bin.sh = %q, want the GOFMT override %q\nresolver stderr:\n%s",
+			resolved, want, stderr)
+	}
+}
+
+// runGofmtBin runs scripts/ci/gofmt-bin.sh and returns its stdout (the resolved
+// path) and stderr separately. Fallback warnings go to stderr, so keeping them
+// apart is what lets a failure report why the resolution went the way it did.
+func runGofmtBin(t *testing.T, overrides map[string]string, args []string) (string, string) {
+	t.Helper()
+	bash := testBash(t)
+	env := map[string]string{
+		"BASH_ENV":  "",
+		"BASHOPTS":  "",
+		"ENV":       "",
+		"GOFMT":     "",
+		"LANG":      "C",
+		"LC_ALL":    "C",
+		"SHELLOPTS": "",
+	}
+	for key, value := range overrides {
+		env[key] = value
+	}
+	// An empty GOFMT is the resolver's "not set" case, but exporting it empty
+	// would make the override test indistinguishable from the default one.
+	if env["GOFMT"] == "" {
+		delete(env, "GOFMT")
+	}
+
+	script := shellVisiblePath(filepath.Join(sourceRepoRoot(), "scripts", "ci", "gofmt-bin.sh"))
+	cmd := exec.Command(bash, append([]string{"--noprofile", "--norc", "--", script}, args...)...)
+	cmd.Dir = sourceRepoRoot()
+	cmd.Env = environment(env)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	stdout, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("gofmt-bin.sh failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr.String())
+	}
+	return strings.TrimSpace(normalizeNewlines(string(stdout))), stderr.String()
+}
+
+// goModToolchainVersion returns go.mod's go directive in GOTOOLCHAIN form, i.e.
+// with the patch component a bare "go 1.26" directive omits.
+func goModToolchainVersion(t *testing.T) string {
+	t.Helper()
+	file, err := os.Open(filepath.Join(sourceRepoRoot(), "go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 2 && fields[0] == "go" {
+			if strings.Count(fields[1], ".") == 1 {
+				return fields[1] + ".0"
+			}
+			return fields[1]
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	t.Fatal("no go directive in go.mod")
+	return ""
+}
+
+func testGo(t *testing.T) string {
+	t.Helper()
+	path, err := exec.LookPath("go")
+	if err != nil {
+		t.Skipf("go is not on PATH: %v", err)
+	}
+	return path
+}

--- a/scripts/prlintmake/prlintmake_test.go
+++ b/scripts/prlintmake/prlintmake_test.go
@@ -11,22 +11,23 @@ import (
 )
 
 func TestFmtCheckClean(t *testing.T) {
-	output, err := runFmtCheck(t, "exit 0\n")
+	gofmt, output, err := runFmtCheck(t, "exit 0\n")
 	if err != nil {
 		t.Fatalf("fmt-check failed: %v\n%s", err, output)
 	}
-	want := "Checking Go formatting...\nAll Go files are properly formatted\n"
+	want := "Checking Go formatting...\nUsing gofmt " + gofmt + "\nAll Go files are properly formatted\n"
 	if output != want {
 		t.Fatalf("output = %q, want %q", output, want)
 	}
 }
 
 func TestFmtCheckReportsUnformattedFiles(t *testing.T) {
-	output, err := runFmtCheck(t, "printf '%s\\n' cmd/bd/main.go internal/config/config.go\n")
+	gofmt, output, err := runFmtCheck(t, "printf '%s\\n' cmd/bd/main.go internal/config/config.go\n")
 	if got := processExitCode(err); got != 1 {
 		t.Fatalf("exit = %d, want 1; error=%v\n%s", got, err, output)
 	}
 	want := "Checking Go formatting...\n" +
+		"Using gofmt " + gofmt + "\n" +
 		"The following files are not properly formatted:\n" +
 		"cmd/bd/main.go\n" +
 		"internal/config/config.go\n\n" +
@@ -37,7 +38,7 @@ func TestFmtCheckReportsUnformattedFiles(t *testing.T) {
 }
 
 func TestFmtCheckPreservesGofmtFailure(t *testing.T) {
-	output, err := runFmtCheck(t, "printf 'synthetic gofmt failure\\n' >&2\nexit 42\n")
+	_, output, err := runFmtCheck(t, "printf 'synthetic gofmt failure\\n' >&2\nexit 42\n")
 	if got := processExitCode(err); got != 42 {
 		t.Fatalf("exit = %d, want 42; error=%v\n%s", got, err, output)
 	}
@@ -52,7 +53,14 @@ func TestFmtCheckPreservesGofmtFailure(t *testing.T) {
 	}
 }
 
-func runFmtCheck(t *testing.T, gofmtBody string) (string, error) {
+// runFmtCheck runs scripts/ci/fmt-check.sh against a gofmt shim with the given
+// body, and returns the shim path fmt-check.sh is expected to report.
+//
+// The shim is injected through GOFMT rather than PATH. fmt-check.sh deliberately
+// ignores a PATH gofmt -- that is the whole of be-gx8 -- so a PATH shim would be
+// silently bypassed and these tests would grade the real toolchain instead of
+// the case they name. TestGofmtBinIgnoresPathGofmt covers the resolution itself.
+func runFmtCheck(t *testing.T, gofmtBody string) (string, string, error) {
 	t.Helper()
 	bash := testBash(t)
 	testRoot := t.TempDir()
@@ -60,12 +68,10 @@ func runFmtCheck(t *testing.T, gofmtBody string) (string, error) {
 	if err := os.MkdirAll(shimDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeShellExecutable(t, bash, filepath.Join(shimDir, "gofmt"), "#!/usr/bin/env bash\nset -euo pipefail\n"+gofmtBody)
+	shim := filepath.Join(shimDir, "gofmt")
+	writeShellExecutable(t, bash, shim, "#!/usr/bin/env bash\nset -euo pipefail\n"+gofmtBody)
+	gofmt := shellVisiblePath(shim)
 
-	path := shimDir + string(os.PathListSeparator) + os.Getenv("PATH")
-	if runtime.GOOS == "windows" {
-		path = msysPath(shimDir) + ":/usr/bin:/bin"
-	}
 	cmd := exec.Command(
 		bash,
 		"--noprofile",
@@ -78,13 +84,13 @@ func runFmtCheck(t *testing.T, gofmtBody string) (string, error) {
 		"BASH_ENV":  "",
 		"BASHOPTS":  "",
 		"ENV":       "",
+		"GOFMT":     gofmt,
 		"LANG":      "C",
 		"LC_ALL":    "C",
-		"PATH":      path,
 		"SHELLOPTS": "",
 	})
 	output, err := cmd.CombinedOutput()
-	return normalizeNewlines(string(output)), err
+	return gofmt, normalizeNewlines(string(output)), err
 }
 
 func writeShellExecutable(t *testing.T, bash, path, body string) {


### PR DESCRIPTION
## The defect

`gofmt`'s output is not stable across Go releases, so whichever binary runs decides the formatting verdict. Three sites reached for a bare `gofmt` on `PATH`, and `PATH` belongs to whatever Go happens to be installed locally:

| site | call |
|---|---|
| `scripts/ci/fmt-check.sh:12` | `gofmt -l .` |
| `Makefile:351` (`make fmt`) | `gofmt -w .` |
| `.githooks/pre-commit:31` | `xargs gofmt -w` |

CI has no such freedom — `actions/setup-go` installs exactly the `go.mod` version via `go-version-file`, so CI's gofmt is always the pinned one.

**`GOTOOLCHAIN=auto` does not correct for this**, which is why `go env GOROOT` or `go fmt` would not have been a fix either: the toolchain switch only ever moves **up** to satisfy the `go` directive, never down. Measured against `go.mod`'s `go 1.26.5` on a `go1.27.0` host:

```
go env GOROOT                       /usr/local/go                     <- the 1.27 root
GOTOOLCHAIN=go1.26.5 go env GOROOT  .../toolchain@v0.0.1-go1.26.5...  <- the pinned one

gofmt 1.27.0 -l   internal/storage/{dolt,embeddeddolt,uow}/role_fixture_kit_test.go
gofmt 1.26.5 -l   clean
```

No branch touches those three files; they are byte-identical to `origin/main`.

## Why it matters, and the direction it fails in

The required lint gate went red on untouched code, which reads as *"main's lint is broken"* — and it poisons the pre-existing-on-main judgement every PR author uses to decide whether a red gate is theirs.

Then the gate's own advice, *"Run `make fmt` to fix formatting"*, rewrites those files into a form CI's pinned gofmt rejects. **The tool tells you to do the thing that breaks it.** The pre-commit hook performed that same rewrite *and re-staged it*, silently, on every Go commit, with nobody choosing it.

## The fix

One resolver rather than three patches, so the next gofmt call site cannot drift. `scripts/ci/gofmt-bin.sh` names `go.mod`'s toolchain explicitly and reads `GOROOT` from it, short-circuiting to a plain `go env GOROOT` when the host `go` already **is** the pinned version — the CI case, so nothing is fetched where nothing needs fetching. `GOFMT` overrides it.

Falling back to the `PATH` binary stays available but **warns loudly on stderr**: a silent fallback is indistinguishable from a correct resolution, and reintroduces exactly the skew this removes. `fmt-check.sh` now prints the gofmt it used, so a skew presents as a skew instead of as a repo defect:

```
Checking Go formatting...
Using gofmt go1.26.5 (/home/.../toolchain@v0.0.1-go1.26.5.linux-amd64/bin/gofmt)
All Go files are properly formatted
```

`.githooks/pre-commit` already pinned `GOTOOLCHAIN` for `golangci-lint` six lines above the broken `gofmt` call, for the same class of reason.

## Tests

`scripts/prlintmake/gofmtbin_test.go` pins the **resolution**, not the reporting, because the resolution is where the bug lived — every output assertion around the bare `gofmt` stayed green while it shipped.

- `TestGofmtBinMatchesGoModDirective` — `go version <resolved>` equals `go.mod`'s directive
- `TestGofmtBinIgnoresPathGofmt` — a `PATH` shim named `gofmt` is not returned
- `TestGofmtBinHonorsGOFMTOverride` — the escape hatch

**Positive control:** reverting `gofmt-bin.sh` to a bare `command -v gofmt` fails all three (`resolved /usr/local/go/bin/gofmt (built with go1.27.0), want a go1.26.5 gofmt`). Restored, all pass.

The three pre-existing `fmt-check` tests move their shim from `PATH` to `GOFMT`. A `PATH` shim is now correctly ignored, so leaving them there would have made them silently grade the real toolchain instead of the case they name.

## Verification

All run from the branch worktree with `PATH=/usr/local/go/bin:$PATH` (i.e. the go1.27.0 host that reproduced the bug):

| gate | result |
|---|---|
| `make ci-pr-lint` | **rc=0** — this is the gate the bug reported red |
| `make fmt` | rewrites nothing; `git status` clean of `.go` files |
| `make fmt-check` | rc=0, reports `go1.26.5` |
| `go vet ./...` | rc=0 |
| `make build` | rc=0 |
| `go test ./scripts/prlintmake/` | ok |
| `codex exec review --base main` | no findings |

The pre-commit hook ran on this branch's own commit and rewrote nothing.

Closes be-gx8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoN7f9TMmGTCLRpDPzSH4y
