### PR TITLE
fix(init): reject non-directory embedded roots on Windows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -279,7 +279,7 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           if (-not $IsWindows) { throw 'The embedded init regression requires Windows' }
-          $go = (Get-Command go -CommandType Application -ErrorAction Stop).Source
+          $go = (Get-Command go -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
           if (((& $go env GOHOSTOS GOOS) -join '/') -ne 'windows/windows') {
             throw 'The embedded init regression requires native Windows Go'
           }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -271,6 +271,32 @@ jobs:
       - name: Run Windows liveness regression test
         run: go test -tags gms_pure_go -count=1 -run '^TestIsServerProbablyRunning' ./cmd/bd
 
+      # Reuse this required native cmd/bd job for the Windows ReadDir regression.
+      - name: Run Windows embedded init guard
+        shell: pwsh
+        env:
+          CGO_ENABLED: "1"
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not $IsWindows) { throw 'The embedded init regression requires Windows' }
+          $go = (Get-Command go -CommandType Application -ErrorAction Stop).Source
+          if (((& $go env GOHOSTOS GOOS) -join '/') -ne 'windows/windows') {
+            throw 'The embedded init regression requires native Windows Go'
+          }
+
+          # This singleton owns the embedded-root contract; all child cases run.
+          $testName = 'TestCheckExistingBeadsDataOperationalErrorNotMasked'
+          $testOutput = & $go test -tags gms_pure_go -count=1 -v -run "^${testName}$" ./cmd/bd 2>&1
+          $testExit = $LASTEXITCODE
+          $testOutput | Write-Output
+          if ($testExit -ne 0) { exit $testExit }
+
+          $passPattern = '^--- PASS: ' + [regex]::Escape($testName) + ' \('
+          if (@($testOutput -match $passPattern).Count -ne 1 -or
+              $testOutput -match '^\s*--- (FAIL|SKIP): ') {
+            throw 'Expected the embedded init regression to pass without skipped cases'
+          }
+
   # internal/doltversion carries Windows-specific branches (PATHEXT
   # extension completion in Resolve, ERROR_BAD_EXE_FORMAT detection, the
   # executable-bit carve-out) and its behavioral tests run there via .cmd

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -2497,7 +2497,11 @@ Aborting.`, ui.RenderWarn("⚠"), proxiedRoot, ui.RenderAccent("bd list"))
 			entries, err := os.ReadDir(embeddedRoot)
 			if err != nil {
 				if os.IsNotExist(err) {
-					return nil // No embedded root -> fresh clone, safe to init
+					// On Windows, ReadDir can report a missing path for a regular file.
+					// Confirm absence before treating the root as a fresh clone.
+					if _, statErr := os.Stat(embeddedRoot); os.IsNotExist(statErr) {
+						return nil // No embedded root -> fresh clone, safe to init
+					}
 				}
 				return fmt.Errorf("failed to read embedded dolt directory %s: %w", embeddedRoot, err)
 			}

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -425,6 +425,27 @@ func TestCheckExistingBeadsDataOperationalErrorNotMasked(t *testing.T) {
 		}
 	}
 
+	for _, tt := range []struct {
+		name       string
+		createRoot bool
+	}{
+		{name: "missing embedded root"},
+		{name: "empty embedded root", createRoot: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			beadsDir := t.TempDir()
+			saveEmbeddedConfig(t, beadsDir)
+			if tt.createRoot {
+				if err := os.Mkdir(filepath.Join(beadsDir, "embeddeddolt"), 0o750); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := checkExistingBeadsDataAt(beadsDir, "mydb"); err != nil {
+				t.Fatalf("fresh embedded workspace must allow init: %v", err)
+			}
+		})
+	}
+
 	t.Run("existing database matches sentinel", func(t *testing.T) {
 		beadsDir := t.TempDir()
 		saveEmbeddedConfig(t, beadsDir)
@@ -444,9 +465,10 @@ func TestCheckExistingBeadsDataOperationalErrorNotMasked(t *testing.T) {
 	t.Run("operational error not masked", func(t *testing.T) {
 		beadsDir := t.TempDir()
 		saveEmbeddedConfig(t, beadsDir)
-		// Make embeddeddolt a regular file so os.ReadDir fails with a
-		// non-IsNotExist (operational) error rather than "already initialized".
-		if err := os.WriteFile(filepath.Join(beadsDir, "embeddeddolt"), []byte("not a dir"), 0o600); err != nil {
+		// A regular file is an operational error, including on Windows where
+		// os.ReadDir reports it as a not-exist error.
+		embeddedRoot := filepath.Join(beadsDir, "embeddeddolt")
+		if err := os.WriteFile(embeddedRoot, []byte("not a dir"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		err := checkExistingBeadsDataAt(beadsDir, "mydb")
@@ -455,6 +477,14 @@ func TestCheckExistingBeadsDataOperationalErrorNotMasked(t *testing.T) {
 		}
 		if errors.Is(err, errWorkspaceAlreadyInitialized) {
 			t.Errorf("operational error must NOT match errWorkspaceAlreadyInitialized (would be masked by --init-if-missing): %v", err)
+		}
+		if !strings.Contains(err.Error(), embeddedRoot) {
+			t.Errorf("operational error must identify the embedded root %q, got: %v", embeddedRoot, err)
+		}
+		if contents, readErr := os.ReadFile(embeddedRoot); readErr != nil {
+			t.Fatalf("embedded root file must be preserved: %v", readErr)
+		} else if string(contents) != "not a dir" {
+			t.Errorf("embedded root file changed: %q", contents)
 		}
 	})
 }

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -61,6 +61,32 @@ func TestPRCIGateRequiresPolicyAndLintWrappers(t *testing.T) {
 	}
 }
 
+func TestPRCIGateRequiresWindowsEmbeddedInitGuard(t *testing.T) {
+	workflow := readCIWorkflow(t, "pr.yml")
+	job := workflow.job(t, "test-windows-liveness")
+	step := job.step(t, "Run Windows embedded init guard")
+	if job.RunsOn != "windows-latest" || job.If != "" || job.ContinueOnError {
+		t.Error("embedded init guard must run in the required native Windows job")
+	}
+	if step.If != "" || (step.ContinueOnError != nil && step.ContinueOnError != false) {
+		t.Error("embedded init guard must not be conditional or allow failure")
+	}
+	if step.Shell != "pwsh" || step.Env["CGO_ENABLED"] != "1" {
+		t.Error("embedded init guard requires native PowerShell and its CGO test surface")
+	}
+
+	gate := workflow.job(t, "ci-gate")
+	gateEnv := gate.step(t, "Evaluate CI gate").Env
+	if gate.If != "${{ always() }}" || gate.ContinueOnError {
+		t.Error("CI gate must evaluate failed and skipped Windows jobs")
+	}
+	if !contains(gate.Needs, "test-windows-liveness") ||
+		gateEnv["TEST_WINDOWS_LIVENESS"] != "${{ needs.test-windows-liveness.result }}" ||
+		!contains(strings.Fields(gateEnv["CI_GATE_REQUIRED"]), "TEST_WINDOWS_LIVENESS") {
+		t.Error("embedded init guard must propagate through the required CI gate")
+	}
+}
+
 func TestPRComplexityReportIsAdvisoryAndBestEffort(t *testing.T) {
 	workflow := readCIWorkflow(t, "pr.yml")
 	job := workflow.job(t, "complexity-report")


### PR DESCRIPTION
On Windows, `os.ReadDir` can return a not-exist error for an ordinary file at `.beads/embeddeddolt`. The init guard previously accepted that file as a fresh root. Confirm absence with `os.Stat` before allowing initialization, preserving the operational error and its distinction from the already-initialized sentinel.

Extend the existing regression to cover missing and empty roots, an initialized database, and a regular file whose contents must remain unchanged. Run it with CGO enabled in the existing required Windows liveness job, using the first Go application on PATH, checking the native Go target, and rejecting failed, skipped, or unselected tests. A structural test protects that required placement and CI gate propagation.

Closes #6308.

Validation on Go 1.26.5, native Windows, with `gms_pure_go`:

- Reproduced the original guard failure on base `c0d8da42de5fd15c95adac85e342ba4a121da0fb`.
- Both exact Windows workflow commands pass locally with two Go applications on PATH: the real module-selected Go first and a failing fallback second. The embedded-root guard passes all four child cases; adjacent init guards pass four top-level tests and nine child cases, with zero skips or failures.
- Focused workflow tests pass six top-level tests and three child cases. The new step rejects missing Go, a non-Windows target, zero selected tests, and failed or skipped output; simulated output probes are separate from the real filesystem tests.
- `mingw32-make ci-pr-lint` passes against the stated base: formatting, native lint, and Windows non-CGO lint. Actionlint passes.

The retained full native Windows baseline has unrelated failures; this focused repair does not claim a green full suite. The reproduced bug is the guard accepting a file; no end-to-end destructive outcome is asserted.
