### PR TITLE
fix(close): report and refuse a close reason first-close-wins discards

### DIFF
--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -36,7 +36,17 @@ the fallback anywhere, or =0 to disable it entirely.
 When closing multiple issues, provide one --reason for all IDs or repeat
 --reason once per ID. Reasons map positionally: the first --reason applies
 to the first ID, the second --reason to the second ID, regardless of where
-the flags appear in the command line.`,
+the flags appear in the command line.
+
+A close reason is FIRST-CLOSE-WINS: re-closing an already-closed issue keeps
+the reason the first close recorded. So a re-close carrying a different
+--reason writes nothing, and bd reports that on stderr and exits non-zero
+rather than confirming a write it did not perform; the success line reports
+the reason on the record, not the one just discarded. To add to a closed
+issue's record use "bd comment"; to replace the reason itself, "bd reopen"
+(which clears it) and close again. Re-closing with no reason, or with the
+reason already stored, stays a silent idempotent success, so a retried close
+is unaffected.`,
 	// Refuse a missing ID in argument validation, before root's
 	// PersistentPreRunE can open the store, migrate, or auto-import
 	// (bd-m00pb); see updateCmd for the full rationale.
@@ -71,7 +81,7 @@ the flags appear in the command line.`,
 			}
 			args = []string{lastTouched}
 		}
-		reasons, updatedArgs, err := resolveCloseReasons(cmd, args)
+		reasons, updatedArgs, reasonExplicit, err := resolveCloseReasons(cmd, args)
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
 		}
@@ -146,6 +156,11 @@ the flags appear in the command line.`,
 		closedCount := 0
 		alreadyClosed := 0
 		firstSettledID := ""
+		// An explicit reason the engine dropped on an already-closed re-close.
+		// It does not undo the close — the issue IS closed, and every retry-safe
+		// post-close contract below still replays — but the command did not do
+		// what it was asked, so it must not exit 0. See closeReasonDiscarded.
+		reasonDiscarded := false
 
 		for i, id := range resolvedIDs {
 			res := outcomes[i]
@@ -173,7 +188,18 @@ the flags appear in the command line.`,
 			issue := results[i].Issue
 
 			if !res.Changed {
-				// Already closed: an idempotent no-op on the step's stored state. The
+				// Already closed. Before anything else, answer the one request this
+				// path CANNOT honor: a reason the caller spelled that disagrees with
+				// the stored one. first-close-wins drops it, so say so on stderr and
+				// mark the command for a non-zero exit — the historical rc=0 with the
+				// caller's own text echoed back is what made a discarded amendment
+				// read as a successful one (be-ctr).
+				if closeReasonDiscarded(res.Changed, reasonExplicit, reason, storedCloseReason(res.Issue, issue)) {
+					fmt.Fprintln(os.Stderr, closeReasonDiscardedRefusal(id, storedCloseReason(res.Issue, issue)))
+					reasonDiscarded = true
+				}
+
+				// An idempotent no-op on the step's stored state. The
 				// old CloseIssue path also returned nil here and still reported the
 				// (already-closed) issue, so keep OUTPUT parity via the shared display
 				// block below — the issue stays in --json output and the text report
@@ -240,7 +266,11 @@ the flags appear in the command line.`,
 					closedIssues = append(closedIssues, closedIssue)
 				}
 			} else {
-				debug.PrintNormal("%s Closed %s: %s\n", ui.RenderPass("✓"), formatFeedbackID(id, issueTitleOrEmpty(issue)), reason)
+				// The reason PRINTED is the one on the record, which on an
+				// already-closed no-op is the stored reason rather than the
+				// discarded one just supplied.
+				debug.PrintNormal("%s Closed %s: %s\n", ui.RenderPass("✓"), formatFeedbackID(id, issueTitleOrEmpty(issue)),
+					closeReportedReason(res.Changed, reason, storedCloseReason(closedIssue, issue)))
 			}
 		}
 
