### PR TITLE
release: prep v1.3.0-rc.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "beads",
       "source": "./plugins/beads",
       "description": "AI-supervised issue tracker for coding workflows",
-      "version": "1.3.0-rc.1"
+      "version": "1.3.0-rc.2"
     }
   ]
 }

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.3.0-rc.1 ---
+# --- BEGIN BEADS INTEGRATION v1.3.0-rc.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -56,4 +56,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.3.0-rc.1 ---
+# --- END BEADS INTEGRATION v1.3.0-rc.2 ---

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.3.0-rc.1 ---
+# --- BEGIN BEADS INTEGRATION v1.3.0-rc.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -56,4 +56,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.3.0-rc.1 ---
+# --- END BEADS INTEGRATION v1.3.0-rc.2 ---

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -40,7 +40,7 @@ if [ -n "$staged_go_files" ]; then
     echo "$staged_go_files" | xargs git add
 fi
 
-# --- BEGIN BEADS INTEGRATION v1.3.0-rc.1 ---
+# --- BEGIN BEADS INTEGRATION v1.3.0-rc.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -97,4 +97,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.3.0-rc.1 ---
+# --- END BEADS INTEGRATION v1.3.0-rc.2 ---

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -39,7 +39,7 @@ fi
 
 exec < <(printf '%s\n' "$push_refs")
 
-# --- BEGIN BEADS INTEGRATION v1.3.0-rc.1 ---
+# --- BEGIN BEADS INTEGRATION v1.3.0-rc.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -96,4 +96,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.3.0-rc.1 ---
+# --- END BEADS INTEGRATION v1.3.0-rc.2 ---

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.3.0-rc.1 ---
+# --- BEGIN BEADS INTEGRATION v1.3.0-rc.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -56,4 +56,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.3.0-rc.1 ---
+# --- END BEADS INTEGRATION v1.3.0-rc.2 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **`bd ready --claim` now refuses a row cap under `--proxied-server`.** The
-  proxied ready role cannot enforce `--max-rows`/`BEADS_MAX_ROWS`, so bd fails
-  loudly rather than silently dropping the limit; `--claim` no longer exempts
-  the command. Agent rigs that set the cap globally must unset it for proxied
-  `bd ready --claim`. Direct mode is unchanged, and a claim there still
-  succeeds against a ready pool larger than the cap.
-
 ## [1.3.0] - 2026-08-28
 
 The first tested release off `main` since the 1.1 line. [1.2.2] was a recovery
@@ -520,6 +511,13 @@ which dumps the entire release history.)
   was a widening — but any stored `--` spelling that is NOT a gascity slash
   encoding changes equivalence class silently, with no error to notice. Longer
   or mixed runs, `__` and `---` included, are unaffected and still collapse.
