### PR TITLE
feat: add explicit bd ownership handoff front door

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -937,6 +937,13 @@ func guardLegacyNoStoreCommand(cmd *cobra.Command, beadsDir string) error {
 		cmd == legacySQLiteCmd {
 		return nil
 	}
+	// Some explicit maintenance front doors validate an operator-selected
+	// target that is not an active workspace. They opt out of the legacy
+	// workspace guard in addition to the store-init guard; ordinary commands
+	// retain the guard by default.
+	if cmd.Annotations["bd:skip_legacy_guard"] == "1" {
+		return nil
+	}
 	if cmd == schemaCmd && cmd.Parent() != nil && cmd.Parent().Parent() == nil {
 		return nil
 	}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -153,6 +153,14 @@ var (
 // store gate locally, without editing the central noDbCommands list.
 const skipStoreAnnotation = "bd:skip_store"
 
+// skipLegacyGuardAnnotation, when set to "1" on a command, exempts that command
+// from the legacy workspace guard. Unlike skipStoreAnnotation it is honored
+// leaf-only, on the invoked command alone: the guard protects an operator from
+// acting on a legacy workspace, and inheriting an opt-out down a subcommand
+// tree would fail open for subcommands nobody vetted. Annotate each maintenance
+// front door that needs it.
+const skipLegacyGuardAnnotation = "bd:skip_legacy_guard"
+
 // commandOptsOutOfStore reports whether cmd or any of its ancestors carries the
 // skipStoreAnnotation set to "1". The whole ancestor chain is walked, so
 // annotating a command exempts that command and every subcommand beneath it.
@@ -941,7 +949,7 @@ func guardLegacyNoStoreCommand(cmd *cobra.Command, beadsDir string) error {
 	// target that is not an active workspace. They opt out of the legacy
 	// workspace guard in addition to the store-init guard; ordinary commands
 	// retain the guard by default.
-	if cmd.Annotations["bd:skip_legacy_guard"] == "1" {
+	if cmd.Annotations[skipLegacyGuardAnnotation] == "1" {
 		return nil
 	}
 	if cmd == schemaCmd && cmd.Parent() != nil && cmd.Parent().Parent() == nil {

--- a/cmd/bd/migrate_ownership_handoff.go
+++ b/cmd/bd/migrate_ownership_handoff.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/ownershiphandoff"
+)
+
+// ownershipHandoffIdentity is the stable operator-facing identity rendered by
+// the handoff front door. It intentionally keeps provider state out of the
+// wire shape; lifecycle details belong to ownershiphandoff.Hooks.
+type ownershipHandoffIdentity struct {
+	Root      string                    `json:"root"`
+	Database  string                    `json:"database"`
+	Workspace string                    `json:"workspace"`
+	Endpoint  ownershiphandoff.Endpoint `json:"endpoint"`
+}
+
+// ownershipHandoffOutput is deliberately separate from the generic bd JSON
+// envelope. Handoff is used by lifecycle tooling, so its fields and nesting
+// are stable and error_code is present on both success and failure.
+type ownershipHandoffOutput struct {
+	Phase     ownershiphandoff.Phase   `json:"phase"`
+	Owner     ownershiphandoff.Owner   `json:"owner"`
+	Identity  ownershipHandoffIdentity `json:"identity"`
+	ErrorCode string                   `json:"error_code"`
+}
+
+// ownershipHandoffProvider is replaced by an embedding/provider integration
+// or a focused test. The default is intentionally unavailable: invoking this
+// explicit escape hatch must never guess how to stop a legacy owner.
+var ownershipHandoffProvider ownershiphandoff.Provider = ownershiphandoff.ProviderFunc(func(_ context.Context, _ ownershiphandoff.Request) (ownershiphandoff.Hooks, error) {
+	return ownershiphandoff.Hooks{}, errors.New("no provider-neutral legacy-owner handoff adapter is configured")
+})
+
+var ownershipHandoffCmd = &cobra.Command{
+	Use:           "ownership-handoff",
+	Short:         "Explicitly hand a legacy local Dolt owner to bd",
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Annotations: map[string]string{
+		skipStoreAnnotation:    "1",
+		"bd:skip_legacy_guard": "1",
+	},
+	RunE: runOwnershipHandoffCommand,
+}
+
+const ownershipHandoffJournalName = "ownership-handoff.json"
+
+func runOwnershipHandoffCommand(cmd *cobra.Command, _ []string) error {
+	root, _ := cmd.Flags().GetString("root")
+	database, _ := cmd.Flags().GetString("database")
+	workspace, _ := cmd.Flags().GetString("workspace")
+	host, _ := cmd.Flags().GetString("host")
+	port, _ := cmd.Flags().GetInt("port")
+	socket, _ := cmd.Flags().GetString("socket")
+	journal, _ := cmd.Flags().GetString("journal")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	resume, _ := cmd.Flags().GetBool("resume")
+	retry, _ := cmd.Flags().GetBool("retry")
+	// Execute is journal-resuming by construction. Both spellings are accepted
+	// for automation readability; normalize the alias here so the front door
+	// does not silently grow a second retry implementation.
+	if retry {
+		resume = true
+	}
+	_ = resume
+	if socket != "" {
+		if cmd.Flags().Changed("host") || cmd.Flags().Changed("port") {
+			err := errors.New("socket endpoint cannot be combined with explicit --host or --port")
+			result := ownershiphandoff.Result{Phase: ownershiphandoff.PhasePrepared, Owner: ownershiphandoff.OwnerLegacyGC,
+				Root: root, Database: database, Workspace: workspace,
+				Endpoint: ownershiphandoff.Endpoint{Host: host, Port: port, Socket: socket}, ErrorCode: "invalid_request"}
+			if outputErr := writeOwnershipHandoffOutput(result, err); outputErr != nil {
+				return outputErr
+			}
+			return &exitError{Code: 1}
+		}
+		host = ""
+		port = 0
+	}
+	request := ownershiphandoff.Request{
+		Root:      root,
+		Database:  database,
+		Workspace: workspace,
+		Endpoint:  ownershiphandoff.Endpoint{Host: host, Port: port, Socket: socket},
+		Owner:     ownershiphandoff.OwnerLegacyGC,
+	}
+	if journal == "" {
+		journal = filepath.Join(root, ownershipHandoffJournalName)
+	}
+	if journal != filepath.Join(root, ownershipHandoffJournalName) {
+		err := errors.New("journal must be the canonical <root>/ownership-handoff.json path")
+		result := ownershiphandoff.Result{Phase: ownershiphandoff.PhasePrepared, Owner: ownershiphandoff.OwnerLegacyGC,
+			Root: root, Database: database, Workspace: workspace, Endpoint: request.Endpoint, ErrorCode: "invalid_journal"}
+		if outputErr := writeOwnershipHandoffOutput(result, err); outputErr != nil {
+			return outputErr
+		}
+		return &exitError{Code: 1}
+	}
+	result, err := ownershiphandoff.Run(getRootContext(), request, journal, ownershipHandoffProvider, dryRun)
+	if outputErr := writeOwnershipHandoffOutput(result, err); outputErr != nil {
+		return outputErr
+	}
+	if err != nil {
+		return &exitError{Code: 1}
+	}
+	return nil
+}
+
+func writeOwnershipHandoffOutput(result ownershiphandoff.Result, runErr error) error {
+	output := ownershipHandoffOutput{
+		Phase: result.Phase,
+		Owner: result.Owner,
+		Identity: ownershipHandoffIdentity{
+			Root:      result.Root,
+			Database:  result.Database,
+			Workspace: result.Workspace,
+			Endpoint:  result.Endpoint,
+		},
+		ErrorCode: result.ErrorCode,
+	}
+	if jsonOutput {
+		if err := outputJSONRaw(output); err != nil {
+			return err
+		}
+	} else {
+		fmt.Fprintf(os.Stdout, "ownership handoff: phase=%s owner=%s root=%s database=%s workspace=%s endpoint=%s error_code=%s\n",
+			output.Phase, output.Owner, output.Identity.Root, output.Identity.Database,
+			output.Identity.Workspace, output.Identity.Endpoint.String(), output.ErrorCode)
+	}
+	if runErr != nil && !jsonOutput {
+		fmt.Fprintf(os.Stderr, "Error: ownership handoff: %v\n", runErr)
+	}
+	return nil
+}
+
+func init() {
+	ownershipHandoffCmd.Flags().String("root", "", "Canonical Dolt root being handed off")
+	ownershipHandoffCmd.Flags().String("database", "", "Database identity being handed off")
+	ownershipHandoffCmd.Flags().String("workspace", "", "Workspace identity being handed off")
+	ownershipHandoffCmd.Flags().String("host", "127.0.0.1", "Loopback host for the legacy server")
+	ownershipHandoffCmd.Flags().Int("port", 3307, "Port for the legacy loopback server")
+	ownershipHandoffCmd.Flags().String("socket", "", "Unix socket beneath --root (alternative to --host/--port)")
+	ownershipHandoffCmd.Flags().String("journal", "", "Handoff journal path (only canonical <root>/ownership-handoff.json is accepted)")
+	ownershipHandoffCmd.Flags().Bool("dry-run", false, "Validate identity without opening a provider or mutating state")
+	ownershipHandoffCmd.Flags().Bool("resume", false, "Resume a journaled handoff (the default retry behavior)")
+	ownershipHandoffCmd.Flags().Bool("retry", false, "Retry a journaled handoff (alias for --resume)")
+	_ = ownershipHandoffCmd.MarkFlagRequired("root")
+	_ = ownershipHandoffCmd.MarkFlagRequired("database")
+	_ = ownershipHandoffCmd.MarkFlagRequired("workspace")
+	migrateCmd.AddCommand(ownershipHandoffCmd)
+}

--- a/cmd/bd/migrate_ownership_handoff.go
+++ b/cmd/bd/migrate_ownership_handoff.go
@@ -152,8 +152,5 @@ func init() {
 	ownershipHandoffCmd.Flags().Bool("dry-run", false, "Validate identity without opening a provider or mutating state")
 	ownershipHandoffCmd.Flags().Bool("resume", false, "Resume a journaled handoff (the default retry behavior)")
 	ownershipHandoffCmd.Flags().Bool("retry", false, "Retry a journaled handoff (alias for --resume)")
-	_ = ownershipHandoffCmd.MarkFlagRequired("root")
-	_ = ownershipHandoffCmd.MarkFlagRequired("database")
-	_ = ownershipHandoffCmd.MarkFlagRequired("workspace")
 	migrateCmd.AddCommand(ownershipHandoffCmd)
 }

--- a/cmd/bd/migrate_ownership_handoff.go
+++ b/cmd/bd/migrate_ownership_handoff.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -15,6 +14,7 @@ import (
 // the handoff front door. It intentionally keeps provider state out of the
 // wire shape; lifecycle details belong to ownershiphandoff.Hooks.
 type ownershipHandoffIdentity struct {
+	CityRoot  string                    `json:"city_root"`
 	Root      string                    `json:"root"`
 	Database  string                    `json:"database"`
 	Workspace string                    `json:"workspace"`
@@ -27,16 +27,15 @@ type ownershipHandoffIdentity struct {
 type ownershipHandoffOutput struct {
 	Phase     ownershiphandoff.Phase   `json:"phase"`
 	Owner     ownershiphandoff.Owner   `json:"owner"`
+	Mutates   bool                     `json:"mutates"`
 	Identity  ownershipHandoffIdentity `json:"identity"`
 	ErrorCode string                   `json:"error_code"`
 }
 
-// ownershipHandoffProvider is replaced by an embedding/provider integration
-// or a focused test. The default is intentionally unavailable: invoking this
-// explicit escape hatch must never guess how to stop a legacy owner.
-var ownershipHandoffProvider ownershiphandoff.Provider = ownershiphandoff.ProviderFunc(func(_ context.Context, _ ownershiphandoff.Request) (ownershiphandoff.Hooks, error) {
-	return ownershiphandoff.Hooks{}, errors.New("no provider-neutral legacy-owner handoff adapter is configured")
-})
+// ownershipHandoffProvider invokes only the explicit GC handoff protocol. It
+// resolves GC_BIN after request/journal validation and while the journal lock
+// is held; absent or untrusted binaries fail closed without process probing.
+var ownershipHandoffProvider ownershiphandoff.Provider = ownershiphandoff.NewGCProviderFromEnv()
 
 var ownershipHandoffCmd = &cobra.Command{
 	Use:           "ownership-handoff",
@@ -55,6 +54,7 @@ const ownershipHandoffJournalName = "ownership-handoff.json"
 
 func runOwnershipHandoffCommand(cmd *cobra.Command, _ []string) error {
 	root, _ := cmd.Flags().GetString("root")
+	cityRoot, _ := cmd.Flags().GetString("city")
 	database, _ := cmd.Flags().GetString("database")
 	workspace, _ := cmd.Flags().GetString("workspace")
 	host, _ := cmd.Flags().GetString("host")
@@ -75,7 +75,7 @@ func runOwnershipHandoffCommand(cmd *cobra.Command, _ []string) error {
 		if cmd.Flags().Changed("host") || cmd.Flags().Changed("port") {
 			err := errors.New("socket endpoint cannot be combined with explicit --host or --port")
 			result := ownershiphandoff.Result{Phase: ownershiphandoff.PhasePrepared, Owner: ownershiphandoff.OwnerLegacyGC,
-				Root: root, Database: database, Workspace: workspace,
+				CityRoot: cityRoot, Root: root, Database: database, Workspace: workspace,
 				Endpoint: ownershiphandoff.Endpoint{Host: host, Port: port, Socket: socket}, ErrorCode: "invalid_request"}
 			if outputErr := writeOwnershipHandoffOutput(result, err); outputErr != nil {
 				return outputErr
@@ -86,6 +86,7 @@ func runOwnershipHandoffCommand(cmd *cobra.Command, _ []string) error {
 		port = 0
 	}
 	request := ownershiphandoff.Request{
+		CityRoot:  cityRoot,
 		Root:      root,
 		Database:  database,
 		Workspace: workspace,
@@ -95,10 +96,20 @@ func runOwnershipHandoffCommand(cmd *cobra.Command, _ []string) error {
 	if journal == "" {
 		journal = filepath.Join(root, ownershipHandoffJournalName)
 	}
+	if cityRoot == "" {
+		err := errors.New("city root is required to identify the lifecycle owner")
+		result := ownershiphandoff.Result{Phase: ownershiphandoff.PhasePrepared, Owner: ownershiphandoff.OwnerLegacyGC,
+			CityRoot: cityRoot, Root: root, Database: database, Workspace: workspace,
+			Endpoint: request.Endpoint, ErrorCode: "invalid_request"}
+		if outputErr := writeOwnershipHandoffOutput(result, err); outputErr != nil {
+			return outputErr
+		}
+		return &exitError{Code: 1}
+	}
 	if journal != filepath.Join(root, ownershipHandoffJournalName) {
 		err := errors.New("journal must be the canonical <root>/ownership-handoff.json path")
 		result := ownershiphandoff.Result{Phase: ownershiphandoff.PhasePrepared, Owner: ownershiphandoff.OwnerLegacyGC,
-			Root: root, Database: database, Workspace: workspace, Endpoint: request.Endpoint, ErrorCode: "invalid_journal"}
+			CityRoot: cityRoot, Root: root, Database: database, Workspace: workspace, Endpoint: request.Endpoint, ErrorCode: "invalid_journal"}
 		if outputErr := writeOwnershipHandoffOutput(result, err); outputErr != nil {
 			return outputErr
 		}
@@ -116,9 +127,11 @@ func runOwnershipHandoffCommand(cmd *cobra.Command, _ []string) error {
 
 func writeOwnershipHandoffOutput(result ownershiphandoff.Result, runErr error) error {
 	output := ownershipHandoffOutput{
-		Phase: result.Phase,
-		Owner: result.Owner,
+		Phase:   result.Phase,
+		Owner:   result.Owner,
+		Mutates: result.Mutates,
 		Identity: ownershipHandoffIdentity{
+			CityRoot:  result.CityRoot,
 			Root:      result.Root,
 			Database:  result.Database,
 			Workspace: result.Workspace,
@@ -131,8 +144,8 @@ func writeOwnershipHandoffOutput(result ownershiphandoff.Result, runErr error) e
 			return err
 		}
 	} else {
-		fmt.Fprintf(os.Stdout, "ownership handoff: phase=%s owner=%s root=%s database=%s workspace=%s endpoint=%s error_code=%s\n",
-			output.Phase, output.Owner, output.Identity.Root, output.Identity.Database,
+		fmt.Fprintf(os.Stdout, "ownership handoff: phase=%s owner=%s mutates=%t city=%s root=%s database=%s workspace=%s endpoint=%s error_code=%s\n",
+			output.Phase, output.Owner, output.Mutates, output.Identity.CityRoot, output.Identity.Root, output.Identity.Database,
 			output.Identity.Workspace, output.Identity.Endpoint.String(), output.ErrorCode)
 	}
 	if runErr != nil && !jsonOutput {
@@ -143,6 +156,7 @@ func writeOwnershipHandoffOutput(result ownershiphandoff.Result, runErr error) e
 
 func init() {
 	ownershipHandoffCmd.Flags().String("root", "", "Canonical Dolt root being handed off")
+	ownershipHandoffCmd.Flags().String("city", "", "Canonical Gas City root owning the legacy server")
 	ownershipHandoffCmd.Flags().String("database", "", "Database identity being handed off")
 	ownershipHandoffCmd.Flags().String("workspace", "", "Workspace identity being handed off")
 	ownershipHandoffCmd.Flags().String("host", "127.0.0.1", "Loopback host for the legacy server")

--- a/cmd/bd/migrate_ownership_handoff.go
+++ b/cmd/bd/migrate_ownership_handoff.go
@@ -44,8 +44,8 @@ var ownershipHandoffCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Annotations: map[string]string{
-		skipStoreAnnotation:    "1",
-		"bd:skip_legacy_guard": "1",
+		skipStoreAnnotation:       "1",
+		skipLegacyGuardAnnotation: "1",
 	},
 	RunE: runOwnershipHandoffCommand,
 }
@@ -164,7 +164,7 @@ func init() {
 	ownershipHandoffCmd.Flags().String("socket", "", "Unix socket beneath --root (alternative to --host/--port)")
 	ownershipHandoffCmd.Flags().String("journal", "", "Handoff journal path (only canonical <root>/ownership-handoff.json is accepted)")
 	ownershipHandoffCmd.Flags().Bool("dry-run", false, "Validate identity without opening a provider or mutating state")
-	ownershipHandoffCmd.Flags().Bool("resume", false, "Resume a journaled handoff (the default retry behavior)")
-	ownershipHandoffCmd.Flags().Bool("retry", false, "Retry a journaled handoff (alias for --resume)")
+	ownershipHandoffCmd.Flags().Bool("resume", false, "Accepted for automation readability; never changes behavior (a handoff always resumes from its journal)")
+	ownershipHandoffCmd.Flags().Bool("retry", false, "Alias for --resume; never changes behavior")
 	migrateCmd.AddCommand(ownershipHandoffCmd)
 }

--- a/cmd/bd/migrate_ownership_handoff_test.go
+++ b/cmd/bd/migrate_ownership_handoff_test.go
@@ -34,6 +34,34 @@ func TestOwnershipHandoffCommandIsExplicitAndSkipsStore(t *testing.T) {
 	}
 }
 
+func TestOwnershipHandoffCommandMissingIdentityUsesTypedJSON(t *testing.T) {
+	setOwnershipHandoffFlag(t, "root", "")
+	setOwnershipHandoffFlag(t, "database", "")
+	setOwnershipHandoffFlag(t, "workspace", "")
+	setOwnershipHandoffFlag(t, "journal", "")
+	setOwnershipHandoffFlag(t, "socket", "")
+	setOwnershipHandoffFlag(t, "host", "127.0.0.1")
+	setOwnershipHandoffFlag(t, "port", "3307")
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+	var runErr error
+	out := captureStdout(t, func() error {
+		runErr = runOwnershipHandoffCommand(ownershipHandoffCmd, nil)
+		return nil
+	})
+	if runErr == nil {
+		t.Fatal("missing identity unexpectedly succeeded")
+	}
+	var got ownershipHandoffOutput
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode strict handoff JSON %q: %v", out, err)
+	}
+	if got.ErrorCode != "invalid_request" || got.Phase != ownershiphandoff.PhasePrepared {
+		t.Fatalf("output=%+v, want typed invalid_request", got)
+	}
+}
+
 func TestOwnershipHandoffRunRejectsInvalidRequestBeforeProvider(t *testing.T) {
 	root := canonicalTempDir(t)
 	called := 0

--- a/cmd/bd/migrate_ownership_handoff_test.go
+++ b/cmd/bd/migrate_ownership_handoff_test.go
@@ -1,0 +1,298 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/ownershiphandoff"
+)
+
+func TestOwnershipHandoffCommandIsExplicitAndSkipsStore(t *testing.T) {
+	if ownershipHandoffCmd == nil {
+		t.Fatal("ownership-handoff command is not registered")
+	}
+	if ownershipHandoffCmd.Parent() != migrateCmd {
+		t.Fatalf("parent = %v, want migrate", ownershipHandoffCmd.Parent())
+	}
+	if ownershipHandoffCmd.Annotations[skipStoreAnnotation] != "1" {
+		t.Fatal("ownership-handoff must skip ordinary store/provider startup")
+	}
+	for _, command := range rootCmd.Commands() {
+		if command == ownershipHandoffCmd {
+			t.Fatal("ownership-handoff must not be an ordinary top-level bd command")
+		}
+	}
+	for _, name := range []string{"root", "database", "workspace", "host", "port", "socket", "journal", "dry-run", "resume", "retry"} {
+		if ownershipHandoffCmd.Flags().Lookup(name) == nil {
+			t.Errorf("missing --%s flag", name)
+		}
+	}
+}
+
+func TestOwnershipHandoffRunRejectsInvalidRequestBeforeProvider(t *testing.T) {
+	root := canonicalTempDir(t)
+	called := 0
+	provider := ownershiphandoff.ProviderFunc(func(context.Context, ownershiphandoff.Request) (ownershiphandoff.Hooks, error) {
+		called++
+		return ownershiphandoff.Hooks{}, nil
+	})
+	request := ownershiphandoff.Request{
+		Root:      root,
+		Database:  "beads",
+		Workspace: "workspace",
+		Endpoint:  ownershiphandoff.Endpoint{Host: "203.0.113.7", Port: 3307},
+		Owner:     ownershiphandoff.OwnerLegacyGC,
+	}
+	result, err := ownershiphandoff.Run(context.Background(), request, filepath.Join(root, "handoff.json"), provider, false)
+	if err == nil || result.ErrorCode != "invalid_request" {
+		t.Fatalf("result=%+v err=%v, want invalid_request", result, err)
+	}
+	if called != 0 {
+		t.Fatalf("provider opened %d times for invalid request", called)
+	}
+}
+
+func TestOwnershipHandoffDryRunDoesNotOpenProvider(t *testing.T) {
+	root := canonicalTempDir(t)
+	called := 0
+	provider := ownershiphandoff.ProviderFunc(func(context.Context, ownershiphandoff.Request) (ownershiphandoff.Hooks, error) {
+		called++
+		return ownershiphandoff.Hooks{}, errors.New("must not open in dry-run")
+	})
+	request := ownershiphandoff.Request{
+		Root:      root,
+		Database:  "beads",
+		Workspace: "workspace",
+		Endpoint:  ownershiphandoff.Endpoint{Host: "127.0.0.1", Port: 3307},
+		Owner:     ownershiphandoff.OwnerLegacyGC,
+	}
+	result, err := ownershiphandoff.Run(context.Background(), request, filepath.Join(root, "handoff.json"), provider, true)
+	if err != nil || result.Phase != ownershiphandoff.PhasePrepared || result.Mutates {
+		t.Fatalf("result=%+v err=%v, want prepared non-mutating dry-run", result, err)
+	}
+	if called != 0 {
+		t.Fatalf("provider opened %d times for dry-run", called)
+	}
+}
+
+func TestOwnershipHandoffResolvesProviderUnderJournalLock(t *testing.T) {
+	root := canonicalTempDir(t)
+	journal := filepath.Join(root, "handoff.json")
+	request := ownershiphandoff.Request{
+		Root:      root,
+		Database:  "beads",
+		Workspace: "workspace",
+		Endpoint:  ownershiphandoff.Endpoint{Host: "127.0.0.1", Port: 3307},
+		Owner:     ownershiphandoff.OwnerLegacyGC,
+	}
+	provider := ownershiphandoff.ProviderFunc(func(ctx context.Context, got ownershiphandoff.Request) (ownershiphandoff.Hooks, error) {
+		// A nested attempt must see the live lock rather than opening a second
+		// provider while the outer call is resolving hooks.
+		nested, err := ownershiphandoff.Run(ctx, got, journal, nil, false)
+		if err == nil || nested.ErrorCode != "concurrent_handoff" {
+			t.Fatalf("nested run result=%+v err=%v, want concurrent_handoff", nested, err)
+		}
+		return ownershiphandoff.Hooks{
+			Snapshot: func(context.Context, ownershiphandoff.Request) (ownershiphandoff.Snapshot, error) {
+				return ownershiphandoff.Snapshot{}, nil
+			},
+			Configure:  func(context.Context, ownershiphandoff.Request, ownershiphandoff.Snapshot) error { return nil },
+			StopLegacy: func(context.Context, ownershiphandoff.Request, ownershiphandoff.Snapshot) error { return nil },
+			Verify:     func(context.Context, ownershiphandoff.Request, ownershiphandoff.Snapshot) error { return nil },
+			Commit:     func(context.Context, ownershiphandoff.Request, ownershiphandoff.Snapshot) error { return nil },
+		}, nil
+	})
+	result, err := ownershiphandoff.Run(context.Background(), request, journal, provider, false)
+	if err != nil || result.Phase != ownershiphandoff.PhaseCommitted {
+		t.Fatalf("result=%+v err=%v, want committed", result, err)
+	}
+}
+
+func TestOwnershipHandoffProviderErrorPreservesJournalState(t *testing.T) {
+	root := canonicalTempDir(t)
+	journal := filepath.Join(root, "handoff.json")
+	request := ownershiphandoff.Request{
+		Root: root, Database: "beads", Workspace: "workspace",
+		Endpoint: ownershiphandoff.Endpoint{Host: "127.0.0.1", Port: 3307},
+		Owner:    ownershiphandoff.OwnerLegacyGC,
+	}
+	seed := ownershiphandoff.Journal{Request: request, Snapshot: ownershiphandoff.Snapshot{Sentinel: "s"}, SnapshotCaptured: true,
+		Phase: ownershiphandoff.PhaseOldOwnerStopped, Owner: ownershiphandoff.OwnerLegacyGC}
+	b, err := json.Marshal(seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(journal, append(b, '\n'), 0600); err != nil {
+		t.Fatal(err)
+	}
+	provider := ownershiphandoff.ProviderFunc(func(context.Context, ownershiphandoff.Request) (ownershiphandoff.Hooks, error) {
+		return ownershiphandoff.Hooks{}, errors.New("provider unavailable")
+	})
+	result, err := ownershiphandoff.Run(context.Background(), request, journal, provider, false)
+	if err == nil || result.Phase != ownershiphandoff.PhaseOldOwnerStopped || result.Owner != ownershiphandoff.OwnerLegacyGC || !result.Mutates || result.ErrorCode != "provider_unavailable" {
+		t.Fatalf("result=%+v err=%v, want preserved old_owner_stopped mutation state", result, err)
+	}
+}
+
+func TestOwnershipHandoffJSONShapeIsStable(t *testing.T) {
+	result := ownershipHandoffOutput{
+		Phase: ownershiphandoff.PhasePrepared,
+		Owner: ownershiphandoff.OwnerLegacyGC,
+		Identity: ownershipHandoffIdentity{
+			Root:      "/srv/beads",
+			Database:  "beads",
+			Workspace: "workspace",
+			Endpoint:  ownershiphandoff.Endpoint{Host: "127.0.0.1", Port: 3307},
+		},
+		ErrorCode: "",
+	}
+	b, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(b, &fields); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"phase", "owner", "identity", "error_code"} {
+		if _, ok := fields[field]; !ok {
+			t.Errorf("JSON missing required field %q: %s", field, b)
+		}
+	}
+	if _, ok := fields["schema_version"]; ok {
+		t.Errorf("handoff JSON must be strict result JSON, got schema wrapper: %s", b)
+	}
+}
+
+func TestOwnershipHandoffCommandDryRunJSONFrontDoor(t *testing.T) {
+	root := canonicalTempDir(t)
+	setOwnershipHandoffFlag(t, "root", root)
+	setOwnershipHandoffFlag(t, "database", "beads")
+	setOwnershipHandoffFlag(t, "workspace", "workspace")
+	setOwnershipHandoffFlag(t, "host", "127.0.0.1")
+	setOwnershipHandoffFlag(t, "port", "3307")
+	setOwnershipHandoffFlag(t, "socket", "")
+	setOwnershipHandoffFlag(t, "journal", filepath.Join(root, ownershipHandoffJournalName))
+	setOwnershipHandoffFlag(t, "dry-run", "true")
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	out := captureStdout(t, func() error {
+		return runOwnershipHandoffCommand(ownershipHandoffCmd, nil)
+	})
+	var got ownershipHandoffOutput
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode strict handoff JSON %q: %v", out, err)
+	}
+	if got.Phase != ownershiphandoff.PhasePrepared || got.Owner != ownershiphandoff.OwnerLegacyGC || got.ErrorCode != "" {
+		t.Fatalf("output=%+v, want prepared legacy-gc success", got)
+	}
+}
+
+func TestOwnershipHandoffCommandSocketEndpoint(t *testing.T) {
+	for _, explicit := range []string{"", "host", "port"} {
+		t.Run("explicit_"+explicit, func(t *testing.T) {
+			root := canonicalTempDir(t)
+			setOwnershipHandoffFlag(t, "root", root)
+			setOwnershipHandoffFlag(t, "database", "beads")
+			setOwnershipHandoffFlag(t, "workspace", "workspace")
+			setOwnershipHandoffFlag(t, "journal", "")
+			setOwnershipHandoffFlag(t, "socket", filepath.Join(root, "beads.sock"))
+			setOwnershipHandoffFlag(t, "dry-run", "true")
+			if explicit == "host" {
+				setOwnershipHandoffFlag(t, "host", "127.0.0.1")
+			}
+			if explicit == "port" {
+				setOwnershipHandoffFlag(t, "port", "3307")
+			}
+			oldJSON := jsonOutput
+			jsonOutput = true
+			t.Cleanup(func() { jsonOutput = oldJSON })
+			var runErr error
+			out := captureStdout(t, func() error {
+				runErr = runOwnershipHandoffCommand(ownershipHandoffCmd, nil)
+				return nil
+			})
+			var got ownershipHandoffOutput
+			if err := json.Unmarshal([]byte(out), &got); err != nil {
+				t.Fatalf("decode handoff JSON %q: %v", out, err)
+			}
+			if explicit == "" {
+				if runErr != nil || got.ErrorCode != "" || got.Identity.Endpoint.Host != "" || got.Identity.Endpoint.Port != 0 {
+					t.Fatalf("socket-only result=%+v err=%v, want socket without implicit TCP defaults", got, runErr)
+				}
+			} else if runErr == nil || got.ErrorCode != "invalid_request" {
+				t.Fatalf("socket with --%s result=%+v err=%v, want invalid_request", explicit, got, runErr)
+			}
+		})
+	}
+}
+
+func TestOwnershipHandoffCommandRejectsAlternateJournal(t *testing.T) {
+	root := canonicalTempDir(t)
+	setOwnershipHandoffFlag(t, "root", root)
+	setOwnershipHandoffFlag(t, "database", "beads")
+	setOwnershipHandoffFlag(t, "workspace", "workspace")
+	setOwnershipHandoffFlag(t, "host", "127.0.0.1")
+	setOwnershipHandoffFlag(t, "port", "3307")
+	setOwnershipHandoffFlag(t, "socket", "")
+	setOwnershipHandoffFlag(t, "journal", filepath.Join(root, "alternate.json"))
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	var runErr error
+	out := captureStdout(t, func() error {
+		runErr = runOwnershipHandoffCommand(ownershipHandoffCmd, nil)
+		return nil // captureStdout treats a command error as a test failure.
+	})
+	if runErr == nil {
+		t.Fatal("alternate journal unexpectedly succeeded")
+	}
+	var got ownershipHandoffOutput
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode strict handoff JSON %q: %v", out, err)
+	}
+	if got.ErrorCode != "invalid_journal" {
+		t.Fatalf("output=%+v, want invalid_journal", got)
+	}
+	if _, err := os.Stat(filepath.Join(root, "alternate.json")); !os.IsNotExist(err) {
+		t.Fatalf("alternate journal was created: %v", err)
+	}
+}
+
+func setOwnershipHandoffFlag(t *testing.T, name, value string) {
+	t.Helper()
+	flag := ownershipHandoffCmd.Flags().Lookup(name)
+	if flag == nil {
+		t.Fatalf("missing handoff flag --%s", name)
+	}
+	old := flag.Value.String()
+	oldChanged := flag.Changed
+	if err := ownershipHandoffCmd.Flags().Set(name, value); err != nil {
+		t.Fatalf("set --%s: %v", name, err)
+	}
+	t.Cleanup(func() {
+		_ = flag.Value.Set(old)
+		flag.Changed = oldChanged
+	})
+}
+
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	canonical, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(canonical) || strings.TrimSpace(canonical) == "" {
+		t.Fatalf("bad canonical temp dir %q", canonical)
+	}
+	return canonical
+}

--- a/cmd/bd/migrate_ownership_handoff_test.go
+++ b/cmd/bd/migrate_ownership_handoff_test.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 
 	"github.com/steveyegge/beads/internal/ownershiphandoff"
 )
@@ -27,7 +30,7 @@ func TestOwnershipHandoffCommandIsExplicitAndSkipsStore(t *testing.T) {
 			t.Fatal("ownership-handoff must not be an ordinary top-level bd command")
 		}
 	}
-	for _, name := range []string{"root", "database", "workspace", "host", "port", "socket", "journal", "dry-run", "resume", "retry"} {
+	for _, name := range []string{"city", "root", "database", "workspace", "host", "port", "socket", "journal", "dry-run", "resume", "retry"} {
 		if ownershipHandoffCmd.Flags().Lookup(name) == nil {
 			t.Errorf("missing --%s flag", name)
 		}
@@ -36,6 +39,7 @@ func TestOwnershipHandoffCommandIsExplicitAndSkipsStore(t *testing.T) {
 
 func TestOwnershipHandoffCommandMissingIdentityUsesTypedJSON(t *testing.T) {
 	setOwnershipHandoffFlag(t, "root", "")
+	setOwnershipHandoffFlag(t, "city", "")
 	setOwnershipHandoffFlag(t, "database", "")
 	setOwnershipHandoffFlag(t, "workspace", "")
 	setOwnershipHandoffFlag(t, "journal", "")
@@ -64,12 +68,14 @@ func TestOwnershipHandoffCommandMissingIdentityUsesTypedJSON(t *testing.T) {
 
 func TestOwnershipHandoffRunRejectsInvalidRequestBeforeProvider(t *testing.T) {
 	root := canonicalTempDir(t)
+	setOwnershipHandoffFlag(t, "city", root)
 	called := 0
 	provider := ownershiphandoff.ProviderFunc(func(context.Context, ownershiphandoff.Request) (ownershiphandoff.Hooks, error) {
 		called++
 		return ownershiphandoff.Hooks{}, nil
 	})
 	request := ownershiphandoff.Request{
+		CityRoot:  root,
 		Root:      root,
 		Database:  "beads",
 		Workspace: "workspace",
@@ -85,6 +91,65 @@ func TestOwnershipHandoffRunRejectsInvalidRequestBeforeProvider(t *testing.T) {
 	}
 }
 
+// TestOwnershipHandoffDefaultProviderFailsClosed pins the shipped provider
+// seam.  With no explicit GC_BIN adapter configured, a valid request must be
+// refused before any provider hooks can run; in particular, the provider must
+// not silently return empty hooks and let Run create a handoff journal.
+func TestOwnershipHandoffDefaultProviderFailsClosed(t *testing.T) {
+	city := canonicalTempDir(t)
+	scope := filepath.Join(city, "scope")
+	if err := os.Mkdir(scope, 0700); err != nil {
+		t.Fatal(err)
+	}
+	before := handoffDirectorySnapshot(t, city)
+	t.Setenv("GC_BIN", "")
+	request := ownershiphandoff.Request{
+		CityRoot:  city,
+		Root:      scope,
+		Database:  "beads",
+		Workspace: "workspace",
+		Endpoint:  ownershiphandoff.Endpoint{Host: "127.0.0.1", Port: 3307},
+		Owner:     ownershiphandoff.OwnerLegacyGC,
+	}
+	_, err := ownershipHandoffProvider.OwnershipHandoffHooks(context.Background(), request)
+	if err == nil {
+		t.Fatal("default ownership handoff provider unexpectedly returned hooks without GC_BIN")
+	}
+	var coded interface{ HandoffErrorCode() string }
+	if !errors.As(err, &coded) || coded.HandoffErrorCode() != "provider_unavailable" {
+		t.Fatalf("provider error = %v, want typed provider_unavailable", err)
+	}
+	if after := handoffDirectorySnapshot(t, city); !reflect.DeepEqual(after, before) {
+		t.Fatalf("default provider mutated its root: before=%v after=%v", before, after)
+	}
+}
+
+// TestOwnershipHandoffLegacyGuardBypass pins the explicit command-only
+// escape hatch.  A metadata-less historical SQLite workspace is refused for
+// an ordinary no-store command, while the ownership-handoff front door is
+// admitted so it can perform its own canonical identity validation.
+func TestOwnershipHandoffLegacyGuardBypass(t *testing.T) {
+	repo := canonicalTempDir(t)
+	beadsDir := filepath.Join(repo, ".beads")
+	if err := os.Mkdir(beadsDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "beads.db"), []byte("SQLite format 3\x00historical"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := guardLegacyNoStoreCommand(ownershipHandoffCmd, beadsDir); err != nil {
+		t.Fatalf("ownership-handoff legacy guard = %v, want explicit bypass", err)
+	}
+
+	control := &cobra.Command{Use: "ordinary-historical", RunE: func(*cobra.Command, []string) error { return nil }}
+	migrateCmd.AddCommand(control)
+	t.Cleanup(func() { migrateCmd.RemoveCommand(control) })
+	if err := guardLegacyNoStoreCommand(control, beadsDir); !isLegacyUpgradeRefusal(err) {
+		t.Fatalf("ordinary command legacy guard = %v, want historical SQLite refusal", err)
+	}
+}
+
 func TestOwnershipHandoffDryRunDoesNotOpenProvider(t *testing.T) {
 	root := canonicalTempDir(t)
 	called := 0
@@ -93,6 +158,7 @@ func TestOwnershipHandoffDryRunDoesNotOpenProvider(t *testing.T) {
 		return ownershiphandoff.Hooks{}, errors.New("must not open in dry-run")
 	})
 	request := ownershiphandoff.Request{
+		CityRoot:  root,
 		Root:      root,
 		Database:  "beads",
 		Workspace: "workspace",
@@ -112,6 +178,7 @@ func TestOwnershipHandoffResolvesProviderUnderJournalLock(t *testing.T) {
 	root := canonicalTempDir(t)
 	journal := filepath.Join(root, "handoff.json")
 	request := ownershiphandoff.Request{
+		CityRoot:  root,
 		Root:      root,
 		Database:  "beads",
 		Workspace: "workspace",
@@ -145,7 +212,8 @@ func TestOwnershipHandoffProviderErrorPreservesJournalState(t *testing.T) {
 	root := canonicalTempDir(t)
 	journal := filepath.Join(root, "handoff.json")
 	request := ownershiphandoff.Request{
-		Root: root, Database: "beads", Workspace: "workspace",
+		CityRoot: root,
+		Root:     root, Database: "beads", Workspace: "workspace",
 		Endpoint: ownershiphandoff.Endpoint{Host: "127.0.0.1", Port: 3307},
 		Owner:    ownershiphandoff.OwnerLegacyGC,
 	}
@@ -169,8 +237,9 @@ func TestOwnershipHandoffProviderErrorPreservesJournalState(t *testing.T) {
 
 func TestOwnershipHandoffJSONShapeIsStable(t *testing.T) {
 	result := ownershipHandoffOutput{
-		Phase: ownershiphandoff.PhasePrepared,
-		Owner: ownershiphandoff.OwnerLegacyGC,
+		Phase:   ownershiphandoff.PhasePrepared,
+		Owner:   ownershiphandoff.OwnerLegacyGC,
+		Mutates: false,
 		Identity: ownershipHandoffIdentity{
 			Root:      "/srv/beads",
 			Database:  "beads",
@@ -187,7 +256,7 @@ func TestOwnershipHandoffJSONShapeIsStable(t *testing.T) {
 	if err := json.Unmarshal(b, &fields); err != nil {
 		t.Fatal(err)
 	}
-	for _, field := range []string{"phase", "owner", "identity", "error_code"} {
+	for _, field := range []string{"phase", "owner", "mutates", "identity", "error_code"} {
 		if _, ok := fields[field]; !ok {
 			t.Errorf("JSON missing required field %q: %s", field, b)
 		}
@@ -199,6 +268,7 @@ func TestOwnershipHandoffJSONShapeIsStable(t *testing.T) {
 
 func TestOwnershipHandoffCommandDryRunJSONFrontDoor(t *testing.T) {
 	root := canonicalTempDir(t)
+	setOwnershipHandoffFlag(t, "city", root)
 	setOwnershipHandoffFlag(t, "root", root)
 	setOwnershipHandoffFlag(t, "database", "beads")
 	setOwnershipHandoffFlag(t, "workspace", "workspace")
@@ -227,6 +297,7 @@ func TestOwnershipHandoffCommandSocketEndpoint(t *testing.T) {
 	for _, explicit := range []string{"", "host", "port"} {
 		t.Run("explicit_"+explicit, func(t *testing.T) {
 			root := canonicalTempDir(t)
+			setOwnershipHandoffFlag(t, "city", root)
 			setOwnershipHandoffFlag(t, "root", root)
 			setOwnershipHandoffFlag(t, "database", "beads")
 			setOwnershipHandoffFlag(t, "workspace", "workspace")
@@ -264,6 +335,7 @@ func TestOwnershipHandoffCommandSocketEndpoint(t *testing.T) {
 
 func TestOwnershipHandoffCommandRejectsAlternateJournal(t *testing.T) {
 	root := canonicalTempDir(t)
+	setOwnershipHandoffFlag(t, "city", root)
 	setOwnershipHandoffFlag(t, "root", root)
 	setOwnershipHandoffFlag(t, "database", "beads")
 	setOwnershipHandoffFlag(t, "workspace", "workspace")
@@ -310,6 +382,45 @@ func setOwnershipHandoffFlag(t *testing.T, name, value string) {
 		_ = flag.Value.Set(old)
 		flag.Changed = oldChanged
 	})
+}
+
+type handoffFileSnapshot struct {
+	Mode     os.FileMode
+	Contents string
+}
+
+func handoffDirectorySnapshot(t *testing.T, root string) map[string]handoffFileSnapshot {
+	t.Helper()
+	files := make(map[string]handoffFileSnapshot)
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		snapshot := handoffFileSnapshot{Mode: info.Mode()}
+		if info.Mode().IsRegular() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			snapshot.Contents = string(data)
+		} else if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			snapshot.Contents = target
+		}
+		files[rel] = snapshot
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshot handoff root: %v", err)
+	}
+	return files
 }
 
 func canonicalTempDir(t *testing.T) string {

--- a/engdocs/design/ownership-handoff-contract.md
+++ b/engdocs/design/ownership-handoff-contract.md
@@ -17,3 +17,52 @@ to advance unless the provider supplies an explicitly idempotent replay hook.
 The per-journal advisory lock is persistent and kernel-released rather than an
 `O_EXCL` marker, so a crashed process cannot leave a stale file that wedges
 future retries.
+
+## Identity and invocation
+
+`bd migrate ownership-handoff` is the only invocation path; nothing else in
+`bd` constructs a handoff request. Request identity includes the canonical Gas
+City root that owns the legacy server, so the same Dolt scope under a different
+city is a different handoff: it is refused as `identity_conflict` rather than
+resumed. A journal written before `city_root` joined the request — pre-release
+builds of this series only — decodes with an empty city root and therefore
+conflicts with every request a current binary makes; discarding such a journal
+is safe when it records no mutation, and the refusal says so. Every
+`identity_conflict` refusal reports the journaled mutation state in `mutates`,
+whichever entry point produced it, so a `--json` caller that never sees the
+refusal text reads the same answer from the field.
+
+Provider hooks are resolved while the journal lock is held, after the request
+and any existing journal have been validated, so a conflicting journal writer
+cannot win the race between preflight and execution. `mutation_occurred` is
+persistent operator state rather than an inference from the phase: once a hook
+reports that it mutated the scope, the journal carries that fact across
+retries, so a later non-mutating refusal cannot report the handoff as clean.
+Commit is not trusted to the phase machine alone — the commit hook must
+re-prove that the legacy owner is gone (a `process_missing` refusal on a fresh
+inspect) before ownership moves to `bd`.
+
+## Provider obligations
+
+This package enforces only the Beads side of the protocol. The peer lives in
+another codebase, so the following obligations are stated here and pinned by
+in-tree fakes rather than by the real provider:
+
+- `StopLegacy` must treat an identity-matching process that is already gone as
+  success — `result=stopped` with `mutates=true` — not as a refusal. A crash
+  between a successful stop and its `old_owner_stopped` checkpoint leaves the
+  journal at `target_configured` while the owner is in fact stopped; the retry
+  re-invokes the stop hook. A provider that refuses that retry (for example
+  with `process_missing`) wedges the handoff mid-migration with the server
+  down and no mutation recorded — the untruthful `mutates=false` the journaled
+  mutation flag exists to prevent. Pinned from both directions by
+  `TestGCProviderResumeCompletesWhenStopTreatsMissingOwnerAsStopped` and
+  `TestGCProviderResumeWedgesWhenStopRefusesMissingOwner`.
+- `Configure` must be non-mutating. Mutation reporting is honored on the
+  `StopLegacy` failure path only, so a `Configure` that mutates the target and
+  then fails is reported as `mutates=false`.
+- A post-stop inspect must keep reporting `owner=legacy-gc`, and must keep
+  answering `process_missing` for the stopped scope until commit completes. A
+  response naming another owner fails the protocol decode, and an eager
+  provider-side cleanup that answers `state_missing` instead wedges a resumed
+  handoff at `old_owner_stopped`.

--- a/internal/ownershiphandoff/gcprovider.go
+++ b/internal/ownershiphandoff/gcprovider.go
@@ -1,0 +1,254 @@
+package ownershiphandoff
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const gcHandoffSchemaVersion = 1
+
+// GCProvider invokes the explicit hidden Gas City handoff protocol. The
+// binary path must be absolute, canonical, and executable; no PATH lookup or
+// process-state fallback is permitted.
+type GCProvider struct {
+	Binary string
+}
+
+// NewGCProvider validates a trusted absolute GC executable path.
+func NewGCProvider(binary string) (Provider, error) {
+	if err := validateGCExecutable(binary); err != nil {
+		return nil, err
+	}
+	return &GCProvider{Binary: binary}, nil
+}
+
+func validateGCExecutable(binary string) error {
+	if !filepath.IsAbs(binary) || filepath.Clean(binary) != binary {
+		return CodedError{Code: "provider_unavailable", Err: errors.New("GC_BIN must be an absolute canonical path")}
+	}
+	info, err := os.Lstat(binary)
+	if err != nil {
+		return CodedError{Code: "provider_unavailable", Err: fmt.Errorf("stat GC_BIN: %w", err)}
+	}
+	if !info.Mode().IsRegular() || info.Mode()&0111 == 0 {
+		return CodedError{Code: "provider_unavailable", Err: errors.New("GC_BIN must be an executable regular file")}
+	}
+	real, err := filepath.EvalSymlinks(binary)
+	if err != nil || real != binary {
+		if err == nil {
+			err = errors.New("GC_BIN must not be symlinked")
+		}
+		return CodedError{Code: "provider_unavailable", Err: err}
+	}
+	return nil
+}
+
+// NewGCProviderFromEnv creates a provider using the trusted GC_BIN
+// environment variable. An unset variable returns an unavailable provider
+// rather than searching PATH.
+func NewGCProviderFromEnv() Provider {
+	return ProviderFunc(func(ctx context.Context, r Request) (Hooks, error) {
+		binary := os.Getenv("GC_BIN")
+		if binary == "" {
+			return Hooks{}, CodedError{Code: "provider_unavailable", Err: errors.New("GC_BIN is not configured")}
+		}
+		provider, err := NewGCProvider(binary)
+		if err != nil {
+			return Hooks{}, err
+		}
+		return provider.OwnershipHandoffHooks(ctx, r)
+	})
+}
+
+type gcHandoffIdentity struct {
+	CityRoot       string   `json:"city_root"`
+	ScopeRoot      string   `json:"scope_root"`
+	Database       string   `json:"database"`
+	Workspace      string   `json:"workspace"`
+	Endpoint       Endpoint `json:"endpoint"`
+	DataDir        string   `json:"data_dir"`
+	ConfigFile     string   `json:"config_file"`
+	PID            int      `json:"pid"`
+	StartIdentity  string   `json:"start_identity"`
+	StartTimeTicks int64    `json:"start_time_ticks"`
+	PortHolderPID  int      `json:"port_holder_pid"`
+}
+
+type gcHandoffResponse struct {
+	SchemaVersion int               `json:"schema_version"`
+	Operation     string            `json:"operation"`
+	Result        string            `json:"result"`
+	Owner         Owner             `json:"owner"`
+	Mutates       bool              `json:"mutates"`
+	Identity      gcHandoffIdentity `json:"identity"`
+	IdentityToken string            `json:"identity_token"`
+	ErrorCode     string            `json:"error_code"`
+}
+
+func (p *GCProvider) OwnershipHandoffHooks(ctx context.Context, r Request) (Hooks, error) {
+	if p == nil {
+		return Hooks{}, CodedError{Code: "provider_unavailable", Err: errors.New("GC provider is nil")}
+	}
+	if err := validateGCExecutable(p.Binary); err != nil {
+		return Hooks{}, err
+	}
+	if r.CityRoot == "" {
+		return Hooks{}, CodedError{Code: "invalid_request", Err: errors.New("city root is required by the GC handoff protocol")}
+	}
+	response, raw, err := p.invoke(ctx, r, "handoff-inspect", "")
+	if err != nil {
+		return Hooks{}, err
+	}
+	if response.Operation != "handoff-inspect" {
+		return Hooks{}, CodedError{Code: "protocol_version", Err: errors.New("GC handoff inspect returned an unexpected operation")}
+	}
+	if response.Result != "eligible" {
+		return Hooks{}, responseError(response, "handoff inspect refused")
+	}
+	if err := validateGCIdentity(r, response); err != nil {
+		return Hooks{}, err
+	}
+	if err := validateIdentityToken(response.IdentityToken); err != nil {
+		return Hooks{}, err
+	}
+	metadata := append([]byte(nil), raw...)
+	identityToken := response.IdentityToken
+	return Hooks{
+		Snapshot: func(context.Context, Request) (Snapshot, error) {
+			return Snapshot{Metadata: metadata, Sentinel: identityToken}, nil
+		},
+		// GC already owns target configuration. Configure is intentionally a
+		// config-only no-op; it must never start a second server.
+		Configure: func(context.Context, Request, Snapshot) error { return nil },
+		StopLegacy: func(stopCtx context.Context, request Request, _ Snapshot) error {
+			stopped, _, err := p.invoke(stopCtx, request, "handoff-stop", identityToken)
+			if err != nil {
+				return err
+			}
+			if stopped.Operation != "handoff-stop" {
+				return CodedError{Code: "protocol_version", Err: errors.New("GC handoff stop returned an unexpected operation")}
+			}
+			if stopped.Result != "stopped" || !stopped.Mutates {
+				return responseError(stopped, "GC handoff stop refused")
+			}
+			if err := validateGCIdentity(request, stopped); err != nil {
+				return err
+			}
+			if stopped.IdentityToken != identityToken {
+				return CodedError{Code: "identity_changed", Err: errors.New("GC handoff stop token changed")}
+			}
+			return nil
+		},
+		Verify:       func(context.Context, Request, Snapshot) error { return nil },
+		Commit:       func(context.Context, Request, Snapshot) error { return nil },
+		CommitReplay: func(context.Context, Request, Snapshot) error { return nil },
+	}, nil
+}
+
+func (p *GCProvider) invoke(ctx context.Context, r Request, operation, token string) (gcHandoffResponse, []byte, error) {
+	args := []string{"dolt-state", operation, "--json", "--city", r.CityRoot, "--scope-root", r.Root,
+		"--database", r.Database, "--workspace", r.Workspace}
+	if r.Endpoint.Socket != "" {
+		args = append(args, "--socket", r.Endpoint.Socket)
+	} else {
+		args = append(args, "--host", r.Endpoint.Host, "--port", strconv.Itoa(r.Endpoint.Port))
+	}
+	if token != "" {
+		args = append(args, "--identity-token", token)
+	}
+	cmd := exec.CommandContext(ctx, p.Binary, args...) // #nosec G204 -- Binary is validated by NewGCProvider.
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	runErr := cmd.Run()
+	response, err := decodeGCResponse(stdout.Bytes())
+	if err != nil {
+		if runErr != nil {
+			return gcHandoffResponse{}, nil, CodedError{Code: "provider_unavailable", Err: errors.New("GC handoff protocol command failed")}
+		}
+		return gcHandoffResponse{}, nil, err
+	}
+	if runErr != nil && response.Result != "refused" {
+		return gcHandoffResponse{}, nil, CodedError{Code: "provider_unavailable", Err: errors.New("GC handoff protocol command failed")}
+	}
+	return response, stdout.Bytes(), nil
+}
+
+func decodeGCResponse(raw []byte) (gcHandoffResponse, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var response gcHandoffResponse
+	if err := decoder.Decode(&response); err != nil {
+		return gcHandoffResponse{}, CodedError{Code: "protocol_version", Err: fmt.Errorf("decode GC handoff response: %w", err)}
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return gcHandoffResponse{}, CodedError{Code: "protocol_version", Err: errors.New("GC handoff response must contain one JSON object")}
+	}
+	if response.SchemaVersion != gcHandoffSchemaVersion {
+		return gcHandoffResponse{}, CodedError{Code: "protocol_version", Err: errors.New("unsupported GC handoff schema version")}
+	}
+	if response.Owner != OwnerLegacyGC {
+		return gcHandoffResponse{}, CodedError{Code: "process_unowned", Err: errors.New("GC handoff owner is not legacy-gc")}
+	}
+	return response, nil
+}
+
+func responseError(response gcHandoffResponse, message string) error {
+	code := stableErrorCode(response.ErrorCode, "provider_unavailable")
+	return CodedError{Code: code, Err: errors.New(message)}
+}
+
+func validateIdentityToken(token string) error {
+	const prefix = "sha256:"
+	if len(token) != len(prefix)+sha256.Size*2 || token[:len(prefix)] != prefix {
+		return CodedError{Code: "protocol_version", Err: errors.New("GC handoff identity token is not sha256 encoded")}
+	}
+	if _, err := hex.DecodeString(token[len(prefix):]); err != nil {
+		return CodedError{Code: "protocol_version", Err: errors.New("GC handoff identity token is not hexadecimal")}
+	}
+	return nil
+}
+
+func validateGCIdentity(r Request, response gcHandoffResponse) error {
+	i := response.Identity
+	if i.CityRoot != r.CityRoot || i.ScopeRoot != r.Root || i.Database != r.Database || i.Workspace != r.Workspace || i.Endpoint != r.Endpoint {
+		return CodedError{Code: "identity_changed", Err: errors.New("GC handoff identity does not match request")}
+	}
+	if i.PID <= 0 || i.StartIdentity == "" || i.StartTimeTicks < 0 || i.PortHolderPID < 0 {
+		return CodedError{Code: "protocol_version", Err: errors.New("GC handoff identity has invalid process fields")}
+	}
+	for _, field := range []struct {
+		name string
+		path string
+	}{
+		{name: "data_dir", path: i.DataDir},
+		{name: "config_file", path: i.ConfigFile},
+	} {
+		name, path := field.name, field.path
+		if err := validateIdentityPath(r.CityRoot, path); err != nil {
+			return CodedError{Code: "identity_changed", Err: fmt.Errorf("%s: %w", name, err)}
+		}
+	}
+	return nil
+}
+
+func validateIdentityPath(root, path string) error {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return errors.New("path must be absolute and canonical")
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return errors.New("path must be beneath city root")
+	}
+	return nil
+}

--- a/internal/ownershiphandoff/gcprovider.go
+++ b/internal/ownershiphandoff/gcprovider.go
@@ -115,32 +115,22 @@ func (p *GCProvider) OwnershipHandoffHooks(ctx context.Context, r Request) (Hook
 	if r.CityRoot == "" {
 		return Hooks{}, CodedError{Code: "invalid_request", Err: errors.New("city root is required by the GC handoff protocol")}
 	}
-	response, raw, err := p.invoke(ctx, r, "handoff-inspect", "")
-	if err != nil {
-		return Hooks{}, err
-	}
-	if response.Operation != "handoff-inspect" {
-		return Hooks{}, CodedError{Code: "protocol_version", Err: errors.New("GC handoff inspect returned an unexpected operation")}
-	}
-	if response.Result != "eligible" {
-		return Hooks{}, responseError(response, "handoff inspect refused")
-	}
-	if err := validateGCIdentity(r, response); err != nil {
-		return Hooks{}, err
-	}
-	if err := validateIdentityToken(response.IdentityToken); err != nil {
-		return Hooks{}, err
-	}
-	metadata := append([]byte(nil), raw...)
-	identityToken := response.IdentityToken
 	return Hooks{
-		Snapshot: func(context.Context, Request) (Snapshot, error) {
-			return Snapshot{Metadata: metadata, Sentinel: identityToken}, nil
+		Snapshot: func(snapshotCtx context.Context, request Request) (Snapshot, error) {
+			response, raw, err := p.inspect(snapshotCtx, request)
+			if err != nil {
+				return Snapshot{}, err
+			}
+			return Snapshot{Metadata: append([]byte(nil), raw...), Sentinel: response.IdentityToken}, nil
 		},
 		// GC already owns target configuration. Configure is intentionally a
 		// config-only no-op; it must never start a second server.
 		Configure: func(context.Context, Request, Snapshot) error { return nil },
-		StopLegacy: func(stopCtx context.Context, request Request, _ Snapshot) error {
+		StopLegacy: func(stopCtx context.Context, request Request, snapshot Snapshot) error {
+			identityToken, err := snapshotIdentityToken(request, snapshot)
+			if err != nil {
+				return err
+			}
 			stopped, _, err := p.invoke(stopCtx, request, "handoff-stop", identityToken)
 			if err != nil {
 				return err
@@ -149,13 +139,13 @@ func (p *GCProvider) OwnershipHandoffHooks(ctx context.Context, r Request) (Hook
 				return CodedError{Code: "protocol_version", Err: errors.New("GC handoff stop returned an unexpected operation")}
 			}
 			if stopped.Result != "stopped" || !stopped.Mutates {
-				return responseError(stopped, "GC handoff stop refused")
+				return withReportedMutation(responseError(stopped, "GC handoff stop refused"), stopped.Mutates)
 			}
 			if err := validateGCIdentity(request, stopped); err != nil {
-				return err
+				return withReportedMutation(err, stopped.Mutates)
 			}
 			if stopped.IdentityToken != identityToken {
-				return CodedError{Code: "identity_changed", Err: errors.New("GC handoff stop token changed")}
+				return withReportedMutation(CodedError{Code: "identity_changed", Err: errors.New("GC handoff stop token changed")}, stopped.Mutates)
 			}
 			return nil
 		},
@@ -169,6 +159,46 @@ func (p *GCProvider) OwnershipHandoffHooks(ctx context.Context, r Request) (Hook
 			return p.verifyStopped(commitCtx, request)
 		},
 	}, nil
+}
+
+func (p *GCProvider) inspect(ctx context.Context, r Request) (gcHandoffResponse, []byte, error) {
+	response, raw, err := p.invoke(ctx, r, "handoff-inspect", "")
+	if err != nil {
+		return gcHandoffResponse{}, nil, err
+	}
+	if response.Operation != "handoff-inspect" {
+		return gcHandoffResponse{}, nil, CodedError{Code: "protocol_version", Err: errors.New("GC handoff inspect returned an unexpected operation")}
+	}
+	if response.Result != "eligible" {
+		return gcHandoffResponse{}, nil, responseError(response, "handoff inspect refused")
+	}
+	if err := validateGCIdentity(r, response); err != nil {
+		return gcHandoffResponse{}, nil, err
+	}
+	if err := validateIdentityToken(response.IdentityToken); err != nil {
+		return gcHandoffResponse{}, nil, err
+	}
+	return response, raw, nil
+}
+
+func snapshotIdentityToken(r Request, snapshot Snapshot) (string, error) {
+	response, err := decodeGCResponse(snapshot.Metadata)
+	if err != nil {
+		return "", err
+	}
+	if response.Operation != "handoff-inspect" || response.Result != "eligible" {
+		return "", CodedError{Code: "protocol_version", Err: errors.New("handoff snapshot is not an eligible inspect response")}
+	}
+	if err := validateGCIdentity(r, response); err != nil {
+		return "", err
+	}
+	if err := validateIdentityToken(response.IdentityToken); err != nil {
+		return "", err
+	}
+	if snapshot.Sentinel != response.IdentityToken {
+		return "", CodedError{Code: "identity_changed", Err: errors.New("handoff snapshot token does not match its inspect response")}
+	}
+	return response.IdentityToken, nil
 }
 
 // verifyStopped asks the lifecycle owner to re-inspect the captured scope.
@@ -206,6 +236,7 @@ func (p *GCProvider) invoke(ctx context.Context, r Request, operation, token str
 	commandCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	cmd := exec.CommandContext(commandCtx, p.Binary, args...) // #nosec G204 -- Binary is validated by NewGCProvider.
+	configureGCHandoffCommand(cmd)
 	stdout := &limitedBuffer{limit: maxGCHandoffProtocolOutput}
 	stderr := &limitedBuffer{limit: maxGCHandoffProtocolOutput}
 	cmd.Stdout = stdout

--- a/internal/ownershiphandoff/gcprovider.go
+++ b/internal/ownershiphandoff/gcprovider.go
@@ -14,44 +14,53 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const gcHandoffSchemaVersion = 1
+
+const defaultGCHandoffTimeout = 30 * time.Second
+
+const maxGCHandoffProtocolOutput = 1 << 20
 
 // GCProvider invokes the explicit hidden Gas City handoff protocol. The
 // binary path must be absolute, canonical, and executable; no PATH lookup or
 // process-state fallback is permitted.
 type GCProvider struct {
-	Binary string
+	Binary  string
+	timeout time.Duration
 }
 
 // NewGCProvider validates a trusted absolute GC executable path.
 func NewGCProvider(binary string) (Provider, error) {
-	if err := validateGCExecutable(binary); err != nil {
+	canonical, err := canonicalGCExecutable(binary)
+	if err != nil {
 		return nil, err
 	}
-	return &GCProvider{Binary: binary}, nil
+	return &GCProvider{Binary: canonical, timeout: defaultGCHandoffTimeout}, nil
 }
 
 func validateGCExecutable(binary string) error {
+	_, err := canonicalGCExecutable(binary)
+	return err
+}
+
+func canonicalGCExecutable(binary string) (string, error) {
 	if !filepath.IsAbs(binary) || filepath.Clean(binary) != binary {
-		return CodedError{Code: "provider_unavailable", Err: errors.New("GC_BIN must be an absolute canonical path")}
+		return "", CodedError{Code: "provider_unavailable", Err: errors.New("GC_BIN must be an absolute canonical path")}
 	}
 	info, err := os.Lstat(binary)
 	if err != nil {
-		return CodedError{Code: "provider_unavailable", Err: fmt.Errorf("stat GC_BIN: %w", err)}
+		return "", CodedError{Code: "provider_unavailable", Err: fmt.Errorf("stat GC_BIN: %w", err)}
 	}
 	if !info.Mode().IsRegular() || info.Mode()&0111 == 0 {
-		return CodedError{Code: "provider_unavailable", Err: errors.New("GC_BIN must be an executable regular file")}
+		return "", CodedError{Code: "provider_unavailable", Err: errors.New("GC_BIN must be an executable regular file")}
 	}
 	real, err := filepath.EvalSymlinks(binary)
-	if err != nil || real != binary {
-		if err == nil {
-			err = errors.New("GC_BIN must not be symlinked")
-		}
-		return CodedError{Code: "provider_unavailable", Err: err}
+	if err != nil {
+		return "", CodedError{Code: "provider_unavailable", Err: fmt.Errorf("resolve GC_BIN: %w", err)}
 	}
-	return nil
+	return real, nil
 }
 
 // NewGCProviderFromEnv creates a provider using the trusted GC_BIN
@@ -150,10 +159,33 @@ func (p *GCProvider) OwnershipHandoffHooks(ctx context.Context, r Request) (Hook
 			}
 			return nil
 		},
-		Verify:       func(context.Context, Request, Snapshot) error { return nil },
-		Commit:       func(context.Context, Request, Snapshot) error { return nil },
-		CommitReplay: func(context.Context, Request, Snapshot) error { return nil },
+		Verify: func(verifyCtx context.Context, request Request, _ Snapshot) error {
+			return p.verifyStopped(verifyCtx, request)
+		},
+		Commit: func(commitCtx context.Context, request Request, _ Snapshot) error {
+			return p.verifyStopped(commitCtx, request)
+		},
+		CommitReplay: func(commitCtx context.Context, request Request, _ Snapshot) error {
+			return p.verifyStopped(commitCtx, request)
+		},
 	}, nil
+}
+
+// verifyStopped asks the lifecycle owner to re-inspect the captured scope.
+// A post-stop inspect must refuse with process_missing; any eligible or other
+// response means the legacy owner has not proven that it released the scope.
+func (p *GCProvider) verifyStopped(ctx context.Context, r Request) error {
+	response, _, err := p.invoke(ctx, r, "handoff-inspect", "")
+	if err != nil {
+		return err
+	}
+	if response.Operation != "handoff-inspect" {
+		return CodedError{Code: "protocol_version", Err: errors.New("GC handoff verification returned an unexpected operation")}
+	}
+	if response.Result == "refused" && response.ErrorCode == "process_missing" {
+		return nil
+	}
+	return CodedError{Code: "verification_failed", Err: errors.New("GC handoff verification did not confirm the legacy owner stopped")}
 }
 
 func (p *GCProvider) invoke(ctx context.Context, r Request, operation, token string) (gcHandoffResponse, []byte, error) {
@@ -167,21 +199,52 @@ func (p *GCProvider) invoke(ctx context.Context, r Request, operation, token str
 	if token != "" {
 		args = append(args, "--identity-token", token)
 	}
-	cmd := exec.CommandContext(ctx, p.Binary, args...) // #nosec G204 -- Binary is validated by NewGCProvider.
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
+	timeout := p.timeout
+	if timeout <= 0 {
+		timeout = defaultGCHandoffTimeout
+	}
+	commandCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	cmd := exec.CommandContext(commandCtx, p.Binary, args...) // #nosec G204 -- Binary is validated by NewGCProvider.
+	stdout := &limitedBuffer{limit: maxGCHandoffProtocolOutput}
+	stderr := &limitedBuffer{limit: maxGCHandoffProtocolOutput}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	runErr := cmd.Run()
 	response, err := decodeGCResponse(stdout.Bytes())
 	if err != nil {
 		if runErr != nil {
-			return gcHandoffResponse{}, nil, CodedError{Code: "provider_unavailable", Err: errors.New("GC handoff protocol command failed")}
+			return gcHandoffResponse{}, nil, CodedError{Code: "provider_unavailable", Err: protocolCommandError(commandCtx, runErr, stderr.String())}
 		}
 		return gcHandoffResponse{}, nil, err
 	}
 	if runErr != nil && response.Result != "refused" {
-		return gcHandoffResponse{}, nil, CodedError{Code: "provider_unavailable", Err: errors.New("GC handoff protocol command failed")}
+		return gcHandoffResponse{}, nil, CodedError{Code: "provider_unavailable", Err: protocolCommandError(commandCtx, runErr, stderr.String())}
 	}
 	return response, stdout.Bytes(), nil
+}
+
+func protocolCommandError(ctx context.Context, runErr error, stderr string) error {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return errors.New("GC handoff protocol command timed out")
+	}
+	if detail := strings.TrimSpace(stderr); detail != "" {
+		return fmt.Errorf("GC handoff protocol command failed: %s", detail)
+	}
+	return fmt.Errorf("GC handoff protocol command failed: %w", runErr)
+}
+
+type limitedBuffer struct {
+	bytes.Buffer
+	limit int
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	remaining := b.limit - b.Len()
+	if remaining <= 0 || len(p) > remaining {
+		return 0, errors.New("GC handoff protocol output exceeds limit")
+	}
+	return b.Buffer.Write(p)
 }
 
 func decodeGCResponse(raw []byte) (gcHandoffResponse, error) {

--- a/internal/ownershiphandoff/gcprovider_command_unix.go
+++ b/internal/ownershiphandoff/gcprovider_command_unix.go
@@ -1,0 +1,26 @@
+//go:build unix
+
+package ownershiphandoff
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+const gcHandoffPipeDrainDelay = 100 * time.Millisecond
+
+func configureGCHandoffCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+			return err
+		}
+		return nil
+	}
+	cmd.WaitDelay = gcHandoffPipeDrainDelay
+}

--- a/internal/ownershiphandoff/gcprovider_command_windows.go
+++ b/internal/ownershiphandoff/gcprovider_command_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package ownershiphandoff
+
+import (
+	"os/exec"
+	"time"
+)
+
+const gcHandoffPipeDrainDelay = 100 * time.Millisecond
+
+func configureGCHandoffCommand(cmd *exec.Cmd) {
+	cmd.WaitDelay = gcHandoffPipeDrainDelay
+}

--- a/internal/ownershiphandoff/gcprovider_test.go
+++ b/internal/ownershiphandoff/gcprovider_test.go
@@ -1,0 +1,167 @@
+package ownershiphandoff
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const fakeHandoffToken = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func TestGCProviderCompletesOnlyThroughTrustedProtocol(t *testing.T) {
+	city := canonicalTestDir(t)
+	scope := filepath.Join(city, "scope")
+	if err := os.Mkdir(scope, 0700); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(city, "gc.log")
+	errLogPath := filepath.Join(city, "gc.err")
+	binary := fakeGCProtocol(t)
+	t.Setenv("GC_HANDOFF_LOG", logPath)
+	t.Setenv("GC_HANDOFF_ERR_LOG", errLogPath)
+	request := Request{CityRoot: city, Root: scope, Database: "beads", Workspace: "ws",
+		Endpoint: Endpoint{Host: "127.0.0.1", Port: 3307}, Owner: OwnerLegacyGC}
+	provider, err := NewGCProvider(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := Run(context.Background(), request, filepath.Join(scope, "ownership-handoff.json"), provider, false)
+	if err != nil || result.Phase != PhaseCommitted || result.Owner != OwnerBD || !result.Mutates {
+		errLog, _ := os.ReadFile(errLogPath)
+		t.Fatalf("result=%+v err=%v, want committed bd-owned handoff; fake stderr=%q", result, err, errLog)
+	}
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(log)); got != "handoff-inspect\nhandoff-stop" {
+		t.Fatalf("protocol operations=%q, want inspect then stop", got)
+	}
+}
+
+func TestGCProviderRefusalNeverInvokesStop(t *testing.T) {
+	city := canonicalTestDir(t)
+	scope := filepath.Join(city, "scope")
+	if err := os.Mkdir(scope, 0700); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(city, "gc.log")
+	errLogPath := filepath.Join(city, "gc.err")
+	binary := fakeGCProtocol(t)
+	t.Setenv("GC_HANDOFF_LOG", logPath)
+	t.Setenv("GC_HANDOFF_ERR_LOG", errLogPath)
+	t.Setenv("GC_HANDOFF_REFUSE", "1")
+	request := Request{CityRoot: city, Root: scope, Database: "beads", Workspace: "ws",
+		Endpoint: Endpoint{Host: "127.0.0.1", Port: 3307}, Owner: OwnerLegacyGC}
+	provider, err := NewGCProvider(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := Run(context.Background(), request, filepath.Join(scope, "ownership-handoff.json"), provider, false)
+	if err == nil || result.ErrorCode != "process_unowned" || result.Mutates {
+		errLog, _ := os.ReadFile(errLogPath)
+		t.Fatalf("result=%+v err=%v, want process_unowned refusal; fake stderr=%q", result, err, errLog)
+	}
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(log)); got != "handoff-inspect" {
+		t.Fatalf("protocol operations=%q, want inspect only", got)
+	}
+}
+
+func TestGCProviderRejectsUntrustedBinary(t *testing.T) {
+	if _, err := NewGCProvider("gc"); err == nil {
+		t.Fatal("relative GC binary accepted")
+	}
+}
+
+func TestDecodeGCResponseRejectsUnknownFieldsAndTrailingObjects(t *testing.T) {
+	response := gcHandoffResponse{SchemaVersion: gcHandoffSchemaVersion, Operation: "handoff-inspect",
+		Result: "eligible", Owner: OwnerLegacyGC, IdentityToken: fakeHandoffToken}
+	raw, err := json.Marshal(response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeGCResponse(append(raw, []byte("{}")...)); err == nil {
+		t.Fatal("trailing JSON object accepted")
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatal(err)
+	}
+	fields["extra"] = json.RawMessage("true")
+	raw, err = json.Marshal(fields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeGCResponse(raw); err == nil {
+		t.Fatal("unknown response field accepted")
+	}
+}
+
+func canonicalTestDir(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	canonical, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return canonical
+}
+
+func fakeGCProtocol(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gc")
+	script := `#!/bin/sh
+set -e
+exec 2>"$GC_HANDOFF_ERR_LOG"
+operation="$2"
+city=""
+scope=""
+database=""
+workspace=""
+host=""
+port=""
+socket=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --city) city="$2"; shift 2 ;;
+    --scope-root) scope="$2"; shift 2 ;;
+    --database) database="$2"; shift 2 ;;
+    --workspace) workspace="$2"; shift 2 ;;
+    --host) host="$2"; shift 2 ;;
+    --port) port="$2"; shift 2 ;;
+    --socket) socket="$2"; shift 2 ;;
+    --identity-token) shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '%s\n' "$operation" >> "$GC_HANDOFF_LOG"
+result=eligible
+mutates=false
+error_code=""
+if [ "$GC_HANDOFF_REFUSE" = "1" ]; then
+  result=refused
+  error_code=process_unowned
+fi
+if [ "$operation" = "handoff-stop" ]; then
+  result=stopped
+  mutates=true
+fi
+if [ -n "$socket" ]; then
+  endpoint=$(printf '{"host":"","port":0,"socket":"%s"}' "$socket")
+else
+  endpoint=$(printf '{"host":"%s","port":%s,"socket":""}' "$host" "$port")
+fi
+printf '{"schema_version":1,"operation":"%s","result":"%s","owner":"legacy-gc","mutates":%s,"identity":{"city_root":"%s","scope_root":"%s","database":"%s","workspace":"%s","endpoint":%s,"data_dir":"%s/.gc/data","config_file":"%s/.gc/config","pid":%s,"start_identity":"fake","start_time_ticks":1,"port_holder_pid":%s},"identity_token":"%s","error_code":"%s"}\n' "$operation" "$result" "$mutates" "$city" "$scope" "$database" "$workspace" "$endpoint" "$city" "$city" "$$" "$$" "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" "$error_code"
+`
+	if err := os.WriteFile(path, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/ownershiphandoff/gcprovider_test.go
+++ b/internal/ownershiphandoff/gcprovider_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -115,12 +117,16 @@ func TestGCProviderRejectsIdentityAndTokenSubstitution(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("GC_HANDOFF_DATABASE", "other")
-	if _, err := provider.OwnershipHandoffHooks(context.Background(), request); err == nil {
+	hooks, err := provider.OwnershipHandoffHooks(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := hooks.Snapshot(context.Background(), request); err == nil {
 		t.Fatal("provider accepted substituted identity")
 	}
 	t.Setenv("GC_HANDOFF_DATABASE", "")
 	t.Setenv("GC_HANDOFF_TOKEN", "not-a-token")
-	if _, err := provider.OwnershipHandoffHooks(context.Background(), request); err == nil {
+	if _, err := hooks.Snapshot(context.Background(), request); err == nil {
 		t.Fatal("provider accepted malformed identity token")
 	}
 }
@@ -163,8 +169,160 @@ func TestGCProviderBoundsProtocolCommand(t *testing.T) {
 	}
 	provider.(*GCProvider).timeout = 10 * time.Millisecond
 	request := Request{CityRoot: city, Root: scope, Database: "beads", Workspace: "ws", Endpoint: Endpoint{Host: "127.0.0.1", Port: 3307}, Owner: OwnerLegacyGC}
-	if _, err := provider.OwnershipHandoffHooks(context.Background(), request); err == nil {
+	hooks, err := provider.OwnershipHandoffHooks(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := hooks.Snapshot(context.Background(), request); err == nil {
 		t.Fatal("provider accepted a timed-out protocol command")
+	}
+}
+
+func TestGCProviderStopRefusalReportsProviderMutation(t *testing.T) {
+	for _, mutates := range []bool{false, true} {
+		t.Run(strconv.FormatBool(mutates), func(t *testing.T) {
+			city := canonicalTestDir(t)
+			scope := filepath.Join(city, "scope")
+			if err := os.Mkdir(scope, 0700); err != nil {
+				t.Fatal(err)
+			}
+			binary := fakeGCProtocol(t)
+			t.Setenv("GC_HANDOFF_LOG", filepath.Join(city, "gc.log"))
+			t.Setenv("GC_HANDOFF_ERR_LOG", filepath.Join(city, "gc.err"))
+			t.Setenv("GC_HANDOFF_STOP_REFUSE", "1")
+			t.Setenv("GC_HANDOFF_STOP_MUTATES", strconv.FormatBool(mutates))
+			request := Request{CityRoot: city, Root: scope, Database: "beads", Workspace: "ws", Endpoint: Endpoint{Host: "127.0.0.1", Port: 3307}, Owner: OwnerLegacyGC}
+			provider, err := NewGCProvider(binary)
+			if err != nil {
+				t.Fatal(err)
+			}
+			journalPath := filepath.Join(scope, "ownership-handoff.json")
+			result, err := Run(context.Background(), request, journalPath, provider, false)
+			if err == nil || result.Owner != OwnerLegacyGC || result.Phase != PhaseTargetConfigured || result.ErrorCode != "process_unowned" || result.Mutates != mutates {
+				t.Fatalf("result=%+v err=%v, want typed stop refusal with mutates=%t", result, err, mutates)
+			}
+			journal, err := Load(journalPath)
+			if err != nil || journal.MutationOccurred != mutates {
+				t.Fatalf("journal=%+v err=%v, want mutation_occurred=%t", journal, err, mutates)
+			}
+		})
+	}
+}
+
+func TestGCProviderResumeUsesPersistedSnapshotToken(t *testing.T) {
+	city := canonicalTestDir(t)
+	scope := filepath.Join(city, "scope")
+	if err := os.Mkdir(scope, 0700); err != nil {
+		t.Fatal(err)
+	}
+	binary := fakeGCProtocol(t)
+	logPath := filepath.Join(city, "gc.log")
+	t.Setenv("GC_HANDOFF_LOG", logPath)
+	t.Setenv("GC_HANDOFF_ERR_LOG", filepath.Join(city, "gc.err"))
+	t.Setenv("GC_HANDOFF_STOP_REFUSE", "1")
+	t.Setenv("GC_HANDOFF_STOP_MUTATES", "false")
+	request := Request{CityRoot: city, Root: scope, Database: "beads", Workspace: "ws", Endpoint: Endpoint{Host: "127.0.0.1", Port: 3307}, Owner: OwnerLegacyGC}
+	provider, err := NewGCProvider(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	journalPath := filepath.Join(scope, "ownership-handoff.json")
+	first, err := Run(context.Background(), request, journalPath, provider, false)
+	if err == nil || first.Phase != PhaseTargetConfigured || first.Mutates {
+		t.Fatalf("first result=%+v err=%v, want non-mutating stop refusal", first, err)
+	}
+	t.Setenv("GC_HANDOFF_STOP_REFUSE", "")
+	t.Setenv("GC_HANDOFF_TOKEN", "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+	second, err := Run(context.Background(), request, journalPath, provider, false)
+	if err == nil || second.ErrorCode != "identity_changed" || !second.Mutates {
+		t.Fatalf("second result=%+v err=%v, want mutated identity-changed refusal", second, err)
+	}
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(log)); got != "handoff-inspect\nhandoff-stop\nhandoff-stop" {
+		t.Fatalf("protocol operations=%q, want retry to use persisted snapshot without re-inspect", got)
+	}
+}
+
+func TestGCProviderResumeAfterStoppedOwnerDoesNotReinspectSnapshot(t *testing.T) {
+	city := canonicalTestDir(t)
+	scope := filepath.Join(city, "scope")
+	if err := os.Mkdir(scope, 0700); err != nil {
+		t.Fatal(err)
+	}
+	binary := fakeGCProtocol(t)
+	logPath := filepath.Join(city, "gc.log")
+	t.Setenv("GC_HANDOFF_LOG", logPath)
+	t.Setenv("GC_HANDOFF_ERR_LOG", filepath.Join(city, "gc.err"))
+	t.Setenv("GC_HANDOFF_VERIFY_REFUSE_ONCE", filepath.Join(city, "verify-once"))
+	request := Request{CityRoot: city, Root: scope, Database: "beads", Workspace: "ws", Endpoint: Endpoint{Host: "127.0.0.1", Port: 3307}, Owner: OwnerLegacyGC}
+	provider, err := NewGCProvider(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	journalPath := filepath.Join(scope, "ownership-handoff.json")
+	first, err := Run(context.Background(), request, journalPath, provider, false)
+	if err == nil || first.Phase != PhaseOldOwnerStopped || first.Owner != OwnerLegacyGC || !first.Mutates {
+		t.Fatalf("first result=%+v err=%v, want stopped-owner verification failure", first, err)
+	}
+	second, err := Run(context.Background(), request, journalPath, provider, false)
+	if err != nil || second.Phase != PhaseCommitted || second.Owner != OwnerBD || !second.Mutates {
+		t.Fatalf("second result=%+v err=%v, want committed resume", second, err)
+	}
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(log)); got != "handoff-inspect\nhandoff-stop\nhandoff-inspect\nhandoff-inspect\nhandoff-inspect" {
+		t.Fatalf("protocol operations=%q, want stop resume without a new eligible inspect", got)
+	}
+}
+
+func TestGCProviderTimeoutKillsPipeHoldingDescendant(t *testing.T) {
+	city := canonicalTestDir(t)
+	scope := filepath.Join(city, "scope")
+	if err := os.Mkdir(scope, 0700); err != nil {
+		t.Fatal(err)
+	}
+	binary := fakeGCProtocol(t)
+	pidPath := filepath.Join(city, "descendant.pid")
+	t.Setenv("GC_HANDOFF_LOG", filepath.Join(city, "gc.log"))
+	t.Setenv("GC_HANDOFF_ERR_LOG", filepath.Join(city, "gc.err"))
+	t.Setenv("GC_HANDOFF_DESCENDANT", "1")
+	t.Setenv("GC_HANDOFF_DESCENDANT_PID", pidPath)
+	provider, err := NewGCProvider(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider.(*GCProvider).timeout = 10 * time.Millisecond
+	request := Request{CityRoot: city, Root: scope, Database: "beads", Workspace: "ws", Endpoint: Endpoint{Host: "127.0.0.1", Port: 3307}, Owner: OwnerLegacyGC}
+	started := time.Now()
+	hooks, err := provider.OwnershipHandoffHooks(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := hooks.Snapshot(context.Background(), request); err == nil {
+		t.Fatal("provider accepted a timed-out protocol command")
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("timed-out command returned after %s, want bounded pipe drain", elapsed)
+	}
+	rawPID, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatalf("read descendant pid: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(rawPID)))
+	if err != nil {
+		t.Fatalf("parse descendant pid %q: %v", rawPID, err)
+	}
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for processAlive(pid) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if processAlive(pid) {
+		t.Fatalf("pipe-holding descendant %d survived timeout", pid)
 	}
 }
 
@@ -202,6 +360,14 @@ func canonicalTestDir(t *testing.T) string {
 	return canonical
 }
 
+func processAlive(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return process.Signal(syscall.Signal(0)) == nil
+}
+
 func fakeGCProtocol(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "gc")
@@ -231,6 +397,11 @@ while [ "$#" -gt 0 ]; do
 done
 printf '%s\n' "$operation" >> "$GC_HANDOFF_LOG"
 if [ "$GC_HANDOFF_SLEEP" = "1" ]; then sleep 1; fi
+if [ "$GC_HANDOFF_DESCENDANT" = "1" ]; then
+  sleep 5 &
+  printf '%s\n' "$!" > "$GC_HANDOFF_DESCENDANT_PID"
+  wait
+fi
 stopped_file="${GC_HANDOFF_STOPPED_FILE:-$scope/.gc-handoff-stopped}"
 result=eligible
 mutates=false
@@ -238,6 +409,10 @@ error_code=""
 if [ "$operation" = "handoff-inspect" ] && [ -f "$stopped_file" ]; then
   result=refused
   error_code=process_missing
+  if [ -n "$GC_HANDOFF_VERIFY_REFUSE_ONCE" ] && [ ! -f "$GC_HANDOFF_VERIFY_REFUSE_ONCE" ]; then
+    : > "$GC_HANDOFF_VERIFY_REFUSE_ONCE"
+    error_code=lifecycle_busy
+  fi
 fi
 if [ "$GC_HANDOFF_REFUSE" = "1" ]; then
   result=refused
@@ -247,6 +422,11 @@ if [ "$operation" = "handoff-stop" ]; then
   result=stopped
   mutates=true
   if [ "$GC_HANDOFF_STOP_LEAVES_LIVE" != "1" ]; then : > "$stopped_file"; fi
+fi
+if [ "$operation" = "handoff-stop" ] && [ "$GC_HANDOFF_STOP_REFUSE" = "1" ]; then
+  result=refused
+  mutates="${GC_HANDOFF_STOP_MUTATES:-false}"
+  error_code=process_unowned
 fi
 if [ -n "$socket" ]; then
   endpoint=$(printf '{"host":"","port":0,"socket":"%s"}' "$socket")

--- a/internal/ownershiphandoff/gcprovider_test.go
+++ b/internal/ownershiphandoff/gcprovider_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 const fakeHandoffToken = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -37,8 +38,8 @@ func TestGCProviderCompletesOnlyThroughTrustedProtocol(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := strings.TrimSpace(string(log)); got != "handoff-inspect\nhandoff-stop" {
-		t.Fatalf("protocol operations=%q, want inspect then stop", got)
+	if got := strings.TrimSpace(string(log)); got != "handoff-inspect\nhandoff-stop\nhandoff-inspect\nhandoff-inspect" {
+		t.Fatalf("protocol operations=%q, want inspect, stop, then two post-stop checks", got)
 	}
 }
 
@@ -77,6 +78,93 @@ func TestGCProviderRefusalNeverInvokesStop(t *testing.T) {
 func TestGCProviderRejectsUntrustedBinary(t *testing.T) {
 	if _, err := NewGCProvider("gc"); err == nil {
 		t.Fatal("relative GC binary accepted")
+	}
+}
+
+func TestGCProviderCanonicalizesSymlinkedAncestor(t *testing.T) {
+	physical := t.TempDir()
+	link := filepath.Join(t.TempDir(), "gc-bin-dir")
+	if err := os.Symlink(physical, link); err != nil {
+		t.Fatal(err)
+	}
+	binary := filepath.Join(physical, "gc")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	provider, err := NewGCProvider(filepath.Join(link, "gc"))
+	if err != nil {
+		t.Fatalf("NewGCProvider through a symlinked ancestor: %v", err)
+	}
+	if provider.(*GCProvider).Binary != binary {
+		t.Fatalf("provider binary = %q, want canonical %q", provider.(*GCProvider).Binary, binary)
+	}
+}
+
+func TestGCProviderRejectsIdentityAndTokenSubstitution(t *testing.T) {
+	city := canonicalTestDir(t)
+	scope := filepath.Join(city, "scope")
+	if err := os.Mkdir(scope, 0700); err != nil {
+		t.Fatal(err)
+	}
+	binary := fakeGCProtocol(t)
+	t.Setenv("GC_HANDOFF_LOG", filepath.Join(city, "gc.log"))
+	t.Setenv("GC_HANDOFF_ERR_LOG", filepath.Join(city, "gc.err"))
+	request := Request{CityRoot: city, Root: scope, Database: "beads", Workspace: "ws", Endpoint: Endpoint{Host: "127.0.0.1", Port: 3307}, Owner: OwnerLegacyGC}
+	provider, err := NewGCProvider(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_HANDOFF_DATABASE", "other")
+	if _, err := provider.OwnershipHandoffHooks(context.Background(), request); err == nil {
+		t.Fatal("provider accepted substituted identity")
+	}
+	t.Setenv("GC_HANDOFF_DATABASE", "")
+	t.Setenv("GC_HANDOFF_TOKEN", "not-a-token")
+	if _, err := provider.OwnershipHandoffHooks(context.Background(), request); err == nil {
+		t.Fatal("provider accepted malformed identity token")
+	}
+}
+
+func TestGCProviderRefusesCommitWhenStopDidNotReleaseOwner(t *testing.T) {
+	city := canonicalTestDir(t)
+	scope := filepath.Join(city, "scope")
+	if err := os.Mkdir(scope, 0700); err != nil {
+		t.Fatal(err)
+	}
+	binary := fakeGCProtocol(t)
+	t.Setenv("GC_HANDOFF_LOG", filepath.Join(city, "gc.log"))
+	t.Setenv("GC_HANDOFF_ERR_LOG", filepath.Join(city, "gc.err"))
+	t.Setenv("GC_HANDOFF_STOPPED_FILE", filepath.Join(city, "stopped"))
+	t.Setenv("GC_HANDOFF_STOP_LEAVES_LIVE", "1")
+	request := Request{CityRoot: city, Root: scope, Database: "beads", Workspace: "ws", Endpoint: Endpoint{Host: "127.0.0.1", Port: 3307}, Owner: OwnerLegacyGC}
+	provider, err := NewGCProvider(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := Run(context.Background(), request, filepath.Join(scope, "ownership-handoff.json"), provider, false)
+	if err == nil || result.Phase != PhaseOldOwnerStopped || result.Owner != OwnerLegacyGC || result.ErrorCode != "verification_failed" {
+		t.Fatalf("result=%+v err=%v, want uncommitted verification failure", result, err)
+	}
+}
+
+func TestGCProviderBoundsProtocolCommand(t *testing.T) {
+	city := canonicalTestDir(t)
+	scope := filepath.Join(city, "scope")
+	if err := os.Mkdir(scope, 0700); err != nil {
+		t.Fatal(err)
+	}
+	binary := fakeGCProtocol(t)
+	t.Setenv("GC_HANDOFF_LOG", filepath.Join(city, "gc.log"))
+	t.Setenv("GC_HANDOFF_ERR_LOG", filepath.Join(city, "gc.err"))
+	t.Setenv("GC_HANDOFF_SLEEP", "1")
+	provider, err := NewGCProvider(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider.(*GCProvider).timeout = 10 * time.Millisecond
+	request := Request{CityRoot: city, Root: scope, Database: "beads", Workspace: "ws", Endpoint: Endpoint{Host: "127.0.0.1", Port: 3307}, Owner: OwnerLegacyGC}
+	if _, err := provider.OwnershipHandoffHooks(context.Background(), request); err == nil {
+		t.Fatal("provider accepted a timed-out protocol command")
 	}
 }
 
@@ -142,9 +230,15 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 printf '%s\n' "$operation" >> "$GC_HANDOFF_LOG"
+if [ "$GC_HANDOFF_SLEEP" = "1" ]; then sleep 1; fi
+stopped_file="${GC_HANDOFF_STOPPED_FILE:-$scope/.gc-handoff-stopped}"
 result=eligible
 mutates=false
 error_code=""
+if [ "$operation" = "handoff-inspect" ] && [ -f "$stopped_file" ]; then
+  result=refused
+  error_code=process_missing
+fi
 if [ "$GC_HANDOFF_REFUSE" = "1" ]; then
   result=refused
   error_code=process_unowned
@@ -152,13 +246,16 @@ fi
 if [ "$operation" = "handoff-stop" ]; then
   result=stopped
   mutates=true
+  if [ "$GC_HANDOFF_STOP_LEAVES_LIVE" != "1" ]; then : > "$stopped_file"; fi
 fi
 if [ -n "$socket" ]; then
   endpoint=$(printf '{"host":"","port":0,"socket":"%s"}' "$socket")
 else
   endpoint=$(printf '{"host":"%s","port":%s,"socket":""}' "$host" "$port")
 fi
-printf '{"schema_version":1,"operation":"%s","result":"%s","owner":"legacy-gc","mutates":%s,"identity":{"city_root":"%s","scope_root":"%s","database":"%s","workspace":"%s","endpoint":%s,"data_dir":"%s/.gc/data","config_file":"%s/.gc/config","pid":%s,"start_identity":"fake","start_time_ticks":1,"port_holder_pid":%s},"identity_token":"%s","error_code":"%s"}\n' "$operation" "$result" "$mutates" "$city" "$scope" "$database" "$workspace" "$endpoint" "$city" "$city" "$$" "$$" "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" "$error_code"
+if [ -n "$GC_HANDOFF_DATABASE" ]; then database="$GC_HANDOFF_DATABASE"; fi
+if [ -n "$GC_HANDOFF_TOKEN" ]; then token="$GC_HANDOFF_TOKEN"; else token="sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"; fi
+printf '{"schema_version":1,"operation":"%s","result":"%s","owner":"legacy-gc","mutates":%s,"identity":{"city_root":"%s","scope_root":"%s","database":"%s","workspace":"%s","endpoint":%s,"data_dir":"%s/.gc/data","config_file":"%s/.gc/config","pid":%s,"start_identity":"fake","start_time_ticks":1,"port_holder_pid":%s},"identity_token":"%s","error_code":"%s"}\n' "$operation" "$result" "$mutates" "$city" "$scope" "$database" "$workspace" "$endpoint" "$city" "$city" "$$" "$$" "$token" "$error_code"
 `
 	if err := os.WriteFile(path, []byte(script), 0700); err != nil {
 		t.Fatal(err)

--- a/internal/ownershiphandoff/gcprovider_test.go
+++ b/internal/ownershiphandoff/gcprovider_test.go
@@ -278,6 +278,107 @@ func TestGCProviderResumeUsesPersistedSnapshotToken(t *testing.T) {
 	}
 }
 
+// stopCrashWindow parks a handoff at target_configured without mutating
+// anything and then makes the legacy owner gone. That is byte-for-byte the
+// state a crash between a successful handoff-stop and its old_owner_stopped
+// checkpoint leaves behind: journal at target_configured with
+// mutation_occurred=false, owner actually released. It returns the request and
+// journal path for the retry that resumes from there.
+func stopCrashWindow(t *testing.T, city, scope, stoppedFile string, provider Provider) (Request, string) {
+	t.Helper()
+	t.Setenv("GC_HANDOFF_STOP_REFUSE", "1")
+	t.Setenv("GC_HANDOFF_STOP_MUTATES", "false")
+	t.Setenv("GC_HANDOFF_STOP_LEAVES_LIVE", "1")
+	request := Request{CityRoot: city, Root: scope, Database: "beads", Workspace: "ws",
+		Endpoint: Endpoint{Host: "127.0.0.1", Port: 3307}, Owner: OwnerLegacyGC}
+	journalPath := filepath.Join(scope, "ownership-handoff.json")
+	first, err := Run(context.Background(), request, journalPath, provider, false)
+	if err == nil || first.Phase != PhaseTargetConfigured || first.Mutates {
+		t.Fatalf("first result=%+v err=%v, want a non-mutating stop refusal", first, err)
+	}
+	if err := os.WriteFile(stoppedFile, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	journal, err := Load(journalPath)
+	if err != nil || journal.Phase != PhaseTargetConfigured || journal.MutationOccurred {
+		t.Fatalf("journal=%+v err=%v, want an unmutated target_configured resume state", journal, err)
+	}
+	t.Setenv("GC_HANDOFF_STOP_REFUSE", "")
+	t.Setenv("GC_HANDOFF_STOP_LEAVES_LIVE", "")
+	return request, journalPath
+}
+
+// TestGCProviderResumeCompletesWhenStopTreatsMissingOwnerAsStopped pins the
+// stop-hook obligation stated in engdocs/design/ownership-handoff-contract.md:
+// a provider that answers an already-gone identity-matching process with
+// result=stopped/mutates=true lets the handoff converge out of the stop crash
+// window. The in-tree fake models that provider, so this is what the rest of
+// the suite silently assumes; the companion test below prices the alternative.
+func TestGCProviderResumeCompletesWhenStopTreatsMissingOwnerAsStopped(t *testing.T) {
+	city := canonicalTestDir(t)
+	scope := filepath.Join(city, "scope")
+	if err := os.Mkdir(scope, 0700); err != nil {
+		t.Fatal(err)
+	}
+	binary := fakeGCProtocol(t)
+	logPath := filepath.Join(city, "gc.log")
+	stoppedFile := filepath.Join(city, "stopped")
+	t.Setenv("GC_HANDOFF_LOG", logPath)
+	t.Setenv("GC_HANDOFF_ERR_LOG", filepath.Join(city, "gc.err"))
+	t.Setenv("GC_HANDOFF_STOPPED_FILE", stoppedFile)
+	provider, err := NewGCProvider(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, journalPath := stopCrashWindow(t, city, scope, stoppedFile, provider)
+	second, err := Run(context.Background(), request, journalPath, provider, false)
+	if err != nil || second.Phase != PhaseCommitted || second.Owner != OwnerBD || !second.Mutates {
+		t.Fatalf("second result=%+v err=%v, want a committed resume across the stop crash window", second, err)
+	}
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(log)); got != "handoff-inspect\nhandoff-stop\nhandoff-stop\nhandoff-inspect\nhandoff-inspect" {
+		t.Fatalf("protocol operations=%q, want the retry to re-stop from the persisted snapshot and then verify", got)
+	}
+}
+
+// TestGCProviderResumeWedgesWhenStopRefusesMissingOwner is the counterfactual
+// for the obligation above: a strict provider that refuses to stop a process it
+// can no longer see leaves the handoff wedged at target_configured with the
+// legacy server actually down and mutation_occurred=false. The refusal is
+// fail-closed and journaled, so nothing is silently committed — but the handoff
+// cannot complete, which is why the contract states the obligation the in-tree
+// fake cannot enforce.
+func TestGCProviderResumeWedgesWhenStopRefusesMissingOwner(t *testing.T) {
+	city := canonicalTestDir(t)
+	scope := filepath.Join(city, "scope")
+	if err := os.Mkdir(scope, 0700); err != nil {
+		t.Fatal(err)
+	}
+	binary := fakeGCProtocol(t)
+	stoppedFile := filepath.Join(city, "stopped")
+	t.Setenv("GC_HANDOFF_LOG", filepath.Join(city, "gc.log"))
+	t.Setenv("GC_HANDOFF_ERR_LOG", filepath.Join(city, "gc.err"))
+	t.Setenv("GC_HANDOFF_STOPPED_FILE", stoppedFile)
+	t.Setenv("GC_HANDOFF_STOP_STRICT_MISSING", "1")
+	provider, err := NewGCProvider(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, journalPath := stopCrashWindow(t, city, scope, stoppedFile, provider)
+	second, err := Run(context.Background(), request, journalPath, provider, false)
+	if err == nil || second.Phase != PhaseTargetConfigured || second.Owner != OwnerLegacyGC ||
+		second.ErrorCode != "process_missing" || second.Mutates {
+		t.Fatalf("second result=%+v err=%v, want a wedged, fail-closed target_configured refusal", second, err)
+	}
+	journal, err := Load(journalPath)
+	if err != nil || journal.Phase != PhaseTargetConfigured || journal.Owner != OwnerLegacyGC || journal.MutationOccurred {
+		t.Fatalf("journal=%+v err=%v, want the handoff to stay uncommitted and legacy-owned", journal, err)
+	}
+}
+
 func TestGCProviderResumeAfterStoppedOwnerDoesNotReinspectSnapshot(t *testing.T) {
 	city := canonicalTestDir(t)
 	scope := filepath.Join(city, "scope")
@@ -435,6 +536,8 @@ if [ "$GC_HANDOFF_DESCENDANT" = "1" ]; then
   wait
 fi
 stopped_file="${GC_HANDOFF_STOPPED_FILE:-$scope/.gc-handoff-stopped}"
+already_stopped=0
+if [ -f "$stopped_file" ]; then already_stopped=1; fi
 result=eligible
 mutates=false
 error_code=""
@@ -459,6 +562,14 @@ if [ "$operation" = "handoff-stop" ] && [ "$GC_HANDOFF_STOP_REFUSE" = "1" ]; the
   result=refused
   mutates="${GC_HANDOFF_STOP_MUTATES:-false}"
   error_code=process_unowned
+fi
+# Variant provider that violates the stop-hook obligation in
+# engdocs/design/ownership-handoff-contract.md by refusing to "stop" an
+# identity-matching process that is already gone.
+if [ "$operation" = "handoff-stop" ] && [ "$GC_HANDOFF_STOP_STRICT_MISSING" = "1" ] && [ "$already_stopped" = "1" ]; then
+  result=refused
+  mutates=false
+  error_code=process_missing
 fi
 if [ -n "$socket" ]; then
   endpoint=$(printf '{"host":"","port":0,"socket":"%s"}' "$socket")

--- a/internal/ownershiphandoff/gcprovider_test.go
+++ b/internal/ownershiphandoff/gcprovider_test.go
@@ -209,6 +209,38 @@ func TestGCProviderStopRefusalReportsProviderMutation(t *testing.T) {
 	}
 }
 
+func TestGCProviderRetryRetainsReportedPartialMutation(t *testing.T) {
+	city := canonicalTestDir(t)
+	scope := filepath.Join(city, "scope")
+	if err := os.Mkdir(scope, 0700); err != nil {
+		t.Fatal(err)
+	}
+	binary := fakeGCProtocol(t)
+	t.Setenv("GC_HANDOFF_LOG", filepath.Join(city, "gc.log"))
+	t.Setenv("GC_HANDOFF_ERR_LOG", filepath.Join(city, "gc.err"))
+	t.Setenv("GC_HANDOFF_STOP_REFUSE", "1")
+	t.Setenv("GC_HANDOFF_STOP_MUTATES", "true")
+	request := Request{CityRoot: city, Root: scope, Database: "beads", Workspace: "ws", Endpoint: Endpoint{Host: "127.0.0.1", Port: 3307}, Owner: OwnerLegacyGC}
+	provider, err := NewGCProvider(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	journalPath := filepath.Join(scope, "ownership-handoff.json")
+	first, err := Run(context.Background(), request, journalPath, provider, false)
+	if err == nil || !first.Mutates || first.Phase != PhaseTargetConfigured {
+		t.Fatalf("first result=%+v err=%v, want partial mutation", first, err)
+	}
+	t.Setenv("GC_HANDOFF_STOP_MUTATES", "false")
+	second, err := Run(context.Background(), request, journalPath, provider, false)
+	if err == nil || !second.Mutates || second.Phase != PhaseTargetConfigured {
+		t.Fatalf("second result=%+v err=%v, want retained partial mutation", second, err)
+	}
+	journal, err := Load(journalPath)
+	if err != nil || !journal.MutationOccurred {
+		t.Fatalf("journal=%+v err=%v, want retained mutation_occurred", journal, err)
+	}
+}
+
 func TestGCProviderResumeUsesPersistedSnapshotToken(t *testing.T) {
 	city := canonicalTestDir(t)
 	scope := filepath.Join(city, "scope")

--- a/internal/ownershiphandoff/ownershiphandoff.go
+++ b/internal/ownershiphandoff/ownershiphandoff.go
@@ -89,6 +89,7 @@ type Result struct {
 	Owner     Owner    `json:"owner"`
 	Root      string   `json:"root"`
 	Database  string   `json:"database"`
+	Workspace string   `json:"workspace"`
 	Endpoint  Endpoint `json:"endpoint"`
 	Mutates   bool     `json:"mutates"`
 	ErrorCode string   `json:"error_code,omitempty"`
@@ -109,6 +110,22 @@ type Hooks struct {
 	// explicit provider guarantee, Execute refuses to guess or invoke Commit a
 	// second time.
 	CommitReplay func(context.Context, Request, Snapshot) error
+}
+
+// Provider resolves the provider-owned lifecycle hooks for a handoff. The
+// provider is opened only after the request and any existing journal have been
+// validated. Providers must not infer ownership or stop an unidentified
+// process; those decisions belong in the returned hooks.
+type Provider interface {
+	OwnershipHandoffHooks(context.Context, Request) (Hooks, error)
+}
+
+// ProviderFunc adapts a function to Provider.
+type ProviderFunc func(context.Context, Request) (Hooks, error)
+
+// OwnershipHandoffHooks implements Provider.
+func (f ProviderFunc) OwnershipHandoffHooks(ctx context.Context, r Request) (Hooks, error) {
+	return f(ctx, r)
 }
 
 // ValidateRequest rejects incomplete, non-canonical, or remotely managed identities.
@@ -198,6 +215,46 @@ func resolvePathForContainment(path string) (string, error) {
 	}
 }
 
+// validateJournalPath keeps the journal and its persistent lock beneath the
+// validated root. Missing parents are refused rather than implicitly created.
+func validateJournalPath(root, path string) error {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return errors.New("journal must be an absolute canonical path")
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return errors.New("journal must be beneath the handoff root")
+	}
+	parent := filepath.Dir(path)
+	info, err := os.Stat(parent)
+	if err != nil {
+		return fmt.Errorf("stat journal parent: %w", err)
+	}
+	if !info.IsDir() {
+		return errors.New("journal parent must be an existing directory")
+	}
+	real, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		return fmt.Errorf("resolve journal parent: %w", err)
+	}
+	if real != parent {
+		return errors.New("journal parent must be canonical and not symlinked")
+	}
+	for _, candidate := range []string{path, path + ".lock"} {
+		info, err := os.Lstat(candidate)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("stat journal artifact: %w", err)
+		}
+		if !info.Mode().IsRegular() {
+			return errors.New("journal and lock must be regular, non-symlinked files")
+		}
+	}
+	return nil
+}
+
 // Load reads and validates a handoff journal from path.
 func Load(path string) (Journal, error) {
 	b, err := os.ReadFile(path) //nolint:gosec // path is the operator-selected journal path
@@ -264,11 +321,89 @@ func save(path string, j Journal) error {
 }
 
 func result(j Journal, mutates bool) Result {
-	return Result{Phase: j.Phase, Owner: j.Owner, Root: j.Request.Root, Database: j.Request.Database, Endpoint: j.Request.Endpoint, Mutates: mutates, ErrorCode: j.ErrorCode}
+	return Result{Phase: j.Phase, Owner: j.Owner, Root: j.Request.Root, Database: j.Request.Database, Workspace: j.Request.Workspace, Endpoint: j.Request.Endpoint, Mutates: mutates, ErrorCode: j.ErrorCode}
+}
+
+func requestResult(r Request, code string) Result {
+	return Result{Phase: PhasePrepared, Owner: OwnerLegacyGC, Root: r.Root, Database: r.Database, Workspace: r.Workspace, Endpoint: r.Endpoint, Mutates: false, ErrorCode: code}
+}
+
+// Run resolves provider-owned hooks and executes a handoff. Request and
+// journal identity validation happen before Provider is called, so malformed,
+// remote, or conflicting requests cannot start a provider. Dry-runs validate
+// the request and journal only and never call Provider or any lifecycle hook.
+func Run(ctx context.Context, r Request, journalPath string, provider Provider, dryRun bool) (Result, error) {
+	if err := ValidateRequest(r); err != nil {
+		return requestResult(r, "invalid_request"), err
+	}
+	if err := validateJournalPath(r.Root, journalPath); err != nil {
+		return requestResult(r, "invalid_journal"), err
+	}
+	var existing *Journal
+	if j, err := Load(journalPath); err == nil {
+		if j.Request != r {
+			j.ErrorCode = "identity_conflict"
+			return result(j, false), errors.New("handoff journal identity conflicts with request")
+		}
+		existing = &j
+	} else if !os.IsNotExist(err) {
+		return requestResult(r, "journal_unreadable"), err
+	}
+	if dryRun {
+		if existing != nil {
+			return result(*existing, false), nil
+		}
+		return requestResult(r, ""), nil
+	}
+	// Hold the same journal lock while resolving provider hooks and executing
+	// the handoff. A provider may open a runtime or inspect lifecycle state, so
+	// resolving it outside the lock would permit a conflicting journal writer
+	// to win the race between preflight and Execute.
+	lock, err := acquireLock(journalPath + ".lock")
+	if err != nil {
+		if existing != nil {
+			existing.ErrorCode = "concurrent_handoff"
+			return result(*existing, mutationOccurred(*existing)), fmt.Errorf("acquire handoff lock: %w", err)
+		}
+		return requestResult(r, "concurrent_handoff"), fmt.Errorf("acquire handoff lock: %w", err)
+	}
+	defer func() {
+		_ = lockfile.FlockUnlock(lock)
+		_ = lock.Close()
+	}()
+	existing = nil
+	if j, err := Load(journalPath); err == nil {
+		if j.Request != r {
+			j.ErrorCode = "identity_conflict"
+			return result(j, mutationOccurred(j)), errors.New("handoff journal identity conflicts with request")
+		}
+		if j.Phase == PhaseCommitted {
+			return result(j, false), nil
+		}
+		existing = &j
+	} else if !os.IsNotExist(err) {
+		return requestResult(r, "journal_unreadable"), err
+	}
+	if provider == nil {
+		if existing != nil {
+			existing.ErrorCode = "provider_unavailable"
+			return result(*existing, mutationOccurred(*existing)), errors.New("ownership handoff provider is unavailable")
+		}
+		return requestResult(r, "provider_unavailable"), errors.New("ownership handoff provider is unavailable")
+	}
+	hooks, err := provider.OwnershipHandoffHooks(ctx, r)
+	if err != nil {
+		if existing != nil {
+			existing.ErrorCode = "provider_unavailable"
+			return result(*existing, mutationOccurred(*existing)), fmt.Errorf("resolve ownership handoff provider: %w", err)
+		}
+		return requestResult(r, "provider_unavailable"), fmt.Errorf("resolve ownership handoff provider: %w", err)
+	}
+	return executeLocked(ctx, r, journalPath, hooks)
 }
 
 func mutationOccurred(j Journal) bool {
-	return j.Phase == PhaseOldOwnerStopped || j.Phase == PhaseVerified ||
+	return j.Phase == PhaseTargetConfigured || j.Phase == PhaseOldOwnerStopped || j.Phase == PhaseVerified ||
 		j.Phase == PhaseCommitted || j.CommitHookRan || j.CommitHookInProgress
 }
 
@@ -302,33 +437,16 @@ func acquireLock(path string) (*os.File, error) {
 // and never invokes a hook or opens a provider. A committed journal replays as
 // a no-op. Failures are journaled and leave legacy-gc authoritative.
 func Execute(ctx context.Context, r Request, journalPath string, h Hooks, dryRun bool) (Result, error) {
-	if err := ValidateRequest(r); err != nil {
-		return Result{Phase: PhasePrepared, Owner: OwnerLegacyGC, Root: r.Root, Database: r.Database, Endpoint: r.Endpoint, ErrorCode: "invalid_request"}, err
-	}
-	if j, err := Load(journalPath); err == nil {
-		if j.Request != r {
-			j.ErrorCode = "identity_conflict"
-			return result(j, false), errors.New("handoff journal identity conflicts with request")
-		}
-		if j.Phase == PhaseCommitted {
-			return result(j, false), nil
-		}
-		r = j.Request
-	} else if !os.IsNotExist(err) {
-		return Result{Phase: PhasePrepared, Owner: OwnerLegacyGC, Root: r.Root, Database: r.Database, Endpoint: r.Endpoint, ErrorCode: "journal_unreadable"}, err
-	}
-	if dryRun {
-		return Result{Phase: PhasePrepared, Owner: OwnerLegacyGC, Root: r.Root, Database: r.Database, Endpoint: r.Endpoint, Mutates: false}, nil
-	}
-	lockPath := journalPath + ".lock"
-	lock, err := acquireLock(lockPath)
-	if err != nil {
-		return Result{Phase: PhasePrepared, Owner: OwnerLegacyGC, Root: r.Root, Database: r.Database, Endpoint: r.Endpoint, ErrorCode: "concurrent_handoff"}, fmt.Errorf("acquire handoff lock: %w", err)
-	}
-	defer func() {
-		_ = lockfile.FlockUnlock(lock)
-		_ = lock.Close()
-	}()
+	return Run(ctx, r, journalPath, ProviderFunc(func(context.Context, Request) (Hooks, error) {
+		return h, nil
+	}), dryRun)
+}
+
+// executeLocked performs the journaled handoff while the caller owns the
+// persistent advisory lock. Keeping this separate lets Run resolve provider
+// hooks while that lock is held, so validation and provider startup are one
+// serialized operation.
+func executeLocked(ctx context.Context, r Request, journalPath string, h Hooks) (Result, error) {
 	j := Journal{Request: r, Owner: OwnerLegacyGC, Phase: PhasePrepared, UpdatedAt: time.Now().UTC()}
 	if old, err := Load(journalPath); err == nil {
 		if old.Request != r {

--- a/internal/ownershiphandoff/ownershiphandoff.go
+++ b/internal/ownershiphandoff/ownershiphandoff.go
@@ -55,6 +55,7 @@ func (e Endpoint) String() string {
 
 // Request identifies the exact scope being handed off.
 type Request struct {
+	CityRoot  string   `json:"city_root"`
 	Root      string   `json:"root"`
 	Database  string   `json:"database"`
 	Workspace string   `json:"workspace"`
@@ -87,6 +88,7 @@ type Journal struct {
 type Result struct {
 	Phase     Phase    `json:"phase"`
 	Owner     Owner    `json:"owner"`
+	CityRoot  string   `json:"city_root"`
 	Root      string   `json:"root"`
 	Database  string   `json:"database"`
 	Workspace string   `json:"workspace"`
@@ -128,6 +130,27 @@ func (f ProviderFunc) OwnershipHandoffHooks(ctx context.Context, r Request) (Hoo
 	return f(ctx, r)
 }
 
+// CodedError lets a provider preserve a stable protocol error code at the
+// handoff front door while retaining the underlying cause for diagnostics.
+type CodedError struct {
+	Code string
+	Err  error
+}
+
+// Error implements error.
+func (e CodedError) Error() string {
+	if e.Err == nil {
+		return e.Code
+	}
+	return e.Err.Error()
+}
+
+// Unwrap exposes the provider cause to errors.Is and errors.As.
+func (e CodedError) Unwrap() error { return e.Err }
+
+// HandoffErrorCode returns the stable provider protocol code.
+func (e CodedError) HandoffErrorCode() string { return stableErrorCode(e.Code, "provider_unavailable") }
+
 // ValidateRequest rejects incomplete, non-canonical, or remotely managed identities.
 func ValidateRequest(r Request) error {
 	if !filepath.IsAbs(r.Root) || filepath.Clean(r.Root) != r.Root {
@@ -141,6 +164,26 @@ func ValidateRequest(r Request) error {
 	}
 	if r.Root == "" {
 		return errors.New("root is required")
+	}
+	if r.CityRoot == "" {
+		return errors.New("city root is required")
+	}
+	if !filepath.IsAbs(r.CityRoot) || filepath.Clean(r.CityRoot) != r.CityRoot {
+		return errors.New("city root must be an absolute canonical path")
+	}
+	cityInfo, err := os.Stat(r.CityRoot)
+	if err != nil {
+		return fmt.Errorf("city root must be an existing directory: %w", err)
+	}
+	if !cityInfo.IsDir() {
+		return errors.New("city root must be an existing directory")
+	}
+	cityReal, err := filepath.EvalSymlinks(r.CityRoot)
+	if err != nil {
+		return fmt.Errorf("resolve city root: %w", err)
+	}
+	if filepath.Clean(r.CityRoot) != filepath.Clean(cityReal) {
+		return errors.New("city root must be canonical and not symlinked")
 	}
 	abs := r.Root
 	info, err := os.Stat(abs)
@@ -321,11 +364,11 @@ func save(path string, j Journal) error {
 }
 
 func result(j Journal, mutates bool) Result {
-	return Result{Phase: j.Phase, Owner: j.Owner, Root: j.Request.Root, Database: j.Request.Database, Workspace: j.Request.Workspace, Endpoint: j.Request.Endpoint, Mutates: mutates, ErrorCode: j.ErrorCode}
+	return Result{Phase: j.Phase, Owner: j.Owner, CityRoot: j.Request.CityRoot, Root: j.Request.Root, Database: j.Request.Database, Workspace: j.Request.Workspace, Endpoint: j.Request.Endpoint, Mutates: mutates, ErrorCode: j.ErrorCode}
 }
 
 func requestResult(r Request, code string) Result {
-	return Result{Phase: PhasePrepared, Owner: OwnerLegacyGC, Root: r.Root, Database: r.Database, Workspace: r.Workspace, Endpoint: r.Endpoint, Mutates: false, ErrorCode: code}
+	return Result{Phase: PhasePrepared, Owner: OwnerLegacyGC, CityRoot: r.CityRoot, Root: r.Root, Database: r.Database, Workspace: r.Workspace, Endpoint: r.Endpoint, Mutates: false, ErrorCode: code}
 }
 
 // Run resolves provider-owned hooks and executes a handoff. Request and
@@ -393,11 +436,12 @@ func Run(ctx context.Context, r Request, journalPath string, provider Provider, 
 	}
 	hooks, err := provider.OwnershipHandoffHooks(ctx, r)
 	if err != nil {
+		code := handoffErrorCode(err, "provider_unavailable")
 		if existing != nil {
-			existing.ErrorCode = "provider_unavailable"
+			existing.ErrorCode = code
 			return result(*existing, mutationOccurred(*existing)), fmt.Errorf("resolve ownership handoff provider: %w", err)
 		}
-		return requestResult(r, "provider_unavailable"), fmt.Errorf("resolve ownership handoff provider: %w", err)
+		return requestResult(r, code), fmt.Errorf("resolve ownership handoff provider: %w", err)
 	}
 	return executeLocked(ctx, r, journalPath, hooks)
 }
@@ -405,6 +449,33 @@ func Run(ctx context.Context, r Request, journalPath string, provider Provider, 
 func mutationOccurred(j Journal) bool {
 	return j.Phase == PhaseTargetConfigured || j.Phase == PhaseOldOwnerStopped || j.Phase == PhaseVerified ||
 		j.Phase == PhaseCommitted || j.CommitHookRan || j.CommitHookInProgress
+}
+
+func handoffErrorCode(err error, fallback string) string {
+	if err == nil {
+		return fallback
+	}
+	var coded interface{ HandoffErrorCode() string }
+	if errors.As(err, &coded) && coded.HandoffErrorCode() != "" {
+		return stableErrorCode(coded.HandoffErrorCode(), fallback)
+	}
+	return fallback
+}
+
+func stableErrorCode(code, fallback string) string {
+	switch code {
+	case "invalid_request", "invalid_journal", "journal_unreadable", "concurrent_handoff",
+		"provider_unavailable", "snapshot_unavailable", "snapshot_failed", "configure_unavailable",
+		"target_configure_failed", "owner_stop_unavailable", "owner_stop_failed", "verification_failed",
+		"verify_unavailable", "commit_unavailable", "commit_failed", "commit_recovery_required",
+		"commit_recovery_failed", "journal_save_failed", "protocol_version", "unsupported_scope",
+		"managed_owner_missing", "state_missing", "process_missing", "process_unowned",
+		"endpoint_unreachable", "port_conflict", "identity_changed", "lifecycle_busy", "data_lock_held",
+		"stop_failed":
+		return code
+	default:
+		return fallback
+	}
 }
 
 func snapshotCaptured(j Journal) bool {
@@ -474,7 +545,7 @@ func executeLocked(ctx context.Context, r Request, journalPath string, h Hooks) 
 			}
 			s, err := h.Snapshot(ctx, r)
 			if err != nil {
-				return fail("snapshot_failed", err)
+				return fail(handoffErrorCode(err, "snapshot_failed"), err)
 			}
 			j.Snapshot = s
 			j.SnapshotCaptured = true
@@ -488,7 +559,7 @@ func executeLocked(ctx context.Context, r Request, journalPath string, h Hooks) 
 			return fail("configure_unavailable", errors.New("configure hook is required"))
 		}
 		if err := h.Configure(ctx, r, j.Snapshot); err != nil {
-			return fail("target_configure_failed", err)
+			return fail(handoffErrorCode(err, "target_configure_failed"), err)
 		}
 		j.Phase = PhaseTargetConfigured
 		j.UpdatedAt = time.Now().UTC()
@@ -501,7 +572,7 @@ func executeLocked(ctx context.Context, r Request, journalPath string, h Hooks) 
 			return fail("owner_stop_unavailable", errors.New("legacy owner stop hook is required"))
 		}
 		if err := h.StopLegacy(ctx, r, j.Snapshot); err != nil {
-			return fail("owner_stop_failed", err)
+			return fail(handoffErrorCode(err, "owner_stop_failed"), err)
 		}
 		j.Phase = PhaseOldOwnerStopped
 		j.UpdatedAt = time.Now().UTC()
@@ -514,7 +585,7 @@ func executeLocked(ctx context.Context, r Request, journalPath string, h Hooks) 
 			return fail("verify_unavailable", errors.New("verify hook is required"))
 		}
 		if err := h.Verify(ctx, r, j.Snapshot); err != nil {
-			return fail("verification_failed", err)
+			return fail(handoffErrorCode(err, "verification_failed"), err)
 		}
 		j.Phase = PhaseVerified
 		j.UpdatedAt = time.Now().UTC()
@@ -532,7 +603,7 @@ func executeLocked(ctx context.Context, r Request, journalPath string, h Hooks) 
 				return fail("commit_recovery_required", errors.New(message))
 			}
 			if err := h.CommitReplay(ctx, r, j.Snapshot); err != nil {
-				return fail("commit_recovery_failed", err)
+				return fail(handoffErrorCode(err, "commit_recovery_failed"), err)
 			}
 			j.CommitHookRan = true
 			j.CommitHookInProgress = false
@@ -558,7 +629,7 @@ func executeLocked(ctx context.Context, r Request, journalPath string, h Hooks) 
 				return journalSaveError(j, err)
 			}
 			if err := h.Commit(ctx, r, j.Snapshot); err != nil {
-				j.ErrorCode = "commit_failed"
+				j.ErrorCode = handoffErrorCode(err, "commit_failed")
 				j.Error = err.Error()
 				j.UpdatedAt = time.Now().UTC()
 				if saveErr := save(journalPath, j); saveErr != nil {

--- a/internal/ownershiphandoff/ownershiphandoff.go
+++ b/internal/ownershiphandoff/ownershiphandoff.go
@@ -601,7 +601,7 @@ func executeLocked(ctx context.Context, r Request, journalPath string, h Hooks) 
 		}
 		if err := h.StopLegacy(ctx, r, j.Snapshot); err != nil {
 			if mutates, reported := reportedMutation(err); reported {
-				j.MutationOccurred = mutates
+				j.MutationOccurred = j.MutationOccurred || mutates
 			}
 			return fail(handoffErrorCode(err, "owner_stop_failed"), err)
 		}

--- a/internal/ownershiphandoff/ownershiphandoff.go
+++ b/internal/ownershiphandoff/ownershiphandoff.go
@@ -77,6 +77,7 @@ type Journal struct {
 	SnapshotCaptured     bool      `json:"snapshot_captured,omitempty"`
 	CommitHookInProgress bool      `json:"commit_hook_in_progress,omitempty"`
 	CommitHookRan        bool      `json:"commit_hook_ran,omitempty"`
+	MutationOccurred     bool      `json:"mutation_occurred,omitempty"`
 	Phase                Phase     `json:"phase"`
 	Owner                Owner     `json:"owner"`
 	ErrorCode            string    `json:"error_code,omitempty"`
@@ -135,6 +136,25 @@ func (f ProviderFunc) OwnershipHandoffHooks(ctx context.Context, r Request) (Hoo
 type CodedError struct {
 	Code string
 	Err  error
+}
+
+type mutationReporter interface {
+	HandoffMutationOccurred() bool
+}
+
+type mutationError struct {
+	err     error
+	mutates bool
+}
+
+func (e mutationError) Error() string { return e.err.Error() }
+
+func (e mutationError) Unwrap() error { return e.err }
+
+func (e mutationError) HandoffMutationOccurred() bool { return e.mutates }
+
+func withReportedMutation(err error, mutates bool) error {
+	return mutationError{err: err, mutates: mutates}
 }
 
 // Error implements error.
@@ -447,8 +467,16 @@ func Run(ctx context.Context, r Request, journalPath string, provider Provider, 
 }
 
 func mutationOccurred(j Journal) bool {
-	return j.Phase == PhaseTargetConfigured || j.Phase == PhaseOldOwnerStopped || j.Phase == PhaseVerified ||
+	return j.MutationOccurred || j.Phase == PhaseOldOwnerStopped || j.Phase == PhaseVerified ||
 		j.Phase == PhaseCommitted || j.CommitHookRan || j.CommitHookInProgress
+}
+
+func reportedMutation(err error) (bool, bool) {
+	var reporter mutationReporter
+	if !errors.As(err, &reporter) {
+		return false, false
+	}
+	return reporter.HandoffMutationOccurred(), true
 }
 
 func handoffErrorCode(err error, fallback string) string {
@@ -572,8 +600,12 @@ func executeLocked(ctx context.Context, r Request, journalPath string, h Hooks) 
 			return fail("owner_stop_unavailable", errors.New("legacy owner stop hook is required"))
 		}
 		if err := h.StopLegacy(ctx, r, j.Snapshot); err != nil {
+			if mutates, reported := reportedMutation(err); reported {
+				j.MutationOccurred = mutates
+			}
 			return fail(handoffErrorCode(err, "owner_stop_failed"), err)
 		}
+		j.MutationOccurred = true
 		j.Phase = PhaseOldOwnerStopped
 		j.UpdatedAt = time.Now().UTC()
 		if err := save(journalPath, j); err != nil {

--- a/internal/ownershiphandoff/ownershiphandoff.go
+++ b/internal/ownershiphandoff/ownershiphandoff.go
@@ -100,7 +100,12 @@ type Result struct {
 
 // Hooks are provider-owned operations. StopLegacy must refuse unless it can
 // positively identify the process as the legacy owner; it must never kill an
-// unknown process.
+// unknown process. It must, however, report an identity-matching process that
+// is already gone as a successful stop, so a retry whose predecessor lost its
+// checkpoint converges instead of wedging. Configure must be non-mutating:
+// only a StopLegacy failure can report a partial mutation, so a Configure that
+// mutates the target and then fails is reported as mutates=false. See
+// engdocs/design/ownership-handoff-contract.md for the full obligation list.
 type Hooks struct {
 	Snapshot   func(context.Context, Request) (Snapshot, error)
 	Configure  func(context.Context, Request, Snapshot) error
@@ -387,6 +392,25 @@ func result(j Journal, mutates bool) Result {
 	return Result{Phase: j.Phase, Owner: j.Owner, CityRoot: j.Request.CityRoot, Root: j.Request.Root, Database: j.Request.Database, Workspace: j.Request.Workspace, Endpoint: j.Request.Endpoint, Mutates: mutates, ErrorCode: j.ErrorCode}
 }
 
+// identityConflictError explains a journal/request identity mismatch in
+// operator terms. The refusal is fail-closed and sticky — every later attempt
+// meets the same journal — so the message names the journal it is refusing,
+// both identities, and whether discarding the journal would lose a recorded
+// mutation.
+func identityConflictError(journalPath string, j Journal, r Request) error {
+	remediation := "it records a mutation, so reconcile the scope with the lifecycle owner before removing it"
+	if !mutationOccurred(j) {
+		remediation = "it records no mutation, so removing it while no handoff is running is safe"
+	}
+	return fmt.Errorf("handoff journal identity conflicts with request: %s holds %s at phase %s, request is %s; %s",
+		journalPath, handoffIdentity(j.Request), j.Phase, handoffIdentity(r), remediation)
+}
+
+func handoffIdentity(r Request) string {
+	return fmt.Sprintf("city=%s root=%s database=%s workspace=%s endpoint=%s",
+		r.CityRoot, r.Root, r.Database, r.Workspace, r.Endpoint)
+}
+
 func requestResult(r Request, code string) Result {
 	return Result{Phase: PhasePrepared, Owner: OwnerLegacyGC, CityRoot: r.CityRoot, Root: r.Root, Database: r.Database, Workspace: r.Workspace, Endpoint: r.Endpoint, Mutates: false, ErrorCode: code}
 }
@@ -406,7 +430,10 @@ func Run(ctx context.Context, r Request, journalPath string, provider Provider, 
 	if j, err := Load(journalPath); err == nil {
 		if j.Request != r {
 			j.ErrorCode = "identity_conflict"
-			return result(j, false), errors.New("handoff journal identity conflicts with request")
+			// Report the journaled mutation, exactly as the under-lock arms
+			// do: the refusal keys its deletion-safety guidance on the same
+			// state, and a --json caller sees only this field.
+			return result(j, mutationOccurred(j)), identityConflictError(journalPath, j, r)
 		}
 		existing = &j
 	} else if !os.IsNotExist(err) {
@@ -438,7 +465,7 @@ func Run(ctx context.Context, r Request, journalPath string, provider Provider, 
 	if j, err := Load(journalPath); err == nil {
 		if j.Request != r {
 			j.ErrorCode = "identity_conflict"
-			return result(j, mutationOccurred(j)), errors.New("handoff journal identity conflicts with request")
+			return result(j, mutationOccurred(j)), identityConflictError(journalPath, j, r)
 		}
 		if j.Phase == PhaseCommitted {
 			return result(j, false), nil
@@ -550,13 +577,17 @@ func executeLocked(ctx context.Context, r Request, journalPath string, h Hooks) 
 	if old, err := Load(journalPath); err == nil {
 		if old.Request != r {
 			old.ErrorCode = "identity_conflict"
-			return result(old, mutationOccurred(old)), errors.New("handoff journal identity conflicts with request")
+			return result(old, mutationOccurred(old)), identityConflictError(journalPath, old, r)
 		}
 		if old.Phase == PhaseCommitted {
 			return result(old, false), nil
 		}
 		j = old
 	} else if !os.IsNotExist(err) {
+		// Mirror Run's code for the same failure: the front door promises a
+		// stable error_code on every failure, so this residual read cannot exit
+		// with an empty one.
+		j.ErrorCode = "journal_unreadable"
 		return result(j, false), err
 	}
 	fail := func(code string, err error) (Result, error) {

--- a/internal/ownershiphandoff/ownershiphandoff_test.go
+++ b/internal/ownershiphandoff/ownershiphandoff_test.go
@@ -106,6 +106,129 @@ func TestDryRunDoesNotInvokeHooks(t *testing.T) {
 	}
 }
 
+func TestRunRejectsUnsafeJournalBeforeProviderOrMutation(t *testing.T) {
+	tests := []struct {
+		name string
+		path func(*testing.T, Request) string
+	}{
+		{name: "relative", path: func(_ *testing.T, _ Request) string { return "handoff.json" }},
+		{name: "noncanonical", path: func(_ *testing.T, r Request) string {
+			return r.Root + string(filepath.Separator) + "." + string(filepath.Separator) + "handoff.json"
+		}},
+		{name: "outside root", path: func(t *testing.T, _ Request) string {
+			return filepath.Join(validRequest(t).Root, "handoff.json")
+		}},
+		{name: "missing parent", path: func(_ *testing.T, r Request) string {
+			return filepath.Join(r.Root, "missing", "handoff.json")
+		}},
+		{name: "symlinked parent", path: func(t *testing.T, r Request) string {
+			parent := filepath.Join(r.Root, "alias")
+			if err := os.Symlink(validRequest(t).Root, parent); err != nil {
+				t.Fatal(err)
+			}
+			return filepath.Join(parent, "handoff.json")
+		}},
+		{name: "symlinked journal", path: func(t *testing.T, r Request) string {
+			path := filepath.Join(r.Root, "handoff.json")
+			if err := os.Symlink(filepath.Join(validRequest(t).Root, "handoff.json"), path); err != nil {
+				t.Fatal(err)
+			}
+			return path
+		}},
+		{name: "symlinked lock", path: func(t *testing.T, r Request) string {
+			path := filepath.Join(r.Root, "handoff.json")
+			if err := os.Symlink(filepath.Join(validRequest(t).Root, "handoff.json.lock"), path+".lock"); err != nil {
+				t.Fatal(err)
+			}
+			return path
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := validRequest(t)
+			path := tc.path(t, r)
+			before, err := os.ReadDir(r.Root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			called := false
+			provider := ProviderFunc(func(context.Context, Request) (Hooks, error) {
+				called = true
+				return Hooks{}, nil
+			})
+			for _, dryRun := range []bool{true, false} {
+				got, err := Run(context.Background(), r, path, provider, dryRun)
+				if err == nil || got.ErrorCode != "invalid_journal" || got.Mutates || called {
+					t.Fatalf("dry-run=%v result=%+v err=%v provider=%v, want preflight refusal", dryRun, got, err, called)
+				}
+			}
+			after, err := os.ReadDir(r.Root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(after) != len(before) {
+				t.Fatalf("journal preflight mutated root: before=%v after=%v", before, after)
+			}
+		})
+	}
+}
+
+func TestRunLockConflictPreservesExistingJournal(t *testing.T) {
+	r := validRequest(t)
+	path := filepath.Join(r.Root, "handoff.json")
+	seed := Journal{Request: r, Snapshot: Snapshot{Sentinel: "s"}, SnapshotCaptured: true,
+		Phase: PhaseTargetConfigured, Owner: OwnerLegacyGC}
+	b, err := json.Marshal(seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(b, '\n'), 0600); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := acquireLock(path + ".lock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = lockfile.FlockUnlock(lock)
+		_ = lock.Close()
+	}()
+	called := false
+	got, err := Run(context.Background(), r, path, ProviderFunc(func(context.Context, Request) (Hooks, error) {
+		called = true
+		return Hooks{}, nil
+	}), false)
+	if err == nil || got.Phase != PhaseTargetConfigured || got.Owner != OwnerLegacyGC || !got.Mutates ||
+		got.ErrorCode != "concurrent_handoff" || called {
+		t.Fatalf("result=%+v err=%v provider=%v, want existing state and lock refusal", got, err, called)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.ErrorCode != "" || loaded.Phase != PhaseTargetConfigured {
+		t.Fatalf("lock conflict rewrote journal: %+v", loaded)
+	}
+}
+
+func TestDryRunReportsExistingJournalPhase(t *testing.T) {
+	r := validRequest(t)
+	path := filepath.Join(r.Root, "handoff.json")
+	j := Journal{Request: r, Snapshot: Snapshot{Sentinel: "s"}, SnapshotCaptured: true,
+		Phase: PhaseTargetConfigured, Owner: OwnerLegacyGC}
+	b, err := json.Marshal(j)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(b, '\n'), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Execute(context.Background(), r, path, Hooks{}, true)
+	if err != nil || got.Phase != PhaseTargetConfigured || got.Owner != OwnerLegacyGC || got.Mutates {
+		t.Fatalf("dry-run result=%+v err=%v, want existing target_configured state without mutation", got, err)
+	}
+}
+
 func TestExecutePersistsPhasesAndCommittedReplayIsNoop(t *testing.T) {
 	r := validRequest(t)
 	path := filepath.Join(r.Root, "handoff.json")

--- a/internal/ownershiphandoff/ownershiphandoff_test.go
+++ b/internal/ownershiphandoff/ownershiphandoff_test.go
@@ -21,7 +21,7 @@ func validRequest(t *testing.T) Request {
 		t.Fatal(err)
 	}
 	root = canonical
-	return Request{Root: root, Database: "beads", Workspace: "ws-1", Endpoint: Endpoint{Host: "127.0.0.1", Port: 3307}, Owner: OwnerLegacyGC}
+	return Request{CityRoot: root, Root: root, Database: "beads", Workspace: "ws-1", Endpoint: Endpoint{Host: "127.0.0.1", Port: 3307}, Owner: OwnerLegacyGC}
 }
 
 func TestValidateRejectsSymlinkRootAndExternalEndpoint(t *testing.T) {

--- a/internal/ownershiphandoff/ownershiphandoff_test.go
+++ b/internal/ownershiphandoff/ownershiphandoff_test.go
@@ -491,6 +491,73 @@ func TestJournalIdentityConflictIsTyped(t *testing.T) {
 	}
 }
 
+// TestPreflightIdentityConflictReportsJournaledMutation pins the preflight
+// identity-conflict arm to the same mutation reporting as its under-lock twins.
+// The refusal keys its deletion-safety guidance on the journaled mutation, and
+// a --json caller sees only Mutates, so reporting mutates=false for a
+// mutation-recording journal would tell tooling the opposite of the message.
+// Any existing journal is refused before the lock is taken, so the lock is held
+// here to prove the refusal came from that preflight arm: without it the
+// request would be refused as concurrent_handoff instead.
+func TestPreflightIdentityConflictReportsJournaledMutation(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		journal func(Request) Journal
+	}{
+		{
+			name: "durable mutation flag",
+			journal: func(r Request) Journal {
+				other := r
+				other.Database = "other"
+				return Journal{Request: other, Snapshot: Snapshot{Sentinel: "s"}, SnapshotCaptured: true,
+					MutationOccurred: true, Phase: PhaseTargetConfigured, Owner: OwnerLegacyGC}
+			},
+		},
+		{
+			// A journal written before city_root joined the request decodes
+			// with an empty city root, so it conflicts with every request a
+			// current binary makes. At old_owner_stopped the legacy server is
+			// genuinely stopped, which is exactly when an operator must not be
+			// told the journal records no mutation.
+			name: "pre-release journal at old_owner_stopped",
+			journal: func(Request) Journal {
+				return Journal{Phase: PhaseOldOwnerStopped, Owner: OwnerLegacyGC}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := validRequest(t)
+			path := filepath.Join(r.Root, "handoff.json")
+			b, err := json.Marshal(tc.journal(r))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, append(b, '\n'), 0600); err != nil {
+				t.Fatal(err)
+			}
+			lock, err := acquireLock(path + ".lock")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				_ = lockfile.FlockUnlock(lock)
+				_ = lock.Close()
+			}()
+			called := false
+			got, err := Run(context.Background(), r, path, ProviderFunc(func(context.Context, Request) (Hooks, error) {
+				called = true
+				return Hooks{}, nil
+			}), false)
+			if err == nil || got.ErrorCode != "identity_conflict" || !got.Mutates || called {
+				t.Fatalf("result=%+v err=%v provider=%v, want a preflight identity conflict reporting the journaled mutation", got, err, called)
+			}
+			if !strings.Contains(err.Error(), "records a mutation") {
+				t.Fatalf("refusal text disagrees with the reported mutation: %v", err)
+			}
+		})
+	}
+}
+
 func TestLoadRejectsUnknownPhase(t *testing.T) {
 	r := validRequest(t)
 	path := filepath.Join(r.Root, "handoff.json")

--- a/internal/ownershiphandoff/ownershiphandoff_test.go
+++ b/internal/ownershiphandoff/ownershiphandoff_test.go
@@ -198,7 +198,7 @@ func TestRunLockConflictPreservesExistingJournal(t *testing.T) {
 		called = true
 		return Hooks{}, nil
 	}), false)
-	if err == nil || got.Phase != PhaseTargetConfigured || got.Owner != OwnerLegacyGC || !got.Mutates ||
+	if err == nil || got.Phase != PhaseTargetConfigured || got.Owner != OwnerLegacyGC || got.Mutates ||
 		got.ErrorCode != "concurrent_handoff" || called {
 		t.Fatalf("result=%+v err=%v provider=%v, want existing state and lock refusal", got, err, called)
 	}


### PR DESCRIPTION
Adds the explicit `bd migrate ownership-handoff` front door and the GC legacy-owner protocol adapter on top of #6281. Requests bind the canonical city, root, database, workspace, endpoint, and persisted process token. The command validates the journal before provider resolution, resumes durable checkpoints, and reports typed errors with cumulative mutation state.

`GC_BIN` must resolve to an absolute regular executable. Protocol calls have bounded output and deadlines, including descendant cleanup. Stop uses the original persisted identity token, and retries after stop do not recapture eligibility or overwrite the original snapshot.

This PR implements the front door and legacy release protocol. Starting and verifying the same direct store under Beads ownership remains a separately tracked implementation prerequisite; this PR alone does not complete that lifecycle transfer.

Validation on reviewed head `d07f952b6`: ownership-package race tests, focused CLI/legacy-guard tests, and regression probes passed in review; Windows compilation was checked. Visible GitHub CI passed the Docs checks and all 14 Migration Test Harness legs. The latest external delta review approves this head. The full local suite has separately tracked baseline/environment failures (`mc-broxl`); native Windows runtime and real GC peer interoperability were not validated. The reviewed transport repair makes cancellation, signals, pipe-drain errors, and output overflow take precedence over refusal JSON.