@@ -373,6 +403,12 @@ the flags appear in the command line.`,
 		if totalAttempted > 0 && closedCount == 0 && alreadyClosed == 0 {
 			return SilentExit()
 		}
+		// A discarded reason exits non-zero. The refusal is already on stderr,
+		// naming the id and both amendment paths, so there is nothing left to
+		// print — what a caller still needs is a status it can branch on.
+		if reasonDiscarded {
+			return SilentExit()
+		}
 		return nil
 	},
 }
@@ -426,14 +462,25 @@ func (v *closeReasonFlagValue) Values() []string {
 	return out
 }
 
-func resolveCloseReasons(cmd *cobra.Command, args []string) ([]string, []string, error) {
+// resolveCloseReasons resolves `bd close`'s reason list, and reports whether
+// the CALLER spelled one.
+//
+// The explicit bool is not cosmetic. Every close carries a reason, because an
+// unflagged one falls through to bd's own "Closed" default below, so the
+// reason VALUE cannot distinguish "the caller asked for this text" from "the
+// caller asked for nothing". closeReasonDiscarded needs exactly that
+// distinction — an unrequested default that the engine drops on a re-close is
+// nothing to report, and a reason the caller typed and lost is (be-ctr) — so
+// it is decided here, at the one place that knows, rather than re-derived by
+// each route from the flags.
+func resolveCloseReasons(cmd *cobra.Command, args []string) ([]string, []string, bool, error) {
 	reasons, err := collectCloseReasonFlags(cmd)
 	if err != nil {
-		return nil, args, err
+		return nil, args, false, err
 	}
 
 	if fileReason, ok, err := resolveReasonFile(cmd, len(reasons) > 0); err != nil {
-		return nil, args, err
+		return nil, args, false, err
 	} else if ok {
 		reasons = []string{fileReason}
 	}
@@ -445,13 +492,88 @@ func resolveCloseReasons(cmd *cobra.Command, args []string) ([]string, []string,
 		args = args[:len(args)-1]
 	}
 
+	// Everything above this line came from the caller; the default below does not.
+	explicit := len(reasons) > 0
+
 	if len(reasons) == 0 {
 		reasons = []string{"Closed"}
 	}
 	if len(reasons) > 1 && len(reasons) != len(args) {
-		return nil, args, fmt.Errorf("got %d close reasons for %d issue IDs; provide exactly one shared reason or one reason per issue", len(reasons), len(args))
+		return nil, args, explicit, fmt.Errorf("got %d close reasons for %d issue IDs; provide exactly one shared reason or one reason per issue", len(reasons), len(args))
 	}
-	return reasons, args, nil
+	return reasons, args, explicit, nil
+}
+
+// closeReasonDiscarded reports the one case where `bd close --reason` reads
+// like it worked and did not: the issue was ALREADY closed, so the engine's
+// first-close-wins rule (issueops.CloseRequest.Reason) keeps the stored reason
+// and drops the one just supplied. Both `bd close` routes ask here.
+//
+// It is deliberately narrow, because the ordinary idempotent retry must stay a
+// silent rc=0 success and every other re-close still is one:
+//
+//   - a re-close carrying no reason of its own is not an amendment attempt, so
+//     `explicit` gates it — the "Closed" default is bd's word, not the caller's;
+//   - a re-close carrying the SAME reason already stored asked for the state
+//     that exists, which is precisely what a crashed close replays.
+//
+// What is left is an explicit reason that DISAGREES with the stored one: a
+// request the command cannot honor, which today it answers with rc=0 and an
+// echo of the caller's own text. That is the defect — an agent repairing a
+// misleading close_reason is told it succeeded and has written nothing.
+func closeReasonDiscarded(changed, explicit bool, supplied, stored string) bool {
+	if changed || !explicit {
+		return false
+	}
+	return strings.TrimSpace(supplied) != "" && supplied != stored
+}
+
+// closeReasonDiscardedRefusal spells that case for one id.
+//
+// It names BOTH amendment paths, because "already closed" on its own only
+// relocates the dead end. `bd comment` adds to the record and works on a
+// closed issue; reopen-then-close is what actually replaces close_reason,
+// since a reopen clears the field the first close won.
+func closeReasonDiscardedRefusal(id, stored string) string {
+	// An issue closed without one has no stored reason to quote, and %q would
+	// render that as an empty pair of quotes — which reads like a reason the
+	// close wrote rather than one it never had.
+	held := fmt.Sprintf("the stored reason %q is unchanged", stored)
+	if stored == "" {
+		held = "the issue keeps the empty close reason its first close left"
+	}
+	return fmt.Sprintf("close reason NOT recorded on %s: it was already closed, and a close reason is first-close-wins, so %s.\n"+
+		"  To add to the record:  bd comment %s \"...\"\n"+
+		"  To replace the reason: bd reopen %s && bd close %s --reason \"...\"", id, held, id, id, id)
+}
+
+// closeReportedReason is the reason `bd close` PRINTS for one settled id.
+//
+// A real close reports the reason it just wrote. An already-closed no-op
+// reports the STORED one — echoing back text the close discarded is what made
+// this failure read as confirmation, and it reads most like confirmation
+// exactly when the caller passed --reason-file and sees its whole file come
+// back out (be-ctr). A no-op with nothing stored has nothing truer to print,
+// so it keeps the supplied text rather than printing an empty reason.
+func closeReportedReason(changed bool, supplied, stored string) string {
+	if changed || strings.TrimSpace(stored) == "" {
+		return supplied
+	}
+	return stored
+}
+
+// storedCloseReason reads the close reason already on the record, preferring
+// the operation's own post-state snapshot and falling back to the pre-close
+// read. On the no-op path the two agree by construction; the fallback is for
+// a route whose post-state snapshot is absent.
+func storedCloseReason(after, before *types.Issue) string {
+	if after != nil && after.CloseReason != "" {
+		return after.CloseReason
+	}
+	if before != nil {
+		return before.CloseReason
+	}
+	return ""
 }
 
 func collectCloseReasonFlags(cmd *cobra.Command) ([]string, error) {

--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -576,12 +576,17 @@ func closeReportedReason(changed bool, supplied, stored string) string {
 // reports. Parenthesized so it cannot be mistaken for a reason someone wrote.
 const noCloseReasonRecorded = "(no close reason recorded)"
 
-// storedCloseReason reads the close reason already on the record, preferring
-// the operation's own post-state snapshot and falling back to the pre-close
-// read. On the no-op path the two agree by construction; the fallback is for
-// a route whose post-state snapshot is absent.
+// storedCloseReason reads the close reason already on the record.
+//
+// The operation's own POST-STATE snapshot is authoritative and is used
+// whenever there is one, INCLUDING when it is empty. An earlier revision fell
+// back to the pre-close read on an empty post-state; codex caught that this
+// makes a concurrent reopen-and-reclose report the reason the old closure had
+// — and, worse, lets a supplied reason match that stale value and pass as an
+// idempotent success. The pre-close read is a fallback for a route that hands
+// back no post-state at all, and for nothing else.
 func storedCloseReason(after, before *types.Issue) string {
-	if after != nil && after.CloseReason != "" {
+	if after != nil {
 		return after.CloseReason
 	}
 	if before != nil {

--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -550,17 +550,31 @@ func closeReasonDiscardedRefusal(id, stored string) string {
 // closeReportedReason is the reason `bd close` PRINTS for one settled id.
 //
 // A real close reports the reason it just wrote. An already-closed no-op
-// reports the STORED one — echoing back text the close discarded is what made
-// this failure read as confirmation, and it reads most like confirmation
-// exactly when the caller passed --reason-file and sees its whole file come
-// back out (be-ctr). A no-op with nothing stored has nothing truer to print,
-// so it keeps the supplied text rather than printing an empty reason.
+// reports what is ON THE RECORD and NEVER the supplied text — echoing back
+// text the close discarded is what made this failure read as confirmation, and
+// it reads most like confirmation exactly when the caller passed --reason-file
+// and sees its whole file come back out (be-ctr).
+//
+// A no-op with nothing stored says so rather than borrowing the caller's text.
+// An earlier revision fell back to the supplied reason here, on the grounds
+// that an empty reason is nothing to print; codex caught that it reintroduced
+// the exact defect for issues closed WITHOUT a reason, which is the shape the
+// live instance (be-mh0, close_reason "Closed") is closest to. "Nothing truer
+// to print" was wrong: that a close recorded no reason is itself true, and it
+// is the fact an agent amending the record most needs to see.
 func closeReportedReason(changed bool, supplied, stored string) string {
-	if changed || strings.TrimSpace(stored) == "" {
+	if changed {
 		return supplied
+	}
+	if strings.TrimSpace(stored) == "" {
+		return noCloseReasonRecorded
 	}
 	return stored
 }
+
+// noCloseReasonRecorded is what an already-closed issue with no stored reason
+// reports. Parenthesized so it cannot be mistaken for a reason someone wrote.
+const noCloseReasonRecorded = "(no close reason recorded)"
 
 // storedCloseReason reads the close reason already on the record, preferring
 // the operation's own post-state snapshot and falling back to the pre-close

--- a/cmd/bd/close_proxied_integration_test.go
+++ b/cmd/bd/close_proxied_integration_test.go
@@ -318,12 +318,29 @@ func TestProxiedServerClose(t *testing.T) {
 		issue := bdProxiedCreate(t, bd, p.dir, "Double close")
 		bdProxiedClose(t, bd, p.dir, issue.ID, "--reason", "first")
 		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "close", issue.ID, "--reason", "second")
-		_ = stdout
-		_ = stderr
-		_ = err
 		db := openProxiedDB(t, p)
 		if got := readCloseReason(t, db, issue.ID); got != "first" {
 			t.Errorf("re-close must not overwrite reason: got %q, want %q", got, "first")
+		}
+		// The write not happening is only half of it. This route reported that
+		// no-op as rc=0 with "second" echoed onto stdout, which is what made a
+		// discarded amendment read as a successful one (be-ctr). It refuses
+		// loudly now, and the direct route is pinned to the same behavior in
+		// close_reason_amend_test.go.
+		if err == nil {
+			t.Error("re-close with a different reason exited 0; rc=0 is what made this read as success")
+		}
+		if !strings.Contains(stderr, "close reason NOT recorded on "+issue.ID) {
+			t.Errorf("stderr does not report the discarded reason:\n%s", stderr)
+		}
+		if !strings.Contains(stderr, "bd comment "+issue.ID) {
+			t.Errorf("stderr does not name bd comment as the amendment path:\n%s", stderr)
+		}
+		if strings.Contains(stdout, "second") {
+			t.Errorf("stdout echoed the discarded reason back:\n%s", stdout)
+		}
+		if !strings.Contains(stdout, "first") {
+			t.Errorf("stdout does not report the reason on the record:\n%s", stdout)
 		}
 	})
 

--- a/cmd/bd/close_proxied_server.go
+++ b/cmd/bd/close_proxied_server.go
@@ -69,7 +69,7 @@ func runCloseProxiedServer(cmd *cobra.Command, ctx context.Context, args []strin
 		return HandleErrorRespectJSON("no issue ID provided")
 	}
 
-	reasons, updatedArgs, err := resolveCloseReasons(cmd, args)
+	reasons, updatedArgs, reasonExplicit, err := resolveCloseReasons(cmd, args)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
@@ -119,7 +119,7 @@ func runCloseProxiedServer(cmd *cobra.Command, ctx context.Context, args []strin
 		}
 	}
 
-	outcomes, closeReasons := closeProxiedOutcomes(&pre, result)
+	outcomes, closeReasons, reasonDiscarded := closeProxiedOutcomes(&pre, result, reasonExplicit)
 	post := closeProxiedRunPostClose(ctx, args, in, outcomes)
 
 	for _, e := range pre.errors {
@@ -183,6 +183,12 @@ func runCloseProxiedServer(cmd *cobra.Command, ctx context.Context, args []strin
 	}
 
 	if len(args) > 0 && len(outcomes) == 0 {
+		return SilentExit()
+	}
+	// A reason the caller spelled and first-close-wins dropped exits non-zero,
+	// matching the direct route. The refusal is already on stderr with the
+	// argument-ordered ones above it.
+	if reasonDiscarded {
 		return SilentExit()
 	}
 	return nil
@@ -285,9 +291,13 @@ func closeProxiedCheckOne(ctx context.Context, uw uow.UnitOfWork, id string, in 
 // argument list: a refusal lands in its argument's own error slot so the
 // stderr report stays in typed order, and the survivors keep the shape the
 // display block has always consumed.
-func closeProxiedOutcomes(pre *closeProxiedPreflight, result issueops.CloseBatchResult) ([]closeProxiedOutcome, []string) {
+// The third return reports whether any item discarded a reason the caller
+// spelled, under closeReasonDiscarded's rule; the route turns that into a
+// non-zero exit.
+func closeProxiedOutcomes(pre *closeProxiedPreflight, result issueops.CloseBatchResult, reasonExplicit bool) ([]closeProxiedOutcome, []string, bool) {
 	var outcomes []closeProxiedOutcome
 	var reasons []string
+	reasonDiscarded := false
 	for j, outcome := range result.Outcomes {
 		item := pre.items[j]
 		if outcome.Err != nil {
@@ -306,6 +316,16 @@ func closeProxiedOutcomes(pre *closeProxiedPreflight, result issueops.CloseBatch
 			// snapshot for exactly this reason.
 			after.Dependencies = nil
 		}
+		// A reason first-close-wins dropped goes into this argument's own error
+		// slot, so it prints in typed order beside every other refusal — and the
+		// ✓ line below reports the STORED reason rather than echoing the one the
+		// close discarded (be-ctr).
+		stored := storedCloseReason(after, before)
+		if closeReasonDiscarded(outcome.Changed, reasonExplicit, item.Reason, stored) {
+			pre.errors[pre.itemArgs[j]] = closeReasonDiscardedRefusal(item.IssueID, stored)
+			reasonDiscarded = true
+		}
+
 		outcomes = append(outcomes, closeProxiedOutcome{
 			id:          item.IssueID,
 			before:      before,
@@ -314,9 +334,9 @@ func closeProxiedOutcomes(pre *closeProxiedPreflight, result issueops.CloseBatch
 			auditOld:    oldStatus,
 			auditReason: item.Reason,
 		})
-		reasons = append(reasons, item.Reason)
+		reasons = append(reasons, closeReportedReason(outcome.Changed, item.Reason, stored))
 	}
-	return outcomes, reasons
+	return outcomes, reasons, reasonDiscarded
 }
 
 // closeProxiedRefusal spells one item's typed refusal the way this route has

--- a/cmd/bd/close_reason_amend_test.go
+++ b/cmd/bd/close_reason_amend_test.go
@@ -130,6 +130,15 @@ func TestCloseAlreadyClosedRefusesReasonOnEmptyStored(t *testing.T) {
 	if !strings.Contains(res.stderr, "empty close reason") {
 		t.Errorf("refusal does not say the stored reason is empty:\n%s", res.stderr)
 	}
+	// The gap codex caught on the first revision: an empty stored reason made
+	// the success line fall back to the SUPPLIED text, echoing the discarded
+	// reason back on exactly the shape this bead was filed about.
+	if strings.Contains(res.stdout, amendSuppliedReason) {
+		t.Errorf("stdout echoed the discarded reason back:\n%s", res.stdout)
+	}
+	if !strings.Contains(res.stdout, "(no close reason recorded)") {
+		t.Errorf("stdout does not say the record carries no reason:\n%s", res.stdout)
+	}
 	if got := env.get("test-amd4").CloseReason; got != "" {
 		t.Errorf("close_reason = %q, want it still empty", got)
 	}
@@ -175,7 +184,8 @@ func TestCloseReportedReason(t *testing.T) {
 	}{
 		{"a real close reports what it wrote", true, "new", "", "new"},
 		{"a no-op reports the stored reason", false, "new", "stored", "stored"},
-		{"a no-op with nothing stored has nothing truer to print", false, "new", "", "new"},
+		{"a no-op with nothing stored never borrows the supplied text", false, "new", "", noCloseReasonRecorded},
+		{"whitespace is not a stored reason either", false, "new", "  \n ", noCloseReasonRecorded},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/bd/close_reason_amend_test.go
+++ b/cmd/bd/close_reason_amend_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// A close reason is first-close-wins (issueops.CloseRequest.Reason), so a
+// re-close cannot rewrite it. These tests pin what `bd close` DOES about that,
+// which before be-ctr was nothing: rc=0, no stderr, and the caller's own
+// discarded text echoed back on stdout as if it had landed.
+//
+// The line the whole group draws is between an ordinary idempotent retry — which
+// must stay a silent success, because a crashed close has to be replayable — and
+// an AMENDMENT the command cannot honor. Only the second is reported.
+
+const (
+	amendStoredReason   = "REASON-A-first-close"
+	amendSuppliedReason = "REASON-B-second-close"
+)
+
+// seedClosed seeds an issue already closed and carrying a stored close reason,
+// directly through the store, so the fixture never depends on the behavior
+// under test.
+func seedClosed(t *testing.T, env *parityEnv, id, title, reason string) {
+	t.Helper()
+	env.seed(id, title, func(i *types.Issue) {
+		i.Status = types.StatusClosed
+		i.CloseReason = reason
+	})
+}
+
+// TestCloseAlreadyClosedRefusesDiscardedReason is the be-ctr case: an agent
+// repairing a thin or wrong close_reason. The write cannot happen, so the
+// command must not report that it did.
+func TestCloseAlreadyClosedRefusesDiscardedReason(t *testing.T) {
+	env := newParityEnv(t)
+	seedClosed(t, env, "test-amd1", "Amend a closed reason", amendStoredReason)
+
+	env.setFlags(closeCmd, map[string]string{"reason": amendSuppliedReason})
+	res := env.run(closeCmd, "test-amd1")
+
+	if res.exitCode == 0 {
+		t.Errorf("exit = 0 for a discarded reason; rc=0 is what made this read as success")
+	}
+	if !strings.Contains(res.stderr, "close reason NOT recorded on test-amd1") {
+		t.Errorf("stderr does not say the reason was dropped:\n%s", res.stderr)
+	}
+	// The refusal has to carry a way forward, or it only relocates the dead end.
+	if !strings.Contains(res.stderr, "bd comment test-amd1") {
+		t.Errorf("stderr does not name bd comment as the add-to-record path:\n%s", res.stderr)
+	}
+	if !strings.Contains(res.stderr, "bd reopen test-amd1") {
+		t.Errorf("stderr does not name reopen+close as the replace path:\n%s", res.stderr)
+	}
+	// stdout must not echo the text that was discarded — the echo is what a
+	// --reason-file caller reads as confirmation.
+	if strings.Contains(res.stdout, amendSuppliedReason) {
+		t.Errorf("stdout echoed the discarded reason back:\n%s", res.stdout)
+	}
+	if !strings.Contains(res.stdout, amendStoredReason) {
+		t.Errorf("stdout does not report the reason actually on the record:\n%s", res.stdout)
+	}
+	if got := env.get("test-amd1").CloseReason; got != amendStoredReason {
+		t.Errorf("close_reason = %q, want %q unchanged (first-close-wins)", got, amendStoredReason)
+	}
+}
+
+// TestCloseAlreadyClosedIdenticalReasonIsSilentSuccess is the retry. It asks
+// for the state that already exists, so nothing was lost and nothing is said.
+func TestCloseAlreadyClosedIdenticalReasonIsSilentSuccess(t *testing.T) {
+	env := newParityEnv(t)
+	seedClosed(t, env, "test-amd2", "Replay the same close", amendStoredReason)
+
+	env.setFlags(closeCmd, map[string]string{"reason": amendStoredReason})
+	res := env.run(closeCmd, "test-amd2")
+
+	if res.exitCode != 0 {
+		t.Errorf("exit = %d, want 0: replaying a close with its own reason is the retry-safe no-op\nstderr:\n%s", res.exitCode, res.stderr)
+	}
+	if res.stderr != "" {
+		t.Errorf("stderr = %q, want empty for an identical replay", res.stderr)
+	}
+	if got := env.lastTouched(); got != "test-amd2" {
+		t.Errorf("last-touched = %q, want %q: the retry-safe post-close contracts still replay", got, "test-amd2")
+	}
+}
+
+// TestCloseAlreadyClosedWithoutReasonIsSilentSuccess covers the bare `bd close
+// <id>` replay. bd supplies "Closed" itself, and its own default disagreeing
+// with a stored reason is not a caller asking for anything.
+func TestCloseAlreadyClosedWithoutReasonIsSilentSuccess(t *testing.T) {
+	env := newParityEnv(t)
+	seedClosed(t, env, "test-amd3", "Replay with no reason", amendStoredReason)
+
+	env.setFlags(closeCmd, nil)
+	res := env.run(closeCmd, "test-amd3")
+
+	if res.exitCode != 0 {
+		t.Errorf("exit = %d, want 0 for a bare re-close\nstderr:\n%s", res.exitCode, res.stderr)
+	}
+	if res.stderr != "" {
+		t.Errorf("stderr = %q, want empty for a bare re-close", res.stderr)
+	}
+	// It still reports the record rather than bd's unused default.
+	if !strings.Contains(res.stdout, amendStoredReason) {
+		t.Errorf("stdout does not report the stored reason:\n%s", res.stdout)
+	}
+}
+
+// TestCloseAlreadyClosedRefusesReasonOnEmptyStored covers the be-mh0 shape:
+// an issue closed with NO reason at all. Filling the blank in is still a write
+// that did not happen, and the refusal must not quote an empty reason as if
+// the first close had written one.
+func TestCloseAlreadyClosedRefusesReasonOnEmptyStored(t *testing.T) {
+	env := newParityEnv(t)
+	seedClosed(t, env, "test-amd4", "Closed with no reason", "")
+
+	env.setFlags(closeCmd, map[string]string{"reason": amendSuppliedReason})
+	res := env.run(closeCmd, "test-amd4")
+
+	if res.exitCode == 0 {
+		t.Errorf("exit = 0; filling in an empty close_reason did not happen either")
+	}
+	if strings.Contains(res.stderr, `reason ""`) {
+		t.Errorf("refusal quotes an empty stored reason as if one were written:\n%s", res.stderr)
+	}
+	if !strings.Contains(res.stderr, "empty close reason") {
+		t.Errorf("refusal does not say the stored reason is empty:\n%s", res.stderr)
+	}
+	if got := env.get("test-amd4").CloseReason; got != "" {
+		t.Errorf("close_reason = %q, want it still empty", got)
+	}
+}
+
+// TestCloseReasonDiscarded pins the predicate itself, including the two arms
+// that keep an ordinary retry silent.
+func TestCloseReasonDiscarded(t *testing.T) {
+	tests := []struct {
+		name     string
+		changed  bool
+		explicit bool
+		supplied string
+		stored   string
+		want     bool
+	}{
+		{"real close writes what it was given", true, true, "new", "", false},
+		{"bd's own default is not an amendment", false, false, "Closed", "stored", false},
+		{"identical reason is a replay", false, true, "stored", "stored", false},
+		{"blank explicit reason asks for nothing", false, true, "   ", "stored", false},
+		{"explicit reason disagreeing with the record", false, true, "new", "stored", true},
+		{"filling in an empty stored reason is still a write that did not happen", false, true, "new", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := closeReasonDiscarded(tt.changed, tt.explicit, tt.supplied, tt.stored); got != tt.want {
+				t.Errorf("closeReasonDiscarded(%v, %v, %q, %q) = %v, want %v",
+					tt.changed, tt.explicit, tt.supplied, tt.stored, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCloseReportedReason pins what the ✓ line prints: the reason on the
+// record, never the one the close threw away.
+func TestCloseReportedReason(t *testing.T) {
+	tests := []struct {
+		name     string
+		changed  bool
+		supplied string
+		stored   string
+		want     string
+	}{
+		{"a real close reports what it wrote", true, "new", "", "new"},
+		{"a no-op reports the stored reason", false, "new", "stored", "stored"},
+		{"a no-op with nothing stored has nothing truer to print", false, "new", "", "new"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := closeReportedReason(tt.changed, tt.supplied, tt.stored); got != tt.want {
+				t.Errorf("closeReportedReason(%v, %q, %q) = %q, want %q",
+					tt.changed, tt.supplied, tt.stored, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/bd/close_reason_file_test.go
+++ b/cmd/bd/close_reason_file_test.go
@@ -176,9 +176,10 @@ func TestCloseResolveReasons_PerIDReasons(t *testing.T) {
 	cmd.SetArgs([]string{"issue-a", "--reason", "reason A", "issue-b", "--reason", "reason B"})
 
 	var gotReasons, gotArgs []string
+	var gotExplicit bool
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		var err error
-		gotReasons, gotArgs, err = resolveCloseReasons(cmd, args)
+		gotReasons, gotArgs, gotExplicit, err = resolveCloseReasons(cmd, args)
 		if err != nil {
 			t.Fatalf("resolveCloseReasons: %v", err)
 		}
@@ -193,6 +194,9 @@ func TestCloseResolveReasons_PerIDReasons(t *testing.T) {
 	if !slices.Equal(gotReasons, []string{"reason A", "reason B"}) {
 		t.Fatalf("reasons = %v, want per-ID reasons", gotReasons)
 	}
+	if !gotExplicit {
+		t.Error("explicit = false; --reason is the caller spelling one")
+	}
 }
 
 func TestCloseResolveReasons_SharedReasonForMultipleIDs(t *testing.T) {
@@ -200,9 +204,10 @@ func TestCloseResolveReasons_SharedReasonForMultipleIDs(t *testing.T) {
 	cmd.SetArgs([]string{"issue-a", "issue-b", "--reason", "same reason"})
 
 	var gotReasons, gotArgs []string
+	var gotExplicit bool
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		var err error
-		gotReasons, gotArgs, err = resolveCloseReasons(cmd, args)
+		gotReasons, gotArgs, gotExplicit, err = resolveCloseReasons(cmd, args)
 		if err != nil {
 			t.Fatalf("resolveCloseReasons: %v", err)
 		}
@@ -217,6 +222,9 @@ func TestCloseResolveReasons_SharedReasonForMultipleIDs(t *testing.T) {
 	if !slices.Equal(gotReasons, []string{"same reason"}) {
 		t.Fatalf("reasons = %v, want one shared reason", gotReasons)
 	}
+	if !gotExplicit {
+		t.Error("explicit = false; --reason is the caller spelling one")
+	}
 }
 
 func TestCloseResolveReasons_EmptyReasonFallsBackToDefault(t *testing.T) {
@@ -224,9 +232,10 @@ func TestCloseResolveReasons_EmptyReasonFallsBackToDefault(t *testing.T) {
 	cmd.SetArgs([]string{"issue-a", "--reason", ""})
 
 	var gotReasons, gotArgs []string
+	var gotExplicit bool
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		var err error
-		gotReasons, gotArgs, err = resolveCloseReasons(cmd, args)
+		gotReasons, gotArgs, gotExplicit, err = resolveCloseReasons(cmd, args)
 		if err != nil {
 			t.Fatalf("resolveCloseReasons: %v", err)
 		}
@@ -241,6 +250,11 @@ func TestCloseResolveReasons_EmptyReasonFallsBackToDefault(t *testing.T) {
 	if !slices.Equal(gotReasons, []string{"Closed"}) {
 		t.Fatalf("reasons = %v, want default reason", gotReasons)
 	}
+	// The "Closed" default is bd's word, not the caller's, so an empty
+	// --reason must not read as an amendment request on a re-close.
+	if gotExplicit {
+		t.Error("explicit = true for the fallback default; it is not caller-supplied")
+	}
 }
 
 func TestCloseResolveReasons_EmptyReasonDoesNotConflictWithReasonFile(t *testing.T) {
@@ -254,9 +268,10 @@ func TestCloseResolveReasons_EmptyReasonDoesNotConflictWithReasonFile(t *testing
 	cmd.SetArgs([]string{"issue-a", "--reason", "", "--reason-file", path})
 
 	var gotReasons, gotArgs []string
+	var gotExplicit bool
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		var err error
-		gotReasons, gotArgs, err = resolveCloseReasons(cmd, args)
+		gotReasons, gotArgs, gotExplicit, err = resolveCloseReasons(cmd, args)
 		if err != nil {
 			t.Fatalf("resolveCloseReasons: %v", err)
 		}
@@ -271,6 +286,9 @@ func TestCloseResolveReasons_EmptyReasonDoesNotConflictWithReasonFile(t *testing
 	if !slices.Equal(gotReasons, []string{"from file"}) {
 		t.Fatalf("reasons = %v, want file reason", gotReasons)
 	}
+	if !gotExplicit {
+		t.Error("explicit = false; --reason-file is the caller spelling one")
+	}
 }
 
 func TestCloseResolveReasons_RejectsMismatchedPerIDReasons(t *testing.T) {
@@ -278,7 +296,7 @@ func TestCloseResolveReasons_RejectsMismatchedPerIDReasons(t *testing.T) {
 	cmd.SetArgs([]string{"issue-a", "--reason", "reason A", "issue-b", "--reason", "reason B", "issue-c"})
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		_, _, err := resolveCloseReasons(cmd, args)
+		_, _, _, err := resolveCloseReasons(cmd, args)
 		if err == nil {
 			t.Fatal("expected mismatch error, got nil")
 		}

--- a/cmd/bd/serve_close_proxied_integration_test.go
+++ b/cmd/bd/serve_close_proxied_integration_test.go
@@ -201,6 +201,15 @@ func TestProxiedServerServeClose(t *testing.T) {
 	// row from the same post-state snapshot. `bd show --json` is deliberately
 	// not the oracle — it answers IssueDetails, with the counts and the revision
 	// this response does not carry, so it would compare two different shapes.
+	//
+	// The re-close replays the reason the first close ALREADY STORED. It used to
+	// pass a different one, spelled "ignored under first-close-wins", which is
+	// now the one re-close `bd close` refuses: an explicit reason it must drop
+	// exits non-zero rather than reporting a write it did not perform (be-ctr).
+	// A replay of the stored reason is the same idempotent no-op against the same
+	// snapshot, so the oracle is unchanged — and that a DIFFERING reason is
+	// dropped is still pinned, by the first-close-wins subtest above and by
+	// cmd/bd/close_reason_amend_test.go.
 	t.Run("the closed issue matches bd close --json element 0", func(t *testing.T) {
 		issue := bdProxiedCreate(t, bd, p.dir, "parity oracle", "-p", "1",
 			"-d", "described", "--acceptance", "accepted", "--label", "oracle")
@@ -214,7 +223,7 @@ func TestProxiedServerServeClose(t *testing.T) {
 			t.Fatalf("issue = %#v, want an object", body["issue"])
 		}
 
-		fromCLI := bdProxiedCloseOneRaw(t, bd, p.dir, issue.ID, "--reason", "ignored under first-close-wins")
+		fromCLI := bdProxiedCloseOneRaw(t, bd, p.dir, issue.ID, "--reason", "done")
 
 		// The allowlist is EMPTY: both surfaces marshal the same canonical
 		// struct from the same post-state snapshot, so any difference at all is


### PR DESCRIPTION
## The defect

`bd close --reason` on an **already-closed** issue reported success and wrote nothing: `rc=0`, nothing on stderr, and the caller's own text echoed back on stdout as if it had landed.

```
$ bd close X --reason "REASON-A-first-close"     # open -> closed
✓ Closed X: REASON-A-first-close                 # written

$ bd close X --reason "REASON-B-second-close"    # already closed
✓ Closed X: REASON-B-second-close                # rc=0, and NOTHING was written
```

`close_reason` is the field that distinguishes a real fix from a symptom cleared by hand, so an agent repairing a thin or wrong one was told it had succeeded and had changed nothing. `--reason-file` made it worse: the whole file came back on stdout, which reads like confirmation.

## What is NOT changed

**first-close-wins itself.** It is spelled on `issueops.CloseRequest.Reason`, carried through the batch applier and the HTTP API, and `openapi.v0.yaml` names the amendment path outright — *"the way to write a new reason is to reopen and close again, not to re-close"*. Overturning that is a cross-implementation API change, not a CLI fix.

What was wrong is that the CLI answered an amendment it could not perform with a success line.

## What changed

Both close routes — direct and proxied — when the issue was already closed and the caller spelled a reason that **disagrees** with the stored one:

1. **Loud.** A refusal on stderr naming the id, the stored reason, and both amendment paths:

```
close reason NOT recorded on X: it was already closed, and a close reason is
first-close-wins, so the stored reason "REASON-A-first-close" is unchanged.
  To add to the record:  bd comment X "..."
  To replace the reason: bd reopen X && bd close X --reason "..."
```

2. **Non-zero exit.** A message alone is not something a script can branch on, and `rc=0` was the defect.

3. **No echo.** The success line reports the reason **on the record**, or `(no close reason recorded)` when there is none — never the supplied text. `--json` was already truthful (it carries the post-state issue), so only the human line was untrue.

## Why this is safe for retries

The predicate is deliberately narrow. It fires only when the issue was already closed **and** the caller explicitly spelled a reason **and** that reason differs from the stored one:

| re-close | behavior |
|---|---|
| `bd close <id>` (no reason) | silent `rc=0`, unchanged |
| same reason as stored | silent `rc=0`, unchanged — this is the crash retry |
| `--reason ""` | not explicit, unchanged |
| explicit reason that differs | refusal + `rc=1` |

A crashed close replays with its own reason, which by definition matches, so retry-safety is preserved exactly. `resolveCloseReasons` now reports whether the *caller* spelled a reason, because the value cannot carry that: bd's own `"Closed"` default is indistinguishable from a caller typing `"Closed"`.

The HTTP surface is untouched — `POST {id}:close` already answers a re-close with `already_closed: true` and the stored reason in the body, so a client can tell its reason was dropped. The CLI had no such flag; its exit status is where that information belongs.

## Tests

`cmd/bd/close_reason_amend_test.go` — four end-to-end cases through `closeCmd.RunE` against a real store (the refusal, the empty-stored variant, and both replay shapes that must stay silent successes), plus table tests on the two predicates.

Two existing tests were strengthened or adjusted:

- `close_proxied_integration_test.go`'s `close_already_closed` assigned stdout, stderr and err into blanks, so it observed the write not happening and nothing about how the command *reported* it. It now pins the refusal, the exit status and the stdout text, and passes against a real proxied server — the proof the second route matches the first.
- `serve_close_proxied_integration_test.go`'s rule-8 parity oracle re-closed with a *different* reason (literally `"ignored under first-close-wins"`), now exactly the case bd refuses, so it failed on exit status while its actual subject — the item JSON — was unaffected. It replays the **stored** reason instead: the same idempotent no-op against the same snapshot, oracle unchanged. That a differing reason is dropped stays pinned by the first-close-wins subtest beside it.

**Negative control run, not assumed:** with the two new predicates short-circuited to their old behavior, the integration tests fail. The identical-reason replay passes both ways by design — it pins the contract that must not change.

## Verification

- `go vet ./...`, `make build`, `gofmt` — clean.
- `scripts/check-cli-docs-drift.sh` — PASS. `docs/cli-reference` is pinned to release v1.2.2 via `docs/cli-docs.pin`, so the new `closeCmd.Long` text lands in the generated page at the next release bump.
- `go test ./cmd/bd/` failure **sets** compared (not counts) against a checkout of the base commit in the same environment: identical both directions. `./issueops` and `./internal/httpapi` green. One failure in the close/serve sweep, `TestSharedServerModeServeGlobalReportsTheServedDatabase`, was confirmed to fail on the pre-change tree too.
- `codex exec review --base main`: three rounds. Two real findings, both mine, both fixed (an empty stored reason still echoing the discarded text; `storedCloseReason` falling back to a stale pre-close read). Third round clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuPqRMo5JRF274pMHwYC5B