### PR TITLE
perf(ready): honor the lite projection on the ready scan and the claim scan; make it the default for `bd ready --json`

### DIFF
--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -746,7 +746,18 @@ func init() {
 			"payload, waiters) from each row. Filters that read those fields still "+
 			"select on them. An omitted field is indistinguishable from an empty "+
 			"one; fetch a whole issue with bd show. Requires --json, and cannot be "+
-			"combined with --claim, --gated, --mol or --explain.")
+			"combined with --claim, --gated, --mol or --explain. NOTE: --json "+
+			"listings omit that text by DEFAULT now, so this flag only restates it.")
+	// The opt-OUT, and the flag half of the lite default's rollback (the other
+	// half is BEADS_READY_HYDRATION=full, which moves the default for every
+	// caller at once rather than one command line at a time).
+	readyCmd.Flags().Bool("full", false,
+		"Hydrate the free-form text (description, design, acceptance criteria, "+
+			"notes, payload, waiters) on every row. --json listings omit it by "+
+			"default because no polling caller reads it and it is ~94% of the "+
+			"bytes those queries carry; pass this when you do read it, or set "+
+			"BEADS_READY_HYDRATION=full to move the default back. Cannot be "+
+			"combined with --brief.")
 	// Metadata filtering (GH#1406)
 	readyCmd.Flags().StringArray("metadata-field", nil, "Filter by metadata field (key=value, repeatable)")
 	readyCmd.Flags().String("has-metadata-key", "", "Filter issues that have this metadata key set")

--- a/cmd/bd/ready_hydration.go
+++ b/cmd/bd/ready_hydration.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// EnvReadyHydration names the projection `bd ready` uses when the command line
+// asks for neither --brief nor --full. It is THE ROLLBACK for the lite default:
+// an operator who needs the old fully-hydrated ready listing back sets
+//
+//	BEADS_READY_HYDRATION=full
+//
+// in the environment the bd/gc processes are started with, and gets it at the
+// next restart with no rebuild and no flag change anywhere. "lite" (or unset)
+// is the default.
+//
+// It governs the DEFAULT only. An explicit --brief or --full on the command
+// line always wins, in both directions, so a caller that states its projection
+// is never surprised by an environment it did not set.
+//
+// It deliberately does NOT govern the claim scan (issueops.ClaimReadyIssueInTx).
+// That projection has no observable effect to roll back: the scan's rows are
+// read for their ID alone and the row a claim wins is refetched whole before it
+// is returned, so there is no output that can differ. A knob offered there
+// would be a knob that does nothing.
+const EnvReadyHydration = "BEADS_READY_HYDRATION"
+
+// readyHydrationDefaultLite reports the projection default for `bd ready`,
+// and a warning line when the environment named something unrecognized.
+//
+// AN UNREADABLE VALUE FALLS BACK TO FULL HYDRATION AND SAYS SO. Every other
+// direction fails toward the reassuring answer: a typo'd BEADS_READY_HYDRATION
+// that silently kept the lite default would leave an operator who believed they
+// had rolled back reading projected rows, which is the one state this knob
+// exists to let them leave.
+func readyHydrationDefaultLite(env func(string) string) (lite bool, warning string) {
+	raw := strings.TrimSpace(env(EnvReadyHydration))
+	switch strings.ToLower(raw) {
+	case "":
+		return true, ""
+	case "lite":
+		return true, ""
+	case "full":
+		return false, ""
+	default:
+		return false, fmt.Sprintf(
+			"warning: %s=%q is not a recognized value (want \"lite\" or \"full\"); using full hydration",
+			EnvReadyHydration, raw)
+	}
+}
+
+// resolveReadyProjection decides whether this `bd ready` invocation runs the
+// lite projection, given the two flags and the four modes that reach a
+// different query.
+//
+// THE MODES ARE NOT REFUSED HERE, THEY FALL BACK. briefModeConflict refuses
+// --brief against --claim, --gated, --mol, --explain and the text renderings,
+// because a flag the user TYPED that no route can honor is a silent no-op and
+// must be reported. A DEFAULT is a different thing: the same combination just
+// means this invocation is not on the projected route, and refusing `bd ready
+// --claim` because of an environment default nobody typed would break every
+// claiming caller in the town on the day the default flipped.
+func resolveReadyProjection(brief, full, claim, gated, explain bool, molID string, jsonOut bool, env func(string) string) (lite bool, warning string) {
+	if full {
+		return false, ""
+	}
+	if brief {
+		// Already validated by briefModeConflict, which refuses every
+		// combination the projection cannot reach.
+		return true, ""
+	}
+	// The counts mega-query is the only ready query that carries a projection,
+	// and `bd ready` runs it for --json alone; --claim, --gated, --mol and
+	// --explain each answer with a shape of their own. Defaulting lite on those
+	// routes would set a field nothing reads.
+	if !jsonOut || claim || gated || explain || molID != "" {
+		return false, ""
+	}
+	return readyHydrationDefaultLite(env)
+}
+
+// osEnv is resolveReadyProjection's production environment reader.
+func osEnv(key string) string { return os.Getenv(key) }

