### PR TITLE
Phase 1: additive schema + migration slot claim for versioned beads (#6134)

### DIFF
--- a/internal/storage/dolt/initschema_0067_versioned_beads_replay_test.go
+++ b/internal/storage/dolt/initschema_0067_versioned_beads_replay_test.go
@@ -1,0 +1,106 @@
+//go:build integration && !windows
+
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing reproduces,
+// against a real shared dolt sql-server, the designated-migrator replay
+// scenario for migration 0067 (issue_versions, store_epoch,
+// issues.current_revision): the schema_migrations bookkeeping row for version
+// 67 is missing, but the physical tables and column already exist from the
+// original init — the same state stageBehindRemoteBackedDB
+// (cmd/bd/protocol/versioning_contract_test.go) forges before
+// TestProtocol_V2_DesignatedMigratorOverride runs `bd create` with
+// BD_ALLOW_REMOTE_MIGRATE=1.
+//
+// Before the fix, replaying migration 67's frozen CREATE TABLE issue_versions
+// dies with Error 1105 ("table with name issue_versions already exists");
+// once that's guarded, CREATE TABLE store_epoch would die the same way, and
+// once both are guarded, ALTER TABLE issues ADD COLUMN current_revision would
+// die on a duplicate-column error. Editing the shipped, content-hashed 0067
+// SQL bytes is constrained the same way 0040/0041 were (see
+// TestSchemaInitRecoversFromPartialNonlocalMigration above): CREATE TABLE IF
+// NOT EXISTS is safe, ordinary MySQL-flavored DDL, but MySQL (which Dolt
+// follows) has no ADD COLUMN IF NOT EXISTS — that is a MariaDB-only extension
+// — so the column guard must come from elsewhere in the runtime migration
+// path, not from the frozen file text itself.
+func TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing(t *testing.T) {
+	skipIfNoDolt(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	if testServerPort == 0 {
+		t.Skip("no Dolt test server available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	rootDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: testServerPort, User: "root"}.String()
+	rootDB, err := sql.Open("mysql", rootDSN)
+	if err != nil {
+		t.Fatalf("open root connection: %v", err)
+	}
+	defer rootDB.Close()
+
+	dbName := uniqueTestDBName(t)
+	if _, err := rootDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+dbName+"`"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	dbDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: testServerPort, User: "root", Database: dbName}.String()
+	db, err := sql.Open("mysql", dbDSN)
+	if err != nil {
+		t.Fatalf("open db connection: %v", err)
+	}
+	defer db.Close()
+
+	// 1. Fully initialize to the latest schema — issue_versions, store_epoch,
+	//    and issues.current_revision all physically exist afterward.
+	if _, err := initSchemaOnDB(ctx, db); err != nil {
+		t.Fatalf("initial initSchemaOnDB: %v", err)
+	}
+	latest := schema.LatestVersion()
+	assertSchemaVersionAtLeast(ctx, t, db, latest)
+
+	// 2. Forge the exact state stageBehindRemoteBackedDB puts a clone in: the
+	//    version-67 bookkeeping row is gone, but nothing about the physical
+	//    tables/column changed. Commit the delete so it is not left staged —
+	//    an uncommitted schema_migrations write would instead trip the
+	//    unrelated "pending migration alters a dirty table" guard
+	//    (gastownhall/beads#4566) before the replay is ever reached, same as
+	//    the 0040/0041 forges above.
+	if _, err := db.ExecContext(ctx, "DELETE FROM schema_migrations WHERE version = 67"); err != nil {
+		t.Fatalf("rewind schema_migrations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		"CALL DOLT_COMMIT('-Am', 'forge missing 0067 bookkeeping row, tables/column already applied')"); err != nil {
+		t.Fatalf("commit forged partial state: %v", err)
+	}
+
+	// 3. Re-init replays migration 67 against a database that already has its
+	//    tables and column. RED (pre-fix): dies on Error 1105, "table with
+	//    name issue_versions already exists" — the same failure
+	//    TestProtocol_V2_DesignatedMigratorOverride hits at the full
+	//    bd-binary integration level. GREEN (post-fix): CREATE TABLE IF NOT
+	//    EXISTS plus the ADD COLUMN idempotency guard make the replay a clean
+	//    no-op, and the chain reaches latest again.
+	if _, err := initSchemaOnDB(ctx, db); err != nil {
+		if !strings.Contains(err.Error(), "already exists") {
+			t.Fatalf("re-init after forged missing 0067 bookkeeping row failed, but not with the expected Error 1105 \"already exists\" shape — want the same failure TestProtocol_V2_DesignatedMigratorOverride hits: %v", err)
+		}
+		t.Fatalf("re-init after forged missing 0067 bookkeeping row (this is the designated-migrator replay bug, be-xrl84): %v", err)
+	}
+	assertSchemaVersionAtLeast(ctx, t, db, latest)
+}

--- a/internal/storage/dolt/initschema_0067_versioned_beads_replay_test.go
+++ b/internal/storage/dolt/initschema_0067_versioned_beads_replay_test.go
@@ -28,13 +28,14 @@ import (
 // dies with Error 1105 ("table with name issue_versions already exists");
 // once that's guarded, CREATE TABLE store_epoch would die the same way, and
 // once both are guarded, ALTER TABLE issues ADD COLUMN current_revision would
-// die on a duplicate-column error. Editing the shipped, content-hashed 0067
-// SQL bytes is constrained the same way 0040/0041 were (see
-// TestSchemaInitRecoversFromPartialNonlocalMigration above): CREATE TABLE IF
-// NOT EXISTS is safe, ordinary MySQL-flavored DDL, but MySQL (which Dolt
-// follows) has no ADD COLUMN IF NOT EXISTS — that is a MariaDB-only extension
-// — so the column guard must come from elsewhere in the runtime migration
-// path, not from the frozen file text itself.
+// die on a duplicate-column error. All four guards now live in the frozen
+// file itself: CREATE TABLE IF NOT EXISTS for the tables, and an
+// INFORMATION_SCHEMA-probed PREPARE for each plane's ADD COLUMN (MySQL, which
+// Dolt follows, has no ADD COLUMN IF NOT EXISTS — that is a MariaDB-only
+// extension). Keeping the guard in the SQL rather than in the Go runtime path
+// is what makes the file idempotent for callers that execute its bytes
+// directly, which is the shape
+// TestPR4107Migration0067ReplaysIdempotentlyAsRawSQL exercises.
 func TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing(t *testing.T) {
 	skipIfNoDolt(t)
 	acquireTestSlot()
@@ -90,11 +91,11 @@ func TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing(t *testing.T) {
 	}
 
 	// 3. Re-init replays migration 67 against a database that already has its
-	//    tables and column. RED (pre-fix): dies on Error 1105, "table with
+	//    tables and columns. RED (pre-fix): dies on Error 1105, "table with
 	//    name issue_versions already exists" — the same failure
 	//    TestProtocol_V2_DesignatedMigratorOverride hits at the full
 	//    bd-binary integration level. GREEN (post-fix): CREATE TABLE IF NOT
-	//    EXISTS plus the ADD COLUMN idempotency guard make the replay a clean
+	//    EXISTS plus the two guarded ADD COLUMNs make the replay a clean
 	//    no-op, and the chain reaches latest again.
 	if _, err := initSchemaOnDB(ctx, db); err != nil {
 		if !strings.Contains(err.Error(), "already exists") {
@@ -103,4 +104,90 @@ func TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing(t *testing.T) {
 		t.Fatalf("re-init after forged missing 0067 bookkeeping row (this is the designated-migrator replay bug, be-xrl84): %v", err)
 	}
 	assertSchemaVersionAtLeast(ctx, t, db, latest)
+}
+
+// TestMigration0067ReplaysIdempotentlyAsRawSQLThroughPR4107Harness is the
+// raw-SQL half of the same guarantee, and the half no Go-side guard can
+// provide.
+//
+// pr4107_corruption_test.go's runMigrationSQLFilesFrom re-executes the frozen
+// .up.sql bytes from 0046 onward straight through the driver, against a store
+// setupTestStore has already migrated to latest. Nothing in
+// internal/storage/schema is in that path — not execMigrationBody, not any
+// filename-keyed override — so every migration >= 0046 has to be idempotent
+// as raw SQL on its own. 0067's two ADD COLUMNs are guarded on
+// INFORMATION_SCHEMA for exactly this, and this test is the proof, run
+// through that harness rather than a hand-written double-apply: the same call
+// TestPR4107IssueIsBlockedMigrationMatchesRuntimeMixedGraphSemantics makes,
+// made twice.
+//
+// It also pins that the guard NO-OPS rather than re-applies: a column whose
+// replay silently dropped and re-added it would pass a mere "the column
+// exists" check while resetting every row to the DEFAULT. Phase 1 writes no
+// revisions, so the seeded value below is the only way to see that
+// difference from here.
+func TestMigration0067ReplaysIdempotentlyAsRawSQLThroughPR4107Harness(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mig0067-replay-subject")
+	if _, err := store.db.ExecContext(ctx,
+		"UPDATE issues SET current_revision = 42 WHERE id = 'mig0067-replay-subject'"); err != nil {
+		t.Fatalf("seed current_revision: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO issue_versions (issue_id, revision, epoch, change_at)
+		VALUES ('mig0067-replay-subject', 42, 1, '2026-09-05 00:00:00')`); err != nil {
+		t.Fatalf("seed issue_versions row: %v", err)
+	}
+
+	for pass := 1; pass <= 2; pass++ {
+		runMigrationSQLFilesFrom(t, ctx, store, "../schema/migrations", 46)
+
+		for _, table := range []string{"issues", "wisps"} {
+			if got := countColumn(t, ctx, store, table, "current_revision"); got != 1 {
+				t.Fatalf("pass %d: %s.current_revision column count = %d, want exactly 1", pass, table, got)
+			}
+		}
+
+		var revision int64
+		if err := store.db.QueryRowContext(ctx,
+			"SELECT current_revision FROM issues WHERE id = 'mig0067-replay-subject'").Scan(&revision); err != nil {
+			t.Fatalf("pass %d: read back current_revision: %v", pass, err)
+		}
+		if revision != 42 {
+			t.Fatalf("pass %d: issues.current_revision = %d, want the seeded 42 — the replay re-applied the ADD COLUMN instead of no-opping", pass, revision)
+		}
+
+		var versionRows int
+		if err := store.db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM issue_versions WHERE issue_id = 'mig0067-replay-subject'").Scan(&versionRows); err != nil {
+			t.Fatalf("pass %d: count issue_versions: %v", pass, err)
+		}
+		if versionRows != 1 {
+			t.Fatalf("pass %d: issue_versions row count = %d, want 1 — CREATE TABLE IF NOT EXISTS must not recreate the table", pass, versionRows)
+		}
+
+		if got := countColumn(t, ctx, store, "store_epoch", "epoch"); got != 1 {
+			t.Fatalf("pass %d: store_epoch.epoch column count = %d, want 1", pass, got)
+		}
+	}
+}
+
+// countColumn returns how many INFORMATION_SCHEMA.COLUMNS rows table.column
+// has in the current database — 0 or 1 in practice, and the assertion that
+// distinguishes "the guard held" from "the replay added a second one".
+func countColumn(t *testing.T, ctx context.Context, store *DoltStore, table, column string) int {
+	t.Helper()
+	var n int
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+		table, column).Scan(&n); err != nil {
+		t.Fatalf("count %s.%s: %v", table, column, err)
+	}
+	return n
 }

--- a/internal/storage/dolt/initschema_0067_versioned_beads_replay_test.go
+++ b/internal/storage/dolt/initschema_0067_versioned_beads_replay_test.go
@@ -35,7 +35,8 @@ import (
 // extension). Keeping the guard in the SQL rather than in the Go runtime path
 // is what makes the file idempotent for callers that execute its bytes
 // directly, which is the shape
-// TestPR4107Migration0067ReplaysIdempotentlyAsRawSQL exercises.
+// TestMigration0067ReplaysIdempotentlyAsRawSQLThroughPR4107Harness
+// exercises.
 func TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing(t *testing.T) {
 	skipIfNoDolt(t)
 	acquireTestSlot()

--- a/internal/storage/schema/cli_migrations.go
+++ b/internal/storage/schema/cli_migrations.go
@@ -126,6 +126,18 @@ func cliCompatibleMigrationSQL(name, sqlText string) string {
 		// itself is always present here: 0064's prepared RENAME executes on
 		// 2.2.0 (same measurement), so a fresh bundle always needs the column.
 		return cliMigration0066AddEventsJournalActor
+	case "0067_add_versioned_beads_schema.up.sql":
+		// Direct DDL for the same reason as 0060: the source migration's
+		// PREPARE guards (INFORMATION_SCHEMA probes) are what make the raw
+		// .up.sql idempotent when replayed onto an already-migrated store,
+		// and the 2.2.x CLI no-ops a prepared ADD COLUMN. Both planes always
+		// need the column here -- a fresh bundle runs the whole main series
+		// in order, so `issues` and `wisps` both exist and neither carries
+		// current_revision yet. The CREATE TABLEs are carried over verbatim:
+		// IF NOT EXISTS is ordinary unwrapped DDL that the CLI executes.
+		// Replays over a database that never synced the wisp tables must use
+		// the frozen source text instead -- see cliSubstituteAssumesWispTables.
+		return cliMigration0067AddVersionedBeadsSchema
 	default:
 		return sqlText
 	}
@@ -157,6 +169,10 @@ func cliSubstituteAssumesWispTables(name string) bool {
 	case "0065_widen_wisp_comments_text.up.sql":
 		// cliMigration0065WidenWispCommentsText is a bare MODIFY on
 		// wisp_comments.
+		return true
+	case "0067_add_versioned_beads_schema.up.sql":
+		// cliMigration0067AddVersionedBeadsSchema drops the source's
+		// @wisps_cr_needs_add table-exists guard and ALTERs wisps directly.
 		return true
 	default:
 		return false
@@ -204,6 +220,34 @@ ALTER TABLE wisps ADD COLUMN storage_class VARCHAR(16);`
 
 const cliMigration0065WidenWispCommentsText = `ALTER TABLE wisp_comments MODIFY COLUMN text LONGTEXT NOT NULL;`
 const cliMigration0066AddEventsJournalActor = `ALTER TABLE bd_events_journal ADD COLUMN actor VARCHAR(255) NOT NULL DEFAULT '';`
+
+// cliMigration0067AddVersionedBeadsSchema is 0067 with its two guarded
+// PREPARE blocks replaced by the direct ALTERs they would run on a fresh
+// database. The CREATE TABLEs are the source file's own text: CREATE TABLE
+// IF NOT EXISTS executes on the CLI batch path unchanged.
+const cliMigration0067AddVersionedBeadsSchema = `CREATE TABLE IF NOT EXISTS issue_versions (
+    issue_id VARCHAR(255) NOT NULL,
+    revision BIGINT NOT NULL,
+    epoch INT NOT NULL,
+    durable_state JSON,
+    change_actor VARCHAR(255),
+    change_agent VARCHAR(255),
+    change_message TEXT,
+    change_at DATETIME NOT NULL,
+    removed_at DATETIME,
+    removed_reason VARCHAR(255),
+    PRIMARY KEY (issue_id, revision)
+);
+CREATE TABLE IF NOT EXISTS store_epoch (
+    id TINYINT(1) NOT NULL DEFAULT 1,
+    epoch INT NOT NULL DEFAULT 1,
+    bumped_at DATETIME,
+    bumped_reason VARCHAR(255),
+    PRIMARY KEY (id),
+    CONSTRAINT ck_store_epoch_singleton CHECK (id = 1)
+);
+ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;
+ALTER TABLE wisps ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;`
 
 const cliMigration0041SplitDependenciesTarget = `DELETE FROM dolt_nonlocal_tables;
 CALL DOLT_COMMIT('-Am', 'disable nonlocal tables for fk migrations');

--- a/internal/storage/schema/migration_0067_versioned_beads_test.go
+++ b/internal/storage/schema/migration_0067_versioned_beads_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -63,10 +64,15 @@ func TestMigration0067AddsVersionedBeadsSchema(t *testing.T) {
 		t.Error("0067 up migration must not seed store_epoch — every new table starts empty in Phase 1 (no reads/writes of the new surfaces until Phase 2)")
 	}
 
-	downSQL, err := MigrationSQL(migration0067Down)
+	// down.sql files are not part of the embedded FS (only migrations/*.up.sql
+	// is //go:embed'd — see mainSource.files), so unlike the up side above,
+	// this reads straight from disk by package-relative path, matching
+	// TestMigration0035HandlesLegacyWispDependenciesShape's precedent.
+	downBytes, err := os.ReadFile("migrations/" + migration0067Down)
 	if err != nil {
-		t.Fatalf("MigrationSQL(%s) error = %v, want the migration file to exist", migration0067Down, err)
+		t.Fatalf("read %s: %v, want the migration file to exist", migration0067Down, err)
 	}
+	downSQL := string(downBytes)
 	for _, want := range []string{
 		"DROP TABLE",
 		"issue_versions",
@@ -105,7 +111,7 @@ func TestMigration0067AddsVersionedBeadsSchemaThroughDoltCLI(t *testing.T) {
 	requireDoltDataType(t, dir, "issue_versions", "durable_state", "json", "YES")
 	requireDoltColumnShape(t, dir, "issue_versions", "change_actor", "varchar(255)", "YES")
 	requireDoltColumnShape(t, dir, "issue_versions", "change_agent", "varchar(255)", "YES")
-	requireDoltColumnShape(t, dir, "issue_versions", "change_message", "longtext", "YES")
+	requireDoltColumnShape(t, dir, "issue_versions", "change_message", "text", "YES")
 	requireDoltColumnShape(t, dir, "issue_versions", "change_at", "datetime", "NO")
 	requireDoltColumnShape(t, dir, "issue_versions", "removed_at", "datetime", "YES")
 	requireDoltColumnShape(t, dir, "issue_versions", "removed_reason", "varchar(255)", "YES")

--- a/internal/storage/schema/migration_0067_versioned_beads_test.go
+++ b/internal/storage/schema/migration_0067_versioned_beads_test.go
@@ -48,8 +48,8 @@ func TestMigration0067AddsVersionedBeadsSchema(t *testing.T) {
 		t.Fatalf("MigrationSQL(%s) error = %v, want the migration file to exist", migration0067Up, err)
 	}
 	for _, want := range []string{
-		"CREATE TABLE issue_versions",
-		"CREATE TABLE store_epoch",
+		"CREATE TABLE IF NOT EXISTS issue_versions",
+		"CREATE TABLE IF NOT EXISTS store_epoch",
 		"PRIMARY KEY (issue_id, revision)",
 		"ALTER TABLE issues ADD COLUMN current_revision",
 	} {

--- a/internal/storage/schema/migration_0067_versioned_beads_test.go
+++ b/internal/storage/schema/migration_0067_versioned_beads_test.go
@@ -35,13 +35,26 @@ func TestLatestVersionIncludesMigration0067(t *testing.T) {
 
 // TestMigration0067AddsVersionedBeadsSchema is a pure-Go, DB-independent
 // check of the frozen migration bytes themselves — it runs even where no
-// `dolt` binary is available. It also freezes the one hazard this phase's
-// research surfaced: a PREPARE'd ADD COLUMN/DROP COLUMN silently vanishes
-// under the CLI-bundle path on a pre-2.3 Dolt CLI (see cli_prepared_ddl.go),
-// and unlike migration 0066's guarded actor-column PREPARE, an analogous
-// guard here would still fire on a fresh bundle (issues always exists),
-// so no preparedALTERSafeOnFreshBundle justification would be honest. The
-// column/table churn this phase adds must stay plain, unwrapped DDL.
+// `dolt` binary is available.
+//
+// It pins the shape both ADD COLUMNs must keep: an INFORMATION_SCHEMA-guarded
+// PREPARE, on both planes. That guard is not decoration — it is what makes a
+// raw replay of this file onto an already-migrated store a no-op, which
+// internal/storage/dolt's pr4107 replay harness requires of every migration
+// >= 0046 (it re-executes the .up.sql bytes directly, so no Go-side guard is
+// in the path). Dolt accepts no unprepared conditional DDL that would do the
+// same job: ADD COLUMN IF NOT EXISTS, DROP COLUMN IF EXISTS and a top-level
+// IF are all parse errors, and a stored procedure's body needs a client-side
+// DELIMITER the CLI batch path requires and the Go driver rejects.
+//
+// The cost is the pre-2.3 CLI hazard a PREPARE'd ADD COLUMN carries (it
+// silently vanishes on the CLI-bundle path — see cli_prepared_ddl.go), and
+// the fix for that is the same one 0060/0065/0066 use: a direct-DDL override
+// in cliCompatibleMigrationSQL, which
+// TestBundleMigrationsWithPreparedALTERAreOverriddenOrJustified and
+// TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities both police.
+// The assertion below is the local anchor for that pairing: if someone ever
+// unwraps these PREPAREs, the override silently becomes a lie.
 func TestMigration0067AddsVersionedBeadsSchema(t *testing.T) {
 	upSQL, err := MigrationSQL(migration0067Up)
 	if err != nil {
@@ -51,14 +64,36 @@ func TestMigration0067AddsVersionedBeadsSchema(t *testing.T) {
 		"CREATE TABLE IF NOT EXISTS issue_versions",
 		"CREATE TABLE IF NOT EXISTS store_epoch",
 		"PRIMARY KEY (issue_id, revision)",
-		"ALTER TABLE issues ADD COLUMN current_revision",
+		"ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1",
+		// Shape parity with issues, identical type. Nothing reads or writes
+		// this column in any phase — see the migration header's asymmetry
+		// note and ignored/0026.
+		"ALTER TABLE wisps ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1",
+		// Both ALTERs are INFORMATION_SCHEMA-guarded so a raw replay no-ops.
+		"COLUMN_NAME = 'current_revision'",
+		"@issues_cr_needs_add",
+		"@wisps_cr_needs_add",
 	} {
 		if !strings.Contains(upSQL, want) {
 			t.Errorf("0067 up migration missing %q\nfull SQL:\n%s", want, upSQL)
 		}
 	}
-	if strings.Contains(strings.ToUpper(upSQL), "PREPARE ") {
-		t.Error("0067 up migration must not PREPARE/EXECUTE its ALTER TABLE ADD COLUMN — ADD COLUMN vanishes under the CLI-bundle PREPARE path on a fresh database (cli_prepared_ddl.go); use plain unwrapped DDL")
+	if !strings.Contains(strings.ToUpper(upSQL), "PREPARE STMT FROM @SQL") {
+		t.Error("0067 up migration must keep its guarded PREPARE blocks — they are what make a raw .up.sql replay onto an already-migrated store a no-op (pr4107_corruption_test.go's harness bypasses every Go-side guard), and Dolt accepts no unprepared conditional ADD COLUMN. Unwrapping them also invalidates cliMigration0067AddVersionedBeadsSchema.")
+	}
+	// The bundle override is what keeps the PREPARE above off the pre-2.3
+	// CLI path. Assert it directly rather than trusting the two schema_test
+	// assertions to stay pointed at this migration.
+	for _, want := range []string{
+		"ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;",
+		"ALTER TABLE wisps ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;",
+	} {
+		if !strings.Contains(cliCompatibleMigrationSQL(migration0067Up, upSQL), want) {
+			t.Errorf("0067's CLI bundle substitute missing direct DDL %q", want)
+		}
+	}
+	if !cliSubstituteAssumesWispTables(migration0067Up) {
+		t.Error("0067's CLI substitute ALTERs wisps unguarded, so it must be listed in cliSubstituteAssumesWispTables — a replay over a clone that never synced the wisp tables has to fall back to the frozen source text")
 	}
 	if strings.Contains(upSQL, "INSERT INTO store_epoch") || strings.Contains(upSQL, "INSERT IGNORE INTO store_epoch") {
 		t.Error("0067 up migration must not seed store_epoch — every new table starts empty in Phase 1 (no reads/writes of the new surfaces until Phase 2)")
@@ -78,13 +113,19 @@ func TestMigration0067AddsVersionedBeadsSchema(t *testing.T) {
 		"issue_versions",
 		"store_epoch",
 		"ALTER TABLE issues DROP COLUMN current_revision",
+		// The down side reverses both planes, or a rolled-back workspace
+		// keeps a wisps column its binary no longer knows about.
+		"ALTER TABLE wisps DROP COLUMN current_revision",
 	} {
 		if !strings.Contains(downSQL, want) {
 			t.Errorf("0067 down migration missing %q\nfull SQL:\n%s", want, downSQL)
 		}
 	}
-	if strings.Contains(strings.ToUpper(downSQL), "PREPARE ") {
-		t.Error("0067 down migration must not PREPARE/EXECUTE its ALTER TABLE DROP COLUMN — DROP COLUMN is in the same CLI-bundle vanishing bucket as ADD COLUMN (cli_prepared_ddl.go)")
+	// Only migrations/*.up.sql is embedded into the CLI fresh bundle
+	// (mainSource.files), so the pre-2.3 prepared-DDL hazard never reaches a
+	// down migration and the guard is free — 0060's down is the precedent.
+	if !strings.Contains(strings.ToUpper(downSQL), "PREPARE STMT FROM @SQL") {
+		t.Error("0067 down migration must guard its DROP COLUMNs the way the up migration guards its ADD COLUMNs, so an issues-only or partially-applied workspace rolls back as safely as it migrated up")
 	}
 }
 
@@ -125,8 +166,17 @@ func TestMigration0067AddsVersionedBeadsSchemaThroughDoltCLI(t *testing.T) {
 	requireDoltColumnShape(t, dir, "store_epoch", "bumped_reason", "varchar(255)", "YES")
 	requireDoltNoRows(t, dir, "SELECT id FROM store_epoch", "store_epoch")
 
-	// issues.current_revision — the fast-path CAS column.
+	// current_revision on BOTH planes. issues.current_revision is the
+	// fast-path CAS column later phases read and write; wisps.current_revision
+	// is shape parity only (nothing ever reads or writes it — see the
+	// migration header and ignored/0026), and it is asserted here for exactly
+	// the reason the parity oracle exists: the two planes share
+	// column-list-shaped code paths, so the shape obligation is real even
+	// where the semantics are not. Same type on both, or
+	// TestSchemaParityIssuesVsWisps' type check fails instead of its
+	// name check.
 	requireDoltDataType(t, dir, "issues", "current_revision", "bigint", "NO")
+	requireDoltDataType(t, dir, "wisps", "current_revision", "bigint", "NO")
 
 	// Composite PK (issue_id, revision) is enforced: same pair twice fails.
 	runDoltSQL(t, dir, `INSERT INTO issue_versions (issue_id, revision, epoch, change_at) VALUES ('iv-1', 1, 1, '2026-09-01 00:00:00')`)

--- a/internal/storage/schema/migration_0067_versioned_beads_test.go
+++ b/internal/storage/schema/migration_0067_versioned_beads_test.go
@@ -1,0 +1,172 @@
+package schema
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/testutil"
+)
+
+// Phase 1 of the versioned-beads epic (be-hs42e / gastownhall/beads#6132,
+// this slice: be-hs42e.2 / #6134) adds purely additive schema: a per-issue
+// version log, a store-global epoch singleton, and a fast-path revision
+// column on issues. Nothing reads or writes these surfaces yet — that is
+// Phase 2 (#6135) and Phase 3 (#6136). These tests only assert the DDL
+// itself: shape, emptiness, and that old, unmodified callers of `issues`
+// are unaffected.
+
+const migration0067Up = "0067_add_versioned_beads_schema.up.sql"
+const migration0067Down = "0067_add_versioned_beads_schema.down.sql"
+
+// TestLatestVersionIncludesMigration0067 pins the real next free slot this
+// phase claims. It is deliberately a hardcoded literal, not a comparison
+// against another derived value: schema.LatestVersion() drifting to 67 for
+// the wrong reason (an unrelated migration landing first) should still be
+// caught by this test failing to explain why 67 is versioned-beads-shaped,
+// which the CLI test below checks.
+func TestLatestVersionIncludesMigration0067(t *testing.T) {
+	const want = 67
+	if got := LatestVersion(); got != want {
+		t.Fatalf("LatestVersion() = %d, want %d (issue_versions/store_epoch/issues.current_revision migration slot claimed by be-hs42e.2)", got, want)
+	}
+}
+
+// TestMigration0067AddsVersionedBeadsSchema is a pure-Go, DB-independent
+// check of the frozen migration bytes themselves — it runs even where no
+// `dolt` binary is available. It also freezes the one hazard this phase's
+// research surfaced: a PREPARE'd ADD COLUMN/DROP COLUMN silently vanishes
+// under the CLI-bundle path on a pre-2.3 Dolt CLI (see cli_prepared_ddl.go),
+// and unlike migration 0066's guarded actor-column PREPARE, an analogous
+// guard here would still fire on a fresh bundle (issues always exists),
+// so no preparedALTERSafeOnFreshBundle justification would be honest. The
+// column/table churn this phase adds must stay plain, unwrapped DDL.
+func TestMigration0067AddsVersionedBeadsSchema(t *testing.T) {
+	upSQL, err := MigrationSQL(migration0067Up)
+	if err != nil {
+		t.Fatalf("MigrationSQL(%s) error = %v, want the migration file to exist", migration0067Up, err)
+	}
+	for _, want := range []string{
+		"CREATE TABLE issue_versions",
+		"CREATE TABLE store_epoch",
+		"PRIMARY KEY (issue_id, revision)",
+		"ALTER TABLE issues ADD COLUMN current_revision",
+	} {
+		if !strings.Contains(upSQL, want) {
+			t.Errorf("0067 up migration missing %q\nfull SQL:\n%s", want, upSQL)
+		}
+	}
+	if strings.Contains(strings.ToUpper(upSQL), "PREPARE ") {
+		t.Error("0067 up migration must not PREPARE/EXECUTE its ALTER TABLE ADD COLUMN — ADD COLUMN vanishes under the CLI-bundle PREPARE path on a fresh database (cli_prepared_ddl.go); use plain unwrapped DDL")
+	}
+	if strings.Contains(upSQL, "INSERT INTO store_epoch") || strings.Contains(upSQL, "INSERT IGNORE INTO store_epoch") {
+		t.Error("0067 up migration must not seed store_epoch — every new table starts empty in Phase 1 (no reads/writes of the new surfaces until Phase 2)")
+	}
+
+	downSQL, err := MigrationSQL(migration0067Down)
+	if err != nil {
+		t.Fatalf("MigrationSQL(%s) error = %v, want the migration file to exist", migration0067Down, err)
+	}
+	for _, want := range []string{
+		"DROP TABLE",
+		"issue_versions",
+		"store_epoch",
+		"ALTER TABLE issues DROP COLUMN current_revision",
+	} {
+		if !strings.Contains(downSQL, want) {
+			t.Errorf("0067 down migration missing %q\nfull SQL:\n%s", want, downSQL)
+		}
+	}
+	if strings.Contains(strings.ToUpper(downSQL), "PREPARE ") {
+		t.Error("0067 down migration must not PREPARE/EXECUTE its ALTER TABLE DROP COLUMN — DROP COLUMN is in the same CLI-bundle vanishing bucket as ADD COLUMN (cli_prepared_ddl.go)")
+	}
+}
+
+// TestMigration0067AddsVersionedBeadsSchemaThroughDoltCLI applies the full
+// migration bundle through a real `dolt` binary (skipped without one — see
+// testutil.RequireDoltBinary) and checks the shape acceptance criteria a
+// pure-Go SQL-text check cannot: actual column types/nullability as Dolt
+// reports them, that both new tables start empty, that the composite and
+// singleton primary keys are enforced, and compat direction 1 — an
+// old-shaped INSERT/SELECT against `issues` that has never heard of
+// current_revision still behaves unchanged, because the column is
+// NOT NULL DEFAULT 1 rather than a value old callers must supply.
+func TestMigration0067AddsVersionedBeadsSchemaThroughDoltCLI(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+
+	dir := t.TempDir()
+	runDoltCommand(t, dir, "init", "--name", "test", "--email", "test@example.com")
+	runDoltSQL(t, dir, AllMigrationsSQL())
+
+	// issue_versions shape.
+	requireDoltColumnShape(t, dir, "issue_versions", "issue_id", "varchar(255)", "NO")
+	requireDoltDataType(t, dir, "issue_versions", "revision", "bigint", "NO")
+	requireDoltDataType(t, dir, "issue_versions", "epoch", "int", "NO")
+	requireDoltDataType(t, dir, "issue_versions", "durable_state", "json", "YES")
+	requireDoltColumnShape(t, dir, "issue_versions", "change_actor", "varchar(255)", "YES")
+	requireDoltColumnShape(t, dir, "issue_versions", "change_agent", "varchar(255)", "YES")
+	requireDoltColumnShape(t, dir, "issue_versions", "change_message", "longtext", "YES")
+	requireDoltColumnShape(t, dir, "issue_versions", "change_at", "datetime", "NO")
+	requireDoltColumnShape(t, dir, "issue_versions", "removed_at", "datetime", "YES")
+	requireDoltColumnShape(t, dir, "issue_versions", "removed_reason", "varchar(255)", "YES")
+	requireDoltNoRows(t, dir, "SELECT issue_id FROM issue_versions", "issue_versions")
+
+	// store_epoch shape — singleton table, starts empty (Phase 1 does not
+	// seed it; a later phase's lazy-init owns creating the id=1 row).
+	requireDoltColumnShape(t, dir, "store_epoch", "id", "tinyint(1)", "NO")
+	requireDoltDataType(t, dir, "store_epoch", "epoch", "int", "NO")
+	requireDoltColumnShape(t, dir, "store_epoch", "bumped_at", "datetime", "YES")
+	requireDoltColumnShape(t, dir, "store_epoch", "bumped_reason", "varchar(255)", "YES")
+	requireDoltNoRows(t, dir, "SELECT id FROM store_epoch", "store_epoch")
+
+	// issues.current_revision — the fast-path CAS column.
+	requireDoltDataType(t, dir, "issues", "current_revision", "bigint", "NO")
+
+	// Composite PK (issue_id, revision) is enforced: same pair twice fails.
+	runDoltSQL(t, dir, `INSERT INTO issue_versions (issue_id, revision, epoch, change_at) VALUES ('iv-1', 1, 1, '2026-09-01 00:00:00')`)
+	if err := runDoltSQLExpectingError(t, dir, `INSERT INTO issue_versions (issue_id, revision, epoch, change_at) VALUES ('iv-1', 1, 1, '2026-09-01 00:00:01')`); err == nil {
+		t.Error("duplicate (issue_id, revision) insert into issue_versions succeeded, want primary key violation")
+	}
+
+	// Singleton PK (id) is enforced the same way.
+	runDoltSQL(t, dir, `INSERT INTO store_epoch (id) VALUES (1)`)
+	if err := runDoltSQLExpectingError(t, dir, `INSERT INTO store_epoch (id) VALUES (1)`); err == nil {
+		t.Error("duplicate id=1 insert into store_epoch succeeded, want primary key violation")
+	}
+	if err := runDoltSQLExpectingError(t, dir, `INSERT INTO store_epoch (id) VALUES (2)`); err == nil {
+		t.Error("id=2 insert into store_epoch succeeded, want the singleton CHECK constraint to reject any id other than 1")
+	}
+
+	// Compat direction 1: an old (pre-Phase-1) binary only ever issues
+	// explicit-column statements against `issues` that don't mention
+	// current_revision. Those must still work unchanged post-migration.
+	runDoltSQL(t, dir, `INSERT INTO issues (id, title, description, design, acceptance_criteria, notes) VALUES ('old-style-1', 'Old-style insert', 'd', 'des', 'ac', 'n')`)
+	rows := queryDoltCSV(t, dir, `SELECT title FROM issues WHERE id = 'old-style-1'`)
+	if len(rows) != 1 || rows[0]["title"] != "Old-style insert" {
+		t.Fatalf("old-shaped explicit-column insert/select round-trip failed post-migration: %v", rows)
+	}
+}
+
+// requireDoltDataType is requireDoltColumnShape's data_type-based sibling:
+// it asserts the coarse, display-width-independent information_schema
+// column (always "bigint"/"int"/"json", never e.g. "bigint(20)"), for
+// column types this package has no existing column_type-string precedent
+// to match against.
+func requireDoltDataType(t *testing.T, dir, tableName, columnName, wantDataType, wantNullable string) {
+	t.Helper()
+	rows := queryDoltCSV(t, dir, fmt.Sprintf(`
+SELECT data_type AS data_type, is_nullable AS is_nullable
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = %s
+  AND column_name = %s`, doltSQLString(tableName), doltSQLString(columnName)))
+	if len(rows) != 1 {
+		t.Fatalf("%s.%s column query returned %d rows, want 1: %v", tableName, columnName, len(rows), rows)
+	}
+	if got := rows[0]["data_type"]; got != wantDataType {
+		t.Fatalf("%s.%s DATA_TYPE = %s, want %s", tableName, columnName, got, wantDataType)
+	}
+	if got := rows[0]["is_nullable"]; got != wantNullable {
+		t.Fatalf("%s.%s IS_NULLABLE = %s, want %s", tableName, columnName, got, wantNullable)
+	}
+}

--- a/internal/storage/schema/migration_0067_versioned_beads_test.go
+++ b/internal/storage/schema/migration_0067_versioned_beads_test.go
@@ -73,6 +73,18 @@ func TestMigration0067AddsVersionedBeadsSchema(t *testing.T) {
 		"COLUMN_NAME = 'current_revision'",
 		"@issues_cr_needs_add",
 		"@wisps_cr_needs_add",
+		// The wisps arm carries a second sub-guard the issues arm does not:
+		// the table itself must exist, so a drifted store that never
+		// materialized the clone-local wisp tables no-ops instead of
+		// aborting the whole batch. No test executes that arm against an
+		// absent wisps table — the full-chain test seeds bounded at v46 and
+		// 0047's repair recreates wisps before 0067's frozen text runs — so
+		// this string pin is the only thing standing between dropping the
+		// sub-guard and a still-green suite. It has to be the TABLES probe:
+		// the file's other TABLE_NAME = 'wisps' occurrence is the COLUMNS
+		// probe below, which survives dropping the table-exists arm.
+		"FROM INFORMATION_SCHEMA.TABLES",
+		"WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps') > 0",
 	} {
 		if !strings.Contains(upSQL, want) {
 			t.Errorf("0067 up migration missing %q\nfull SQL:\n%s", want, upSQL)
@@ -123,7 +135,10 @@ func TestMigration0067AddsVersionedBeadsSchema(t *testing.T) {
 	}
 	// Only migrations/*.up.sql is embedded into the CLI fresh bundle
 	// (mainSource.files), so the pre-2.3 prepared-DDL hazard never reaches a
-	// down migration and the guard is free — 0060's down is the precedent.
+	// down migration through the bundle and the guard is free there — 0060's
+	// down is the precedent. A manual `dolt sql -f` rollback on a pre-2.3 CLI
+	// does hit it (the DROP COLUMNs silently no-op); the down file's own
+	// header steers operators to a server connection or dolt >= 2.3.
 	if !strings.Contains(strings.ToUpper(downSQL), "PREPARE STMT FROM @SQL") {
 		t.Error("0067 down migration must guard its DROP COLUMNs the way the up migration guards its ADD COLUMNs, so an issues-only or partially-applied workspace rolls back as safely as it migrated up")
 	}

--- a/internal/storage/schema/migrations/0067_add_versioned_beads_schema.down.sql
+++ b/internal/storage/schema/migrations/0067_add_versioned_beads_schema.down.sql
@@ -1,0 +1,10 @@
+-- Reverse of 0067. Plain, unwrapped DDL -- see the up migration for why no
+-- PREPARE/EXECUTE wrapper applies here (DROP COLUMN is in the same
+-- CLI-bundle vanishing bucket as ADD COLUMN; see cli_prepared_ddl.go).
+-- Every surface this reverses is still unread and unwritten in Phase 1, so
+-- this is a plain schema rollback, not a data-loss concern.
+ALTER TABLE issues DROP COLUMN current_revision;
+
+DROP TABLE IF EXISTS store_epoch;
+
+DROP TABLE IF EXISTS issue_versions;

--- a/internal/storage/schema/migrations/0067_add_versioned_beads_schema.down.sql
+++ b/internal/storage/schema/migrations/0067_add_versioned_beads_schema.down.sql
@@ -1,9 +1,32 @@
--- Reverse of 0067. Plain, unwrapped DDL -- see the up migration for why no
--- PREPARE/EXECUTE wrapper applies here (DROP COLUMN is in the same
--- CLI-bundle vanishing bucket as ADD COLUMN; see cli_prepared_ddl.go).
--- Every surface this reverses is still unread and unwritten in Phase 1, so
--- this is a plain schema rollback, not a data-loss concern.
-ALTER TABLE issues DROP COLUMN current_revision;
+-- Reverse of 0067. Every surface this reverses is still unread and unwritten
+-- in Phase 1, so this is a plain schema rollback, not a data-loss concern.
+--
+-- Guarded on INFORMATION_SCHEMA the same way the up migration is, so an
+-- issues-only or partially-applied workspace rolls back as safely as it
+-- migrated up (0060's down is the precedent). Only migrations/*.up.sql is
+-- embedded into the CLI fresh bundle, so the PREPARE hazard
+-- (cli_prepared_ddl.go) never reaches this file.
+SET @issues_cr_has = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'current_revision'
+);
+SET @sql = IF(@issues_cr_has > 0,
+    'ALTER TABLE issues DROP COLUMN current_revision',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @wisps_cr_has = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisps'
+      AND COLUMN_NAME = 'current_revision'
+);
+SET @sql = IF(@wisps_cr_has > 0,
+    'ALTER TABLE wisps DROP COLUMN current_revision',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 DROP TABLE IF EXISTS store_epoch;
 

--- a/internal/storage/schema/migrations/0067_add_versioned_beads_schema.down.sql
+++ b/internal/storage/schema/migrations/0067_add_versioned_beads_schema.down.sql
@@ -5,7 +5,14 @@
 -- issues-only or partially-applied workspace rolls back as safely as it
 -- migrated up (0060's down is the precedent). Only migrations/*.up.sql is
 -- embedded into the CLI fresh bundle, so the PREPARE hazard
--- (cli_prepared_ddl.go) never reaches this file.
+-- (cli_prepared_ddl.go) never reaches this file through the bundle. It does
+-- reach a manual rollback: run this through a server connection or dolt
+-- >= 2.3, because a pre-2.3 `dolt sql -f` silently no-ops the guarded DROP
+-- COLUMNs (dolthub/dolt#11345) while still dropping the tables, leaving both
+-- current_revision columns behind. The residue is inert in Phase 1 -- nothing
+-- reads the columns, both planes keep them so parity holds, and re-running
+-- the up migration no-ops -- but the rollback is partial while reporting
+-- success. 0060's down carries the same hazard.
 SET @issues_cr_has = (
     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
     WHERE TABLE_SCHEMA = DATABASE()

--- a/internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql
+++ b/internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql
@@ -2,31 +2,55 @@
 -- this slice: be-hs42e.2 / #6134).
 --
 -- Purely additive: a per-issue version log (issue_versions), a store-global
--- epoch singleton (store_epoch), and a fast-path revision column on issues
--- (current_revision). Nothing reads or writes these surfaces yet -- CAS
--- enforcement, dual-write and epoch-bump logic land in Phase 2 (#6135) and
--- Phase 3 (#6136). No DML/backfill here: current_revision has a safe default
--- for every existing row, and both new tables start completely empty.
+-- epoch singleton (store_epoch), and a fast-path revision column on BOTH
+-- record planes (issues.current_revision, wisps.current_revision). Nothing
+-- reads or writes these surfaces yet -- CAS enforcement, dual-write and
+-- epoch-bump logic land in Phase 2 (#6135) and Phase 3 (#6136). No
+-- DML/backfill here: current_revision has a safe default for every existing
+-- row, and both new tables start completely empty.
 --
--- Plain, unwrapped DDL throughout -- no PREPARE/EXECUTE. `issues` always
--- exists by the time any migration runs, so unlike 0066's guarded ADD COLUMN
--- (needed because bd_events_journal is a dolt-ignored table that a fresh
--- clone may materialize from the ignored series instead of via this file),
--- no PREPARE-based idempotent-replay justification applies here, and a
--- PREPARE'd ADD COLUMN/DROP COLUMN silently vanishes under the CLI-bundle
--- path on a pre-2.3 Dolt CLI (see cli_prepared_ddl.go).
+-- SEMANTIC ASYMMETRY, DELIBERATE: only the issues column is ever read or
+-- written. Versioning is an issues-plane contract -- wisps are the ephemeral
+-- plane and no phase of this epic (2 or 3) will CAS on, bump, or log a wisp
+-- revision. The wisps column is a SHAPE obligation, not a semantic one:
+-- issues and wisps share the row shape and the shared scans build one column
+-- list for both tables (TestSchemaParityIssuesVsWisps in
+-- internal/storage/dolt enforces strict column-name parity with no exemption
+-- list), so a column on one plane only is a live drift hazard for
+-- column-list-shaped code paths regardless of whether anything reads it.
+-- wisps.row_lock (0054 + ignored/0013) is the precedent: carried on both
+-- planes, meaningful on one.
 --
--- The CREATE TABLEs below are guarded with IF NOT EXISTS -- ordinary,
--- unwrapped MySQL-flavored DDL, so this doesn't reintroduce the PREPARE
--- hazard -- so a designated-migrator replay (schema_migrations bookkeeping
--- row missing, e.g. BD_ALLOW_REMOTE_MIGRATE=1 against a clone that already
--- has these tables) doesn't die on Error 1105. The ADD COLUMN below has no
--- equivalent IF NOT EXISTS: MySQL, which Dolt follows, has never had that
--- construct for ADD COLUMN (it's a MariaDB-only extension), and PREPARE-ing
--- it to fake one is exactly the vanishing hazard above. Its replay guard
--- instead lives in Go, keyed to this migration's filename, right where the
--- runtime executes migration bodies (see execMigration0067Body in
--- schema.go).
+-- The CREATE TABLEs are guarded with IF NOT EXISTS -- ordinary, unwrapped
+-- MySQL-flavored DDL -- so a designated-migrator replay (schema_migrations
+-- bookkeeping row missing, e.g. BD_ALLOW_REMOTE_MIGRATE=1 against a clone
+-- that already has these tables) doesn't die on Error 1105.
+--
+-- The ADD COLUMNs have no equivalent IF NOT EXISTS: MySQL, which Dolt
+-- follows, has never had that construct for ADD COLUMN (it's a MariaDB-only
+-- extension; measured on dolt 2.2.3 -- `syntax error at position 33 near
+-- 'IF'`). Neither does Dolt accept `DROP COLUMN IF EXISTS` or a top-level
+-- IF. The only conditional DDL forms Dolt does accept are the PREPARE guard
+-- below and a stored procedure, and a procedure body's inner semicolons
+-- need a client-side DELIMITER that the CLI batch path requires and the Go
+-- driver rejects -- the frozen file cannot satisfy both. So these are the
+-- guarded PREPARE shape 0060 and 0066 already use for exactly this: their
+-- INFORMATION_SCHEMA probe makes a raw-SQL replay of this whole file a clean
+-- no-op on an already-migrated store, which is what
+-- pr4107_corruption_test.go's replay harness (raw .up.sql from 0046 onward
+-- onto a live store) requires of every migration >= 0046.
+--
+-- A PREPARE'd ADD COLUMN silently vanishes under the CLI-bundle path on a
+-- pre-2.3 Dolt CLI (dolthub/dolt#11345; see cli_prepared_ddl.go), so the
+-- fresh bundle gets a direct-DDL override -- cliMigration0067AddVersionedBeadsSchema
+-- in cli_migrations.go, the same escape hatch 0060/0065/0066 use, guarded by
+-- TestBundleMigrationsWithPreparedALTERAreOverriddenOrJustified.
+--
+-- wisps is dolt-ignored (clone-local), so this file's wisps ALTER never runs
+-- on a fresh clone: it ships with the ignored-series twin ignored/0026, the
+-- mechanism check D of scripts/check-migration-hygiene.sh enforces and
+-- ignored/0013 (0054's row_lock) and ignored/0020 (0060's storage_class)
+-- record.
 CREATE TABLE IF NOT EXISTS issue_versions (
     issue_id VARCHAR(255) NOT NULL,
     revision BIGINT NOT NULL,
@@ -53,4 +77,36 @@ CREATE TABLE IF NOT EXISTS store_epoch (
     CONSTRAINT ck_store_epoch_singleton CHECK (id = 1)
 );
 
-ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;
+-- issues.current_revision -- the fast-path CAS column, the only one any
+-- later phase reads or writes.
+SET @issues_cr_needs_add = (
+    SELECT IF(COUNT(*) = 0, 1, 0)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'current_revision'
+);
+SET @sql = IF(@issues_cr_needs_add = 1,
+    'ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- wisps.current_revision -- shape parity only (see the asymmetry note above).
+-- Guarded on the wisps table existing as well as the column: older
+-- workspaces created issues-only, and a clone that never synced the
+-- clone-local wisp tables must no-op rather than abort the pass (0060
+-- precedent).
+SET @wisps_cr_needs_add = IF(
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps') > 0
+    AND
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisps'
+          AND COLUMN_NAME = 'current_revision') = 0,
+    1, 0
+);
+SET @sql = IF(@wisps_cr_needs_add = 1,
+    'ALTER TABLE wisps ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql
+++ b/internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql
@@ -1,0 +1,44 @@
+-- Migration 0067: Phase 1 schema for versioned beads (be-hs42e / gastownhall/beads#6132,
+-- this slice: be-hs42e.2 / #6134).
+--
+-- Purely additive: a per-issue version log (issue_versions), a store-global
+-- epoch singleton (store_epoch), and a fast-path revision column on issues
+-- (current_revision). Nothing reads or writes these surfaces yet -- CAS
+-- enforcement, dual-write and epoch-bump logic land in Phase 2 (#6135) and
+-- Phase 3 (#6136). No DML/backfill here: current_revision has a safe default
+-- for every existing row, and both new tables start completely empty.
+--
+-- Plain, unwrapped DDL throughout -- no PREPARE/EXECUTE. `issues` always
+-- exists by the time any migration runs, so unlike 0066's guarded ADD COLUMN
+-- (needed because bd_events_journal is a dolt-ignored table that a fresh
+-- clone may materialize from the ignored series instead of via this file),
+-- no idempotent-replay justification applies here, and a PREPARE'd ADD
+-- COLUMN/DROP COLUMN silently vanishes under the CLI-bundle path on a
+-- pre-2.3 Dolt CLI (see cli_prepared_ddl.go).
+CREATE TABLE issue_versions (
+    issue_id VARCHAR(255) NOT NULL,
+    revision BIGINT NOT NULL,
+    epoch INT NOT NULL,
+    durable_state JSON,
+    change_actor VARCHAR(255),
+    change_agent VARCHAR(255),
+    change_message TEXT,
+    change_at DATETIME NOT NULL,
+    removed_at DATETIME,
+    removed_reason VARCHAR(255),
+    PRIMARY KEY (issue_id, revision)
+);
+
+-- Singleton: exactly one row, id=1, once a later phase creates it. Phase 1
+-- leaves the table empty -- the CHECK just pins the shape the lazy-init that
+-- eventually seeds it (Phase 2/3) must follow.
+CREATE TABLE store_epoch (
+    id TINYINT(1) NOT NULL DEFAULT 1,
+    epoch INT NOT NULL DEFAULT 1,
+    bumped_at DATETIME,
+    bumped_reason VARCHAR(255),
+    PRIMARY KEY (id),
+    CONSTRAINT ck_store_epoch_singleton CHECK (id = 1)
+);
+
+ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;

--- a/internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql
+++ b/internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql
@@ -12,10 +12,22 @@
 -- exists by the time any migration runs, so unlike 0066's guarded ADD COLUMN
 -- (needed because bd_events_journal is a dolt-ignored table that a fresh
 -- clone may materialize from the ignored series instead of via this file),
--- no idempotent-replay justification applies here, and a PREPARE'd ADD
--- COLUMN/DROP COLUMN silently vanishes under the CLI-bundle path on a
--- pre-2.3 Dolt CLI (see cli_prepared_ddl.go).
-CREATE TABLE issue_versions (
+-- no PREPARE-based idempotent-replay justification applies here, and a
+-- PREPARE'd ADD COLUMN/DROP COLUMN silently vanishes under the CLI-bundle
+-- path on a pre-2.3 Dolt CLI (see cli_prepared_ddl.go).
+--
+-- The CREATE TABLEs below are guarded with IF NOT EXISTS -- ordinary,
+-- unwrapped MySQL-flavored DDL, so this doesn't reintroduce the PREPARE
+-- hazard -- so a designated-migrator replay (schema_migrations bookkeeping
+-- row missing, e.g. BD_ALLOW_REMOTE_MIGRATE=1 against a clone that already
+-- has these tables) doesn't die on Error 1105. The ADD COLUMN below has no
+-- equivalent IF NOT EXISTS: MySQL, which Dolt follows, has never had that
+-- construct for ADD COLUMN (it's a MariaDB-only extension), and PREPARE-ing
+-- it to fake one is exactly the vanishing hazard above. Its replay guard
+-- instead lives in Go, keyed to this migration's filename, right where the
+-- runtime executes migration bodies (see execMigration0067Body in
+-- schema.go).
+CREATE TABLE IF NOT EXISTS issue_versions (
     issue_id VARCHAR(255) NOT NULL,
     revision BIGINT NOT NULL,
     epoch INT NOT NULL,
@@ -32,7 +44,7 @@ CREATE TABLE issue_versions (
 -- Singleton: exactly one row, id=1, once a later phase creates it. Phase 1
 -- leaves the table empty -- the CHECK just pins the shape the lazy-init that
 -- eventually seeds it (Phase 2/3) must follow.
-CREATE TABLE store_epoch (
+CREATE TABLE IF NOT EXISTS store_epoch (
     id TINYINT(1) NOT NULL DEFAULT 1,
     epoch INT NOT NULL DEFAULT 1,
     bumped_at DATETIME,

--- a/internal/storage/schema/migrations/ignored/0026_add_wisps_current_revision.up.sql
+++ b/internal/storage/schema/migrations/ignored/0026_add_wisps_current_revision.up.sql
@@ -1,0 +1,38 @@
+-- Ignored migration 0026: ensure wisps.current_revision exists on every clone
+-- (be-hs42e.2 / gastownhall/beads#6134).
+--
+-- Synced migration 0067 adds current_revision to issues and wisps — but wisps
+-- is dolt-ignored (migration 0019), so its schema is clone-local, and a
+-- workspace that bootstraps or re-clones from a remote whose
+-- schema_migrations cursor is already >= 0067 adopts the cursor without ever
+-- executing 0067. Its wisps table (materialized by ignored/0001, which
+-- predates current_revision) would then permanently lack the column, and the
+-- shared issues/wisps column lists would drift by one column between the
+-- fresh-clone door and the fresh-init door. Same mechanism, same shape, same
+-- fix as ignored/0013 (wisps.row_lock, wy-pt82l) and ignored/0020
+-- (wisps.storage_class, bd-hs7fa).
+--
+-- Carried here for SHAPE only. Nothing in Phase 2 (#6135) or Phase 3 (#6136)
+-- reads or writes the wisps column: versioning is an issues-plane contract
+-- and wisps are the ephemeral plane. wisps.row_lock is the precedent for a
+-- column that exists on both planes and means something on one — see 0067's
+-- header for the full asymmetry note.
+--
+-- The guard makes this a no-op on in-place-upgraded workspaces where synced
+-- 0067 already added the column, and on workspaces with no local wisps table
+-- yet. Definition mirrors 0067 exactly: BIGINT NOT NULL DEFAULT 1, so every
+-- pre-existing row reads as revision 1 with no backfill.
+SET @needs_add = IF(
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps') > 0
+    AND
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisps'
+          AND COLUMN_NAME = 'current_revision') = 0,
+    1, 0
+);
+SET @sql = IF(@needs_add = 1,
+    'ALTER TABLE wisps ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -1551,6 +1551,79 @@ func execMigrationBody(ctx context.Context, db DBConn, sqlText string) error {
 	return DrainCall(ctx, db, sqlText)
 }
 
+// migration0067Filename keys the designated-migrator replay guard below to
+// exactly one frozen migration file — see execMigrationBodyForFile.
+const migration0067Filename = "0067_add_versioned_beads_schema.up.sql"
+
+// alterIssuesAddCurrentRevision is the exact leading text of migration 0067's
+// one ALTER TABLE statement, frozen alongside the migration file itself. Used
+// only to recognize that one statement out of the handful splitSQLStatements
+// hands back; not a general SQL parser.
+const alterIssuesAddCurrentRevision = "ALTER TABLE issues ADD COLUMN current_revision"
+
+// execMigrationBodyForFile is runMigrations' single dispatch point: most
+// migrations run through the shared execMigrationBody, but a migration whose
+// frozen SQL cannot fully guard its own idempotent replay gets a
+// filename-keyed override here instead.
+func execMigrationBodyForFile(ctx context.Context, db DBConn, name, sqlText string) error {
+	if name == migration0067Filename {
+		return execMigration0067Body(ctx, db, sqlText)
+	}
+	return execMigrationBody(ctx, db, sqlText)
+}
+
+// execMigration0067Body applies migration 0067's frozen SQL exactly like
+// execMigrationBody — one ExecContext call, the file's bytes unchanged — so
+// an ordinary forward migration (the only shape any pre-existing test in this
+// package simulates, e.g. lock_test.go's expectOnePendingMigration) is
+// byte-for-byte identical in call shape and behavior to before this guard
+// existed. It only does something different when that single call fails: a
+// designated-migrator replay (be-xrl84) hits this file again after
+// issue_versions, store_epoch and issues.current_revision all already exist.
+// The two CREATE TABLEs guard themselves (CREATE TABLE IF NOT EXISTS is
+// ordinary, unwrapped MySQL DDL), so on replay the batch fails on the ALTER's
+// duplicate-column condition specifically — MySQL, which Dolt follows, has
+// never had ADD COLUMN IF NOT EXISTS (it's a MariaDB-only extension), and
+// PREPARE-ing one to fake it silently vanishes under the CLI-bundle path on a
+// pre-2.3 Dolt CLI (see cli_prepared_ddl.go).
+//
+// Rather than pattern-match Dolt's DDL-conflict error text or number to
+// confirm that guess, failure is confirmed the same way success is: reread
+// INFORMATION_SCHEMA. CREATE TABLE's own conflict surfaces as a generic
+// Error 1105 ("table ... already exists") rather than MySQL's usual
+// table-exists code, so there is no reason to trust the ALTER's conflict is
+// any more standardized. If issues.current_revision exists after the
+// failure, that failure is this exact replay collision — retry once with the
+// ALTER statement stripped from the batch (statements re-derived from sqlText
+// itself via splitSQLStatements, not a hand-maintained copy, so the retry
+// cannot silently drift from the frozen file it is guarding). Any other
+// failure (column still absent) is a real error and is returned unchanged.
+func execMigration0067Body(ctx context.Context, db DBConn, sqlText string) error {
+	_, err := db.ExecContext(ctx, sqlText)
+	if err == nil {
+		return nil
+	}
+
+	exists, existsErr := schemaColumnExists(ctx, db, "issues", "current_revision")
+	if existsErr != nil || !exists {
+		return err
+	}
+
+	var kept []string
+	for _, stmt := range splitSQLStatements(sqlText) {
+		text := strings.TrimSpace(stmt.text)
+		if text == "" || strings.HasPrefix(text, alterIssuesAddCurrentRevision) {
+			continue
+		}
+		kept = append(kept, text)
+	}
+	if len(kept) == 0 {
+		return nil
+	}
+	_, err = db.ExecContext(ctx, strings.Join(kept, ";\n")+";")
+	return err
+}
+
 // migrate brings the source up to its latest version and returns the number of
 // numbered migrations applied plus whether it added the content_hash column to a
 // pre-existing cursor table. The column signal lets MigrateUp stage and commit
@@ -1668,7 +1741,7 @@ func runMigrations(ctx context.Context, db DBConn, src migrationSource, minVersi
 
 		fmt.Fprintf(stderr, "Applying migration %04d: %s…\n", mf.version, humanMigrationName(mf.name))
 		start := time.Now()
-		if err := execMigrationBody(ctx, db, string(data)); err != nil {
+		if err := execMigrationBodyForFile(ctx, db, mf.name, string(data)); err != nil {
 			return count, fmt.Errorf("migration %s: %w", mf.name, err)
 		}
 		sum := sha256.Sum256(data)

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -1551,79 +1551,6 @@ func execMigrationBody(ctx context.Context, db DBConn, sqlText string) error {
 	return DrainCall(ctx, db, sqlText)
 }
 
-// migration0067Filename keys the designated-migrator replay guard below to
-// exactly one frozen migration file — see execMigrationBodyForFile.
-const migration0067Filename = "0067_add_versioned_beads_schema.up.sql"
-
-// alterIssuesAddCurrentRevision is the exact leading text of migration 0067's
-// one ALTER TABLE statement, frozen alongside the migration file itself. Used
-// only to recognize that one statement out of the handful splitSQLStatements
-// hands back; not a general SQL parser.
-const alterIssuesAddCurrentRevision = "ALTER TABLE issues ADD COLUMN current_revision"
-
-// execMigrationBodyForFile is runMigrations' single dispatch point: most
-// migrations run through the shared execMigrationBody, but a migration whose
-// frozen SQL cannot fully guard its own idempotent replay gets a
-// filename-keyed override here instead.
-func execMigrationBodyForFile(ctx context.Context, db DBConn, name, sqlText string) error {
-	if name == migration0067Filename {
-		return execMigration0067Body(ctx, db, sqlText)
-	}
-	return execMigrationBody(ctx, db, sqlText)
-}
-
-// execMigration0067Body applies migration 0067's frozen SQL exactly like
-// execMigrationBody — one ExecContext call, the file's bytes unchanged — so
-// an ordinary forward migration (the only shape any pre-existing test in this
-// package simulates, e.g. lock_test.go's expectOnePendingMigration) is
-// byte-for-byte identical in call shape and behavior to before this guard
-// existed. It only does something different when that single call fails: a
-// designated-migrator replay (be-xrl84) hits this file again after
-// issue_versions, store_epoch and issues.current_revision all already exist.
-// The two CREATE TABLEs guard themselves (CREATE TABLE IF NOT EXISTS is
-// ordinary, unwrapped MySQL DDL), so on replay the batch fails on the ALTER's
-// duplicate-column condition specifically — MySQL, which Dolt follows, has
-// never had ADD COLUMN IF NOT EXISTS (it's a MariaDB-only extension), and
-// PREPARE-ing one to fake it silently vanishes under the CLI-bundle path on a
-// pre-2.3 Dolt CLI (see cli_prepared_ddl.go).
-//
-// Rather than pattern-match Dolt's DDL-conflict error text or number to
-// confirm that guess, failure is confirmed the same way success is: reread
-// INFORMATION_SCHEMA. CREATE TABLE's own conflict surfaces as a generic
-// Error 1105 ("table ... already exists") rather than MySQL's usual
-// table-exists code, so there is no reason to trust the ALTER's conflict is
-// any more standardized. If issues.current_revision exists after the
-// failure, that failure is this exact replay collision — retry once with the
-// ALTER statement stripped from the batch (statements re-derived from sqlText
-// itself via splitSQLStatements, not a hand-maintained copy, so the retry
-// cannot silently drift from the frozen file it is guarding). Any other
-// failure (column still absent) is a real error and is returned unchanged.
-func execMigration0067Body(ctx context.Context, db DBConn, sqlText string) error {
-	_, err := db.ExecContext(ctx, sqlText)
-	if err == nil {
-		return nil
-	}
-
-	exists, existsErr := schemaColumnExists(ctx, db, "issues", "current_revision")
-	if existsErr != nil || !exists {
-		return err
-	}
-
-	var kept []string
-	for _, stmt := range splitSQLStatements(sqlText) {
-		text := strings.TrimSpace(stmt.text)
-		if text == "" || strings.HasPrefix(text, alterIssuesAddCurrentRevision) {
-			continue
-		}
-		kept = append(kept, text)
-	}
-	if len(kept) == 0 {
-		return nil
-	}
-	_, err = db.ExecContext(ctx, strings.Join(kept, ";\n")+";")
-	return err
-}
-
 // migrate brings the source up to its latest version and returns the number of
 // numbered migrations applied plus whether it added the content_hash column to a
 // pre-existing cursor table. The column signal lets MigrateUp stage and commit
@@ -1741,7 +1668,7 @@ func runMigrations(ctx context.Context, db DBConn, src migrationSource, minVersi
 
 		fmt.Fprintf(stderr, "Applying migration %04d: %s…\n", mf.version, humanMigrationName(mf.name))
 		start := time.Now()
-		if err := execMigrationBodyForFile(ctx, db, mf.name, string(data)); err != nil {
+		if err := execMigrationBody(ctx, db, string(data)); err != nil {
 			return count, fmt.Errorf("migration %s: %w", mf.name, err)
 		}
 		sum := sha256.Sum256(data)

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -1927,6 +1927,9 @@ func TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities(t *testing.T)
 		"ALTER TABLE wisp_comments MODIFY COLUMN text LONGTEXT NOT NULL;",
 		// 0066: same prepared-ALTER shape as 0060, same CLI no-op on 2.2.x.
 		"ALTER TABLE bd_events_journal ADD COLUMN actor VARCHAR(255) NOT NULL DEFAULT '';",
+		// 0067: two-plane prepared ADD COLUMN, same shape as 0060.
+		"ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;",
+		"ALTER TABLE wisps ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("AllMigrationsSQL missing direct CLI DDL %q", want)
@@ -1948,6 +1951,11 @@ func TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities(t *testing.T)
 		// 0066 guards its ALTER the same way; only its source text carries
 		// this probe (the events table's actor column is a bare CREATE).
 		"COLUMN_NAME = 'actor'",
+		// 0067 guards both planes' ALTERs the same way. Its two guard
+		// variables are the per-migration anchors; the probe token would
+		// also appear in the ignored twin, which is not bundled.
+		"@issues_cr_needs_add",
+		"@wisps_cr_needs_add",
 	} {
 		if strings.Contains(got, forbidden) {
 			t.Fatalf("AllMigrationsSQL contains source prepared-DDL guard %q", forbidden)

--- a/release-gates/be-dy66n-gate.md
+++ b/release-gates/be-dy66n-gate.md
@@ -78,3 +78,15 @@ This follows established precedent: be-gd3v, be-79jh, be-39ss, be-pp7e, be-r3ysh
 ## Disposition
 
 **PASS, 7/7, no waivers.** PR [gastownhall/beads#6304](https://github.com/gastownhall/beads/pull/6304) opened, verified OPEN and MERGEABLE, authored by our own account (no external-contributor human-hold triggered). Four pre-existing, non-diff-owned failure/finding classes encountered during gate evaluation, all attributed to their exact pre-existing tracker beads (be-9ogs6, be-irise, be-w4qbu, be-a0dxu) with clause-3 proof and citation comments posted this round. Reporting to mayor for visibility only; no merge-request routed, per contributor-only merge-authority carve-out.
+
+## Fix-round amendment — 2026-09-05, maintainer review of PR #6304
+
+This gate's verdict stands as recorded for source commit `26033d8e4`. It is **not** re-run here; this section exists so the record does not read as current for a head it never evaluated.
+
+Maintainer review on PR #6304 returned two decisions that change facts asserted above:
+
+1. **`current_revision` is now on both planes.** `wisps.current_revision BIGINT NOT NULL DEFAULT 1` is carried for shape parity (nothing reads or writes it in any phase) — `TestSchemaParityIssuesVsWisps` enforces strict issues↔wisps column-name parity with no exemption list. This amends the section-8 issues-only decision the gated commit encoded. Because `wisps` is dolt-ignored, the change ships with an ignored-series twin, `migrations/ignored/0026_add_wisps_current_revision.up.sql` (check D of `scripts/check-migration-hygiene.sh`; precedent ignored/0013 for 0054, ignored/0020 for 0060).
+
+2. **The ADD COLUMN idempotency guard moved from Go into the SQL.** Criterion 1's evidence line above records a verified "non-PREPARE ADD COLUMN idempotency guard" (`execMigration0067Body` in `schema.go`). That guard is gone and `schema.go` is back at `origin/main`: `internal/storage/dolt/pr4107_corruption_test.go`'s replay harness re-executes the frozen `.up.sql` bytes directly, so no Go-side guard is in that path and every migration ≥ 0046 must be idempotent as raw SQL on its own. Both ADD COLUMNs are now INFORMATION_SCHEMA-guarded PREPAREs (0060/0066 pattern), with a direct-DDL fresh-bundle override in `cliCompatibleMigrationSQL` for the pre-2.3 CLI hazard (0060/0065/0066 precedent).
+
+The diffstat recorded above is likewise the gated commit's, not the fix round's.

--- a/release-gates/be-dy66n-gate.md
+++ b/release-gates/be-dy66n-gate.md
@@ -1,0 +1,80 @@
+# Release gate — be-dy66n (Review: Phase 1: additive schema + migration slot claim - gastownhall/beads#6134)
+
+**Date:** 2026-09-05
+**Deployer:** beads/deployer
+**Bead (deploy):** be-4ka6t
+**Source bead:** be-dy66n — status closed, verdict `pass`. Reviewer notes confirm: gofmt/vet/build clean, full OWASP-Top-10-style security walk (9 categories, all N/A/checked, one non-blocking minor: insufficient logging, not required for this PR's exit contract), and all 5 exit-contract items verified first-hand (IF NOT EXISTS on both CREATE TABLEs; non-PREPARE ADD COLUMN idempotency guard; `TestProtocol_V2_DesignatedMigratorOverride` passes; no regression in 3 pre-existing diff-owned tests; redundant CLAIMED.md commit dropped). `uncovered_criteria: none`.
+**Source commit:** `26033d8e476a88c6220ea9febd42e51272b0455c`
+  - Parent: `41fd9c9b12737f5933c7ab9baf2c9efccf0f58af` (test(feat): red, refs be-xrl84)
+  - Branch history: `460a2e660` (red, refs be-hs42e.2) → `74a9b8906` (green, refs be-hs42e.2) → `41fd9c9b1` (red, refs be-xrl84) → `26033d8e4` (green, refs be-xrl84)
+  - All 5 SHAs (4 commits + base) independently re-verified via `git rev-parse --verify --quiet "<sha>^{commit}"` — all resolve.
+  - Base: `origin/main` @ `c0d8da42de5fd15c95adac85e342ba4a121da0fb`. Re-confirmed via fresh `git fetch origin main` immediately before writing this gate: `origin/main` tip and `merge-base(HEAD, origin/main)` are identical — origin/main has not moved since the branch was cut.
+**Branch:** `deploy/be-dy66n-gate`
+**Push target:** `headfork` (`quad341/beads-sec003-contrib`) — pushed and independently re-verified: `git ls-remote headfork refs/heads/deploy/be-dy66n-gate` returns `26033d8e476a88c6220ea9febd42e51272b0455c`, matching local `HEAD` exactly.
+**PR:** [gastownhall/beads#6304](https://github.com/gastownhall/beads/pull/6304) — `quad341:deploy/be-dy66n-gate` → `gastownhall:main`. Verified via `gh pr view 6304`: `state=OPEN`, `mergeable=MERGEABLE`, `author=quad341` (our own account — not an external contributor, no human-hold triggered).
+
+## Verdict: 7/7 — PASS, no waivers
+
+## Criteria walk
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review pass | PASS | be-dy66n closed, verdict `pass`, full first-hand reviewer verification of all 5 exit-contract items |
+| 2 | Acceptance criteria met | PASS | All 4 diff-owned tests confirmed passing (see Criterion 3); reviewer's exit-contract walk independently corroborates |
+| 3 | Full-suite tests | PASS (attributed) | See Criterion 3 detail below — 4 pre-existing, non-diff-owned failure classes attributed to trackers; zero diff-owned failures |
+| 3a | Pre-existing-failure attribution | PASS | 4 failure classes, all attributed with clause-3 proof (see below) |
+| 3b | Policy/lint lane (`ci-pr-policy` + `ci-pr-lint`) | PASS (attributed) | 2 further pre-existing findings attributed to trackers; see Criterion 3 detail |
+| 3c | CI-config-diff live-run | N/A | Diff touches no `.github/` or `scripts/ci/` files (`git diff --name-only origin/main...HEAD` confirms) |
+| 4 | Zero open HIGH | PASS | Reviewer's OWASP walk: 9 categories, all N/A/checked, one non-blocking minor (logging), no HIGH findings |
+| 5 | Clean git status | PASS | `git status --short` clean on `deploy/be-dy66n-gate` at SHA `26033d8e4` |
+| 6 | No merge conflicts with BASE_REF | PASS | `origin/main` unchanged since branch cut; merge-base == origin/main tip; no conflict possible |
+| 7 | Single feature theme/ancestry scope | PASS | 5 files, +424/-1, all on-theme for migration-0067 versioned-beads schema (see diffstat below) |
+
+**Diffstat** (`git diff --stat origin/main...HEAD`):
+```
+internal/storage/dolt/initschema_0067_versioned_beads_replay_test.go | 106 ++++++++++++
+internal/storage/schema/migration_0067_versioned_beads_test.go      | 178 +++++++++++++++++++++
+internal/storage/schema/migrations/0067_add_versioned_beads_schema.down.sql |  10 ++
+internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql   |  56 +++++++
+internal/storage/schema/schema.go                                   |  75 ++++++++-
+5 files changed, 424 insertions(+), 1 deletion(-)
+```
+
+## Criterion 3 — full-suite test evidence + policy/lint lane + CI-config-diff (3c)
+
+**test_cmd:** `TEST_COVER=1 ./scripts/test.sh` (via `make test`)
+**test_cmd_scope:** whole-repo, `BEADS_TEST_SKIP=dolt` default (skips all Dolt-backed tests repo-wide, including all `internal/storage/dolt` package tests)
+**test_counts:** 90+ packages clean; `cmd/bd` package FAILed overall (282.560s) due to 4 named tests (below); all other packages `ok`
+
+**diff_tests_executed** (all PASS):
+- `TestLatestVersionIncludesMigration0067`
+- `TestMigration0067AddsVersionedBeadsSchema`
+- `TestMigration0067AddsVersionedBeadsSchemaThroughDoltCLI`
+- `TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing` — independently re-verified by name under `BEADS_TEST_ENV_RUN_DOLT=1` + `-tags=integration,gms_pure_go` (this test lives in `internal/storage/dolt`, package-skipped by plain `make test`'s `BEADS_TEST_SKIP=dolt`)
+
+**failure_attribution:**
+
+1. `TestFindBeadsRepoRoot_WorktreeFallback, TestCountExistingIssues_WorktreeNoBeadsAnywhere, TestReset_WorktreeNoBeadsReturnsEmpty, TestReset_WorktreeSubdirFindsBeadsDir` (`cmd/bd`) -> `be-9ogs6` | clause 3: same root-condition class as be-9ogs6's tracked "ambient `.beads` directory defeats clean-workspace walk-up assumption" — this environment has a real ambient `/tmp/.beads` (birth ~13h before this run, unrelated to this diff) that satisfies these tests' "no `.beads` found anywhere under `/tmp`" assumption during walk-up. SHA `26033d8e476a88c6220ea9febd42e51272b0455c`, log in deployer scratchpad `be-dy66n-full-suite.log`.
+2. `internal/storage/dolt` package, 9 pre-existing failures -> `be-irise` | clause 3: pre-existing, independently tracked failure class, not caused by this diff. clause 4 note: this diff adds a new test file to the *same package* (`initschema_0067_versioned_beads_replay_test.go`); flagged as a non-blocking observation on `be-irise` for whoever next runs the whole-package suite. Not gate-blocking: `make test`'s required full-suite command skips Dolt tests entirely, so none of the 9 appear in this gate's own criterion-3 evidence — confirmed via this run's own full-suite output, `internal/storage/dolt` reports clean `ok`.
+3. `ci-pr-lint` (`golangci-lint`): 3x `G602: slice index out of range (gosec)` in `backend/conformance/importer_contract.go:390,392` and `relations_contract.go:672` -> `be-w4qbu` | clause 3: matches `be-w4qbu`'s known false-positive class (via its own comment history citing `be-ckoic`); confirmed not diff-owned (`git diff --name-only origin/main...HEAD -- backend/` empty). A first `ci-pr-lint` attempt also surfaced 29 issues under a phantom, nonexistent path (`../builder/worktrees/be-kh65q/...`) — diagnosed as a stale, content-hash-keyed `golangci-lint` shared result cache (`~/quad341-claude/.cache/golangci-lint`) leaking path metadata from a since-deleted worktree; `golangci-lint cache clean` + rerun reproduced only the 3 genuine, correctly-pathed findings above. This cache phenomenon itself also matches `be-w4qbu`'s own tracked history (`be-vf95`). Log `be-dy66n-ci-lint-2.log`.
+4. `ci-pr-policy`: "check version consistency" step fails on `.githooks/commit-msg: no 'BEGIN BEADS INTEGRATION' marker found` -> `be-a0dxu` | clause 3: identical symptom reproduced verbatim, matches `be-a0dxu`'s tracked condition exactly — `.githooks/commit-msg` on disk is a local, untracked dev shim (excluded via `.git/info/exclude:40`), not part of the repo's committed `.githooks/` fileset; confirmed not diff-owned (`git diff --name-only origin/main...HEAD -- .githooks/` empty). **Cross-confirmed by the real upstream CI**: PR #6304's own "Check version consistency" GitHub Actions check passed cleanly on first report — this local-only shim does not exist on a clean checkout. Log `be-dy66n-ci-policy.log`.
+
+**attribution_evidence:** all 4 citations posted as `bd comment` to their respective tracker beads this gate round (be-9ogs6, be-irise, be-w4qbu, be-a0dxu), each including SHA, log reference, and clause-3 proof.
+
+**ci_lane_run (3c):** N/A — diff touches no `.github/` or `scripts/ci/` paths, so no CI-config live-run is required. `make ci-pr-policy` and `make ci-pr-lint` were still run in full as the standard 3b policy/lint lane (see failure_attribution items 3–4 above); both are attributed-PASS with zero diff-owned findings.
+
+**waiver_ref:** none — no waiver needed, all failures cleanly attributed to pre-existing, non-diff-owned conditions with clause-3 proof and zero clause-4 path overlap (except the single non-blocking dolt-package observation on be-irise, which does not block this gate per the reasoning above).
+
+**uncovered_criteria:** none
+
+Beyond the above, `gc beads-contributor pre-pr-check` (10-point pre-PR sanity check) ran clean: 0 blockers, 0 warnings — branch 0 commits behind origin/main, 5 changed files, 4 commits, 1 top-level dir touched, no `.claude/**` paths, no postgres tokens, no undefined build tags. On the live PR, `gh pr checks 6304` at open time shows two already-resolved checks passing (`Resolve versions to test`, `Check version consistency` — the latter corroborating the local-shim diagnosis above) and the remainder queued/pending with zero immediate failures.
+
+## Merge authority
+
+This rig is a **contributor-only** participant in `gastownhall/beads` (upstream `origin` is fetch-only by design; all push/PR traffic goes through `headfork`/`prhead`, both `quad341/beads-sec003-contrib`). No rig agent — builder, reviewer, or deployer — holds merge rights on `gastownhall/beads`, and no rig agent ever runs `gh pr merge`. Per standing policy, the deployer's job for a contributor-only rig ends at a verified open, mergeable PR; this gate stops there and reports to mayor for **visibility only**, with no merge-request routed.
+
+This follows established precedent: be-gd3v, be-79jh, be-39ss, be-pp7e, be-r3ysh, be-krza3, be-vc1m (PR #5792), be-7q688 (PR #6003), be-6iglh/be-0l89e (PR #6082), be-c8kgv (PR #6221), be-1wwre (PR #6247), be-3vzut (PR #6262), be-kqg23 (PR #6271).
+
+## Disposition
+
+**PASS, 7/7, no waivers.** PR [gastownhall/beads#6304](https://github.com/gastownhall/beads/pull/6304) opened, verified OPEN and MERGEABLE, authored by our own account (no external-contributor human-hold triggered). Four pre-existing, non-diff-owned failure/finding classes encountered during gate evaluation, all attributed to their exact pre-existing tracker beads (be-9ogs6, be-irise, be-w4qbu, be-a0dxu) with clause-3 proof and citation comments posted this round. Reporting to mayor for visibility only; no merge-request routed, per contributor-only merge-authority carve-out.


### PR DESCRIPTION
## Summary

Phase 1 of the versioned-beads epic (`gastownhall/beads#6132`, this slice `#6134`): purely additive schema for a per-issue version log, a store-global epoch singleton, and a fast-path revision column on `issues`. Nothing reads or writes these surfaces yet — that's Phase 2 (`#6135`) and Phase 3 (`#6136`).

- Migration `0067_add_versioned_beads_schema`: adds `issue_versions` (composite PK `issue_id, revision`), `store_epoch` (singleton, CHECK-constrained to `id=1`, starts empty), and `issues.current_revision BIGINT NOT NULL DEFAULT 1`.
- No DML/backfill. No `PREPARE`/`EXECUTE` wrapper on the `ALTER TABLE ADD COLUMN` — `ADD COLUMN` vanishes under the CLI-bundle `PREPARE` path on a pre-2.3 Dolt CLI (see `cli_prepared_ddl.go`), and since `issues` always exists on a fresh bundle, no `preparedALTERSafeOnFreshBundle`-style guard would be honest here — so the column/table churn stays plain, unwrapped DDL.
- Old, unmodified callers of `issues` are unaffected: `current_revision` is `NOT NULL DEFAULT 1`, not a value old callers must supply.

## Test plan

- [x] `TestLatestVersionIncludesMigration0067` — pins the claimed migration slot (67)
- [x] `TestMigration0067AddsVersionedBeadsSchema` — pure-Go, DB-independent check of the frozen migration SQL text (table/column shape, composite PK, no PREPARE, no store_epoch seeding)
- [x] `TestMigration0067AddsVersionedBeadsSchemaThroughDoltCLI` — applies the full migration bundle through a real `dolt` binary: column types/nullability, both new tables start empty, composite and singleton PKs enforced, and an old-shaped explicit-column `issues` insert/select round-trips unchanged post-migration
- [x] `TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing`
- [x] Full suite (`make test`) green outside of pre-existing, non-diff-owned failures (tracked separately; see below)
- [x] `make ci-pr-lint` / `make ci-pr-policy` — only pre-existing, non-diff-owned findings (see below)
- [x] `gofmt`, `go vet`, `go build` clean

### Pre-existing failures encountered (none caused by this diff)

- 4x `cmd/bd` worktree/repo-root-walk tests fail under an ambient `/tmp/.beads` in this environment (unrelated pre-existing condition, tracked upstream-side)
- 9x `internal/storage/dolt` package tests have a separately-tracked pre-existing failure class; not exercised by `make test`'s default `BEADS_TEST_SKIP=dolt`, and independently confirmed the diff's own dolt-tagged test passes in isolation under `-tags=integration,gms_pure_go` with `BEADS_TEST_ENV_RUN_DOLT=1`
- 3x `gosec G602` false positives in `backend/conformance/{importer,relations}_contract.go` (pre-existing, zero path overlap with this diff)
- `ci-pr-policy` version-consistency step flags a local, untracked `.githooks/commit-msg` dev shim (excluded via `.git/info/exclude`, not part of the repo's committed `.githooks/` fileset)

Reviewed and PASSED by beads/reviewer (full OWASP-style security walk, style, and spec checks) prior to this PR.


## Choice-vs-transcription callouts

Same rule as #6147 (per @bee-ghosttrack's condition on #5898): every point where this phase had to **choose** something the thread or the phase design left open — rather than **transcribe** a settled decision — gets a one-line callout. Everything not listed is transcription: the additive-only rule, the "nothing reads or writes yet" boundary, and the slot-claim procedure are all straight from #6134 / #5898 / CLAIMED.md.

From the design pass (be-hs42e.2, §8 trade-offs):

| Surface | What was chosen (not settled by the thread) |
|---|---|
| `issue_versions` as a new, ordinary (never `dolt_ignored`) table | The thread settles that history must survive compaction and that replay is never defined over `dolt_log` (R16.2, #6133 field data). The *vehicle* — a fresh versioned table rather than repurposing `row_lock`/`RowVersion` or writing into `bd_events_journal` — is the design's choice; both alternatives were considered and rejected. |
| Store-global `store_epoch` singleton, not a per-issue epoch column | R20 settles that epochs exist and what they void. Their *granularity* (one epoch per store) is the design's choice, made because R20's triggers are store-level events. |
| Fast-path `issues.current_revision` column | The thread settles that every guarded write composes from a revision token. Denormalizing the current revision onto `issues` (rather than deriving it from `MAX(revision)` on read) is a performance choice for Phase 3's CAS path. |
| Wisps outside durable versioning | Deliberate asymmetry with `row_lock`, which covers both planes. Extending versioning to the ephemeral plane would contradict wisps' already-tested no-durable-history contract; scoped out, flagged as a decision rather than an oversight. |
| `wisps.current_revision` mirrored for shape parity — **amends the row directly above; nothing in it is withdrawn** | Fix round, per @bee-ghosttrack's ruling on this PR (2026-09-05). The *semantic* asymmetry above stands exactly as written: nothing in Phase 1, 2 or 3 reads or writes the wisps column, and wisps keep their tested no-durable-history contract. What the original row missed is the *shape* obligation — the two planes share column-list-shaped code paths, `TestSchemaParityIssuesVsWisps` enforces strict issues↔wisps column-name parity with no exemption list, and `row_lock` (0054 + `ignored/0013`) is precisely the precedent for a column carried on both planes and meaningful on one. Mirrored as `BIGINT NOT NULL DEFAULT 1`, type-identical to `issues` (the parity oracle checks types too, not just names). |

Found at build time (the design's DDL was explicitly illustrative — "builder finalizes exact types"):

| Surface | What was chosen |
|---|---|
| `issue_id VARCHAR(255)` (design sketch said `VARCHAR(64)`) | Widened to match the real `issues.id` column type rather than trust the sketch. |
| `epoch INT NOT NULL` with **no default** (sketch had `DEFAULT 1`) | A version row must state its epoch explicitly; a silent default would let Phase 2's writer omit it and quietly mint epoch-1 rows forever. |
| `durable_state JSON` **nullable** (sketch had `NOT NULL`) | Leaves room for R20 removal (`removed_at`/`removed_reason`) to blank the payload while keeping the row and its attribution — the "Gone with reason" shape from Revision 8. Reviewers should check this is the intended erasure representation and not a leak of nullability. |
| Attribution (`change_actor`/`change_agent`/`change_message`/`change_at`) and removal (`removed_at`/`removed_reason`) as **columns**, not fields inside `durable_state` | R14/R20 settle that these are recorded; making them queryable columns rather than JSON members is a storage-shape choice. |
| `store_epoch` left **empty** in Phase 1 (lazy-init in Phase 2/3), with the singleton CHECK pinning the shape now | Seeding `epoch=1` here would be DML in an additive-only migration; deferring it costs one lazy-init branch later. |
| No `PREPARE`/`EXECUTE` wrapper, unlike migration 0066 | `issues` always exists by the time any migration runs, so 0066's idempotent-replay justification does not apply, and a PREPARE'd `ADD COLUMN` silently vanishes under the CLI-bundle path on a pre-2.3 Dolt CLI (`cli_prepared_ddl.go`). |
| Replay idempotence via `CREATE TABLE IF NOT EXISTS` plus a Go-side guard for the `ADD COLUMN` (`execMigration0067Body`) | MySQL/Dolt have no `ADD COLUMN IF NOT EXISTS`; a designated-migrator replay with the bookkeeping row missing must not die on Error 1105. Pinned by `TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing`. |
| Ignored-series twin `ignored/0026_add_wisps_current_revision.up.sql` shipped alongside the main-plane migration | Found at build time, not ruled on: `wisps` is `dolt_ignored`, so a fresh clone materializes it from the ignored series with the main cursor already at-latest and 0067's wisps `ALTER` never executes there. Check D of `scripts/check-migration-hygiene.sh` requires the twin for exactly this (precedent `ignored/0013` for 0054's `row_lock`, `ignored/0020` for 0060's `storage_class` — the latter's absence is how `wisps.storage_class` missed every fresh clone in prod). The twin is load-bearing, not ceremonial: with it removed, `TestEmbeddedIgnoredSeriesConvergesWithFreshInitShape` fails with "wisps.current_revision: present on the fresh-init door but missing on the fresh-clone door". |
| Guarded `PREPARE` `ADD COLUMN` per plane, a direct-DDL fresh-bundle override, and the Go-side guard removed — **supersedes the two rows above**, which are left in place as the record of what the pre-review head chose | Fix round, per @bee-ghosttrack's ruling on this PR (2026-09-05): the raw `.up.sql` must be idempotent when replayed onto an already-migrated store. `internal/storage/dolt/pr4107_corruption_test.go` re-executes the frozen bytes from 0046 onward straight through the driver, so nothing in `internal/storage/schema` is in that path and `execMigration0067Body` could never have covered it; `schema.go` is back at `origin/main`. The preferred no-`PREPARE` information_schema form is **not expressible in Dolt** — measured on 2.2.3, `ADD COLUMN IF NOT EXISTS`, `DROP COLUMN IF EXISTS` and a top-level `IF` are all parse errors, and the one conditional form Dolt does accept, a stored procedure, needs a client-side `DELIMITER` that the CLI batch path requires and the Go driver rejects, so one frozen file cannot serve both paths. Hence 0060/0066's shape, with 0060/0065/0066's answer to the pre-2.3 CLI vanish (dolthub/dolt#11345): `cliMigration0067AddVersionedBeadsSchema`, listed in `cliSubstituteAssumesWispTables` because its wisps `ALTER` is unguarded. Proven through the harness's own replay, run twice, by `TestMigration0067ReplaysIdempotentlyAsRawSQLThroughPR4107Harness`. |
| Slot **0067**, not the design's provisional 0066 | Transcription, not a choice — listed only so the trail is visible: HEAD was re-read at build time per §7, 0066 had landed for `bd_events_journal`, and 0067 was the real next free slot (pinned by `TestLatestVersionIncludesMigration0067`). CLAIMED.md (#6149) is the advisory for the window between now and merge. |

**Standing constraint carried from #6147:** no compaction-related language here assumes a human operator in the loop. Flag-off byte-identity is trivially true for this phase (no code path reads or writes the new surfaces); the differential harness starts in Phase 2.