+
+- **`bd ready --claim` now refuses a row cap under `--proxied-server`.** The
+  proxied ready role cannot enforce `--max-rows`/`BEADS_MAX_ROWS`, so bd fails
+  loudly rather than silently dropping the limit; `--claim` no longer exempts
+  the command. Agent rigs that set the cap globally must unset it for proxied
+  `bd ready --claim`. Direct mode is unchanged, and a claim there still
+  succeeds against a ready pool larger than the cap. (#6269)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -880,6 +880,32 @@ which dumps the entire release history.)
   doctor was pointed at, not just the one it was launched in. Diagnosis itself
   keeps working under a freeze.
 
+- **An externally-managed Dolt sql-server is no longer mistaken for bd's own**,
+  which had silently disarmed the shared-store migrate gate (#6118). When the
+  port arrived from `BEADS_DOLT_SERVER_PORT`, from `bd init --server-port`, or
+  from a stale port file left by a server that had since died, bd classified a
+  genuinely shared server as workspace-owned and migrated its schema in place —
+  no prompt, no warning, exit 0 — after which every older client on that server
+  was hard-refused with `schema version mismatch`. Ownership is now *proven*
+  from bd's own live port and PID record rather than inferred from how the
+  endpoint was named: bd must have bound that port and the process answering it
+  must still be alive. Everything else is shared, and stays gated.
+
+- **A `dolt.mode: server` workspace declared in `.beads/config.yaml` is no
+  longer refused as a legacy workspace** (#6119). The upgrade guard resolved the
+  connection mode from `metadata.json` alone, so a workspace that names its mode
+  only in config.yaml fell through to the embedded arm and was refused outright
+  — including workspaces this release had just created and was already
+  operating on. The guard now resolves the mode through the same
+  `IsDoltServerMode` precedence chain the rest of bd uses, and a
+  `.local_version` witness naming bd 1.0 or later vetoes the legacy verdict in
+  every mode rather than only in server mode.
+
+- **A server-mode workspace with no `metadata.json` no longer opens a phantom
+  embedded database** and answers `bd list` with a false-empty result and exit 0
+  (#6120). Config substitution now gates on `IsDoltServerMode`, and
+  `BEADS_DOLT_SERVER_MODE` is honored on that path instead of being ignored.
+
 ### Security
 
 - **Release binaries now build with Go 1.26.7** instead of 1.26.5, closing seven

--- a/cmd/bd/info.go
+++ b/cmd/bd/info.go
@@ -221,6 +221,17 @@ type VersionChange struct {
 // versionChanges contains agent-actionable changes for recent versions
 var versionChanges = []VersionChange{
 	{
+		Version: "1.3.0-rc.2",
+		Date:    "2026-09-05",
+		Changes: []string{
+			"RC: candidate for the 1.3.0 line, carrying three server-mode fixes reported against rc.1; the [1.3.0] entry below still describes everything a 1.2.2 user meets, including the migration and backup notes — read it first.",
+			"FIX: an env-pointed Dolt sql-server (BEADS_DOLT_SERVER_PORT) is classified shared, not owned, so the #5920/#6048 shared-store consent gate runs instead of being bypassed. Before this, bd migrated the shared database in place and exited 0, and older co-resident clients were then hard-refused with a schema version mismatch (#6118).",
+			"FIX: a config.yaml server-mode workspace (dolt.mode: server, no metadata.json) is no longer misread as a legacy workspace — the guard resolves mode through the IsDoltServerMode precedence chain, and a .local_version witness naming bd 1.0 or later vetoes the legacy verdict in every mode (#6119).",
+			"FIX: a metadata-less server-mode workspace no longer opens a phantom .beads/embeddeddolt database that answered 'bd list' with a false-empty exit 0; substitution gates on IsDoltServerMode and honors BEADS_DOLT_SERVER_MODE (#6120).",
+			"CHANGE: 'bd ready --claim' under --proxied-server now refuses a --max-rows/BEADS_MAX_ROWS cap instead of silently dropping it; --claim is no longer exempt. Agent rigs that set the cap globally must unset it for proxied 'bd ready --claim'. Direct mode is unchanged.",
+		},
+	},
+	{
 		Version: "1.3.0",
 		Date:    "2026-08-28",
 		Changes: []string{

--- a/cmd/bd/info.go
+++ b/cmd/bd/info.go
@@ -232,6 +232,16 @@ var versionChanges = []VersionChange{
 		},
 	},
 	{
+		// Keyed so an rc.1 tester upgrading to rc.2 gets the rc.2 digest
+		// above instead of the whole release history: getVersionsSince
+		// returns every entry when it cannot find the previous version.
+		Version: "1.3.0-rc.1",
+		Date:    "2026-08-31",
+		Changes: []string{
+			"RC: first candidate for the 1.3.0 line. Everything a 1.2.2 user meets on the way here — the in-place schema migration, the shared-server consent gate, the backup ordering, and the breaking changes — is described in the [1.3.0] entry below; read it first.",
+		},
+	},
+	{
 		Version: "1.3.0",
 		Date:    "2026-08-28",
 		Changes: []string{

--- a/cmd/bd/init_safety.go
+++ b/cmd/bd/init_safety.go
@@ -26,14 +26,18 @@ const (
 	// `--discard-remote`. Ambiguous identity source.
 	ExitRemoteDivergenceRefused = 10
 
-	// ExitLocalExistsRefused signals `bd init` was called against a
-	// directory that already has beads data, without `--force` or
-	// `--reinit-local`. The existing local-safety refusal.
+	// ExitLocalExistsRefused signals the interactive typed-confirmation
+	// for a destructive re-init over existing local data was declined at
+	// the prompt. That TTY-only path is its sole source: the same guard's
+	// non-interactive branch returns ExitDestroyTokenMissing instead, and
+	// a plain `bd init` over an initialized workspace is refused by the
+	// local-safety guard with an ordinary error, not this code.
 	ExitLocalExistsRefused = 11
 
-	// ExitDestroyTokenMissing signals `--discard-remote` was passed in
-	// non-interactive mode without a valid `--destroy-token`. The caller
-	// must look up the token format via `bd help init-safety`.
+	// ExitDestroyTokenMissing signals a destructive re-init was requested
+	// in non-interactive mode without a valid `--destroy-token`: either
+	// `--discard-remote`, or `--reinit-local` over existing local issues.
+	// The caller must look up the token format via `bd help init-safety`.
 	ExitDestroyTokenMissing = 12
 )
 

--- a/cmd/bd/init_safety.go
+++ b/cmd/bd/init_safety.go
@@ -38,6 +38,10 @@ const (
 	// in non-interactive mode without a valid `--destroy-token`: either
 	// `--discard-remote`, or `--reinit-local` over existing local issues.
 	// The caller must look up the token format via `bd help init-safety`.
+	// It is also returned when the interactive `--discard-remote` typed-token
+	// confirmation is declined at the prompt, so a 12 does not on its own
+	// prove the caller was non-interactive. Supplying the token is the
+	// correct remedy for all three sources.
 	ExitDestroyTokenMissing = 12
 )
 

--- a/cmd/bd/init_safety_help.go
+++ b/cmd/bd/init_safety_help.go
@@ -56,8 +56,10 @@ ADOPTING A REMOTE
 
 DESTROY-TOKEN (non-interactive only)
 
-  When running with no TTY (CI, agents, piped input), --discard-remote
-  requires an explicit --destroy-token value. The token format is:
+  When running with no TTY (CI, agents, piped input), a destructive
+  re-init requires an explicit --destroy-token value. That covers both
+  --discard-remote and --reinit-local over existing issues. The token
+  format is:
 
       DESTROY-<issue-prefix>
 
@@ -75,7 +77,9 @@ EXIT CODES
   10    refused: remote has Dolt history and you selected local history
         without --discard-remote
   11    refused: existing local data and you declined the destroy confirm
-  12    refused: --discard-remote passed without a valid --destroy-token
+        (interactive mode only)
+  12    refused: destructive re-init (--discard-remote, or --reinit-local
+        over existing issues) without a valid --destroy-token
         (non-interactive mode)
 
 RECOVERY

--- a/cmd/bd/init_safety_help.go
+++ b/cmd/bd/init_safety_help.go
@@ -80,7 +80,8 @@ EXIT CODES
         (interactive mode only)
   12    refused: destructive re-init (--discard-remote, or --reinit-local
         over existing issues) without a valid --destroy-token
-        (non-interactive mode)
+        (non-interactive mode); also returned when the interactive
+        --discard-remote typed-token confirmation is declined
 
 RECOVERY
 

--- a/cmd/bd/version.go
+++ b/cmd/bd/version.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	// Version is the current version of bd (overridden by ldflags at build time)
-	Version = "1.3.0-rc.1"
+	Version = "1.3.0-rc.2"
 	// Build can be set via ldflags at compile time
 	Build = "dev"
 	// Commit and branch the git revision the binary was built from (optional ldflag)

--- a/cmd/bd/winres/winres.json
+++ b/cmd/bd/winres/winres.json
@@ -18,12 +18,12 @@
             "Comments": "AI-supervised issue tracker for coding workflows",
             "CompanyName": "Steve Yegge",
             "FileDescription": "beads - AI-supervised issue tracker",
-            "FileVersion": "1.3.0-rc.1",
+            "FileVersion": "1.3.0-rc.2",
             "InternalName": "bd",
             "LegalCopyright": "Copyright (c) 2024-2026 Steve Yegge. MIT License.",
             "OriginalFilename": "bd.exe",
             "ProductName": "beads",
-            "ProductVersion": "1.3.0-rc.1"
+            "ProductVersion": "1.3.0-rc.2"
           }
         }
       }

--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@
 }:
 buildGoModule {
   pname = "beads";
-  version = "1.3.0-rc.1";
+  version = "1.3.0-rc.2";
 
   src = self;
 

--- a/docs/recovery/init-safety.md
+++ b/docs/recovery/init-safety.md
@@ -3,14 +3,18 @@ title: Recovery Playbooks
 description: Step-by-step recovery for bd init and bd dolt push/pull refusals, including the primary-key fork playbook
 ---
 
-Last reviewed: 2026-06-09
+Last reviewed: 2026-09-08
 
 Freshness source: `cmd/bd/init.go`, `cmd/bd/init_safety.go`,
 `cmd/bd/init_safety_test.go`, and `cmd/bd/dolt.go`.
 
 This document lives next to the ADRs and matches the structure of `bd`'s
 error messages: each named refusal in `bd init` and `bd dolt push`/`pull`
-points here to a labeled anchor with step-by-step recovery instructions.
+has a labeled anchor here with step-by-step recovery instructions. The
+`bd dolt push`/`pull` fork refusal deep-links its anchor directly; since
+[#5310](https://github.com/gastownhall/beads/pull/5310) the `bd init`
+refusals point at `bd help init-safety`, which links this document as a
+whole — match those by exit code and symptom text.
 
 See also: `bd help init-safety`, and
 [ADR 0002 — `bd init` safety invariants](https://github.com/gastownhall/beads/blob/main/engdocs/adr/0002-init-safety-invariants.md).
@@ -18,8 +22,8 @@ See also: `bd help init-safety`, and
 ## Table of contents
 
 - [init-force-refused — `bd init --force`/`--reinit-local` refused because origin has Dolt history](#init-force-refused)
-- [init-token-missing — `--discard-remote` refused because `--destroy-token` is missing or wrong](#init-token-missing)
-- [init-local-exists — `bd init` refused because local data already exists](#init-local-exists)
+- [init-token-missing — a destructive re-init refused because `--destroy-token` is missing or wrong](#init-token-missing)
+- [init-local-exists — `bd init --reinit-local` refused because local data already exists](#init-local-exists)
 - [pk-fork-refused — `bd dolt pull`/`push` refused because a table has different primary keys in its common ancestor](#pk-fork-refused)
 
 ---
@@ -92,11 +96,25 @@ team before doing this.
 bd init refuses: --discard-remote requires an explicit destroy-token in non-interactive mode.
 ```
 
+Or, re-initializing over existing local issues with no TTY:
+
+```
+Refusing to destroy N issues in non-interactive mode.
+  See 'bd help init-safety' for the required --destroy-token format.
+```
+
 **Why this happens**
 
-You're running non-interactively (CI, agent, piped input) and passed
-`--discard-remote`. Destructive cross-boundary operations cannot be
-authorized silently.
+You're running non-interactively (CI, agent, piped input) and asked for a
+destructive re-init. Destructive operations cannot be authorized silently,
+so `bd` requires `--destroy-token` in place of the interactive confirmation
+it cannot prompt for.
+
+Both destructive paths need the token, not just the cross-boundary one:
+
+- `--discard-remote`, which would discard the remote's Dolt history.
+- plain `--reinit-local` over existing local issues, which would destroy
+  them (see [init-local-exists](#init-local-exists)).
 
 **Recovery paths**
 
@@ -111,6 +129,10 @@ The token format is `DESTROY-<issue-prefix>`. For a project whose issue
 prefix is `bd`:
 
 ```
+# Destroys local issues only:
+bd init --reinit-local --destroy-token=DESTROY-bd
+
+# Also discards the remote's Dolt history:
 bd init --reinit-local --discard-remote --destroy-token=DESTROY-bd
 ```
 
@@ -122,22 +144,36 @@ for why the token is never echoed in `bd`'s error messages.
 
 ## init-local-exists
 
-**Exit code:** `11` (`ExitLocalExistsRefused`)
+**Exit code:** `11` (`ExitLocalExistsRefused`) interactively;
+`12` (`ExitDestroyTokenMissing`) non-interactively
 
 **Symptom**
+
+Interactive (TTY): you declined the typed `destroy N issues` confirmation.
+This is the only path that exits `11`.
+
+```
+Type 'destroy N issues' to confirm:
+Aborted. Database was NOT modified.
+```
+
+Non-interactive (CI, agent, piped input) — note this exits `12`, not `11`:
 
 ```
 Refusing to destroy N issues in non-interactive mode.
   See 'bd help init-safety' for the required --destroy-token format.
 ```
 
-Or, in interactive mode, you declined the typed `destroy N issues`
-confirmation.
-
 **Why this happens**
 
-Local `.beads/` has existing issues. `bd init --reinit-local` would
-permanently destroy them.
+Local `.beads/` has existing issues. `bd init --reinit-local` (or its
+deprecated alias `--force`) would permanently destroy them, so `bd` demands
+an explicit confirmation first: the typed prompt in a TTY, and a
+`--destroy-token` when there is no TTY. This applies to `--reinit-local` on
+its own — `--discard-remote` is not required to trigger it.
+
+A plain `bd init` over an initialized workspace does not reach either code:
+the local-safety guard refuses it with an ordinary error before this point.
 
 **Recovery paths**
 
@@ -145,7 +181,13 @@ permanently destroy them.
 
 ```
 bd export > issue-export.jsonl
+
+# Interactive: confirm at the typed prompt.
 bd init --reinit-local
+
+# Non-interactive: the token stands in for the prompt. Without it this
+# re-runs straight back into the exit-12 refusal above.
+bd init --reinit-local --destroy-token=DESTROY-<issue-prefix>
 ```
 
 `issue-export.jsonl` lets you re-import individual issues if needed. It is not

--- a/integrations/beads-mcp/pyproject.toml
+++ b/integrations/beads-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "beads-mcp"
-version = "1.3.0-rc.1"
+version = "1.3.0-rc.2"
 description = "MCP server for beads issue tracker."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/beads-mcp/src/beads_mcp/__init__.py
+++ b/integrations/beads-mcp/src/beads_mcp/__init__.py
@@ -4,4 +4,4 @@ This package provides an MCP (Model Context Protocol) server that exposes
 beads (bd) issue tracker functionality to MCP Clients.
 """
 
-__version__ = "1.3.0-rc.1"
+__version__ = "1.3.0-rc.2"

--- a/integrations/beads-mcp/uv.lock
+++ b/integrations/beads-mcp/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "beads-mcp"
-version = "1.3.0rc1"
+version = "1.3.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beads/bd",
-  "version": "1.3.0-rc.1",
+  "version": "1.3.0-rc.2",
   "description": "Beads issue tracker - lightweight memory system for coding agents with native binary support",
   "main": "bin/bd.js",
   "bin": {

--- a/plugins/beads/.claude-plugin/plugin.json
+++ b/plugins/beads/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beads",
   "description": "AI-supervised issue tracker for coding workflows. Manage tasks, discover work, and maintain context with simple CLI commands.",
-  "version": "1.3.0-rc.1",
+  "version": "1.3.0-rc.2",
   "author": {
     "name": "Steve Yegge",
     "url": "https://github.com/steveyegge"

--- a/plugins/beads/.codex-plugin/plugin.json
+++ b/plugins/beads/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "beads",
-  "version": "1.3.0-rc.1",
+  "version": "1.3.0-rc.2",
   "description": "AI-supervised issue tracking for coding workflows with agent skills.",
   "author": {
     "name": "Steve Yegge",

--- a/plugins/beads/.copilot-plugin/plugin.json
+++ b/plugins/beads/.copilot-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beads",
   "description": "AI-supervised issue tracker for coding workflows. Manage tasks, discover work, and maintain context with simple CLI commands.",
-  "version": "1.3.0-rc.1",
+  "version": "1.3.0-rc.2",
   "author": {
     "name": "Steve Yegge",
     "url": "https://github.com/steveyegge"

--- a/scripts/check-doc-freshness.sh
+++ b/scripts/check-doc-freshness.sh
@@ -23,7 +23,7 @@ DOCS=(
     "docs/getting-started/ide-setup.md|cmd/bd/setup*.go;internal/recipes/"
     "docs/integrations/azure-devops.md|cmd/bd/ado*.go;internal/ado/"
     "docs/reference/json-schema.md|cmd/bd/output.go;cmd/bd/errors.go;cmd/bd/protocol/json_contract_test.go"
-    "docs/recovery/init-safety.md|cmd/bd/init.go;cmd/bd/init_safety.go;cmd/bd/init_safety_test.go"
+    "docs/recovery/init-safety.md|cmd/bd/init.go;cmd/bd/init_safety.go;cmd/bd/init_safety_test.go;cmd/bd/dolt.go"
     "engdocs/ERROR_HANDLING.md|cmd/bd/*.go;cmd/bd/errors.go"
     "engdocs/SERVE_RUNBOOK.md|internal/httpapi/server.go;internal/httpapi/events_watch.go;cmd/bd/serve.go;internal/httpapi/auth.go"
     "engdocs/LINTING.md|.golangci.yml;scripts/ci/pr-lint.sh;Makefile;.github/workflows/pr.yml;.github/workflows/main.yml"

--- a/scripts/check_doc_freshness_test.go
+++ b/scripts/check_doc_freshness_test.go
@@ -20,7 +20,7 @@ var freshnessDocuments = []struct {
 	{"docs/getting-started/ide-setup.md", []string{"cmd/bd/setup*.go", "internal/recipes/"}},
 	{"docs/integrations/azure-devops.md", []string{"cmd/bd/ado*.go", "internal/ado/"}},
 	{"docs/reference/json-schema.md", []string{"cmd/bd/output.go", "cmd/bd/errors.go", "cmd/bd/protocol/json_contract_test.go"}},
-	{"docs/recovery/init-safety.md", []string{"cmd/bd/init.go", "cmd/bd/init_safety.go", "cmd/bd/init_safety_test.go"}},
+	{"docs/recovery/init-safety.md", []string{"cmd/bd/init.go", "cmd/bd/init_safety.go", "cmd/bd/init_safety_test.go", "cmd/bd/dolt.go"}},
 	{"engdocs/ERROR_HANDLING.md", []string{"cmd/bd/*.go", "cmd/bd/errors.go"}},
 	{"engdocs/SERVE_RUNBOOK.md", []string{"internal/httpapi/server.go", "internal/httpapi/events_watch.go", "cmd/bd/serve.go", "internal/httpapi/auth.go"}},
 	{"engdocs/LINTING.md", []string{".golangci.yml", "scripts/ci/pr-lint.sh", "Makefile", ".github/workflows/pr.yml", ".github/workflows/main.yml"}},


### PR DESCRIPTION
Prep for the `v1.3.0-rc.2` tag, following [RELEASING.md → Cut an RC](https://github.com/gastownhall/beads/blob/release/1.3.0/RELEASING.md#cut-an-rc).

**This must merge before the maintainer tags `v1.3.0-rc.2`.** The release workflow's version-consistency gate compares the tag against `cmd/bd/version.go`, and RELEASING.md requires the tag point at the *merged* commit on `release/1.3.0` — goreleaser packages `CHANGELOG.md` from the tag into every published archive, so a tag cut before this merges would ship the pre-review notes.

## What the bump touched

`./scripts/update-versions.sh 1.3.0-rc.2` — 16 files, no hand edits:

| | |
|---|---|
| `cmd/bd/version.go` | canonical `1.3.0-rc.2` |
| `integrations/beads-mcp/` | `pyproject.toml`, `__init__.py`, `uv.lock` (PEP 440 `1.3.0rc2`) |
| `plugins/beads/.{claude,codex,copilot}-plugin/plugin.json`, `.claude-plugin/marketplace.json` | plugin + marketplace metadata |
| `npm-package/package.json` | npm wrapper |
| `.githooks/*` (5 files) | `BEGIN`/`END BEADS INTEGRATION v<version>` markers |
| `cmd/bd/winres/winres.json` | `FileVersion`/`ProductVersion` strings → `1.3.0-rc.2` |
| `default.nix`, `README.md` | bumped, ungated |

The Windows PE **numeric** fields (`winres` `file_version`/`product_version` and the manifest `<assemblyIdentity>`) deliberately stay at the base version `1.3.0` — PE versions must be purely numeric, `gen-winres.sh` strips the prerelease suffix the same way at build time, and `check-versions.sh` gates them against the base version for exactly that reason. `manifest.xml` is therefore unchanged.

## check-versions.sh

`./scripts/check-versions.sh` — **24/24 gates pass**, no warnings:

```
Canonical version (from version.go): 1.3.0-rc.2

✓ MCP pyproject.toml: 1.3.0-rc.2
✓ MCP __init__.py: 1.3.0-rc.2
✓ Claude plugin.json: 1.3.0-rc.2
✓ Codex plugin.json: 1.3.0-rc.2
✓ Copilot plugin.json: 1.3.0-rc.2
✓ Claude marketplace.json: 1.3.0-rc.2
✓ npm package.json: 1.3.0-rc.2
✓ MCP uv.lock (beads-mcp pin): 1.3.0rc2
✓ MCP uv.lock: fresh (uv lock --check)
✓ .githooks/{post-checkout,post-merge,pre-commit,prepare-commit-msg,pre-push} BEGIN + END markers: 1.3.0-rc.2   (10 gates)
✓ winres.json file_version: 1.3.0
✓ winres.json product_version: 1.3.0
✓ winres.json FileVersion: 1.3.0-rc.2
✓ winres.json ProductVersion: 1.3.0-rc.2
✓ manifest.xml assemblyIdentity version: 1.3.0.0

✓ Version files in sync at: 1.3.0-rc.2
```

## What rc.2 ships since rc.1

rc.1 (`9c6a69ec1`) was tested against gascity's integration suite, which surfaced three product bugs and one CI gap. All four are already merged into `release/1.3.0` and are ancestors of this branch.

- **#6118 — an env-pointed dolt server was classified as workspace-owned, so the shared-store migrate gate never fired.** The silent-data-migration one. rc.1 could migrate a genuinely shared server's schema in place with no prompt and exit 0, then hard-refuse every older client on that server with `schema version mismatch`. Ownership is now *proven* from bd's own live port/PID state files — bd must have bound the port and the process answering it must still be alive — rather than inferred from how the endpoint was named.
- **#6119 — the legacy-upgrade guard misclassified a `dolt.mode: server` workspace declared in `.beads/config.yaml`.** With no `metadata.json` to read the mode from, the guard fell through to the embedded arm and refused the workspace as legacy — including workspaces the RC itself had just created and was operating on. It now reads the full `IsDoltServerMode` precedence chain, and the current-version-witness veto works in every mode instead of only the server arm.
- **#6120 — a metadata-less server-mode workspace opened a phantom embedded database** and returned a false-empty `bd list` with exit 0. Config substitution now gates on `IsDoltServerMode` and honors `BEADS_DOLT_SERVER_MODE`, which it had been ignoring.
- **#6121 — the macOS/coverage/measurement CI lanes had no explicit `go test -timeout`**, so `cmd/bd` intermittently tripped Go's implicit 10m default at ~93% wall utilization. Now 30m, matching the Linux lane (#6091).

## CHANGELOG

The `[1.3.0]` section date is **deliberately not restamped** here — restamping it is a hand edit owed at final-release time.

> **Correction (maintainer review).** An earlier revision of this description said
> "the stamp-changelog step owns it at final-release time." That is wrong, and the
> distinction matters for the 1.3.0 promotion. `stamp-changelog`
> (`.beads/formulas/beads-release.formula.toml`) runs
> `sed "s/## \[Unreleased\]/## [Unreleased]\n\n## [{{version}}] - $DATE/"` — it
> *inserts a new dated header* beneath `[Unreleased]` and never re-dates an
> existing one. Running it at final release while a `## [1.3.0]` header already
> exists would produce a **duplicate** `## [1.3.0]` heading, not a restamp. The
> date must be hand-corrected at promotion instead. Tracked as a follow-up so it
> is not rediscovered at release time.

Added three entries to the existing `[1.3.0]` → `### Fixed` section for #6118, #6119 and #6120, from the proposed lines in those PR bodies (all three deliberately left `CHANGELOG.md` untouched). **#6121 gets no entry**: it is CI-only, proposed no changelog line, and its direct precedent #6091 has none either.

No `<!-- PROVISIONAL -->` fence or stale note remains — rc.1 (#6090) already dropped the #6055/#6056 fence once both PRs merged, and a repo-wide search finds no other.

> **Superseded by the maintainer fixup.** This section originally claimed
> `cmd/bd/info.go`'s `versionChanges` "needs no edit: the entry is keyed to the
> base version `1.3.0`, not per-RC," and that the rollup was complete. Review
> found neither held, and `c1e5e49e3` fixes both: a `1.3.0-rc.2` `versionChanges`
> entry was added (so an rc.2 binary resolves a known `since` for
> `bd info --whats-new` / `bd upgrade review` instead of the unknown-version
> fallback), and the `bd ready --claim` row-cap entry that #6269 stranded under
> `[Unreleased]` was moved into `[1.3.0] ### Changed` tagged `(#6269)`, restoring
> the empty-`[Unreleased]` shape `RELEASING.md` requires.

## Local preflight

| Check | Result |
|---|---|
| `./scripts/check-versions.sh` | pass — 24/24 |
| `goreleaser check` | exit 2, **known-not-blocking** — the only failures are the two pre-existing `archives.format` / `archives.format_overrides.format` deprecations; goreleaser itself reports `configuration is valid`. The real release path runs `goreleaser release`, not `check`, where deprecations are warn-only. |
| `make ci-package-mcp` | **pass** — uv sync, ruff clean, mypy clean (8 files), pytest 228 passed / 5 skipped, built `beads_mcp-1.3.0rc2.tar.gz` + `-py3-none-any.whl` (PEP 440 confirmed end to end) |
| `make ci-package-npm` | **pass** — packs `@beads/bd@1.3.0-rc.2`, 89.1 MB tarball, 7 files |
| `go build ./...` | **pass** |
| `CGO_ENABLED=0 go test -tags gms_pure_go -c ./cmd/bd` | **pass** — pure-Go lane compiles |

Working tree clean after all of it; no build artifacts left behind.

## After this merges

Per RELEASING.md, the maintainer tags the **merged** commit on `release/1.3.0`:

```bash
git checkout release/1.3.0 && git pull
git tag -a v1.3.0-rc.2 -m "Release candidate v1.3.0-rc.2"
git push origin v1.3.0-rc.2
```

The `v*` tag triggers the release workflow with prerelease behavior: GitHub release published and marked prerelease, Homebrew skipped, and `publish-pypi` / `publish-npm` skipped by the `!contains(github.ref_name, '-')` gate. `releases/latest` must stay `v1.2.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