--- a/cmd/bd/ready_hydration_test.go
+++ b/cmd/bd/ready_hydration_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func envFrom(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+// TestResolveReadyProjection pins the whole decision table, because every row
+// of it is a way the default can be wrong in a direction nobody would notice.
+func TestResolveReadyProjection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		brief, full bool
+		claim       bool
+		gated       bool
+		explain     bool
+		molID       string
+		jsonOut     bool
+		env         map[string]string
+		wantLite    bool
+		wantWarning bool
+	}{
+		// THE CHANGE ITSELF: a plain `bd ready --json` is projected now.
+		{name: "plain json defaults lite", jsonOut: true, wantLite: true},
+
+		// THE ROLLBACK, both spellings, and they must agree.
+		{name: "env full moves the default back", jsonOut: true, env: map[string]string{EnvReadyHydration: "full"}},
+		{name: "env FULL is case-insensitive", jsonOut: true, env: map[string]string{EnvReadyHydration: "FULL"}},
+		{name: "env lite is the explicit default", jsonOut: true, env: map[string]string{EnvReadyHydration: "lite"}, wantLite: true},
+		{name: "--full beats the lite default", full: true, jsonOut: true},
+		// …and --full beats the env too, in the direction the env did not go:
+		// a caller that states its projection is never surprised by an
+		// environment it did not set.
+		{name: "--full wins over env lite", full: true, jsonOut: true, env: map[string]string{EnvReadyHydration: "lite"}},
+
+		// AN UNREADABLE KNOB FALLS BACK TO FULL AND WARNS. The reassuring
+		// failure would be to keep the lite default on a typo, leaving an
+		// operator who believed they had rolled back still reading projected
+		// rows.
+		{name: "unrecognized env falls back to full, loudly", jsonOut: true, env: map[string]string{EnvReadyHydration: "brief"}, wantWarning: true},
+		{name: "empty-ish env value is not a typo", jsonOut: true, env: map[string]string{EnvReadyHydration: "   "}, wantLite: true},
+
+		// THE FOUR MODES REACH A DIFFERENT QUERY, so the default must not set a
+		// field nothing there reads — and, far more important, must not refuse
+		// them the way an explicit --brief is refused. `bd ready --claim` is
+		// every claiming caller in the town.
+		{name: "--claim is never defaulted", claim: true, jsonOut: true},
+		{name: "--gated is never defaulted", gated: true, jsonOut: true},
+		{name: "--explain is never defaulted", explain: true, jsonOut: true},
+		{name: "--mol is never defaulted", molID: "bd-1", jsonOut: true},
+		{name: "text output is never defaulted", jsonOut: false},
+
+		// An explicit --brief still means what it always meant. It has already
+		// passed briefModeConflict by the time this runs.
+		{name: "explicit --brief stays lite", brief: true, jsonOut: true, wantLite: true},
+		{name: "explicit --brief ignores an env that says full", brief: true, jsonOut: true, env: map[string]string{EnvReadyHydration: "full"}, wantLite: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			lite, warning := resolveReadyProjection(tt.brief, tt.full, tt.claim, tt.gated, tt.explain, tt.molID, tt.jsonOut, envFrom(tt.env))
+			if lite != tt.wantLite {
+				t.Errorf("lite = %v, want %v", lite, tt.wantLite)
+			}
+			if (warning != "") != tt.wantWarning {
+				t.Errorf("warning = %q, wantWarning = %v", warning, tt.wantWarning)
+			}
+		})
+	}
+}
+
+// TestReadyHydrationDefaultLiteNamesTheKnobInItsWarning keeps the warning
+// actionable: an operator reading it must learn the variable name and the two
+// values without going to look them up.
+func TestReadyHydrationDefaultLiteNamesTheKnobInItsWarning(t *testing.T) {
+	t.Parallel()
+
+	lite, warning := readyHydrationDefaultLite(envFrom(map[string]string{EnvReadyHydration: "nope"}))
+	if lite {
+		t.Error("an unrecognized value must fall back to FULL hydration, not to the lite default")
+	}
+	for _, want := range []string{EnvReadyHydration, `"lite"`, `"full"`, "nope"} {
+		if !strings.Contains(warning, want) {
+			t.Errorf("warning %q does not mention %q", warning, want)
+		}
+	}
+}

