### PR TITLE
community-tools: add the aweb mail delegate for bd mail

### DIFF
--- a/docs/community-tools.md
+++ b/docs/community-tools.md
@@ -81,6 +81,10 @@ Install with `uv tool install git+https://github.com/jklenk/thread`. Built by [@
 
 - **[LoopTroop](https://github.com/looptroop-ai/LoopTroop)** - Local AI coding orchestrator for automated task planning, execution, and feedback loops. Uses a Beads-inspired methodology with LLM Council consensus and worktree isolation. Built by [@looptroop-ai](https://github.com/looptroop-ai). (Node.js/TypeScript)
 
+## Mail Delegates
+
+- **[aweb beads-mail](https://aweb.ai/docs/beads-mail/)** - Gives `bd mail` a mail provider in any beads repo: `npm i -g @awebai/aw`, `aw init`, `bd config set mail.delegate "aw beads-mail"`. [aweb](https://github.com/awebai/aweb) is an open-source communication layer for AI agents: each agent gets a stable identity and address, mail and chat are stored durably on a server so recipients can be offline, and a wake-up event tells the recipient's runtime (Claude Code, Pi, Codex, or any process reading the event stream) that work is waiting. Identities are either local, routable only inside one team, or global, addressable as `domain/name` across organizations and across independently run servers, which federate with each other. Messages are signed by the sender's own key and verified against a public registry, so `From:` is an identity rather than a caller-asserted name. MIT; run the whole stack yourself with Docker, or use the hosted service at app.aweb.ai. Built by [@juanre](https://github.com/juanre). (Go/Python)
+
 ## Coordination Servers
 
 - **[BeadHub](https://github.com/beadhub/beadhub)** - Open-source coordination server for AI agent teams running beads. The `bdh` CLI is a transparent wrapper over `bd` that adds work claiming, file reservation, presence awareness, and inter-agent messaging (async mail and sync chat). Includes a web dashboard. Free hosted at beadhub.ai for open-source projects. Built by [@juanre](https://github.com/juanre). (Python/TypeScript)


### PR DESCRIPTION
Adds a "Mail Delegates" section with the aweb delegate for the `mail.delegate` seam, so any beads repo gets a working `bd mail`.

What aweb is, in case the entry is too short: an open-source (MIT) communication layer for AI agents. Agents get stable identities and addresses; mail and chat are durable server state, so recipients can be offline; a wake-up event tells the recipient's runtime that work is waiting. Identities are local (team-only) or global (`domain/name`, reachable across organizations); independently run servers federate. Sender identity is a signed key verified against a public registry, not an asserted name. You can run the whole stack yourself with Docker, or use app.aweb.ai.

Guide, with a recording of a stock bd 1.2.2 repo: install, init, invite, join, a message to a teammate with nothing running on his side, his Claude Code session waking with it, the reply, and the verified sender: https://aweb.ai/docs/beads-mail/
