### PR TITLE
feat(ids): say when a partial ID resolved to something else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`bd` says when it resolved a partial ID instead of matching one exactly.**
-  ID resolution tries an exact match first and only then falls back to
+  ([#6302](https://github.com/gastownhall/beads/pull/6302)) ID resolution tries an exact match first and only then falls back to
   leading-prefix abbreviation (`a3f8` -> `a3f8e9`). Ambiguity was already a hard
   error naming every candidate, but a *sole* abbreviation match was returned
   silently, so a caller could act on an issue it had not named without any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   signal. bd now writes a one-line note to stderr identifying both the input and
   what it resolved to. The case that motivates it: a hierarchical child is a
   valid leading-prefix match for its own parent's ID, so after a parent is
-  renamed or deleted the vacated ID quietly resolves to the child. stdout and
+  renamed or deleted the vacated ID quietly resolves to the child. Note this
+  covers **every** leading-prefix abbreviation, not only that shape, so the
+  ordinary documented `a3f8` -> `bd-a3f8e9` path now emits a line too, once per
+  resolved argument. That breadth is deliberate: a `.`-boundary rule would fix
+  parent/child but leave `bd-x.1` -> `bd-x.11` just as silent. stdout and
   `--json` are unchanged; silence it with `--quiet` or
   `BD_NO_PARTIAL_ID_NOTICE=1`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`bd` says when it resolved a partial ID instead of matching one exactly.**
+  ID resolution tries an exact match first and only then falls back to
+  leading-prefix abbreviation (`a3f8` -> `a3f8e9`). Ambiguity was already a hard
+  error naming every candidate, but a *sole* abbreviation match was returned
+  silently, so a caller could act on an issue it had not named without any
+  signal. bd now writes a one-line note to stderr identifying both the input and
+  what it resolved to. The case that motivates it: a hierarchical child is a
+  valid leading-prefix match for its own parent's ID, so after a parent is
+  renamed or deleted the vacated ID quietly resolves to the child. stdout and
+  `--json` are unchanged; silence it with `--quiet` or
+  `BD_NO_PARTIAL_ID_NOTICE=1`.
+
 - **`bd count` supports repeatable `--metadata-field key=value` filters**
   ([#6023](https://github.com/gastownhall/beads/issues/6023)), so callers can
   count the same metadata-scoped set `bd list` returns without fetching every

--- a/internal/utils/id_parser.go
+++ b/internal/utils/id_parser.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -224,7 +226,50 @@ func ResolvePartialID(ctx context.Context, store PartialIDResolverStore, input s
 		return "", fmt.Errorf("%w: %q matches %d issues: %v\nUse more characters to disambiguate", ErrAmbiguousID, input, len(matches), matches)
 	}
 
-	return matches[0], nil
+	// Sole leading-prefix match. Every other return from this function is an
+	// exact match (or a prefix-normalized exact match), so this is the one path
+	// that hands back an issue the caller did not name.
+	resolved := matches[0]
+	if shouldNotifyPartialResolution(input, resolved, debug.IsQuiet(), os.Getenv("BD_NO_PARTIAL_ID_NOTICE")) {
+		emitPartialResolutionNotice(input, resolved)
+	}
+	return resolved, nil
+}
+
+// shouldNotifyPartialResolution is the testable predicate behind the
+// partial-resolution notice. It takes the quiet flag and the suppression env
+// value as parameters so tests can cover every combination, the same shape as
+// shouldWarnImplicitBlocksDefault in cmd/bd/dep.go.
+//
+// Deliberately NOT gated on stderr being a terminal, which is where it departs
+// from that precedent. The implicit-blocks warning tells an interactive
+// operator about a default they chose; this one tells a caller that the issue
+// it is about to act on is not the issue it named, and the callers most exposed
+// to that — scripts, hooks and agents — are exactly the non-TTY ones. Gating on
+// a TTY would silence it precisely where it is most needed.
+func shouldNotifyPartialResolution(input, resolved string, quiet bool, noNotifyEnv string) bool {
+	if resolved == "" || resolved == input {
+		return false
+	}
+	// --quiet is documented as "Suppress non-essential output (errors only)",
+	// matching how the other non-error stderr notices behave.
+	if quiet {
+		return false
+	}
+	// Explicit opt-out, following the BD_NO_DEP_TYPE_WARNING precedent.
+	if noNotifyEnv != "" {
+		return false
+	}
+	return true
+}
+
+// emitPartialResolutionNotice writes the notice. Split from the gate so the
+// message text can be asserted under a captured stderr.
+//
+// stderr, never stdout: --json payloads and piped stdout stay byte-for-byte
+// unchanged, so this cannot break a parsing caller.
+func emitPartialResolutionNotice(input, resolved string) {
+	fmt.Fprintf(os.Stderr, "note: %q is not an exact issue ID; resolved to %s (silence with --quiet or BD_NO_PARTIAL_ID_NOTICE=1)\n", input, resolved) //nolint:gosec // G705: stderr, not a browser context
 }
 
 func partialIDSearchPart(hashPart string) (string, bool) {

--- a/internal/utils/id_parser_unit_test.go
+++ b/internal/utils/id_parser_unit_test.go
@@ -89,8 +89,9 @@ func TestEmitPartialResolutionNoticeNamesBothIDs(t *testing.T) {
 // list. It avoids the live-Dolt dependency in id_parser_test.go, which skips
 // when no test server is running and so cannot pin this behaviour in CI.
 type fakeResolverStore struct {
-	ids    []string
-	prefix string
+	ids     []string
+	prefix  string
+	allowed string // allowed_prefixes config, for cross-prefix cases
 }
 
 func (f *fakeResolverStore) SearchIssues(_ context.Context, _ string, filter types.IssueFilter) ([]*types.Issue, error) {
@@ -117,8 +118,11 @@ func (f *fakeResolverStore) SearchIssueIDs(_ context.Context, query string, _ ty
 }
 
 func (f *fakeResolverStore) GetConfig(_ context.Context, key string) (string, error) {
-	if key == "issue_prefix" {
+	switch key {
+	case "issue_prefix":
 		return f.prefix, nil
+	case "allowed_prefixes":
+		return f.allowed, nil
 	}
 	return "", nil
 }
@@ -142,6 +146,66 @@ func TestResolvePartialIDNotifiesWhenParentIDResolvesToItsChild(t *testing.T) {
 	}
 	if !strings.Contains(out, "bd-x.11.1") || !strings.Contains(out, "not an exact issue ID") {
 		t.Fatalf("expected a partial-resolution notice on stderr, got %q", out)
+	}
+}
+
+// Reaching the in-loop exact-hash return needs a CROSS-PREFIX input: both
+// fast paths (raw input, then prefix-normalized input) miss, because the
+// issue's real prefix is an allowed one that is not the configured default, so
+// resolution falls through to the search loop and matches on hash alone. That
+// return is a second silent exit, and an emission planted there survives any
+// test that only exercises the fast paths.
+func TestResolvePartialIDSilentOnCrossPrefixExactHashMatch(t *testing.T) {
+	store := &fakeResolverStore{ids: []string{"hq-a3f8e9"}, prefix: "bd", allowed: "hq"}
+
+	var resolved string
+	var err error
+	out := captureStderr(t, func() {
+		resolved, err = ResolvePartialID(context.Background(), store, "a3f8e9")
+	})
+	if err != nil {
+		t.Fatalf("ResolvePartialID returned error: %v", err)
+	}
+	if resolved != "hq-a3f8e9" {
+		t.Fatalf("resolved = %q, want %q", resolved, "hq-a3f8e9")
+	}
+	if out != "" {
+		t.Fatalf("expected no notice for an exact hash match, got %q", out)
+	}
+}
+
+// A prefix-less exact input is still silent, via the normalized fast path.
+func TestResolvePartialIDSilentOnPrefixlessExactMatch(t *testing.T) {
+	store := &fakeResolverStore{ids: []string{"bd-a3f8e9"}, prefix: "bd"}
+
+	var resolved string
+	var err error
+	out := captureStderr(t, func() {
+		resolved, err = ResolvePartialID(context.Background(), store, "a3f8e9")
+	})
+	if err != nil {
+		t.Fatalf("ResolvePartialID returned error: %v", err)
+	}
+	if resolved != "bd-a3f8e9" {
+		t.Fatalf("resolved = %q, want %q", resolved, "bd-a3f8e9")
+	}
+	if out != "" {
+		t.Fatalf("expected no notice for an exact match, got %q", out)
+	}
+}
+
+// The documented abbreviation path notifies too — this is not limited to the
+// parent/child shape, and the CHANGELOG says so.
+func TestResolvePartialIDNotifiesOnOrdinaryAbbreviation(t *testing.T) {
+	store := &fakeResolverStore{ids: []string{"bd-a3f8e9"}, prefix: "bd"}
+
+	out := captureStderr(t, func() {
+		if _, err := ResolvePartialID(context.Background(), store, "a3f8"); err != nil {
+			t.Errorf("ResolvePartialID returned error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "bd-a3f8e9") {
+		t.Fatalf("expected a notice naming the resolved ID, got %q", out)
 	}
 }
 
@@ -171,6 +235,12 @@ func captureStderr(t *testing.T, fn func()) string {
 	if err != nil {
 		t.Fatalf("os.Pipe: %v", err)
 	}
+	// Restore even if fn panics, so one failure cannot swallow every later
+	// test's stderr. Both pipe ends are closed before returning.
+	defer func() {
+		os.Stderr = orig
+		_ = r.Close()
+	}()
 	os.Stderr = w
 	done := make(chan string, 1)
 	go func() {
@@ -180,6 +250,5 @@ func captureStderr(t *testing.T, fn func()) string {
 	}()
 	fn()
 	_ = w.Close()
-	os.Stderr = orig
 	return <-done
 }

--- a/internal/utils/id_parser_unit_test.go
+++ b/internal/utils/id_parser_unit_test.go
@@ -1,6 +1,14 @@
 package utils
 
-import "testing"
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
 
 func TestPartialIDSearchPartUsesLastHyphenSuffix(t *testing.T) {
 	got, ok := partialIDSearchPart("hacker-news-ko4")
@@ -35,4 +43,143 @@ func TestPartialIDSearchPartRejectsInvalidSearchText(t *testing.T) {
 			t.Fatalf("partialIDSearchPart(%q) = %q, true; want false", input, got)
 		}
 	}
+}
+
+// --- partial-resolution notice -------------------------------------------------
+
+func TestShouldNotifyPartialResolution(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		resolved   string
+		quiet      bool
+		noNotify   string
+		wantNotify bool
+	}{
+		{"non-exact match notifies", "bd-x.11", "bd-x.11.1", false, "", true},
+		{"identical resolution is silent", "bd-x.11", "bd-x.11", false, "", false},
+		{"empty resolution is silent", "bd-x.11", "", false, "", false},
+		{"quiet suppresses", "bd-x.11", "bd-x.11.1", true, "", false},
+		{"env opt-out suppresses", "bd-x.11", "bd-x.11.1", false, "1", false},
+		{"quiet and env together suppress", "bd-x.11", "bd-x.11.1", true, "1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldNotifyPartialResolution(tt.input, tt.resolved, tt.quiet, tt.noNotify)
+			if got != tt.wantNotify {
+				t.Fatalf("shouldNotifyPartialResolution(%q, %q, quiet=%v, env=%q) = %v, want %v",
+					tt.input, tt.resolved, tt.quiet, tt.noNotify, got, tt.wantNotify)
+			}
+		})
+	}
+}
+
+func TestEmitPartialResolutionNoticeNamesBothIDs(t *testing.T) {
+	out := captureStderr(t, func() {
+		emitPartialResolutionNotice("bd-x.11", "bd-x.11.1")
+	})
+	for _, want := range []string{"bd-x.11", "bd-x.11.1", "not an exact issue ID", "BD_NO_PARTIAL_ID_NOTICE"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("notice %q does not contain %q", out, want)
+		}
+	}
+}
+
+// fakeResolverStore is a minimal PartialIDResolverStore over an in-memory ID
+// list. It avoids the live-Dolt dependency in id_parser_test.go, which skips
+// when no test server is running and so cannot pin this behaviour in CI.
+type fakeResolverStore struct {
+	ids    []string
+	prefix string
+}
+
+func (f *fakeResolverStore) SearchIssues(_ context.Context, _ string, filter types.IssueFilter) ([]*types.Issue, error) {
+	var out []*types.Issue
+	for _, want := range filter.IDs {
+		for _, id := range f.ids {
+			if id == want {
+				out = append(out, &types.Issue{ID: id})
+			}
+		}
+	}
+	return out, nil
+}
+
+// SearchIssueIDs mimics the storage layer's `id LIKE %query%` filtering.
+func (f *fakeResolverStore) SearchIssueIDs(_ context.Context, query string, _ types.IssueFilter) ([]string, error) {
+	var out []string
+	for _, id := range f.ids {
+		if query == "" || strings.Contains(id, query) {
+			out = append(out, id)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeResolverStore) GetConfig(_ context.Context, key string) (string, error) {
+	if key == "issue_prefix" {
+		return f.prefix, nil
+	}
+	return "", nil
+}
+
+// A renamed parent leaves its child carrying the old prefix, so the vacated
+// parent ID resolves to that child by leading-prefix abbreviation. The caller
+// must be told it did not get the ID it named.
+func TestResolvePartialIDNotifiesWhenParentIDResolvesToItsChild(t *testing.T) {
+	store := &fakeResolverStore{ids: []string{"bd-x.11.1"}, prefix: "bd"}
+
+	var resolved string
+	var err error
+	out := captureStderr(t, func() {
+		resolved, err = ResolvePartialID(context.Background(), store, "bd-x.11")
+	})
+	if err != nil {
+		t.Fatalf("ResolvePartialID returned error: %v", err)
+	}
+	if resolved != "bd-x.11.1" {
+		t.Fatalf("resolved = %q, want %q", resolved, "bd-x.11.1")
+	}
+	if !strings.Contains(out, "bd-x.11.1") || !strings.Contains(out, "not an exact issue ID") {
+		t.Fatalf("expected a partial-resolution notice on stderr, got %q", out)
+	}
+}
+
+func TestResolvePartialIDSilentOnExactMatch(t *testing.T) {
+	store := &fakeResolverStore{ids: []string{"bd-x.11", "bd-x.11.1"}, prefix: "bd"}
+
+	var resolved string
+	var err error
+	out := captureStderr(t, func() {
+		resolved, err = ResolvePartialID(context.Background(), store, "bd-x.11")
+	})
+	if err != nil {
+		t.Fatalf("ResolvePartialID returned error: %v", err)
+	}
+	if resolved != "bd-x.11" {
+		t.Fatalf("resolved = %q, want %q", resolved, "bd-x.11")
+	}
+	if out != "" {
+		t.Fatalf("expected no notice for an exact match, got %q", out)
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var sb strings.Builder
+		_, _ = io.Copy(&sb, r)
+		done <- sb.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stderr = orig
+	return <-done
 }


### PR DESCRIPTION
## The problem

`ResolvePartialID` tries an exact match first and only then falls back to leading-prefix abbreviation (`a3f8` → `a3f8e9`). Ambiguity is already handled well — two or more candidates return `ErrAmbiguousID` naming every one of them. But a **sole** abbreviation match is returned silently, so a caller can act on an issue it never named with nothing to indicate the substitution.

The case that surfaced it: **a hierarchical child is a valid leading-prefix match for its own parent's ID.** `.` is a legal ID character and the prefix test has no boundary, so `pa-x.11` legitimately abbreviates `pa-x.11.1`. Once a parent ID is vacated — renamed away, or deleted — the old ID quietly resolves to the child:

```console
$ bd rename demo-v6p.1 demo-v6p.50      # child demo-v6p.1.1 keeps the old prefix
Renamed demo-v6p.1 -> demo-v6p.50

$ bd show demo-v6p.1                     # before this change
○ demo-v6p.1.1 · Only child   [P2 · OPEN]     # different issue, exit 0, no signal
```

How loud that is depends only on how many descendants were left behind:

| Orphaned descendants | `bd show <vacated-id>` |
|---|---|
| 0 | exit 1, `no issue found matching` |
| **exactly 1** | **exit 0, returns the descendant silently** |
| 2 or more | exit 1, `ambiguous ID … matches 2 issues: […]` |

So beads already catches the multi-candidate case and misses the single one, which is the case a caller is least able to detect for itself.

## The change

Announce the substitution rather than narrow resolution.

The alternative fix — requiring a boundary so a child stops abbreviating its parent — changes resolution semantics and risks breaking legitimate abbreviations. Announcing is general (it covers *every* silent partial resolution, not just the hierarchical shape), non-breaking, and degrades to one extra line of output at worst.

```console
$ bd show demo-v6p.1
note: "demo-v6p.1" is not an exact issue ID; resolved to demo-v6p.1.1 (silence with --quiet or BD_NO_PARTIAL_ID_NOTICE=1)
○ demo-v6p.1.1 · Only child   [P2 · OPEN]
```

Three design points worth your view:

- **Emitted from the resolver, not from individual commands.** `ResolvePartialID` has 64 non-test call sites; a per-command notice would be applied inconsistently and would drift. One emission point covers all of them, and it sits at the only `return` that hands back an issue the caller did not name — every other return is an exact or prefix-normalised-exact match.
- **stderr, never stdout.** `--json` payloads and piped stdout are byte-for-byte unchanged, so this cannot break a parsing caller. Verified.
- **Deliberately not gated on stderr being a terminal**, which is where it departs from `shouldWarnImplicitBlocksDefault` in `cmd/bd/dep.go`, whose shape it otherwise follows. That warning tells an interactive operator about a default they chose; this one tells a caller the issue it is about to act on is not the one it named — and the callers most exposed to that (scripts, hooks, agents) are exactly the non-TTY ones. Gating on a TTY would silence it precisely where it matters most. Happy to add the TTY gate if you'd rather it match the sibling exactly.

Suppression follows the `BD_NO_DEP_TYPE_WARNING` precedent: `--quiet` or `BD_NO_PARTIAL_ID_NOTICE=1`.

## Testing

`make ci-pr-core` passes (exit 0). `gofmt` clean; `golangci-lint run internal/utils/...` reports one pre-existing `gosec` G103 in `path_case_darwin.go`, a file this PR does not touch and which Linux CI never compiles. `check-versions.sh` and `check-go-install-guidance.sh` pass; `check-build-tags.sh` needs bash 4 `mapfile` and cannot run on macOS — this change touches only `.go` files, which that script does not scan.

New tests cover the gate matrix (quiet, env opt-out, identical and empty resolution), the message text under captured stderr, and end-to-end resolution through `ResolvePartialID`. The end-to-end tests use a small in-package fake store: the existing resolver tests in `id_parser_test.go` need a live Dolt server and self-skip without one, so they cannot pin this behaviour in CI. **Verified the end-to-end test fails without the emission** (`expected a partial-resolution notice on stderr, got ""`), and passes with it, including under `-race`.

Also exercised against a real binary on a throwaway database — the console output above is from that run — confirming the default, `--quiet`, `BD_NO_PARTIAL_ID_NOTICE=1`, and `--json` stdout purity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