--- a/cmd/bd/ready_input.go
+++ b/cmd/bd/ready_input.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -28,6 +30,7 @@ type readyInput struct {
 	dirLabels []string
 
 	claim        bool
+	full         bool
 	gated        bool
 	molID        string
 	explain      bool
@@ -61,6 +64,7 @@ func gatherReadyInput(cmd *cobra.Command, resolveCap func(*cobra.Command) (int, 
 	in.molID, _ = cmd.Flags().GetString("mol")
 	in.explain, _ = cmd.Flags().GetBool("explain")
 	in.Brief, _ = cmd.Flags().GetBool("brief")
+	in.full, _ = cmd.Flags().GetBool("full")
 	in.prettyFormat, _ = cmd.Flags().GetBool("pretty")
 	in.plainFormat, _ = cmd.Flags().GetBool("plain")
 	if flat, _ := cmd.Flags().GetBool("flat"); flat {
@@ -114,6 +118,24 @@ func gatherReadyInput(cmd *cobra.Command, resolveCap func(*cobra.Command) (int, 
 	if err := briefModeConflict(in.Brief, in.claim, in.gated, in.explain, in.molID, in.jsonOut); err != nil {
 		return in, err
 	}
+	if in.Brief && in.full {
+		return in, HandleErrorRespectJSON("--brief cannot be combined with --full; they name opposite projections")
+	}
+	// LITE IS THE DEFAULT PROJECTION for the JSON ready route (bd-cz2mp).
+	// Resolved AFTER briefModeConflict so a --brief the user typed is still
+	// validated against the modes that cannot honor it, and so the default
+	// itself never manufactures one of those refusals.
+	//
+	// It is written onto in.Brief rather than carried beside it because Brief
+	// is already the one seam that reaches types.WorkFilter.Lite
+	// (workapi.BuildReadyFilter), on both routes and both backends. A second
+	// field would be a second way to say the same thing, and the two would
+	// drift.
+	lite, warning := resolveReadyProjection(in.Brief, in.full, in.claim, in.gated, in.explain, in.molID, in.jsonOut, osEnv)
+	if warning != "" {
+		fmt.Fprintln(os.Stderr, warning) //nolint:errcheck
+	}
+	in.Brief = lite
 	if in.Offset > 0 && in.claim {
 		return in, HandleErrorRespectJSON("--offset cannot be combined with --claim")
 	}

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -37,6 +37,14 @@ var _ domain.IssueSQLRepository = (*issueSQLRepositoryImpl)(nil)
 // delegates to issueops.ScanIssueFrom, which scans it positionally.
 const issueSelectColumns = sqlbuild.IssueSelectColumns
 
+// issueSelectColumnsLite aliases the shared LITE column list; the scan side
+// delegates to issueops.ScanIssueLiteFrom, which scans it positionally and
+// sets IsLitePartial. The two constants and the two scan functions are always
+// chosen as a PAIR (see fetchIssuesByIDs): both scans are positional, so a
+// mismatched pair shifts every column after the first dropped one rather than
+// failing on the missing text.
+const issueSelectColumnsLite = sqlbuild.IssueSelectColumnsLite
+
 var allowedUpdateFields = map[string]struct{}{
 	"status": {}, "priority": {}, "title": {}, "assignee": {}, "owner": {},
 	"description": {}, "design": {}, "acceptance_criteria": {}, "notes": {},
@@ -833,6 +841,12 @@ type issueScanner interface {
 // that hands timestamps back as text.
 func scanIssue(s issueScanner) (*types.Issue, error) {
 	return issueops.ScanIssueFrom(s)
+}
+
+// scanIssueLite is scanIssue's lite counterpart, paired with
+// issueSelectColumnsLite.
+func scanIssueLite(s issueScanner) (*types.Issue, error) {
+	return issueops.ScanIssueLiteFrom(s)
 }
 
 func nullString(s string) any {

--- a/internal/storage/domain/db/issue_search.go
+++ b/internal/storage/domain/db/issue_search.go
@@ -184,9 +184,18 @@ func (r *issueSQLRepositoryImpl) fetchIssuesByIDs(ctx context.Context, ids []str
 
 	placeholders, args := buildInPlaceholders(ids)
 
+	// Column list and scan function are chosen together; see
+	// issueSelectColumnsLite. filter.Lite is the caller's statement that it
+	// will not read a body off these rows, and honoring it here is what makes
+	// this backend's bare ready scan agree with the counted one.
+	columns, scan := issueSelectColumns, scanIssue
+	if filter.Lite {
+		columns, scan = issueSelectColumnsLite, scanIssueLite
+	}
+
 	//nolint:gosec // G201: tables.Main is "issues" or "wisps"; placeholders are ?.
 	fetchSQL := fmt.Sprintf(`SELECT %s FROM %s %s WHERE id IN (%s)`,
-		issueSelectColumns, tables.Main, sqlbuild.LeaseJoin(tables.Main), placeholders)
+		columns, tables.Main, sqlbuild.LeaseJoin(tables.Main), placeholders)
 	rows, err := r.runner.QueryContext(ctx, fetchSQL, args...)
 	if err != nil {
 		return nil, err
@@ -195,7 +204,7 @@ func (r *issueSQLRepositoryImpl) fetchIssuesByIDs(ctx context.Context, ids []str
 	out := make(map[string]*types.Issue, len(ids))
 	ordered := make([]*types.Issue, 0, len(ids))
 	for rows.Next() {
-		issue, scanErr := scanIssue(rows)
+		issue, scanErr := scan(rows)
 		if scanErr != nil {
 			_ = rows.Close()
 			return nil, fmt.Errorf("scan: %w", scanErr)

--- a/internal/storage/domain/db/ready_work_union.go
+++ b/internal/storage/domain/db/ready_work_union.go
@@ -86,13 +86,20 @@ func (r *issueSQLRepositoryImpl) getReadyWorkUnion(ctx context.Context, filter t
 		return domain.SearchPage{}, err
 	}
 
-	issuesByID, err := r.fetchIssuesByIDs(ctx, page.issueIDs, issuesFilterTables, types.IssueFilter{})
+	// filter.Lite is CARRIED into the hydration rather than dropped with the
+	// rest of the WorkFilter. The empty IssueFilter here used to mean "no
+	// predicates to re-apply, the ID page already selected the rows" — true of
+	// every filtering field, and false of this one, which is not a predicate
+	// but a PROJECTION, and describes exactly the fetch this line performs. A
+	// caller that asked for a lite ready scan got a fully hydrated one on this
+	// backend and no error to say so.
+	issuesByID, err := r.fetchIssuesByIDs(ctx, page.issueIDs, issuesFilterTables, types.IssueFilter{Lite: filter.Lite})
 	if err != nil {
 		return domain.SearchPage{}, fmt.Errorf("ready work union: hydrate issues: %w", err)
 	}
 	var wispsByID map[string]*types.Issue
 	if len(page.wispIDs) > 0 {
-		wispsByID, err = r.fetchIssuesByIDs(ctx, page.wispIDs, wispsFilterTables, types.IssueFilter{})
+		wispsByID, err = r.fetchIssuesByIDs(ctx, page.wispIDs, wispsFilterTables, types.IssueFilter{Lite: filter.Lite})
 		if err != nil && !dberrors.IsTableNotExist(err) {
 			return domain.SearchPage{}, fmt.Errorf("ready work union: hydrate wisps: %w", err)
 		}

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -280,6 +280,29 @@ func ClaimReadyIssueInTx(
 	claimFilter.MaxRows = 0
 	claimFilter.MaxRowsSource = ""
 
+	// THE SCAN IS PROJECTED, UNCONDITIONALLY, AND NOTHING IT DROPS CAN ESCAPE.
+	// The loop below reads exactly one field off these rows - issue.ID - and
+	// the row it wins is refetched WHOLE by GetIssueInTx before it is returned,
+	// which is the contract ClaimNextRequest.Filter already states in prose
+	// ("the claim refetches its winning row whole rather than reading it
+	// through the page's query"). So the six heavy TEXT columns are read from
+	// the database, carried across the wire and discarded on every claim, for
+	// every candidate in an UNBOUNDED ready front.
+	//
+	// That cost is the reason this line exists rather than a preference for
+	// smaller queries. Measured on this town's store 2026-09-04: `description`
+	// alone is 874.7 MB across 36,704 rows (~25 KB/row), against 51.4 MB in the
+	// columns routing actually reads - about 94% of the bytes every claim's
+	// scan carries. The counts mega-query behind this scan and the ready-scan
+	// iteration together were 76.8% of server time at ~449 q/s.
+	//
+	// It is set HERE, on the claim's own copy of the filter, rather than being
+	// asked of the caller: ValidateClaimNextRequest REFUSES a projected
+	// ReadyRequest precisely because a caller must not be able to project the
+	// row it gets BACK. The scan's projection is not that row and is not the
+	// caller's to choose.
+	claimFilter.Lite = true
+
 	readyIssues, err := GetReadyWorkInTx(ctx, tx, claimFilter)
 	if err != nil {
 		return nil, err

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -1003,8 +1003,39 @@ func mergeRecomputeIsBlockedResult(target *RecomputeIsBlockedResult, source Reco
 //
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
 func GetIssuesByIDsInTx(ctx context.Context, tx DBTX, ids []string, wispSet map[string]struct{}) ([]*types.Issue, error) {
+	return getIssuesByIDsInTx(ctx, tx, ids, wispSet, false)
+}
+
+// GetIssuesByIDsLiteInTx is GetIssuesByIDsInTx with the LITE projection: it
+// reads IssueSelectColumnsLite and scans with ScanIssueLiteFrom, so the six
+// heavy TEXT columns (description, design, acceptance_criteria, notes, payload,
+// waiters) come back zero-valued with IsLitePartial=true on every row. Labels
+// are hydrated exactly as the full form hydrates them - lite drops free-form
+// TEXT, never a relationship.
+//
+// It exists as a second exported name rather than a bool parameter on the
+// existing one because the two answer different questions and the caller must
+// say which: a row from here CANNOT be handed to anything that reads a body,
+// and a signature change would have made every one of the twelve existing call
+// sites silently re-classify. Use it only where the rows are consumed for
+// identity, routing or ordering; a caller that needs a body refetches by id.
+func GetIssuesByIDsLiteInTx(ctx context.Context, tx DBTX, ids []string, wispSet map[string]struct{}) ([]*types.Issue, error) {
+	return getIssuesByIDsInTx(ctx, tx, ids, wispSet, true)
+}
+
+func getIssuesByIDsInTx(ctx context.Context, tx DBTX, ids []string, wispSet map[string]struct{}, lite bool) ([]*types.Issue, error) {
 	if len(ids) == 0 {
 		return nil, nil
+	}
+
+	// The column list and the scan function are chosen together, never
+	// separately: ScanIssueFrom and ScanIssueLiteFrom scan POSITIONALLY, so a
+	// mismatched pair does not fail on the missing text - it shifts every
+	// column after the first dropped one. The schema-parity test pins the two
+	// lists against each other; this pairs them at the one place they are used.
+	columns, scan := IssueSelectColumns, ScanIssueFrom
+	if lite {
+		columns, scan = IssueSelectColumnsLite, ScanIssueLiteFrom
 	}
 
 	if wispSet == nil {
@@ -1047,13 +1078,13 @@ func GetIssuesByIDsInTx(ctx context.Context, tx DBTX, ids []string, wispSet map[
 
 			rows, err := tx.QueryContext(ctx, fmt.Sprintf(
 				`SELECT %s FROM %s %s WHERE id IN (%s)`,
-				IssueSelectColumns, pair.table, sqlbuild.LeaseJoin(pair.table), inClause), args...)
+				columns, pair.table, sqlbuild.LeaseJoin(pair.table), inClause), args...)
 			if err != nil {
 				return nil, fmt.Errorf("get issues by IDs from %s: %w", pair.table, err)
 			}
 			issueMap := make(map[string]*types.Issue)
 			for rows.Next() {
-				issue, scanErr := ScanIssueFrom(rows)
+				issue, scanErr := scan(rows)
 				if scanErr != nil {
 					_ = rows.Close()
 					return nil, fmt.Errorf("get issues by IDs: scan: %w", scanErr)

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -114,7 +114,26 @@ func GetReadyWorkInTx(
 		return nil, err
 	}
 
-	issues, err := GetIssuesByIDsInTx(ctx, tx, issueIDs, nil)
+	// THE READY SCAN IS THE OTHER HOT SHAPE, and this is where its bytes are.
+	// The query above projects `id` only; this call is what hydrates the page,
+	// and until now it always hydrated it WHOLE - every description, design,
+	// acceptance_criteria, notes, payload and waiters column for every ready
+	// row, on a scan the claim path deliberately leaves UNBOUNDED (see
+	// ClaimReadyIssueInTx). Measured on one live store 2026-09-04: 874.7 MB of
+	// `description` across 36,704 rows against 51.4 MB in the columns routing
+	// reads.
+	//
+	// filter.Lite has always described exactly this - "the heavy TEXT columns
+	// were not fetched; refetch by id if you need a body" - and reached the
+	// counts mega-query alone. Honoring it here makes the bare ready scan agree
+	// with the counted one instead of quietly hydrating six columns the caller
+	// said it did not want. Rows come back with IsLitePartial=true, which is
+	// what lets a consumer tell "no description" from "description not read".
+	fetch := GetIssuesByIDsInTx
+	if filter.Lite {
+		fetch = GetIssuesByIDsLiteInTx
+	}
+	issues, err := fetch(ctx, tx, issueIDs, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get ready work: fetch issues: %w", err)
 	}
@@ -178,7 +197,11 @@ func getReadyWispsInTx(ctx context.Context, tx DBTX, filter types.WorkFilter, de
 	wispFilter := readyWorkWispIssueFilter(filter)
 	if filter.Limit <= 0 {
 		wispFilter.Limit = 0
-		wisps, err := searchTableInTxT(ctx, tx, "", wispFilter, WispsFilterTables, issueProjection)
+		wispProj := issueProjection
+		if filter.Lite {
+			wispProj = issueLiteProjection
+		}
+		wisps, err := searchTableInTxT(ctx, tx, "", wispFilter, WispsFilterTables, wispProj)
 		if err != nil {
 			if missingOptionalWispTable(err) {
 				return nil, nil
@@ -203,7 +226,7 @@ func getReadyWispsInTx(ctx context.Context, tx DBTX, filter types.WorkFilter, de
 			break
 		}
 
-		pageWisps, err := getWispIssuesByIDsInOrderInTx(ctx, tx, pageIDs)
+		pageWisps, err := getWispIssuesByIDsInOrderInTx(ctx, tx, pageIDs, filter.Lite)
 		if err != nil {
 			return nil, fmt.Errorf("search wisps (ready work): %w", err)
 		}
@@ -269,7 +292,11 @@ func queryReadyWispIssueIDPage(ctx context.Context, tx DBTX, filter types.IssueF
 	return ids, nil
 }
 
-func getWispIssuesByIDsInOrderInTx(ctx context.Context, tx DBTX, ids []string) ([]*types.Issue, error) {
+// lite selects the projection, so the wisp leg of a ready page is hydrated the
+// same way its issues leg is: a merged result whose two legs disagreed would
+// carry IsLitePartial on some rows and not others for no reason a caller could
+// read off the request.
+func getWispIssuesByIDsInOrderInTx(ctx context.Context, tx DBTX, ids []string, lite bool) ([]*types.Issue, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
@@ -277,7 +304,11 @@ func getWispIssuesByIDsInOrderInTx(ctx context.Context, tx DBTX, ids []string) (
 	for _, id := range ids {
 		wispSet[id] = struct{}{}
 	}
-	issues, err := GetIssuesByIDsInTx(ctx, tx, ids, wispSet)
+	fetch := GetIssuesByIDsInTx
+	if lite {
+		fetch = GetIssuesByIDsLiteInTx
+	}
+	issues, err := fetch(ctx, tx, ids, wispSet)
 	if err != nil {
 		return nil, err
 	}
@@ -320,6 +351,10 @@ func readyWorkWispIssueFilter(filter types.WorkFilter) types.IssueFilter {
 		// lets EffectiveSearchLimit bound that query to cap+1 up front.
 		MaxRows:       filter.MaxRows,
 		MaxRowsSource: filter.MaxRowsSource,
+		// The projection travels with the request across the WorkFilter ->
+		// IssueFilter boundary. Every other field here is a PREDICATE; this one
+		// is not, and dropping it silently re-hydrated the wisp leg in full.
+		Lite: filter.Lite,
 	}
 	switch {
 	case filter.Status != "":

--- a/internal/storage/issueops/ready_work_lite_test.go
+++ b/internal/storage/issueops/ready_work_lite_test.go
@@ -1,0 +1,128 @@
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// heavyTextColumns are the six columns the lite projection drops. Named here
+// rather than inlined so a column added to HeavyDropList without being added to
+// IssueBaseColumnsLite is a failure in this file too, not only in the
+// schema-parity test.
+var heavyTextColumns = []string{"description", "design", "acceptance_criteria", "notes", "payload", "waiters"}
+
+// TestGetReadyWorkInTxLiteProjectsWithoutHeavyText is the control this car
+// turns on: with filter.Lite the ready scan's HYDRATION query must not name a
+// single heavy TEXT column. Before the change the scan projected `id` and then
+// hydrated the page WHOLE regardless of Lite, so the flag was accepted and
+// silently ignored — the exact shape ("accepted and dropped") the projection's
+// own refusals elsewhere exist to prevent.
+func TestGetReadyWorkInTxLiteProjectsWithoutHeavyText(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	mock.ExpectQuery(deferredParentProbeRegex("issues")).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(deferredParentProbeRegex("wisps")).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`SELECT id FROM issues`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("bd-1"))
+	// The wisp-set probe GetIssuesByIDsInTx runs when it is handed a nil set.
+	mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).WillReturnError(sql.ErrNoRows)
+	// THE ASSERTION. sqlmock matches the expectation as a regex against the
+	// query text, so a hydration that named `description` would not match this
+	// and the test fails with the offending SQL printed.
+	mock.ExpectQuery(`SELECT id, content_hash, title,\s+status,`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).WillReturnError(sql.ErrNoRows)
+
+	if _, err := GetReadyWorkInTx(context.Background(), tx, types.WorkFilter{Status: types.StatusOpen, Lite: true}); err != nil {
+		t.Fatalf("GetReadyWorkInTx(Lite): %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+// TestGetReadyWorkInTxDefaultStillHydratesFully is the NEGATIVE control, and it
+// is the half that keeps the change honest: a filter that did NOT ask for the
+// projection must still get every column. Without it, a mistake that made lite
+// unconditional would leave the positive test above green.
+func TestGetReadyWorkInTxDefaultStillHydratesFully(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	mock.ExpectQuery(deferredParentProbeRegex("issues")).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(deferredParentProbeRegex("wisps")).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`SELECT id FROM issues`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("bd-1"))
+	mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`SELECT id, content_hash, title, description, design,`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).WillReturnError(sql.ErrNoRows)
+
+	if _, err := GetReadyWorkInTx(context.Background(), tx, types.WorkFilter{Status: types.StatusOpen}); err != nil {
+		t.Fatalf("GetReadyWorkInTx(default): %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+// TestIssueSelectColumnsLiteNamesNoHeavyText pins the two column lists directly:
+// the lite one names none of the six, the full one names all six. It is the
+// cheap standing guard behind both SQL-shape tests above, which can only prove
+// which CONSTANT was used, not what is in it.
+func TestIssueSelectColumnsLiteNamesNoHeavyText(t *testing.T) {
+	t.Parallel()
+
+	for _, col := range heavyTextColumns {
+		if strings.Contains(IssueSelectColumnsLite, col) {
+			t.Errorf("IssueSelectColumnsLite names %q; the lite projection must drop every heavy TEXT column", col)
+		}
+		if !strings.Contains(IssueSelectColumns, col) {
+			t.Errorf("IssueSelectColumns does NOT name %q; full hydration must still read every heavy TEXT column", col)
+		}
+	}
+}
+
+// TestClaimReadyIssueInTxScansLite proves the claim's own candidate scan is
+// projected. It is the shape that matters most and the one no consumer can
+// observe: ClaimReadyIssueInTx walks an UNBOUNDED ready front, reads exactly
+// `issue.ID` off each row, and refetches the row it wins whole — so every heavy
+// TEXT column that scan carried was read from the store and discarded.
+//
+// The mock returns one candidate id and then NO row for the hydration, which
+// leaves the ready set empty and returns before the claim CAS. That keeps the
+// test about the projection instead of about the compare-and-set.
+func TestClaimReadyIssueInTxScansLite(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	mock.ExpectQuery(deferredParentProbeRegex("issues")).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(deferredParentProbeRegex("wisps")).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`SELECT id FROM issues`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("bd-1"))
+	mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`SELECT id, content_hash, title,\s+status,`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).WillReturnError(sql.ErrNoRows)
+
+	// The caller's filter says nothing about hydration: the claim sets the
+	// projection on its own copy, which is the point — ValidateClaimNextRequest
+	// refuses a caller that tries to project the row it gets BACK, and this is
+	// not that row.
+	got, err := ClaimReadyIssueInTx(context.Background(), tx, types.WorkFilter{Status: types.StatusOpen}, "tester")
+	if err != nil {
+		t.Fatalf("ClaimReadyIssueInTx: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("ClaimReadyIssueInTx = %v, want nil (the hydration returned no rows)", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem
`types.WorkFilter.Lite` is read by exactly one query — the counts mega-query behind
`bd ready --json`. Every other ready read hydrates whole rows regardless, so the flag
is accepted and silently dropped on the two paths where it would matter most.
`GetReadyWorkInTx` projects `id` and then hydrates the page through
`GetIssuesByIDsInTx`, which always reads `IssueSelectColumns`. And
`ClaimReadyIssueInTx` walks that scan **deliberately unbounded** (`Limit = 0`, so a
transiently unclaimable head cannot make a claim report "nothing ready"), reads
exactly `issue.ID` off every row, and refetches the row it wins **whole** via
`GetIssueInTx` — so the six heavy TEXT columns of the entire ready front are read
from the store and discarded on every single claim.

Measured on one production store, 2026-09-04: `issues.description` is **874.7 MB
across 36,704 rows** (~25 KB/row) against **51.4 MB** in the columns routing actually
reads — about **94% of the bytes those queries carry**. The two wide-column shapes
were **76.8% of server time** at ~449 q/s, and the store was the throughput ceiling
for the whole system.

## Changes (two commits)
1. makes the bare ready scan and the claim scan honor the projection. Adds `GetIssuesByIDsLiteInTx` as a second exported name rather than a bool on the existing one (the two answer different questions and a signature change would silently re-classify twelve call sites); carries `Lite` across the `WorkFilter`→`IssueFilter` boundary for the wisp leg; gives the `domain/db` backend the same treatment. **`ClaimReadyIssueInTx` sets the projection on its own copy of the filter, never from the caller** — `ValidateClaimNextRequest` refuses a projected `ClaimNextRequest` precisely because a caller must not project the row it gets *back*, and the scan's rows are not that row.
2. makes lite the default for `bd ready --json`, with `--full` and `BEADS_READY_HYDRATION=full` as the two ways back and an unrecognized value falling back to full **with a warning**. `--claim`, `--gated`, `--mol`, `--explain` and the text renderings fall back to full; they are not refused, because a default must not manufacture the usage error an explicitly typed `--brief` correctly gets. 

Commit 1 stands alone and is the whole of the measured saving on the claim path.
A maintainer who wants the projection fix without the default change can take 0001 only.

## Tests
Both patches ship tests. SQL-shape controls in **both** directions (lite names none
of the six heavy columns; a filter that did not ask still gets all of them), the same
pair for the claim scan, a constant-level guard on the two column lists, and a
17-row decision table for the CLI default. Both negative controls were run
**known-bad** and red as designed. `gofmt` clean, `go vet` clean, `golangci-lint` at
the repo's pinned `v2.10.1` over the touched packages: **0 issues**.

`./cmd/bd` under `-timeout 1800s`: 3 failures —
`TestCollectViperEntriesWithEnvOverride`,
`TestPrepareSelectedCommandContext_RebindsTargetConfig`,
`TestPrepareSelectedCommandContext_DoesNotMergeCallerConfigForUnsetKeys` — **proven
pre-existing** by running the identical set on an UNMODIFIED base worktree, which
produces the byte-identical failure set. Nothing in them touches ready or claim.
