### PR TITLE
fix(repo): store an absolute path for a relative 'bd repo add' target (be-d0t)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`bd repo add` no longer stores a working-directory-relative repository
+  path.** A bare or relative argument (`bd repo add ../other-repo`) was
+  persisted into `repos.additional` exactly as typed, and every consumer —
+  `bd repo sync`, `bd doctor`'s multi-repo checks — re-resolves that string
+  against its own working directory. The entry therefore named a different
+  directory for every cwd a later command ran from, and the `.beads` existence
+  check `repo add` performs proves only that the path resolved at add time,
+  from the adder's cwd. Even read charitably as "relative to the repo root" it
+  never worked, because the resolution is against the process cwd rather than
+  against `config.yaml`'s directory, so a `bd repo sync` from a subdirectory of
+  the same clone already missed. A relative path is now resolved once, at add
+  time, and stored absolute. Absolute paths, remote URLs and `~/`-prefixed
+  paths are still stored verbatim — the last deliberately, since a `~/` entry
+  is already independent of the working directory and absolutizing it would
+  bake one user's home directory into a `config.yaml` that is version
+  controlled and shared across clones. `bd repo remove` matches a configured
+  entry verbatim first and then in the same canonical form, so entries written
+  by older versions stay removable and `bd repo remove ../other-repo` still
+  finds what `bd repo add ../other-repo` wrote from that directory; it also
+  resolves that entry before the delete, so a missing `config.yaml` now fails
+  ahead of the destructive `DeleteIssuesBySourceRepo` rather than after it.
+
 - **`bd prime` says when it could NOT read the memory plane**
   ([#5877](https://github.com/gastownhall/beads/issues/5877)). A broken or
   unreachable store made prime omit the memory section entirely, so a session

--- a/cmd/bd/repo.go
+++ b/cmd/bd/repo.go
@@ -34,7 +34,7 @@ Configuration is stored in .beads/config.yaml under the 'repos' section:
 
 Examples:
   bd repo add ~/beads-planning       # Add planning repo
-  bd repo add ../other-repo          # Add relative path repo
+  bd repo add ../other-repo          # Relative path, stored as absolute
   bd repo list                       # Show all configured repos
   bd repo remove ~/beads-planning    # Remove by path
   bd repo sync                       # Sync from all configured repos`,
@@ -46,7 +46,10 @@ var repoAddCmd = &cobra.Command{
 	Long: `Add a repository path to the repos.additional list in config.yaml.
 
 The path should point to a directory containing a .beads folder.
-Paths can be absolute or relative (they are stored as-is).
+
+A relative path is resolved against the current directory and stored as an
+absolute path, so later commands run from anywhere resolve the same repository.
+Absolute paths and "~/"-prefixed paths are stored verbatim.
 
 This modifies .beads/config.yaml, which is version-controlled and
 shared across all clones of this repository.`,
@@ -69,18 +72,21 @@ shared across all clones of this repository.`,
 		if remotecache.IsRemoteURL(repoPath) {
 			fmt.Fprintf(os.Stderr, "Adding remote repository: %s\n", repoPath)
 		} else {
-			expandedPath := repoPath
-			if len(repoPath) > 0 && repoPath[0] == '~' {
-				home, err := os.UserHomeDir()
-				if err == nil {
-					expandedPath = filepath.Join(home, repoPath[1:])
-				}
-			}
+			expandedPath := expandRepoTilde(repoPath)
 
 			beadsDir := filepath.Join(expandedPath, ".beads")
 			if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
 				return HandleError("no beads workspace found at %s", expandedPath)
 			}
+
+			// The existence check above proves the path resolves *now*, from
+			// this cwd. Canonicalize before persisting so it still resolves
+			// later, from anywhere (be-d0t).
+			normalized, err := normalizeRepoPathForStorage(repoPath)
+			if err != nil {
+				return HandleError("failed to resolve repository path %s: %v", repoPath, err)
+			}
+			repoPath = normalized
 		}
 
 		configPath, err := config.FindConfigYAMLPath()
@@ -111,8 +117,11 @@ var repoRemoveCmd = &cobra.Command{
 	Short: "Remove a repository from sync configuration",
 	Long: `Remove a repository path from the repos.additional list in config.yaml.
 
-The path must exactly match what was added (e.g., if you added "~/foo",
-you must remove "~/foo", not "/home/user/foo").
+The path is matched against the configured entries verbatim first, then in the
+same canonical form 'bd repo add' stores (a relative path resolved against the
+current directory). So "~/foo" removes the entry added as "~/foo", and
+"../other-repo" removes the absolute entry it was stored as, provided you run
+both commands from the same directory.
 
 This command also removes any previously-hydrated issues from the database
 that came from the removed repository.`,
@@ -136,6 +145,17 @@ that came from the removed repository.`,
 			return HandleError("%v", err)
 		}
 
+		// Resolve the configured entry before deleting anything: issues and the
+		// mtime cache are keyed by the string stored in config.yaml, which is
+		// the canonical form 'bd repo add' persists rather than the argument as
+		// typed. Looking the config up first also means a missing config.yaml
+		// fails before the destructive delete rather than after it.
+		configPath, err := config.FindConfigYAMLPath()
+		if err != nil {
+			return HandleError("failed to find config.yaml: %v", err)
+		}
+		repoPath = resolveConfiguredRepoPath(configPath, repoPath)
+
 		ctx := rootCtx
 
 		deletedCount, err := store.DeleteIssuesBySourceRepo(ctx, repoPath)
@@ -145,11 +165,6 @@ that came from the removed repository.`,
 
 		if err := store.ClearRepoMtime(ctx, repoPath); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to clear mtime cache: %v\n", err)
-		}
-
-		configPath, err := config.FindConfigYAMLPath()
-		if err != nil {
-			return HandleError("failed to find config.yaml: %v", err)
 		}
 
 		if err := config.RemoveRepo(configPath, repoPath); err != nil {
@@ -329,13 +344,7 @@ Also triggers Dolt push/pull if a remote is configured.`,
 			}
 
 			// Local path: expand tilde
-			expandedPath := repoPath
-			if len(repoPath) > 0 && repoPath[0] == '~' {
-				home, err := os.UserHomeDir()
-				if err == nil {
-					expandedPath = filepath.Join(home, repoPath[1:])
-				}
-			}
+			expandedPath := expandRepoTilde(repoPath)
 
 			// Resolve to absolute path for consistent mtime caching
 			absPath, err := filepath.Abs(expandedPath)
@@ -483,4 +492,86 @@ func init() {
 	repoSyncCmd.Flags().Bool("verbose", false, "Show detailed sync progress")
 
 	rootCmd.AddCommand(repoCmd)
+}
+
+// expandRepoTilde expands a leading '~' in a `bd repo` path to the user's home
+// directory. It is the expansion every consumer of repos.additional already
+// performs (repo sync here, ResolveBeadsDirForRepo in the doctor checks), kept
+// in one place so add-time and use-time agree on what a stored entry means.
+//
+// A path that does not begin with '~', or a home directory that cannot be
+// determined, is returned unchanged.
+func expandRepoTilde(repoPath string) string {
+	if len(repoPath) == 0 || repoPath[0] != '~' {
+		return repoPath
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return repoPath
+	}
+	return filepath.Join(home, repoPath[1:])
+}
+
+// normalizeRepoPathForStorage canonicalizes a local repository path for
+// persistence in .beads/config.yaml.
+//
+// Remote URLs and '~'-prefixed paths are returned verbatim: the first is not a
+// filesystem path, and the second is anchored to the user's home directory
+// rather than to a working directory, so it stays portable across clones of the
+// shared config. Anything else that is not already absolute is cwd-relative and
+// is resolved against the current directory.
+//
+// Storing a relative path as typed is the be-d0t defect: the entry names a
+// directory relative to the cwd of whoever ran `bd repo add`, so every later
+// resolution — `bd repo sync` from a subdirectory, `bd doctor` from anywhere —
+// points somewhere else, or nowhere. The existence check performed at add time
+// says nothing about resolution at use time, because the two happen from
+// different directories.
+func normalizeRepoPathForStorage(repoPath string) (string, error) {
+	if remotecache.IsRemoteURL(repoPath) {
+		return repoPath, nil
+	}
+	if repoPath == "" || repoPath[0] == '~' || filepath.IsAbs(repoPath) {
+		return repoPath, nil
+	}
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+
+// resolveConfiguredRepoPath maps a user-supplied `bd repo remove` argument onto
+// the entry actually stored in config.yaml.
+//
+// A verbatim match wins, so an entry added before paths were canonicalized (or
+// added as "~/foo") is still removable by the string it is stored under. Failing
+// that, the argument is canonicalized the way `bd repo add` would store it, so
+// `bd repo remove ../other-repo` matches the absolute entry that
+// `bd repo add ../other-repo` wrote from the same directory.
+//
+// The argument is returned unchanged when neither form is configured; the caller
+// reports the resulting "repository not found" against what the user typed.
+func resolveConfiguredRepoPath(configPath, repoPath string) string {
+	repos, err := config.ListRepos(configPath)
+	if err != nil || repos == nil {
+		return repoPath
+	}
+
+	for _, existing := range repos.Additional {
+		if existing == repoPath {
+			return repoPath
+		}
+	}
+
+	normalized, err := normalizeRepoPathForStorage(repoPath)
+	if err != nil || normalized == repoPath {
+		return repoPath
+	}
+	for _, existing := range repos.Additional {
+		if existing == normalized {
+			return normalized
+		}
+	}
+	return repoPath
 }

--- a/cmd/bd/repo_path_test.go
+++ b/cmd/bd/repo_path_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/config"
+)
+
+// TestNormalizeRepoPathForStorage covers what `bd repo add` persists for each
+// shape of argument. The relative cases are the be-d0t regression: a stored
+// relative path re-resolves against whatever cwd a later command runs from.
+func TestNormalizeRepoPathForStorage(t *testing.T) {
+	tmpDir := t.TempDir()
+	// macOS /var is a symlink to /private/var, and t.TempDir hands back the
+	// unresolved form while os.Getwd returns the resolved one. Compare against
+	// what the process actually reports as its working directory.
+	t.Chdir(tmpDir)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"bare name", "gastown", filepath.Join(cwd, "gastown")},
+		{"dot relative", "./sibling", filepath.Join(cwd, "sibling")},
+		{"parent relative", "../other-repo", filepath.Join(filepath.Dir(cwd), "other-repo")},
+		{"absolute kept verbatim", "/srv/beads-planning", "/srv/beads-planning"},
+		{"tilde kept verbatim", "~/beads-planning", "~/beads-planning"},
+		{"bare tilde kept verbatim", "~", "~"},
+		{"remote url kept verbatim", "https://github.com/steveyegge/beads.git", "https://github.com/steveyegge/beads.git"},
+		{"empty kept verbatim", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeRepoPathForStorage(tt.input)
+			if err != nil {
+				t.Fatalf("normalizeRepoPathForStorage(%q) error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("normalizeRepoPathForStorage(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeRepoPathForStorage_SurvivesCwdChange is the defect itself: the
+// value `bd repo add` persists must name the same directory when a later
+// command resolves it from somewhere else.
+func TestNormalizeRepoPathForStorage_SurvivesCwdChange(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "planning")
+	if err := os.MkdirAll(filepath.Join(target, ".beads"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	subdir := filepath.Join(root, "workspace", "nested")
+	if err := os.MkdirAll(subdir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	// `bd repo add ../../planning` run from root/workspace/nested.
+	t.Chdir(subdir)
+	stored, err := normalizeRepoPathForStorage(filepath.Join("..", "..", "planning"))
+	if err != nil {
+		t.Fatalf("normalizeRepoPathForStorage: %v", err)
+	}
+
+	// A later command — `bd repo sync`, `bd doctor` — from a different cwd.
+	t.Chdir(root)
+	resolved, err := filepath.Abs(expandRepoTilde(stored))
+	if err != nil {
+		t.Fatalf("Abs: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(resolved, ".beads")); err != nil {
+		t.Fatalf("stored path %q does not resolve to the added workspace from a different cwd: %v", stored, err)
+	}
+}
+
+func TestExpandRepoTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home directory: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"tilde slash", "~/beads-planning", filepath.Join(home, "beads-planning")},
+		{"bare tilde", "~", home},
+		{"absolute untouched", "/srv/planning", "/srv/planning"},
+		{"relative untouched", "../other-repo", "../other-repo"},
+		{"empty untouched", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := expandRepoTilde(tt.input); got != tt.want {
+				t.Errorf("expandRepoTilde(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveConfiguredRepoPath checks that `bd repo remove` still finds the
+// entry it is asked to drop, whether that entry was stored verbatim (added
+// before paths were canonicalized, or added as "~/foo") or canonicalized.
+func TestResolveConfiguredRepoPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	legacyRelative := "legacy-relative-entry"
+	contents := "repos:\n  primary: \".\"\n  additional:\n    - \"~/beads-planning\"\n    - \"" +
+		filepath.Join(cwd, "planning") + "\"\n    - \"" + legacyRelative + "\"\n"
+	if err := os.WriteFile(configPath, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"verbatim tilde entry", "~/beads-planning", "~/beads-planning"},
+		{"relative arg matches stored absolute", "planning", filepath.Join(cwd, "planning")},
+		{"legacy relative entry still removable", legacyRelative, legacyRelative},
+		{"absolute arg matches itself", filepath.Join(cwd, "planning"), filepath.Join(cwd, "planning")},
+		{"unconfigured arg returned as typed", "../nowhere", "../nowhere"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveConfiguredRepoPath(configPath, tt.input); got != tt.want {
+				t.Errorf("resolveConfiguredRepoPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("missing config returns arg unchanged", func(t *testing.T) {
+		missing := filepath.Join(tmpDir, "does-not-exist.yaml")
+		if got := resolveConfiguredRepoPath(missing, "planning"); got != "planning" {
+			t.Errorf("resolveConfiguredRepoPath with missing config = %q, want %q", got, "planning")
+		}
+	})
+
+	// Guard the assumption the resolution rests on: config.ListRepos returns the
+	// entries verbatim, so a canonicalized argument can be compared to them.
+	repos, err := config.ListRepos(configPath)
+	if err != nil {
+		t.Fatalf("ListRepos: %v", err)
+	}
+	if len(repos.Additional) != 3 {
+		t.Fatalf("expected 3 configured repos, got %d (%v)", len(repos.Additional), repos.Additional)
+	}
+}


### PR DESCRIPTION
## What

`bd repo add ../other-repo` persisted the argument into `repos.additional` exactly as typed, and every consumer re-resolves that string against **its own** working directory:

- `runRepoSync` (`cmd/bd/repo.go`) expands a leading `~`, then calls `filepath.Abs`
- `bd doctor`'s multi-repo checks go through `ResolveBeadsDirForRepo`

So the stored entry named a different directory for every cwd a later command ran from. The `.beads` existence check `runRepoAdd` performs proves only that the path resolved **at add time, from the adder's cwd** — it says nothing about resolution at use time, because the two happen from different directories.

Fixes `be-d0t`. Same class as `be-flg` / #6292 one layer along, found while fixing that one.

## Was the relative behaviour deliberate?

The bead asked this explicitly, so it was checked before changing anything. It was not.

- Nothing consumes `repos.additional` per-cwd on purpose.
- `repos.primary` is `"."` by convention but is **never resolved as a path** — it is only printed by `repo list` and used as a set/unset marker in `internal/config/repos.go`.
- The only support for relative entries was documentation: `repo add`'s help said *"Paths can be absolute or relative (they are stored as-is)"*.

And even read charitably as *"relative to the repo root"*, it never worked: the resolution is against the **process cwd**, not against `config.yaml`'s directory. `bd repo sync` from a subdirectory of the **same clone** already missed.

## The fix

A relative path is resolved once, at add time, via `normalizeRepoPathForStorage`.

Absolute paths, remote URLs and `~/`-prefixed paths stay **verbatim**. The last is deliberate rather than an oversight: a `~/` entry is already independent of the working directory, and absolutizing it would bake one user's home directory into a `config.yaml` that is version-controlled and shared across clones — trading a cwd bug for a portability bug.

`bd repo remove` matches a configured entry verbatim first and then in the same canonical form, so:

- entries written by older versions stay removable
- `bd repo remove ../other-repo` still finds what `bd repo add ../other-repo` wrote from that directory

It also resolves that entry **before** the delete, which moves the `config.yaml` lookup ahead of `DeleteIssuesBySourceRepo` — a missing config now fails before the destructive step rather than after it.

The tilde expansion that `runRepoAdd` and `runRepoSync` each open-coded is now `expandRepoTilde`, so add time and use time cannot drift apart.

## Tests

`cmd/bd/repo_path_test.go`, 23 subtests.

`TestNormalizeRepoPathForStorage_SurvivesCwdChange` is the regression: add from a nested directory, resolve from another. **Negative control run** — with the `filepath.Abs` call reverted it fails with

```
stored path "../../planning" does not resolve to the added workspace
from a different cwd: stat /tmp/planning/.beads: no such file or directory
```

so it exercises the defect rather than passing vacuously.

Verified end to end against the built binary as well: relative add stores absolute and resolves from a different cwd, relative remove matches it, `~/` round-trips verbatim, and a hand-written legacy relative entry is still removable.

## Gates

| gate | result |
|---|---|
| `make ci-pr-lint` | pass — gofmt, golangci-lint, golangci-lint (windows), 0 issues |
| `make test` | pass — 97 packages, 0 failures |
| `scripts/check-cli-docs-drift.sh` | pass |

Two notes on running those locally, both verified rather than assumed:

- **`make ci-pr-lint` fails on three untouched files under a go1.27 toolchain.** `go.mod` pins 1.26.5; go1.27's gofmt reindents a multi-value return of composite literals in `internal/storage/{dolt,embeddeddolt,uow}/role_fixture_kit_test.go`. Under 1.26.5 all three are clean. Not a repo defect.
- **`make test` fails two `cmd/bd` tests when `BD_ACTOR` or `BD_DOLT_AUTO_COMMIT` is set in the environment**, which is the case inside any Gas Town agent session. Both pass in CI and both pass here with those unset; both were confirmed pre-existing at `c0d8da42d` with an empty diff. Isolated by a four-way control and filed separately (`be-6c0`); untouched by this PR.

`docs/` is generated from the release tag in `docs/cli-docs.pin` (`v1.2.2`), so the updated help text introduces no drift and nothing under `docs/` is regenerated here.

## Adjacent work

- **#6292** (`be-flg`) — the same class one layer along, in `bd create --repo`. No file overlap.
- **#6125** (machine-local config keys to a `config.local.yaml` sidecar) — its `MachineLocalKeys` registry covers `dolt.*` and `backup.*` only, not `repos.*`, so there is no conflict. Worth flagging for the reviewer: if `repos.additional` ever becomes machine-local, the `~/`-verbatim carve-out here is the thing to revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEqFxbYyXF3YCsqvxivxky
