### PR TITLE
fix(purge): honor wisp.protected_labels in bd purge (be-edf)

### DIFF
--- a/backend/conformance/role_bundle_cases.go
+++ b/backend/conformance/role_bundle_cases.go
@@ -628,6 +628,8 @@ var roleContractCases = []roleContract{
 		RunSweeperTreatsALegacyTypedWispAsEphemeralTier,
 		RunSweeperLeavesNoHistoryBeadsToTheDurableTier,
 		RunSweeperProtectsPinnedRows,
+		RunSweeperProtectsLabeledRows,
+		RunSweeperWithoutProtectedLabelsSweepsLabeledRows,
 		RunSweeperHonorsTheCutoffAndThePattern,
 		RunSweeperDryRunChangesNothing,
 		RunSweeperProtectsRowsCitedFromAWispComment,

--- a/backend/conformance/sweeper_contract.go
+++ b/backend/conformance/sweeper_contract.go
@@ -286,6 +286,80 @@ func RunSweeperProtectsPinnedRows(t *testing.T, ctx context.Context, fixture Swe
 	sweeperAssertIssueRows(t, ctx, fixture, 1, pinned)
 }
 
+// RunSweeperProtectsLabeledRows pins issueops.SweepRequest.ProtectedLabels on
+// the EPHEMERAL tier, which is where `bd purge` and `bd mol wisp gc` overlap:
+// a closed wisp carrying a protected label is held back, counted in
+// Skipped.Labeled, and STILL THERE afterwards.
+//
+// IT IS A CONTRACT CASE RATHER THAN A UNIT TEST OF THE FILTER because the
+// filter reads issue.Labels, and whether those labels are HYDRATED onto a
+// sweep candidate is a property of each backend's candidate query — not of the
+// pure function. A backend whose ephemeral search returned rows with nil
+// Labels would pass every unit test of the filter and delete every protected
+// wisp in the workspace, silently, with no error to notice. That failure is
+// only visible from here, against a real store, which is why the seeds carry
+// labels through the plane's own create verb.
+//
+// The unlabeled row is the negative control: it is identical to the protected
+// one in every field the sweep reads except the label, so a backend that held
+// back everything fails this rather than passing as a safer version of it.
+func RunSweeperProtectsLabeledRows(t *testing.T, ctx context.Context, fixture SweeperFixture) {
+	t.Helper()
+	plain := sweeperSeedClosedIssue(t, ctx, fixture, "label", true)
+	protected := sweeperSeed(t, ctx, fixture, sweeperIssue(fixture, "label", "keep", true), func(issue *types.Issue) {
+		issue.Labels = []string{"bd:protected"}
+	})
+	// A label the request does NOT name, on a row otherwise identical to the
+	// protected one. It must sweep: this is what separates "honors the
+	// requested set" from "holds back anything labeled".
+	other := sweeperSeed(t, ctx, fixture, sweeperIssue(fixture, "label", "other", true), func(issue *types.Issue) {
+		issue.Labels = []string{"bd:unrelated"}
+	})
+
+	result := sweeperSweep(t, ctx, fixture, publicops.SweepRequest{
+		Tier:            publicops.SweepEphemeral,
+		IDPattern:       sweeperPattern(fixture, "label"),
+		ProtectedLabels: []string{"bd:protected"},
+	})
+
+	if result.Swept != 2 {
+		t.Errorf("Swept = %d, want 2 — the labeled row must not be one of them", result.Swept)
+	}
+	if result.Skipped.Labeled != 1 {
+		t.Errorf("Skipped.Labeled = %d, want 1", result.Skipped.Labeled)
+	}
+	sweeperAssertWispRows(t, ctx, fixture, 0, plain, other)
+	sweeperAssertWispRows(t, ctx, fixture, 1, protected)
+}
+
+// RunSweeperWithoutProtectedLabelsSweepsLabeledRows is the other half of the
+// opt-in, and it is the case that keeps the one above honest. The SAME labeled
+// row, swept with no ProtectedLabels on the request, is DELETED and reports
+// Skipped.Labeled 0.
+//
+// Without it, a backend that protected `bd:protected` unconditionally — a
+// hard-coded default rather than a request field — would satisfy the case
+// above completely.
+func RunSweeperWithoutProtectedLabelsSweepsLabeledRows(t *testing.T, ctx context.Context, fixture SweeperFixture) {
+	t.Helper()
+	labeled := sweeperSeed(t, ctx, fixture, sweeperIssue(fixture, "nolabelreq", "keep", true), func(issue *types.Issue) {
+		issue.Labels = []string{"bd:protected"}
+	})
+
+	result := sweeperSweep(t, ctx, fixture, publicops.SweepRequest{
+		Tier:      publicops.SweepEphemeral,
+		IDPattern: sweeperPattern(fixture, "nolabelreq"),
+	})
+
+	if result.Swept != 1 {
+		t.Errorf("Swept = %d, want 1 — the protection is a REQUEST FIELD, not a standing rule", result.Swept)
+	}
+	if result.Skipped.Labeled != 0 {
+		t.Errorf("Skipped.Labeled = %d, want 0 when the request named no labels", result.Skipped.Labeled)
+	}
+	sweeperAssertWispRows(t, ctx, fixture, 0, labeled)
+}
+
 // RunSweeperHonorsTheCutoffAndThePattern pins the two narrowing fields.
 //
 // The CUTOFF is HALF-OPEN: a row closed exactly at the cutoff is KEPT

--- a/cmd/bd/closed_delete_candidates.go
+++ b/cmd/bd/closed_delete_candidates.go
@@ -17,10 +17,15 @@ import (
 type closedDeletionCandidateStats = issueops.SweepSkips
 
 // filterClosedDeletionCandidates keeps the closed, unpinned, old-enough
-// candidates and reports what it held back. `bd gc` matches no glob, so it
-// passes the empty pattern, which admits everything.
+// candidates and reports what it held back. `bd gc` matches no glob, so the
+// request carries the empty pattern, which admits everything.
+//
+// It carries no ProtectedLabels: `bd gc` sweeps the DURABLE tier, and
+// wisp.protected_labels is a wisp-tier guard. A durable-tier label protection
+// would be its own decision with its own config key, not this one read from a
+// second command.
 func filterClosedDeletionCandidates(issues []*types.Issue, cutoff *time.Time) ([]*types.Issue, closedDeletionCandidateStats) {
-	return workapi.FilterSweepCandidates(issues, "", cutoff)
+	return workapi.FilterSweepCandidates(issues, issueops.SweepRequest{ClosedBefore: cutoff})
 }
 
 func warnClosedDeletionSafetySkips(stats closedDeletionCandidateStats) {

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -973,7 +973,7 @@ var recognizedConfigPrefixes = []string{
 	"status.", "types.", "doctor.suppress.", "routing.", "sync.", "git.",
 	"directory.", "repos.", "external_projects.", "validation.",
 	"lint.", "hierarchy.", "ai.", "backup.", "federation.", "metrics.",
-	"agent.", "claim.", "storage-class.",
+	"agent.", "claim.", "storage-class.", "wisp.",
 }
 
 // validateStorageClassConfig validates a storage-class.<type> per-type

--- a/cmd/bd/config_validate_key_test.go
+++ b/cmd/bd/config_validate_key_test.go
@@ -13,7 +13,7 @@ func TestIsRecognizedConfigKey(t *testing.T) {
 		"doctor.suppress.git-hooks", "no-git-ops", "beads.role",
 		"status.custom", "types.custom", "types.infra", "ai.model",
 		"backup.enabled", "import.path", "dolt.local-only", "agent.profile",
-		"claim.pools",
+		"claim.pools", "wisp.protected_labels",
 		// Tracker namespaces are derived from the registry (GH#4427); cover
 		// ado (the original bug) plus the others removed from the static list.
 		"ado.org", "ado.project", "github.token", "linear.api-key",

--- a/cmd/bd/mol_port.go
+++ b/cmd/bd/mol_port.go
@@ -156,10 +156,18 @@ func (r uowMolReader) GetIssuesByIDs(ctx context.Context, ids []string) ([]*type
 	if err != nil {
 		return nil, err
 	}
-	if labelMap, err := r.uw.LabelUseCase().GetLabelsForIssues(ctx, ids); err == nil { //nolint:forbidigo // in-transaction port read; see GetIssue above
-		for _, issue := range issues {
-			issue.Labels = labelMap[issue.ID]
-		}
+	// A dropped label error is NOT a display defect here. `bd mol wisp gc`
+	// consults Labels to decide what it must not delete (isProtectedWisp), and
+	// a swallowed error leaves every issue looking unlabeled — which reads as
+	// "carries no protected label" and licenses the delete. Silence in a guard
+	// that gates a destructive command is the failure mode, so both label reads
+	// propagate.
+	labelMap, err := r.uw.LabelUseCase().GetLabelsForIssues(ctx, ids) //nolint:forbidigo // in-transaction port read; see GetIssue above
+	if err != nil {
+		return nil, fmt.Errorf("loading labels for %d issue(s): %w", len(ids), err)
+	}
+	for _, issue := range issues {
+		issue.Labels = labelMap[issue.ID]
 	}
 
 	wisps, err := r.uw.IssueUseCase().GetWispsByIDs(ctx, ids)
@@ -167,10 +175,15 @@ func (r uowMolReader) GetIssuesByIDs(ctx context.Context, ids []string) ([]*type
 		wisps = nil //nolint:staticcheck // wisps table may not exist; issues result still valid
 	}
 	if len(wisps) > 0 {
-		if labelMap, err := r.uw.LabelUseCase().GetLabelsForWisps(ctx, ids); err == nil { //nolint:forbidigo // in-transaction port read; see GetIssue above
-			for _, wisp := range wisps {
-				wisp.Labels = labelMap[wisp.ID]
-			}
+		// Reached only when the wisps table exists and returned rows, so
+		// wisp_labels exists too: an error here is a real read failure, not the
+		// optional-table case the branch above tolerates.
+		wispLabels, err := r.uw.LabelUseCase().GetLabelsForWisps(ctx, ids) //nolint:forbidigo // in-transaction port read; see GetIssue above
+		if err != nil {
+			return nil, fmt.Errorf("loading labels for %d wisp(s): %w", len(wisps), err)
+		}
+		for _, wisp := range wisps {
+			wisp.Labels = wispLabels[wisp.ID]
 		}
 	}
 

--- a/cmd/bd/mol_port_labels_test.go
+++ b/cmd/bd/mol_port_labels_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// labelFailIssueUC answers the two ID lookups uowMolReader.GetIssuesByIDs
+// makes; every other method is a nil call, which is the assertion that this
+// path touches nothing else.
+type labelFailIssueUC struct {
+	domain.IssueUseCase
+	issues []*types.Issue
+	wisps  []*types.Issue
+}
+
+func (s labelFailIssueUC) GetIssuesByIDs(context.Context, []string) ([]*types.Issue, error) {
+	return s.issues, nil
+}
+
+func (s labelFailIssueUC) GetWispsByIDs(context.Context, []string) ([]*types.Issue, error) {
+	return s.wisps, nil
+}
+
+// labelFailLabelUC fails whichever of the two label reads is selected.
+type labelFailLabelUC struct {
+	domain.LabelUseCase
+	issueErr error
+	wispErr  error
+}
+
+func (s labelFailLabelUC) GetLabelsForIssues(context.Context, []string) (map[string][]string, error) {
+	if s.issueErr != nil {
+		return nil, s.issueErr
+	}
+	return map[string][]string{}, nil
+}
+
+func (s labelFailLabelUC) GetLabelsForWisps(context.Context, []string) (map[string][]string, error) {
+	if s.wispErr != nil {
+		return nil, s.wispErr
+	}
+	return map[string][]string{}, nil
+}
+
+type labelFailUOW struct {
+	uow.UnitOfWork
+	issues domain.IssueUseCase
+	labels domain.LabelUseCase
+}
+
+func (u labelFailUOW) Close(context.Context)             {}
+func (u labelFailUOW) IssueUseCase() domain.IssueUseCase { return u.issues }
+func (u labelFailUOW) LabelUseCase() domain.LabelUseCase { return u.labels }
+
+// TestUOWMolReaderGetIssuesByIDsPropagatesLabelErrors pins the fail-closed
+// contract the wisp GC guard depends on.
+//
+// This port used to swallow both label reads (`if labelMap, err := …; err ==
+// nil`), which left every returned issue with nil Labels. For a renderer that
+// is a cosmetic defect. For isProtectedWisp it is a licence to delete: an
+// unlabeled issue reads as "carries no protected label", so a transient label
+// read failure during cascade expansion would have made `bd mol wisp gc` reclaim
+// exactly the records wisp.protected_labels promises it never will — silently,
+// with no error anywhere for an operator to notice.
+func TestUOWMolReaderGetIssuesByIDsPropagatesLabelErrors(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("label table read failed")
+
+	for _, tc := range []struct {
+		name   string
+		reader uowMolReader
+	}{
+		{
+			name: "issue label read failure",
+			reader: uowMolReader{uw: labelFailUOW{
+				issues: labelFailIssueUC{issues: []*types.Issue{{ID: "bd-1"}}},
+				labels: labelFailLabelUC{issueErr: boom},
+			}},
+		},
+		{
+			name: "wisp label read failure",
+			reader: uowMolReader{uw: labelFailUOW{
+				issues: labelFailIssueUC{wisps: []*types.Issue{{ID: "bd-wisp-1"}}},
+				labels: labelFailLabelUC{wispErr: boom},
+			}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tc.reader.GetIssuesByIDs(t.Context(), []string{"bd-1", "bd-wisp-1"})
+			if err == nil {
+				t.Fatalf("a failed label read must surface as an error, got issues=%v and nil error", got)
+			}
+			if !errors.Is(err, boom) {
+				t.Errorf("error should wrap the underlying failure; got %v", err)
+			}
+			if got != nil {
+				t.Errorf("no partial result may escape a failed label read; got %v", got)
+			}
+		})
+	}
+}

--- a/cmd/bd/purge.go
+++ b/cmd/bd/purge.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -52,7 +53,22 @@ Closed ephemeral beads (wisps, transient molecules) accumulate rapidly and
 have no value once closed. This command removes them to reclaim storage.
 
 Deletes: issues, dependencies, labels, events, and comments for matching beads.
-Skips: pinned beads (protected).
+Skips: pinned beads, and beads carrying a protected label.
+
+PROTECTED LABELS (wisp.protected_labels, default "bd:protected") are never
+purged. This is the SAME guard ` + "`bd mol wisp gc`" + ` honors, and the two commands
+delete the same rows — a workspace that configured it used to get the
+protection on one command and not on the other, with no warning from either.
+
+Label the records that cannot be regenerated — messages, escalations, any
+write-once record an orchestration layer keeps as an ephemeral bead. Status
+cannot protect those: an unread message sits in plain open status, and closing
+it is what makes it purgeable.
+
+  bd config set wisp.protected_labels bd:protected,my:message
+
+A configured value REPLACES the default (same rule as types.infra);
+--exclude-label ADDS to whatever is configured.
 
 To delete closed non-ephemeral beads (regular tasks, features, bugs, etc.)
 use ` + "`bd prune`" + ` instead.
@@ -65,7 +81,8 @@ EXAMPLES:
   bd purge --force                   # Delete all closed ephemeral beads
   bd purge --older-than 7d --force   # Only purge items closed 7+ days ago
   bd purge --pattern "*-wisp-*"      # Only purge matching ID pattern
-  bd purge --dry-run                 # Detailed preview with stats`,
+  bd purge --dry-run                 # Detailed preview with stats
+  bd purge --exclude-label my:message --force  # Also protect my:message beads`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -99,6 +116,37 @@ func openSweeper() (issueops.Sweeper, error) {
 		}
 	}
 	return store.Sweeper()
+}
+
+// sweepProtectedLabels resolves the wisp-tier protected-label guard on
+// whichever route this invocation is on — the same two-route dispatch
+// openSweeper performs, for the same reason.
+//
+// It is only ever asked for the EPHEMERAL tier. wisp.protected_labels is a
+// wisp-tier key, and `bd prune` sweeps durable issues; reading a wisp key to
+// decide which durable issues survive would be a guard nobody configured for
+// that purpose.
+//
+// A read failure is returned, never swallowed. `bd purge --force` deletes, so
+// a guard that could not be read has to stop the command rather than resolve
+// to the empty set — which would report a clean purge while protecting
+// nothing, and is exactly the silent under-protection this guard exists to
+// prevent.
+func sweepProtectedLabels(ctx context.Context, extra []string) ([]string, error) {
+	if usesProxiedServer() {
+		uw, err := proxiedOpenReadUOW(ctx)
+		if err != nil {
+			return nil, err
+		}
+		defer uw.Close(ctx)
+		return protectedWispLabelList(ctx, uowMolReader{uw: uw}, extra)
+	}
+	if store == nil {
+		if err := ensureStoreActive(); err != nil {
+			return nil, err
+		}
+	}
+	return protectedWispLabelList(ctx, store, extra)
 }
 
 // runPurgeOrPrune implements the shared delete-closed-beads flow used by both
@@ -142,6 +190,16 @@ func runPurgeOrPrune(cmd *cobra.Command, scope purgeScope) error {
 		}
 		cutoff := time.Now().UTC().AddDate(0, 0, -days)
 		request.ClosedBefore = &cutoff
+	}
+	// The label guard is resolved BEFORE the sweeper is opened, so a workspace
+	// whose config cannot be read fails without having selected anything.
+	if scope.tier == issueops.SweepEphemeral {
+		excludeLabels, _ := cmd.Flags().GetStringSlice("exclude-label")
+		protected, err := sweepProtectedLabels(rootCtx, excludeLabels)
+		if err != nil {
+			return HandleErrorRespectJSON("%v", err)
+		}
+		request.ProtectedLabels = protected
 	}
 
 	sweeper, err := openSweeper()
@@ -225,6 +283,11 @@ func emitSweepEmpty(scope purgeScope, olderThan, pattern string, result issueops
 		msg += fmt.Sprintf(" (matching %q)", pattern)
 	}
 	fmt.Println(msg)
+	if result.Skipped.Labeled > 0 {
+		fmt.Println(ui.MutedStyle.Render(fmt.Sprintf(
+			"  (%d closed bead(s) protected by %s)",
+			result.Skipped.Labeled, protectedWispLabelsKey)))
+	}
 	if result.Skipped.Referenced > 0 {
 		fmt.Println(ui.MutedStyle.Render(fmt.Sprintf(
 			"  (%d closed bead(s) protected by open-bead references — use --ignore-references to override)",
@@ -245,6 +308,9 @@ func emitSweepDryRun(scope purgeScope, result issueops.SweepResult) error {
 		if result.Skipped.Pinned > 0 {
 			stats["pinned_skipped"] = result.Skipped.Pinned
 		}
+		if result.Skipped.Labeled > 0 {
+			stats["labeled_skipped"] = result.Skipped.Labeled
+		}
 		addReferenceStats(scope, stats, result)
 		return outputJSON(stats)
 	}
@@ -254,6 +320,9 @@ func emitSweepDryRun(scope purgeScope, result issueops.SweepResult) error {
 	fmt.Printf("  Events:       %d\n", result.Events)
 	if result.Skipped.Pinned > 0 {
 		fmt.Printf("  Pinned (skipped): %d\n", result.Skipped.Pinned)
+	}
+	if result.Skipped.Labeled > 0 {
+		fmt.Printf("  Protected label (skipped): %d\n", result.Skipped.Labeled)
 	}
 	if result.Skipped.Referenced > 0 {
 		fmt.Printf("  %s   %d\n", ui.MutedStyle.Render("Referenced (skipped):"), result.Skipped.Referenced)
@@ -279,6 +348,9 @@ func emitSweepConfirm(scope purgeScope, olderThan, pattern string, result issueo
 	fmt.Printf("Found %d %s(s) to %s\n", result.Swept, scope.subjectNoun, scope.cmdName)
 	if result.Skipped.Pinned > 0 {
 		fmt.Printf("Skipping %d pinned bead(s)\n", result.Skipped.Pinned)
+	}
+	if result.Skipped.Labeled > 0 {
+		fmt.Printf("Skipping %d bead(s) carrying a protected label\n", result.Skipped.Labeled)
 	}
 	if result.Skipped.Referenced > 0 {
 		fmt.Println(ui.MutedStyle.Render(fmt.Sprintf("Skipping %d referenced bead(s)", result.Skipped.Referenced)))
@@ -306,6 +378,9 @@ func emitSweepResult(scope purgeScope, result issueops.SweepResult) error {
 		if result.Skipped.Pinned > 0 {
 			stats["pinned_skipped"] = result.Skipped.Pinned
 		}
+		if result.Skipped.Labeled > 0 {
+			stats["labeled_skipped"] = result.Skipped.Labeled
+		}
 		addReferenceStats(scope, stats, result)
 		return outputJSON(stats)
 	}
@@ -315,6 +390,9 @@ func emitSweepResult(scope purgeScope, result issueops.SweepResult) error {
 	fmt.Printf("  Events removed:       %d\n", result.Events)
 	if result.Skipped.Pinned > 0 {
 		fmt.Printf("  Pinned (skipped):     %d\n", result.Skipped.Pinned)
+	}
+	if result.Skipped.Labeled > 0 {
+		fmt.Printf("  Protected label (skipped): %d\n", result.Skipped.Labeled)
 	}
 	if result.Skipped.Referenced > 0 {
 		fmt.Printf("  %s %d\n", ui.MutedStyle.Render("Referenced (skipped):"), result.Skipped.Referenced)
@@ -377,5 +455,6 @@ func init() {
 	purgeCmd.Flags().Bool("dry-run", false, "Preview what would be purged with stats")
 	purgeCmd.Flags().String("older-than", "", "Only purge beads closed more than N ago (e.g., 7d, 2w, 30)")
 	purgeCmd.Flags().String("pattern", "", "Only purge beads matching ID glob pattern (e.g., *-wisp-*)")
+	purgeCmd.Flags().StringSlice("exclude-label", nil, "Also protect beads carrying these labels (adds to wisp.protected_labels)")
 	rootCmd.AddCommand(purgeCmd)
 }

--- a/cmd/bd/purge.go
+++ b/cmd/bd/purge.go
@@ -272,6 +272,19 @@ func emitSweepEmpty(scope purgeScope, olderThan, pattern string, result issueops
 			scope.countKey: 0,
 			"message":      fmt.Sprintf("No %ss to %s", scope.subjectNoun, scope.cmdName),
 		}
+		// THE EMPTY RESULT IS THE CASE THAT MOST NEEDS THIS COUNT, not the one
+		// that can do without it. When every candidate carried a protected
+		// label, Swept is 0 and this branch is what a scheduled purge reads —
+		// and "no beads to purge" is then indistinguishable from an empty
+		// workspace, which is the exact reading that would send someone
+		// looking for why their records were not swept. The other emitters
+		// report it beside a non-zero count; here it is the whole story.
+		if result.Skipped.Labeled > 0 {
+			stats["labeled_skipped"] = result.Skipped.Labeled
+		}
+		if result.Skipped.Pinned > 0 {
+			stats["pinned_skipped"] = result.Skipped.Pinned
+		}
 		addReferenceStats(scope, stats, result)
 		return outputJSON(stats)
 	}
@@ -283,6 +296,10 @@ func emitSweepEmpty(scope purgeScope, olderThan, pattern string, result issueops
 		msg += fmt.Sprintf(" (matching %q)", pattern)
 	}
 	fmt.Println(msg)
+	if result.Skipped.Pinned > 0 {
+		fmt.Println(ui.MutedStyle.Render(fmt.Sprintf(
+			"  (%d closed bead(s) protected by the pinned flag)", result.Skipped.Pinned)))
+	}
 	if result.Skipped.Labeled > 0 {
 		fmt.Println(ui.MutedStyle.Render(fmt.Sprintf(
 			"  (%d closed bead(s) protected by %s)",

--- a/cmd/bd/purge_protected_label_embedded_test.go
+++ b/cmd/bd/purge_protected_label_embedded_test.go
@@ -1,0 +1,177 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The end-to-end pins for be-edf: `bd purge --force` honors
+// wisp.protected_labels, the guard `bd mol wisp gc` already honored.
+//
+// WHY THIS NEEDED ITS OWN TEST rather than resting on the workapi unit tests
+// and the Sweeper contract. Those two prove the filter holds a labeled row back
+// and that each backend hydrates the labels it filters on. Neither of them can
+// see whether `bd purge` ever RESOLVES the config key and puts it on the
+// request — and that read is the whole of what this command was missing. A
+// purge that sent an empty ProtectedLabels would pass every other test in this
+// change and delete exactly the records the guard exists to keep.
+//
+// Both cases run against a throwaway store from bdInit, never a live one.
+
+// createAndCloseLabeledEphemeral creates a labeled ephemeral bead and closes
+// it, which is the state `bd purge` selects: closed, ephemeral tier.
+func createAndCloseLabeledEphemeral(t *testing.T, bd, dir, title, labels string) string {
+	t.Helper()
+	args := []string{title, "--ephemeral"}
+	if labels != "" {
+		args = append(args, "--label", labels)
+	}
+	issue := bdCreate(t, bd, dir, args...)
+	cmd := exec.Command(bd, "close", issue.ID)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("close %s failed: %v\n%s", issue.ID, err, out)
+	}
+	return issue.ID
+}
+
+// purgeSurvivors returns the ids still resolvable after a purge, so an
+// assertion is about ROWS rather than about what the command printed.
+func purgeSurvivors(t *testing.T, bd, dir string, ids []string) map[string]bool {
+	t.Helper()
+	alive := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		cmd := exec.Command(bd, "show", id, "--json")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		if err := cmd.Run(); err == nil {
+			alive[id] = true
+		}
+	}
+	return alive
+}
+
+// TestPurgeProtectsLabeledBeads is be-edf's regression test.
+//
+// `bd purge --force` and `bd mol wisp gc --closed --force` delete the same
+// rows, and docs/workflows/wisps.md presents them as interchangeable. Before
+// this change a workspace that configured wisp.protected_labels got the guard
+// on one of them and not the other, with no warning from either — so an
+// operator who had verified gc was safe would run purge and lose the records.
+func TestPurgeProtectsLabeledBeads(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "ppl")
+
+	// A configured value REPLACES the built-in default, so name every label
+	// this store wants protected.
+	bdCommand(t, bd, dir, "config", "set", "wisp.protected_labels", "gt:message,gt:escalation")
+
+	plain := createAndCloseLabeledEphemeral(t, bd, dir, "idle wisp", "")
+	otherLabel := createAndCloseLabeledEphemeral(t, bd, dir, "unrelated label", "gt:thread")
+	mail := createAndCloseLabeledEphemeral(t, bd, dir, "read mail", "gt:message")
+	escalation := createAndCloseLabeledEphemeral(t, bd, dir, "resolved escalation", "gt:escalation")
+	// Protection is per-label, not per-bead.
+	mixed := createAndCloseLabeledEphemeral(t, bd, dir, "mail in a thread", "gt:thread,gt:message")
+	// An ad-hoc label named only on the command line adds to the configured set.
+	adHoc := createAndCloseLabeledEphemeral(t, bd, dir, "ad-hoc protected", "keep:me")
+
+	out := bdPurge(t, bd, dir, "--force", "--exclude-label", "keep:me")
+
+	alive := purgeSurvivors(t, bd, dir, []string{plain, otherLabel, mail, escalation, mixed, adHoc})
+
+	for _, tc := range []struct{ id, what string }{
+		{mail, "read mail"},
+		{escalation, "resolved escalation"},
+		{mixed, "mail carrying an extra unprotected label"},
+		{adHoc, "bead protected by --exclude-label"},
+	} {
+		if !alive[tc.id] {
+			t.Errorf("%s (%s) was PURGED; wisp.protected_labels must protect it. output:\n%s", tc.what, tc.id, out)
+		}
+	}
+
+	// The negative control, and it is the half that keeps this honest: a guard
+	// that protected everything would satisfy the loop above completely, while
+	// making `bd purge` silently unable to purge anything.
+	for _, tc := range []struct{ id, what string }{
+		{plain, "unlabeled"},
+		{otherLabel, "unprotected-label"},
+	} {
+		if alive[tc.id] {
+			t.Errorf("%s bead (%s) survived; the guard must not over-protect. output:\n%s", tc.what, tc.id, out)
+		}
+	}
+
+	if !strings.Contains(out, "Protected label (skipped): 4") {
+		t.Errorf("purge output does not report 4 label-protected skips:\n%s", out)
+	}
+}
+
+// TestPurgeJSONReportsLabeledSkips pins the machine-readable half. The skip is
+// reported the way the pinned count is, so a scheduled purge can SEE that its
+// sweep was narrowed rather than inferring it from a smaller number than
+// expected.
+func TestPurgeJSONReportsLabeledSkips(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "pjs")
+	bdCommand(t, bd, dir, "config", "set", "wisp.protected_labels", "gt:message")
+
+	createAndCloseLabeledEphemeral(t, bd, dir, "plain", "")
+	createAndCloseLabeledEphemeral(t, bd, dir, "mail", "gt:message")
+
+	out := bdPurge(t, bd, dir, "--force", "--json")
+
+	var stats map[string]any
+	if err := json.Unmarshal([]byte(out), &stats); err != nil {
+		t.Fatalf("purge --json is not JSON: %v\n%s", err, out)
+	}
+	if got := stats["labeled_skipped"]; got != float64(1) {
+		t.Errorf("labeled_skipped = %v, want 1; full payload: %s", got, out)
+	}
+	if got := stats["purged_count"]; got != float64(1) {
+		t.Errorf("purged_count = %v, want 1 — only the unlabeled bead; full payload: %s", got, out)
+	}
+}
+
+// TestPurgeWithoutConfiguredLabelsStillProtectsTheBuiltInDefault pins the
+// precedence tail: with nothing configured the built-in "bd:protected" applies,
+// so the extension point is usable before anyone has configured it — and a
+// workspace that never set the key is not silently unguarded.
+func TestPurgeWithoutConfiguredLabelsStillProtectsTheBuiltInDefault(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "pdf")
+
+	plain := createAndCloseLabeledEphemeral(t, bd, dir, "plain", "")
+	defaulted := createAndCloseLabeledEphemeral(t, bd, dir, "protected", "bd:protected")
+
+	out := bdPurge(t, bd, dir, "--force")
+	alive := purgeSurvivors(t, bd, dir, []string{plain, defaulted})
+
+	if !alive[defaulted] {
+		t.Errorf("bd:protected bead (%s) was purged with no config set; the built-in default must apply. output:\n%s", defaulted, out)
+	}
+	if alive[plain] {
+		t.Errorf("unlabeled bead (%s) survived; the default must not over-protect. output:\n%s", plain, out)
+	}
+}

--- a/cmd/bd/purge_protected_label_embedded_test.go
+++ b/cmd/bd/purge_protected_label_embedded_test.go
@@ -175,3 +175,39 @@ func TestPurgeWithoutConfiguredLabelsStillProtectsTheBuiltInDefault(t *testing.T
 		t.Errorf("unlabeled bead (%s) survived; the default must not over-protect. output:\n%s", plain, out)
 	}
 }
+
+// TestPurgeJSONReportsLabeledSkipsWhenNOTHINGIsSwept is the case codex found
+// missing, and it is the one that matters most rather than an edge of the one
+// above.
+//
+// When EVERY candidate carries a protected label, Swept is 0 and `bd purge`
+// takes its empty-result branch. Without the count there, a scheduled purge
+// reading JSON sees `{"purged_count": 0, "message": "No closed ephemeral beads
+// to purge"}` — which is byte-identical to what an empty workspace returns.
+// The guard doing its job and there being nothing to do are then
+// indistinguishable, and the reading a person takes from that is "my records
+// were never here", which is the opposite of the truth.
+func TestPurgeJSONReportsLabeledSkipsWhenNOTHINGIsSwept(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "pje")
+	bdCommand(t, bd, dir, "config", "set", "wisp.protected_labels", "gt:message")
+
+	// Every candidate is protected, so the sweep is empty for a REASON.
+	createAndCloseLabeledEphemeral(t, bd, dir, "mail one", "gt:message")
+	createAndCloseLabeledEphemeral(t, bd, dir, "mail two", "gt:message")
+
+	out := bdPurge(t, bd, dir, "--force", "--json")
+
+	var stats map[string]any
+	if err := json.Unmarshal([]byte(out), &stats); err != nil {
+		t.Fatalf("purge --json is not JSON: %v\n%s", err, out)
+	}
+	if got := stats["labeled_skipped"]; got != float64(2) {
+		t.Errorf("labeled_skipped = %v, want 2 — an empty sweep must say WHY it was empty; payload: %s", got, out)
+	}
+}

--- a/cmd/bd/wisp.go
+++ b/cmd/bd/wisp.go
@@ -713,7 +713,14 @@ func protectedWispStatuses(ctx context.Context, r molReader) (map[types.Status]b
 }
 
 // protectedWispLabelsKey is the config key holding the labels that make a wisp
-// unreclaimable by `bd mol wisp gc`.
+// unreclaimable by the two commands that delete closed ephemeral beads:
+// `bd mol wisp gc` and `bd purge`.
+//
+// ONE KEY, BOTH COMMANDS, resolved by the functions below and by nothing else.
+// The two are siblings over the same rows, and the docs present them as
+// interchangeable; a second resolution of "which labels are protected" is how
+// they would come to disagree about it, which is worse than the gap that
+// existed when only one of them had a guard at all.
 const protectedWispLabelsKey = "wisp.protected_labels"
 
 // defaultProtectedWispLabels is the label set honored when nothing is
@@ -724,8 +731,17 @@ const protectedWispLabelsKey = "wisp.protected_labels"
 // to provide the extension point and to fail closed on it.
 var defaultProtectedWispLabels = []string{"bd:protected"}
 
-// protectedWispLabels resolves the labels that make a wisp unreclaimable by
-// `bd mol wisp gc`, with the same precedence the infra-type set uses: the DB
+// protectedWispLabelConfigReader is the one thing resolving the guard needs
+// from a store: the config key. It is narrower than molReader so that `bd
+// purge`, which has no other use for a molecule reader, can resolve the SAME
+// guard without acquiring one — molReader satisfies it structurally, so every
+// existing caller passes unchanged.
+type protectedWispLabelConfigReader interface {
+	GetConfig(ctx context.Context, key string) (string, error)
+}
+
+// protectedWispLabelList resolves the labels that make a closed ephemeral bead
+// unreclaimable, with the same precedence the infra-type set uses: the DB
 // config key wisp.protected_labels, then config.yaml, then the built-in
 // default. A configured value REPLACES the default rather than extending it,
 // matching types.infra.
@@ -734,22 +750,38 @@ var defaultProtectedWispLabels = []string{"bd:protected"}
 // the command line is asking for more protection than the workspace
 // configures, never less.
 //
-// Reading the config is required, not best-effort. This command deletes, so an
-// unreadable guard must abort it rather than silently under-protect — the same
-// contract protectedWispStatuses holds.
-func protectedWispLabels(ctx context.Context, r molReader, extra []string) (map[string]bool, error) {
+// Reading the config is required, not best-effort. Both callers DELETE, so an
+// unreadable guard must abort rather than silently under-protect — the same
+// contract protectedWispStatuses holds. That is why this returns an error at
+// all: the failure mode it exists to prevent is a guard that resolves to the
+// empty set and protects nothing while reporting success.
+func protectedWispLabelList(ctx context.Context, r protectedWispLabelConfigReader, extra []string) ([]string, error) {
 	value, err := r.GetConfig(ctx, protectedWispLabelsKey)
 	if err != nil {
-		return nil, fmt.Errorf("reading %s for wisp gc: %w", protectedWispLabelsKey, err)
+		return nil, fmt.Errorf("reading %s: %w", protectedWispLabelsKey, err)
 	}
-	return resolveProtectedWispLabels(value, config.GetProtectedWispLabelsFromYAML(), extra), nil
+	return resolveProtectedWispLabelList(value, config.GetProtectedWispLabelsFromYAML(), extra), nil
 }
 
-// resolveProtectedWispLabels is protectedWispLabels' precedence rule with the
-// three sources already read, so it can be tested without a store: dbValue is
-// the raw comma-separated wisp.protected_labels config value, yaml is the
-// config.yaml fallback, and extra is --exclude-label.
-func resolveProtectedWispLabels(dbValue string, yaml, extra []string) map[string]bool {
+// protectedWispLabels is protectedWispLabelList as the membership set `bd mol
+// wisp gc` tests candidates against.
+func protectedWispLabels(ctx context.Context, r protectedWispLabelConfigReader, extra []string) (map[string]bool, error) {
+	labels, err := protectedWispLabelList(ctx, r, extra)
+	if err != nil {
+		return nil, err
+	}
+	return protectedWispLabelSet(labels), nil
+}
+
+// resolveProtectedWispLabelList is the precedence rule with the three sources
+// already read, so it can be tested without a store: dbValue is the raw
+// comma-separated wisp.protected_labels config value, yaml is the config.yaml
+// fallback, and extra is --exclude-label.
+//
+// The result is SORTED, so a caller that reports or serializes the resolved
+// set — `bd purge` puts it on a sweep request that crosses an HTTP boundary —
+// gets a stable value rather than Go's map order.
+func resolveProtectedWispLabelList(dbValue string, yaml, extra []string) []string {
 	labels := utils.NormalizeLabels(strings.Split(dbValue, ","))
 	if len(labels) == 0 {
 		labels = utils.NormalizeLabels(yaml)
@@ -757,8 +789,20 @@ func resolveProtectedWispLabels(dbValue string, yaml, extra []string) map[string
 	if len(labels) == 0 {
 		labels = defaultProtectedWispLabels
 	}
-	set := make(map[string]bool, len(labels)+len(extra))
-	for _, l := range utils.NormalizeLabels(append(append([]string{}, labels...), extra...)) {
+	resolved := utils.NormalizeLabels(append(append([]string{}, labels...), extra...))
+	slices.Sort(resolved)
+	return resolved
+}
+
+// resolveProtectedWispLabels is resolveProtectedWispLabelList as a set.
+func resolveProtectedWispLabels(dbValue string, yaml, extra []string) map[string]bool {
+	return protectedWispLabelSet(resolveProtectedWispLabelList(dbValue, yaml, extra))
+}
+
+// protectedWispLabelSet turns a resolved label list into a membership set.
+func protectedWispLabelSet(labels []string) map[string]bool {
+	set := make(map[string]bool, len(labels))
+	for _, l := range labels {
 		set[l] = true
 	}
 	return set

--- a/cmd/bd/wisp.go
+++ b/cmd/bd/wisp.go
@@ -9,11 +9,13 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/formula"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/utils"
 )
 
 // Wisp commands - manage ephemeral molecules
@@ -619,6 +621,19 @@ A wisp is considered abandoned if:
     configured category, so only plain open (active) and closed (done) steps
     are age-reclaimable. If the blocked set or the custom-status list cannot be
     read, the GC aborts rather than risk reclaiming live steps.
+  - AND it carries no protected label.
+
+Protected labels (wisp.protected_labels, default "bd:protected") are never
+reclaimed, in ANY mode of this command — not by age, not by --all, not by
+--closed. Status protection cannot cover a write-once record such as a message
+or an escalation: an unread one sits in plain open status, which is
+age-reclaimable by design, so the longer it went unread the more certainly it
+was deleted. Label such records instead:
+
+  bd config set wisp.protected_labels bd:protected,my:message
+
+A configured value REPLACES the default (same rule as types.infra);
+--exclude-label ADDS to whatever is configured.
 
 Abandoned wisps are deleted without creating a digest. Use 'bd mol squash'
 if you want to preserve a summary before garbage collection.
@@ -639,7 +654,8 @@ Examples:
   bd mol wisp gc --closed --force                   # Delete all closed wisps
   bd mol wisp gc --closed --dry-run                 # Explicit dry-run (same as no --force)
   bd mol wisp gc --exclude-type agent,rig           # Protect agent and rig wisps from GC
-  bd mol wisp gc --closed --force --exclude-type mol # Delete closed wisps except mol type`,
+  bd mol wisp gc --closed --force --exclude-type mol # Delete closed wisps except mol type
+  bd mol wisp gc --exclude-label my:message         # Also protect wisps labeled my:message`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE:          runWispGC,
@@ -696,25 +712,112 @@ func protectedWispStatuses(ctx context.Context, r molReader) (map[types.Status]b
 	return protected, nil
 }
 
-// isProtectedWisp reports whether a wisp is live work that age-based GC must
-// never reclaim. A wisp is protected if it is explicitly pinned, if it is
-// blocked on an open dependency (blockedSet, derived from is_blocked), or if
-// its status falls in a protected category. Reclaiming any of these
-// mid-execution destroys active molecules (GH#4394).
+// protectedWispLabelsKey is the config key holding the labels that make a wisp
+// unreclaimable by `bd mol wisp gc`.
+const protectedWispLabelsKey = "wisp.protected_labels"
+
+// defaultProtectedWispLabels is the label set honored when nothing is
+// configured. It is deliberately a beads-native label rather than any
+// particular orchestrator's: which of an orchestration layer's records are
+// irreplaceable is that layer's policy, and the charter keeps that policy out
+// of core (engdocs/PROJECT_CHARTER.md, Orchestration Boundary). Core's job is
+// to provide the extension point and to fail closed on it.
+var defaultProtectedWispLabels = []string{"bd:protected"}
+
+// protectedWispLabels resolves the labels that make a wisp unreclaimable by
+// `bd mol wisp gc`, with the same precedence the infra-type set uses: the DB
+// config key wisp.protected_labels, then config.yaml, then the built-in
+// default. A configured value REPLACES the default rather than extending it,
+// matching types.infra.
+//
+// extra carries --exclude-label, which is additive: a caller naming a label on
+// the command line is asking for more protection than the workspace
+// configures, never less.
+//
+// Reading the config is required, not best-effort. This command deletes, so an
+// unreadable guard must abort it rather than silently under-protect — the same
+// contract protectedWispStatuses holds.
+func protectedWispLabels(ctx context.Context, r molReader, extra []string) (map[string]bool, error) {
+	value, err := r.GetConfig(ctx, protectedWispLabelsKey)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s for wisp gc: %w", protectedWispLabelsKey, err)
+	}
+	return resolveProtectedWispLabels(value, config.GetProtectedWispLabelsFromYAML(), extra), nil
+}
+
+// resolveProtectedWispLabels is protectedWispLabels' precedence rule with the
+// three sources already read, so it can be tested without a store: dbValue is
+// the raw comma-separated wisp.protected_labels config value, yaml is the
+// config.yaml fallback, and extra is --exclude-label.
+func resolveProtectedWispLabels(dbValue string, yaml, extra []string) map[string]bool {
+	labels := utils.NormalizeLabels(strings.Split(dbValue, ","))
+	if len(labels) == 0 {
+		labels = utils.NormalizeLabels(yaml)
+	}
+	if len(labels) == 0 {
+		labels = defaultProtectedWispLabels
+	}
+	set := make(map[string]bool, len(labels)+len(extra))
+	for _, l := range utils.NormalizeLabels(append(append([]string{}, labels...), extra...)) {
+		set[l] = true
+	}
+	return set
+}
+
+// wispGuard is everything `bd mol wisp gc` must consult before deleting a wisp.
+// It is a struct rather than three parameters so that adding a fourth kind of
+// protection cannot silently miss one of the call sites that filters candidates
+// (the age sweep, its cascade expansion, and the closed purge).
+type wispGuard struct {
+	blocked  map[string]bool
+	statuses map[types.Status]bool
+	labels   map[string]bool
+}
+
+// hasProtectedLabel reports whether the issue carries any protected label.
+func (g wispGuard) hasProtectedLabel(issue *types.Issue) bool {
+	for _, l := range issue.Labels {
+		if g.labels[l] {
+			return true
+		}
+	}
+	return false
+}
+
+// isProtectedWisp reports whether a wisp is live work or an irreplaceable
+// record that GC must never reclaim. A wisp is protected if it is explicitly
+// pinned, if it is blocked on an open dependency (blocked, derived from
+// is_blocked), if its status falls in a protected category, or if it carries a
+// protected label. Reclaiming any of the first three mid-execution destroys
+// active molecules (GH#4394).
+//
+// The label check exists because status protection cannot reach the records
+// that matter most. An orchestration layer that stores mail, escalations or
+// any other write-once record as an ephemeral bead leaves it in plain `open`
+// status for exactly as long as nobody has read it — and open is CategoryActive,
+// which is reclaimable by design. So the longer such a record went unread, the
+// more certainly age GC deleted it, and there is no status the layer could set
+// instead without lying about the record's state. A label is the only handle
+// that survives that, and it must be consulted on every candidate rather than
+// pushed into the search filter, because the cascade expansion below reaches
+// wisps the filter never saw.
 //
 // Named isProtectedWisp rather than isActiveWisp to avoid confusion with
 // (*DoltStore).isActiveWisp in internal/storage/dolt, which is in this same
 // delete path but means only "a row for this ID exists in the wisps table".
-func isProtectedWisp(issue *types.Issue, blockedSet map[string]bool, protectedStatuses map[types.Status]bool) bool {
+func isProtectedWisp(issue *types.Issue, g wispGuard) bool {
 	// The pinned flag is independent of the pinned status; the closed-purge
 	// branch of this same command already honors it (see runWispPurgeClosed).
 	if issue.Pinned {
 		return true
 	}
-	if blockedSet[issue.ID] {
+	if g.blocked[issue.ID] {
 		return true
 	}
-	return protectedStatuses[issue.Status]
+	if g.statuses[issue.Status] {
+		return true
+	}
+	return g.hasProtectedLabel(issue)
 }
 
 func runWispGC(cmd *cobra.Command, args []string) error {
@@ -735,6 +838,7 @@ func runWispGC(cmd *cobra.Command, args []string) error {
 	closedMode, _ := cmd.Flags().GetBool("closed")
 	force, _ := cmd.Flags().GetBool("force")
 	excludeTypeStrs, _ := cmd.Flags().GetStringSlice("exclude-type")
+	excludeLabels, _ := cmd.Flags().GetStringSlice("exclude-label")
 
 	ageThreshold := time.Hour
 	if ageStr != "" {
@@ -751,7 +855,7 @@ func runWispGC(cmd *cobra.Command, args []string) error {
 	}
 
 	if usesProxiedServer() {
-		return runWispGCProxiedServer(rootCtx, dryRun, ageThreshold, cleanAll, closedMode, force, excludeTypes)
+		return runWispGCProxiedServer(rootCtx, dryRun, ageThreshold, cleanAll, closedMode, force, excludeTypes, excludeLabels)
 	}
 
 	if store == nil {
@@ -759,10 +863,10 @@ func runWispGC(cmd *cobra.Command, args []string) error {
 	}
 
 	if closedMode {
-		return runWispPurgeClosed(ctx, dryRun, force, excludeTypes)
+		return runWispPurgeClosed(ctx, dryRun, force, excludeTypes, excludeLabels)
 	}
 
-	abandoned, err := findAbandonedWisps(ctx, store, cleanAll, ageThreshold, excludeTypes)
+	abandoned, err := findAbandonedWisps(ctx, store, cleanAll, ageThreshold, excludeTypes, excludeLabels)
 	if err != nil && abandoned == nil {
 		return HandleError("%v", err)
 	}
@@ -821,8 +925,11 @@ func runWispGC(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func findAbandonedWisps(ctx context.Context, r molReader, cleanAll bool, ageThreshold time.Duration, excludeTypes []types.IssueType) ([]*types.Issue, error) {
+func findAbandonedWisps(ctx context.Context, r molReader, cleanAll bool, ageThreshold time.Duration, excludeTypes []types.IssueType, excludeLabels []string) ([]*types.Issue, error) {
 	ephemeralFlag := true
+	// SkipLabels stays unset deliberately: the guard below reads issue.Labels,
+	// and a lite/label-skipping projection would make every wisp look unlabeled
+	// — a silent, total loss of label protection with no error to notice.
 	filter := types.IssueFilter{
 		Ephemeral:    &ephemeralFlag,
 		ExcludeTypes: excludeTypes,
@@ -847,6 +954,13 @@ func findAbandonedWisps(ctx context.Context, r molReader, cleanAll bool, ageThre
 		return nil, err
 	}
 
+	protectedLabels, err := protectedWispLabels(ctx, r, excludeLabels)
+	if err != nil {
+		return nil, err
+	}
+
+	guard := wispGuard{blocked: blockedSet, statuses: protectedStatuses, labels: protectedLabels}
+
 	now := time.Now()
 	var abandoned []*types.Issue
 	for _, issue := range issues {
@@ -856,7 +970,7 @@ func findAbandonedWisps(ctx context.Context, r molReader, cleanAll bool, ageThre
 		if issue.Status == types.StatusClosed && !cleanAll {
 			continue
 		}
-		if isProtectedWisp(issue, blockedSet, protectedStatuses) {
+		if isProtectedWisp(issue, guard) {
 			continue
 		}
 		if now.Sub(issue.UpdatedAt) > ageThreshold {
@@ -891,7 +1005,7 @@ func findAbandonedWisps(ctx context.Context, r molReader, cleanAll bool, ageThre
 				if r.IsInfraTypeCtx(ctx, child.IssueType) {
 					continue
 				}
-				if isProtectedWisp(child, blockedSet, protectedStatuses) {
+				if isProtectedWisp(child, guard) {
 					continue
 				}
 				abandoned = append(abandoned, child)
@@ -901,7 +1015,68 @@ func findAbandonedWisps(ctx context.Context, r molReader, cleanAll bool, ageThre
 	return abandoned, cascadeErr
 }
 
-func runWispPurgeClosed(ctx context.Context, dryRun bool, force bool, excludeTypes []types.IssueType) error {
+// infraTypeReader is the one thing filterClosedPurgeCandidates needs from a
+// store. Narrowing the parameter keeps the filter testable without standing up
+// the whole molReader surface.
+type infraTypeReader interface {
+	IsInfraTypeCtx(ctx context.Context, t types.IssueType) bool
+}
+
+// closedPurgeSkips counts the closed wisps a purge declined to delete, by
+// reason. It is reported rather than merely applied: a guard that silently
+// removes rows is indistinguishable from having had nothing to delete, and the
+// operator needs to know that the purge left something behind and why.
+type closedPurgeSkips struct {
+	pinned  int
+	infra   int
+	labeled int
+}
+
+func (c closedPurgeSkips) report() {
+	if c.pinned > 0 {
+		fmt.Printf("Skipping %d pinned issue(s) (protected from cleanup)\n", c.pinned)
+	}
+	if c.infra > 0 {
+		fmt.Printf("Skipping %d configured infra issue(s) protected from GC\n", c.infra)
+	}
+	if c.labeled > 0 {
+		fmt.Printf("Skipping %d wisp(s) carrying a protected label (%s)\n", c.labeled, protectedWispLabelsKey)
+	}
+}
+
+// filterClosedPurgeCandidates removes from a closed-wisp purge everything the
+// purge must not delete. It is shared by the direct and proxied-server paths so
+// the two cannot drift on which protections they honor — they already had two
+// hand-copied versions of the pinned/infra filter.
+//
+// Label protection applies here as well as to the age sweep on purpose: the
+// rule a caller has to remember is "wisp gc never reclaims a wisp carrying a
+// protected label", with no mode in which it does. A record whose whole point
+// is that it outlives the run that produced it is not made disposable by having
+// been closed, and `bd delete` remains available for deleting one on purpose.
+func filterClosedPurgeCandidates(ctx context.Context, r infraTypeReader, issues []*types.Issue, protectedLabels map[string]bool) ([]*types.Issue, closedPurgeSkips) {
+	guard := wispGuard{labels: protectedLabels}
+	var skips closedPurgeSkips
+	filtered := make([]*types.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if issue.Pinned {
+			skips.pinned++
+			continue
+		}
+		if r.IsInfraTypeCtx(ctx, issue.IssueType) {
+			skips.infra++
+			continue
+		}
+		if guard.hasProtectedLabel(issue) {
+			skips.labeled++
+			continue
+		}
+		filtered = append(filtered, issue)
+	}
+	return filtered, skips
+}
+
+func runWispPurgeClosed(ctx context.Context, dryRun bool, force bool, excludeTypes []types.IssueType, excludeLabels []string) error {
 	statusClosed := types.StatusClosed
 	ephemeralTrue := true
 	filter := types.IssueFilter{
@@ -916,28 +1091,14 @@ func runWispPurgeClosed(ctx context.Context, dryRun bool, force bool, excludeTyp
 		return HandleError("listing closed wisps: %v", err)
 	}
 
-	// Filter out pinned and infra issues (protected from cleanup)
-	pinnedCount := 0
-	infraCount := 0
-	filtered := make([]*types.Issue, 0, len(closedIssues))
-	for _, issue := range closedIssues {
-		if issue.Pinned {
-			pinnedCount++
-			continue
-		}
-		if store.IsInfraTypeCtx(ctx, issue.IssueType) {
-			infraCount++
-			continue
-		}
-		filtered = append(filtered, issue)
+	protectedLabels, err := protectedWispLabels(ctx, store, excludeLabels)
+	if err != nil {
+		return HandleError("%v", err)
 	}
-	closedIssues = filtered
 
-	if pinnedCount > 0 && !jsonOutput {
-		fmt.Printf("Skipping %d pinned issue(s) (protected from cleanup)\n", pinnedCount)
-	}
-	if infraCount > 0 && !jsonOutput {
-		fmt.Printf("Skipping %d configured infra issue(s) protected from GC\n", infraCount)
+	closedIssues, skips := filterClosedPurgeCandidates(ctx, store, closedIssues, protectedLabels)
+	if !jsonOutput {
+		skips.report()
 	}
 
 	if len(closedIssues) == 0 {
@@ -1015,6 +1176,7 @@ func init() {
 	wispGCCmd.Flags().Bool("closed", false, "Delete all closed wisps (ignores --age threshold)")
 	wispGCCmd.Flags().BoolP("force", "f", false, "Actually delete (default: preview only)")
 	wispGCCmd.Flags().StringSlice("exclude-type", nil, "Exclude wisps of these types from GC (comma-separated, e.g., agent,rig)")
+	wispGCCmd.Flags().StringSlice("exclude-label", nil, "Additionally protect wisps carrying these labels (comma-separated); adds to wisp.protected_labels")
 
 	wispCmd.AddCommand(wispCreateCmd)
 	wispCmd.AddCommand(wispListCmd)

--- a/cmd/bd/wisp_gc_protected_label_embedded_test.go
+++ b/cmd/bd/wisp_gc_protected_label_embedded_test.go
@@ -1,0 +1,154 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestWispGCProtectsLabeledWisps is the regression test for the data loss that
+// motivated the label guard: `bd mol wisp gc --age` deleted unread mail and
+// open escalations that an orchestration layer had stored as ephemeral beads.
+//
+// Nothing else in the predicate could have saved them. Such a record sits in
+// plain `open` status for exactly as long as nobody has acted on it, and open is
+// CategoryActive — age-reclaimable by design — so the longer a message went
+// unread, the more certainly GC deleted it. --exclude-type could not help
+// either: these records are ordinary `task`-typed beads, so excluding their
+// type excludes nearly the whole store.
+//
+// The assertions run against a throwaway store created by bdInit, never a live
+// one; this command deletes, and deletes without a digest.
+func TestWispGCProtectsLabeledWisps(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "gcl")
+
+	// A configured value REPLACES the built-in default, so name every label
+	// this store wants protected.
+	bdCommand(t, bd, dir, "config", "set", "wisp.protected_labels", "gt:message,gt:escalation")
+
+	// Ordering matters for the same reason as in TestWispGCProtectsActiveWisps:
+	// wisps expected to be RECLAIMED are created first, so the age predicate
+	// cannot mistake the most recently touched bead for not-yet-stale if the DB
+	// clock runs ahead of the test process. Protected wisps are excluded
+	// regardless of age.
+	idle := bdCreate(t, bd, dir, "idle wisp", "--ephemeral").ID
+	otherLabel := bdCreate(t, bd, dir, "unrelated label", "--ephemeral", "--label", "gt:thread").ID
+
+	// The two classes that were actually destroyed. Both are plain open tasks.
+	unreadMail := bdCreate(t, bd, dir, "unread mail", "--ephemeral", "--label", "gt:message").ID
+	escalation := bdCreate(t, bd, dir, "open escalation", "--ephemeral", "--label", "gt:escalation").ID
+
+	// Protection is per-label, not per-bead: a record carrying a protected
+	// label alongside unprotected ones is still protected.
+	mixed := bdCreate(t, bd, dir, "mail in a thread", "--ephemeral", "--label", "gt:thread,gt:message").ID
+
+	// An ad-hoc label named only on the command line adds to the configured set.
+	adHoc := bdCreate(t, bd, dir, "ad-hoc protected", "--ephemeral", "--label", "keep:me").ID
+
+	candidates := wispGCCandidates(t, bd, dir, "--age", "1ms", "--dry-run", "--exclude-label", "keep:me")
+
+	for _, tc := range []struct {
+		id   string
+		what string
+	}{
+		{unreadMail, "unread mail"},
+		{escalation, "open escalation"},
+		{mixed, "mail carrying an extra unprotected label"},
+		{adHoc, "wisp protected by --exclude-label"},
+	} {
+		if candidates[tc.id] {
+			t.Errorf("%s wisp %s must NOT be reclaimed by age; candidates=%v", tc.what, tc.id, keys(candidates))
+		}
+	}
+
+	// The guard must not degenerate into "protect everything": a wisp with no
+	// label, and a wisp whose only label is unprotected, stay reclaimable.
+	for _, tc := range []struct {
+		id   string
+		what string
+	}{
+		{idle, "unlabeled idle"},
+		{otherLabel, "unprotected-label"},
+	} {
+		if !candidates[tc.id] {
+			t.Errorf("%s wisp %s should stay a GC candidate (guard must not over-protect); candidates=%v", tc.what, tc.id, keys(candidates))
+		}
+	}
+}
+
+// TestWispGCClosedPurgeProtectsLabeledWisps pins the other half of the rule:
+// `wisp gc` never reclaims a protected label in ANY mode. Closing a record does
+// not make it disposable — a read message and a resolved escalation are exactly
+// the ones worth keeping — and --closed selects purely by status, so without
+// this the age guard would just move the deletion to a different flag.
+func TestWispGCClosedPurgeProtectsLabeledWisps(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "gcc")
+
+	bdCommand(t, bd, dir, "config", "set", "wisp.protected_labels", "gt:message")
+
+	readMail := bdCreate(t, bd, dir, "read mail", "--ephemeral", "--label", "gt:message").ID
+	spent := bdCreate(t, bd, dir, "spent wisp", "--ephemeral").ID
+	bdCommand(t, bd, dir, "close", readMail)
+	bdCommand(t, bd, dir, "close", spent)
+
+	out := bdCommand(t, bd, dir, "mol", "wisp", "gc", "--closed", "--dry-run")
+
+	if !strings.Contains(out, "Found 1 closed wisp(s)") {
+		t.Errorf("closed purge should have exactly one candidate (%s), got:\n%s", spent, out)
+	}
+	if !strings.Contains(out, "protected label") {
+		t.Errorf("closed purge must report the wisp it skipped and why; got:\n%s", out)
+	}
+
+	// The labeled wisp must still be there afterwards; the unlabeled one is the
+	// purge's business.
+	if !strings.Contains(bdCommand(t, bd, dir, "show", readMail), readMail) {
+		t.Errorf("closed wisp %s carrying a protected label must survive --closed", readMail)
+	}
+}
+
+// wispGCCandidates runs `bd mol wisp gc --json` and returns the candidate IDs
+// as a set.
+func wispGCCandidates(t *testing.T, bd, dir string, args ...string) map[string]bool {
+	t.Helper()
+	out := bdCommand(t, bd, dir, append([]string{"mol", "wisp", "gc", "--json"}, args...)...)
+
+	start := strings.Index(out, "{")
+	if start < 0 {
+		t.Fatalf("gc --json produced no JSON object\nraw:\n%s", out)
+	}
+	var res struct {
+		CleanedIDs []string `json:"cleaned_ids"`
+	}
+	if err := json.NewDecoder(strings.NewReader(out[start:])).Decode(&res); err != nil {
+		t.Fatalf("parse gc --json output: %v\nraw:\n%s", err, out)
+	}
+	candidates := make(map[string]bool, len(res.CleanedIDs))
+	for _, id := range res.CleanedIDs {
+		candidates[id] = true
+	}
+	return candidates
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/cmd/bd/wisp_gc_protected_labels_test.go
+++ b/cmd/bd/wisp_gc_protected_labels_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// noInfraReader is an infraTypeReader for which no type is infrastructure, so
+// the closed-purge filter's other branches are what the assertions measure.
+type noInfraReader struct{}
+
+func (noInfraReader) IsInfraTypeCtx(context.Context, types.IssueType) bool { return false }
+
+// TestResolveProtectedWispLabels pins the precedence rule: a configured value
+// REPLACES the built-in default (matching types.infra), config.yaml is consulted
+// only when the DB value is unset, and --exclude-label always ADDS. Getting the
+// precedence backwards would silently widen or narrow what a destructive
+// command refuses to delete.
+func TestResolveProtectedWispLabels(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		dbValue string
+		yaml    []string
+		extra   []string
+		want    []string
+		absent  []string
+	}{
+		{
+			name:   "unset everywhere falls back to the built-in default",
+			want:   []string{"bd:protected"},
+			absent: []string{"gt:message"},
+		},
+		{
+			name:    "configured value replaces the default, it does not extend it",
+			dbValue: "gt:message,gt:escalation",
+			want:    []string{"gt:message", "gt:escalation"},
+			absent:  []string{"bd:protected"},
+		},
+		{
+			name:    "whitespace around a configured label is trimmed",
+			dbValue: " gt:message ,  gt:escalation ",
+			want:    []string{"gt:message", "gt:escalation"},
+		},
+		{
+			name:   "config.yaml is the fallback when the DB value is unset",
+			yaml:   []string{"yaml:keep"},
+			want:   []string{"yaml:keep"},
+			absent: []string{"bd:protected"},
+		},
+		{
+			name:    "the DB value wins over config.yaml",
+			dbValue: "db:keep",
+			yaml:    []string{"yaml:keep"},
+			want:    []string{"db:keep"},
+			absent:  []string{"yaml:keep"},
+		},
+		{
+			name:    "--exclude-label adds to the configured set",
+			dbValue: "gt:message",
+			extra:   []string{"ad:hoc"},
+			want:    []string{"gt:message", "ad:hoc"},
+		},
+		{
+			name:  "--exclude-label adds to the default set",
+			extra: []string{"ad:hoc"},
+			want:  []string{"bd:protected", "ad:hoc"},
+		},
+		{
+			name:    "an all-whitespace config value reads as unset, not as no protection",
+			dbValue: "  ,  ",
+			want:    []string{"bd:protected"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveProtectedWispLabels(tc.dbValue, tc.yaml, tc.extra)
+			for _, l := range tc.want {
+				if !got[l] {
+					t.Errorf("label %q should be protected; got set %v", l, got)
+				}
+			}
+			for _, l := range tc.absent {
+				if got[l] {
+					t.Errorf("label %q should NOT be protected; got set %v", l, got)
+				}
+			}
+		})
+	}
+}
+
+// TestIsProtectedWispLabels is the unit-level regression for the hole this
+// guard closes: an unread message or escalation stored as an ephemeral bead
+// sits in plain open status, which every other protection in this predicate
+// treats as reclaimable. Before the label check it was deleted by age alone.
+func TestIsProtectedWispLabels(t *testing.T) {
+	t.Parallel()
+
+	guard := wispGuard{
+		blocked:  map[string]bool{},
+		statuses: map[types.Status]bool{types.StatusInProgress: true},
+		labels:   map[string]bool{"gt:message": true},
+	}
+
+	unreadMail := &types.Issue{
+		ID:     "gt-wisp-mail",
+		Status: types.StatusOpen,
+		Labels: []string{"gt:message", "gt:thread"},
+	}
+	if !isProtectedWisp(unreadMail, guard) {
+		t.Error("an open wisp carrying a protected label must not be reclaimable by age")
+	}
+
+	// The guard must not degenerate into "protect everything": an ordinary
+	// open wisp with unrelated labels stays a candidate.
+	ordinary := &types.Issue{
+		ID:     "gt-wisp-idle",
+		Status: types.StatusOpen,
+		Labels: []string{"gt:thread"},
+	}
+	if isProtectedWisp(ordinary, guard) {
+		t.Error("an open wisp with no protected label must stay reclaimable")
+	}
+
+	// Label protection is independent of status protection: it must hold for a
+	// closed wisp too, because --closed purges by status alone.
+	closedMail := &types.Issue{
+		ID:     "gt-wisp-read",
+		Status: types.StatusClosed,
+		Labels: []string{"gt:message"},
+	}
+	if !isProtectedWisp(closedMail, guard) {
+		t.Error("a closed wisp carrying a protected label must not be reclaimable")
+	}
+
+	// A wisp with no labels at all must not panic or protect.
+	if isProtectedWisp(&types.Issue{ID: "gt-wisp-bare", Status: types.StatusOpen}, guard) {
+		t.Error("an unlabeled open wisp must stay reclaimable")
+	}
+}
+
+// TestFilterClosedPurgeCandidatesCountsWhatItSkipped pins the reporting half:
+// a guard that silently drops rows is indistinguishable from having had
+// nothing to delete, so the purge must count each reason separately.
+func TestFilterClosedPurgeCandidatesCountsWhatItSkipped(t *testing.T) {
+	t.Parallel()
+
+	issues := []*types.Issue{
+		{ID: "keep-1", Status: types.StatusClosed},
+		{ID: "pinned-1", Status: types.StatusClosed, Pinned: true},
+		{ID: "labeled-1", Status: types.StatusClosed, Labels: []string{"gt:message"}},
+		{ID: "labeled-2", Status: types.StatusClosed, Labels: []string{"other", "gt:message"}},
+		{ID: "keep-2", Status: types.StatusClosed, Labels: []string{"other"}},
+	}
+
+	kept, skips := filterClosedPurgeCandidates(t.Context(), noInfraReader{}, issues, map[string]bool{"gt:message": true})
+
+	var keptIDs []string
+	for _, i := range kept {
+		keptIDs = append(keptIDs, i.ID)
+	}
+	if len(kept) != 2 || keptIDs[0] != "keep-1" || keptIDs[1] != "keep-2" {
+		t.Errorf("kept = %v, want [keep-1 keep-2]", keptIDs)
+	}
+	if skips.pinned != 1 {
+		t.Errorf("skips.pinned = %d, want 1", skips.pinned)
+	}
+	if skips.labeled != 2 {
+		t.Errorf("skips.labeled = %d, want 2", skips.labeled)
+	}
+	if skips.infra != 0 {
+		t.Errorf("skips.infra = %d, want 0", skips.infra)
+	}
+}

--- a/cmd/bd/wisp_gc_protected_labels_test.go
+++ b/cmd/bd/wisp_gc_protected_labels_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/types"
@@ -173,5 +174,31 @@ func TestFilterClosedPurgeCandidatesCountsWhatItSkipped(t *testing.T) {
 	}
 	if skips.infra != 0 {
 		t.Errorf("skips.infra = %d, want 0", skips.infra)
+	}
+}
+
+// TestResolveProtectedWispLabelListIsSorted pins the ordering the list form
+// promises. `bd purge` puts the resolved set on a sweep request that can cross
+// an HTTP boundary and get logged, so Go's map iteration order would make an
+// otherwise identical request serialize differently on every run.
+//
+// It also pins that the list and the set never disagree, which is the property
+// that keeps `bd purge` and `bd mol wisp gc` honoring ONE guard rather than two
+// that happen to be spelled the same.
+func TestResolveProtectedWispLabelListIsSorted(t *testing.T) {
+	got := resolveProtectedWispLabelList("zeta,alpha", nil, []string{"mid"})
+	want := []string{"alpha", "mid", "zeta"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("resolveProtectedWispLabelList = %v, want %v", got, want)
+	}
+
+	set := resolveProtectedWispLabels("zeta,alpha", nil, []string{"mid"})
+	if len(set) != len(got) {
+		t.Fatalf("set has %d entries, list has %d — the two forms must describe one set", len(set), len(got))
+	}
+	for _, l := range got {
+		if !set[l] {
+			t.Errorf("label %q is in the list and not in the set", l)
+		}
 	}
 }

--- a/cmd/bd/wisp_proxied_server.go
+++ b/cmd/bd/wisp_proxied_server.go
@@ -118,7 +118,7 @@ func runWispListProxiedServer(ctx context.Context, showAll bool, typeFilter stri
 	return renderWispListResult(buildWispListResult(issues, showAll))
 }
 
-func runWispGCProxiedServer(ctx context.Context, dryRun bool, ageThreshold time.Duration, cleanAll, closedMode, force bool, excludeTypes []types.IssueType) error {
+func runWispGCProxiedServer(ctx context.Context, dryRun bool, ageThreshold time.Duration, cleanAll, closedMode, force bool, excludeTypes []types.IssueType, excludeLabels []string) error {
 	CheckReadonly("wisp gc")
 
 	if uowProvider == nil {
@@ -126,7 +126,7 @@ func runWispGCProxiedServer(ctx context.Context, dryRun bool, ageThreshold time.
 	}
 
 	if closedMode {
-		return runWispPurgeClosedProxiedServer(ctx, dryRun, force, excludeTypes)
+		return runWispPurgeClosedProxiedServer(ctx, dryRun, force, excludeTypes, excludeLabels)
 	}
 
 	uw, err := proxiedOpenReadUOW(ctx)
@@ -134,7 +134,7 @@ func runWispGCProxiedServer(ctx context.Context, dryRun bool, ageThreshold time.
 		return err
 	}
 	r := uowMolReader{uw: uw}
-	abandoned, err := findAbandonedWisps(ctx, r, cleanAll, ageThreshold, excludeTypes)
+	abandoned, err := findAbandonedWisps(ctx, r, cleanAll, ageThreshold, excludeTypes, excludeLabels)
 	uw.Close(ctx)
 	if err != nil && abandoned == nil {
 		return HandleError("%v", err)
@@ -219,7 +219,7 @@ func renderWispGCDeleteResult(ids []string, res domain.DeleteIssuesResult) error
 	return nil
 }
 
-func runWispPurgeClosedProxiedServer(ctx context.Context, dryRun, force bool, excludeTypes []types.IssueType) error {
+func runWispPurgeClosedProxiedServer(ctx context.Context, dryRun, force bool, excludeTypes []types.IssueType, excludeLabels []string) error {
 	uw, err := proxiedOpenReadUOW(ctx)
 	if err != nil {
 		return err
@@ -240,28 +240,17 @@ func runWispPurgeClosedProxiedServer(ctx context.Context, dryRun, force bool, ex
 		return HandleError("listing closed wisps: %v", err)
 	}
 
-	pinnedCount := 0
-	infraCount := 0
-	filtered := make([]*types.Issue, 0, len(closedIssues))
-	for _, issue := range closedIssues {
-		if issue.Pinned {
-			pinnedCount++
-			continue
-		}
-		if r.IsInfraTypeCtx(ctx, issue.IssueType) {
-			infraCount++
-			continue
-		}
-		filtered = append(filtered, issue)
+	protectedLabels, err := protectedWispLabels(ctx, r, excludeLabels)
+	if err != nil {
+		uw.Close(ctx)
+		return HandleError("%v", err)
 	}
-	closedIssues = filtered
+
+	closedIssues, skips := filterClosedPurgeCandidates(ctx, r, closedIssues, protectedLabels)
 	uw.Close(ctx)
 
-	if pinnedCount > 0 && !jsonOutput {
-		fmt.Printf("Skipping %d pinned issue(s) (protected from cleanup)\n", pinnedCount)
-	}
-	if infraCount > 0 && !jsonOutput {
-		fmt.Printf("Skipping %d configured infra issue(s) protected from GC\n", infraCount)
+	if !jsonOutput {
+		skips.report()
 	}
 
 	if len(closedIssues) == 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1094,6 +1094,14 @@ func GetInfraTypesFromYAML() []string {
 	return getConfigList("types.infra")
 }
 
+// GetProtectedWispLabelsFromYAML retrieves the labels that make a wisp
+// unreclaimable by `bd mol wisp gc`, from config.yaml. Used as a fallback when
+// the database has no wisp.protected_labels value (caller should fall through
+// to the built-in default). Returns nil if the key is unset.
+func GetProtectedWispLabelsFromYAML() []string {
+	return getConfigList("wisp.protected_labels")
+}
+
 // GetCustomStatusesFromYAML retrieves custom statuses from config.yaml.
 // This is used as a fallback when the database doesn't have status.custom set yet
 // or when the database connection is temporarily unavailable.

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -1812,7 +1812,9 @@ type StatsResponse struct {
 	Summary Statistics `json:"summary"`
 }
 
-// SweepRequest Which closed beads to clear. The predicate is FIXED at "closed beads of one tier" and the two narrowing members only narrow it: there is no status, no assignee, no label and no free-text query here, because every one of those would be another way to spell a destructive selection that a caller could get subtly wrong.
+// SweepRequest Which closed beads to clear. The predicate is FIXED at "closed beads of one tier" and the narrowing members only narrow it: there is no status, no assignee and no free-text query here, because every one of those would be another way to spell a destructive selection that a caller could get subtly wrong.
+//
+// `protected_labels` is not a counterexample: it can only SUBTRACT beads from the deletion. There is deliberately no label SELECTOR — no way to say "delete the beads carrying this label" — because a member that can only protect fails toward keeping a bead, and one that can select fails toward deleting one.
 //
 // `additionalProperties: false`, so an unknown member is a `400` naming the member — the same posture the query-parameter rule takes, and for the same reason: on this operation a silently ignored narrowing term widens what is erased.
 type SweepRequest struct {
@@ -1834,6 +1836,13 @@ type SweepRequest struct {
 	//
 	// It costs a full scan of the not-done set and its comments. Sending `protect_referenced: false` buys the cheaper sweep, and asking for it explicitly is the point: that is the request that should be the deliberate one.
 	ProtectReferenced *bool `json:"protect_referenced,omitempty"`
+
+	// ProtectedLabels Skip candidates carrying ANY of these labels, matched WHOLE and exactly. Absent or empty protects nothing.
+	//
+	// It is the member for records that cannot be regenerated and that no STATUS can protect — a message or an escalation an orchestration layer keeps as an ephemeral bead sits in plain open status for exactly as long as nobody has read it, and closing it is what makes it sweepable. A label is the only handle that survives that.
+	//
+	// IT HAS NO DEFAULT HERE, and that is a KNOWN ASYMMETRY with the CLI rather than a considered default. `bd purge` resolves the guard from `wisp.protected_labels` (then config.yaml, then the built-in `bd:protected`) and always sends the result; a remote caller that omits this member gets no label protection at all. Reading that config on this surface is a change to what an omitted member MEANS, which is a decision this operation should not make silently — see `protect_referenced`, which defaults ON for the same class of reason. Until it is made, a deployment that relies on the guard sends the member explicitly.
+	ProtectedLabels *[]string `json:"protected_labels,omitempty"`
 
 	// Tier Which plane to clear. `ephemeral` is the wisp tier (`bd purge`) and `durable` is the issue tier (`bd prune`). The two are DISJOINT: a sweep of one can never touch a bead of the other. Required, with no default — a caller handed the wrong tier has nothing to notice until the beads are gone.
 	Tier SweepRequestTier `json:"tier"`
@@ -1861,17 +1870,20 @@ type SweepResult struct {
 	// ReferencedIds A BOUNDED SAMPLE of the ids `skipped.referenced` counts — at most 100, in the order the candidate query returned them. It is a sample, not the set: compare its length against 100 to tell a truncated one from a complete one. Absent when nothing was protected.
 	ReferencedIds *[]string `json:"referenced_ids,omitempty"`
 
-	// Skipped The candidates a sweep declined to delete, bucketed by WHY. They are separate counters rather than one number because they mean different things: the first two are PROTECTIONS, and the last four are the sweep declining to trust its own input.
+	// Skipped The candidates a sweep declined to delete, bucketed by WHY. They are separate counters rather than one number because they mean different things: the first three are PROTECTIONS, and the last four are the sweep declining to trust its own input.
 	Skipped SweepSkips `json:"skipped"`
 
 	// Swept How many beads were deleted, or under `dry_run` would be.
 	Swept int `json:"swept"`
 }
 
-// SweepSkips The candidates a sweep declined to delete, bucketed by WHY. They are separate counters rather than one number because they mean different things: the first two are PROTECTIONS, and the last four are the sweep declining to trust its own input.
+// SweepSkips The candidates a sweep declined to delete, bucketed by WHY. They are separate counters rather than one number because they mean different things: the first three are PROTECTIONS, and the last four are the sweep declining to trust its own input.
 type SweepSkips struct {
 	// ClosedAtOrAfterCutoff Candidates whose close timestamp did not satisfy `closed_before`. See `not_closed`.
 	ClosedAtOrAfterCutoff int `json:"closed_at_or_after_cutoff"`
+
+	// Labeled Candidates protected by `protected_labels`. Always 0 when that member is absent or empty, so a 0 read without having sent labels says nothing about whether protected beads exist.
+	Labeled int `json:"labeled"`
 
 	// NotClosed Candidates the tier query returned that the recheck found were not closed. A NON-ZERO VALUE HERE IS A DEFENSE FIRING, not a normal outcome: the query asked for exactly the beads this excludes.
 	NotClosed int `json:"not_closed"`

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -7571,10 +7571,17 @@ components:
       required: [tier]
       description: >-
         Which closed beads to clear. The predicate is FIXED at "closed beads of
-        one tier" and the two narrowing members only narrow it: there is no
-        status, no assignee, no label and no free-text query here, because
-        every one of those would be another way to spell a destructive
-        selection that a caller could get subtly wrong.
+        one tier" and the narrowing members only narrow it: there is no status,
+        no assignee and no free-text query here, because every one of those
+        would be another way to spell a destructive selection that a caller
+        could get subtly wrong.
+
+
+        `protected_labels` is not a counterexample: it can only SUBTRACT beads
+        from the deletion. There is deliberately no label SELECTOR — no way to
+        say "delete the beads carrying this label" — because a member that can
+        only protect fails toward keeping a bead, and one that can select fails
+        toward deleting one.
 
 
         `additionalProperties: false`, so an unknown member is a `400` naming
@@ -7644,6 +7651,32 @@ components:
             `protect_referenced: false` buys the cheaper sweep, and asking for
             it explicitly is the point: that is the request that should be the
             deliberate one.
+        protected_labels:
+          type: array
+          items:
+            type: string
+          description: >-
+            Skip candidates carrying ANY of these labels, matched WHOLE and
+            exactly. Absent or empty protects nothing.
+
+
+            It is the member for records that cannot be regenerated and that no
+            STATUS can protect — a message or an escalation an orchestration
+            layer keeps as an ephemeral bead sits in plain open status for
+            exactly as long as nobody has read it, and closing it is what makes
+            it sweepable. A label is the only handle that survives that.
+
+
+            IT HAS NO DEFAULT HERE, and that is a KNOWN ASYMMETRY with the CLI
+            rather than a considered default. `bd purge` resolves the guard
+            from `wisp.protected_labels` (then config.yaml, then the built-in
+            `bd:protected`) and always sends the result; a remote caller that
+            omits this member gets no label protection at all. Reading that
+            config on this surface is a change to what an omitted member MEANS,
+            which is a decision this operation should not make silently — see
+            `protect_referenced`, which defaults ON for the same class of
+            reason. Until it is made, a deployment that relies on the guard
+            sends the member explicitly.
         dry_run:
           type: boolean
           default: false
@@ -7704,6 +7737,7 @@ components:
       required:
         - pinned
         - referenced
+        - labeled
         - not_closed
         - unknown_closed_at
         - closed_at_or_after_cutoff
@@ -7711,8 +7745,8 @@ components:
       description: >-
         The candidates a sweep declined to delete, bucketed by WHY. They are
         separate counters rather than one number because they mean different
-        things: the first two are PROTECTIONS, and the last four are the sweep
-        declining to trust its own input.
+        things: the first three are PROTECTIONS, and the last four are the
+        sweep declining to trust its own input.
       properties:
         pinned:
           type: integer
@@ -7726,6 +7760,12 @@ components:
             Candidates protected by `protect_referenced`. Always 0 when that
             member is false or absent, so a 0 read without having asked says
             nothing about whether beads are cited.
+        labeled:
+          type: integer
+          description: >-
+            Candidates protected by `protected_labels`. Always 0 when that
+            member is absent or empty, so a 0 read without having sent labels
+            says nothing about whether protected beads exist.
         not_closed:
           type: integer
           description: >-

--- a/internal/httpapi/sweep.go
+++ b/internal/httpapi/sweep.go
@@ -23,6 +23,7 @@ const (
 	sweepClosedBeforeMember      = "closed_before"
 	sweepPatternMember           = "pattern"
 	sweepProtectReferencedMember = "protect_referenced"
+	sweepProtectedLabelsMember   = "protected_labels"
 	sweepDryRunMember            = "dry_run"
 )
 
@@ -35,6 +36,7 @@ var sweepMembers = []string{
 	sweepClosedBeforeMember,
 	sweepPatternMember,
 	sweepProtectReferencedMember,
+	sweepProtectedLabelsMember,
 	sweepDryRunMember,
 }
 
@@ -43,7 +45,7 @@ var sweepMembers = []string{
 //
 // WHAT THIS HANDLER DOES NOT DO. It does not decide which beads are closed,
 // does not match the glob, does not recheck closed_at, does not protect pinned
-// beads, and — the one that matters most — does not implement the
+// or labeled beads, and — the one that matters most — does not implement the
 // require-a-filter safety gate. All of that is issueops.Sweeper, the same
 // library surface `bd prune` calls, so this endpoint could not erase every
 // closed bead in a workspace by omission even if a future edit here forgot the
@@ -51,7 +53,7 @@ var sweepMembers = []string{
 // would be one handler away from an unguarded mass delete.
 //
 // Everything above the role here is argument validation: the media type, the
-// body shape, and the six members the document publishes.
+// body shape, and the seven members the document publishes.
 //
 // NO ACTOR IS INFERRED, for the reason the claim gives: the server's own
 // identity is meaningless to a remote caller. Unlike the claim, the actor is
@@ -194,6 +196,25 @@ func (s *Server) sweepRequest(w http.ResponseWriter, r *http.Request) (issueops.
 		request.IDPattern = *value
 	}
 
+	if raw, ok := members[sweepProtectedLabelsMember]; ok {
+		var value *[]string
+		if err := json.Unmarshal(raw, &value); err != nil || value == nil {
+			s.fail(w, r, InvalidArgument(sweepProtectedLabelsMember, ReasonInvalidValue,
+				"`"+sweepProtectedLabelsMember+"` must be an array of strings"))
+			return issueops.SweepRequest{}, false
+		}
+		// NO DEFAULT IS APPLIED when the member is absent, and that is a known
+		// asymmetry rather than a considered default: `bd purge` resolves the
+		// guard from wisp.protected_labels and always sends it, so a remote
+		// caller that omits this member gets weaker protection than the local
+		// operator. Resolving that config here would put a SECOND definition
+		// of "which labels are protected" beside the one in cmd/bd — the
+		// divergence that made this protection necessary in the first place,
+		// reintroduced one surface over. The fix is to share the resolution,
+		// not to copy it. Recorded on the schema member too.
+		request.ProtectedLabels = *value
+	}
+
 	for _, flag := range []struct {
 		member string
 		dest   *bool
@@ -263,6 +284,7 @@ func sweepResponse(result issueops.SweepResult) apigen.SweepResult {
 		Skipped: apigen.SweepSkips{
 			Pinned:                result.Skipped.Pinned,
 			Referenced:            result.Skipped.Referenced,
+			Labeled:               result.Skipped.Labeled,
 			NotClosed:             result.Skipped.NotClosed,
 			UnknownClosedAt:       result.Skipped.UnknownClosedAt,
 			ClosedAtOrAfterCutoff: result.Skipped.ClosedAtOrAfterCutoff,

--- a/internal/httpapi/sweep_test.go
+++ b/internal/httpapi/sweep_test.go
@@ -112,7 +112,7 @@ func TestSweepDefaultsTheOptionalMembers(t *testing.T) {
 	// surface-wide, so an omitted member must not buy weaker protection than
 	// `bd prune` gives by default.
 	want := issueops.SweepRequest{Tier: issueops.SweepEphemeral, ProtectReferenced: true}
-	if reqs[0] != want {
+	if !reflect.DeepEqual(reqs[0], want) {
 		t.Errorf("request = %+v, want %+v", reqs[0], want)
 	}
 }

--- a/internal/storage/dolt/sweeper_contract_test.go
+++ b/internal/storage/dolt/sweeper_contract_test.go
@@ -41,6 +41,12 @@ func TestSweeperContract(t *testing.T) {
 	t.Run("ProtectsPinnedRows", func(t *testing.T) {
 		conformance.RunSweeperProtectsPinnedRows(t, ctx, fixture)
 	})
+	t.Run("ProtectsLabeledRows", func(t *testing.T) {
+		conformance.RunSweeperProtectsLabeledRows(t, ctx, fixture)
+	})
+	t.Run("WithoutProtectedLabelsSweepsLabeledRows", func(t *testing.T) {
+		conformance.RunSweeperWithoutProtectedLabelsSweepsLabeledRows(t, ctx, fixture)
+	})
 	t.Run("HonorsTheCutoffAndThePattern", func(t *testing.T) {
 		conformance.RunSweeperHonorsTheCutoffAndThePattern(t, ctx, fixture)
 	})

--- a/internal/storage/embeddeddolt/sweeper_contract_test.go
+++ b/internal/storage/embeddeddolt/sweeper_contract_test.go
@@ -46,6 +46,12 @@ func TestSweeperContract(t *testing.T) {
 	t.Run("ProtectsPinnedRows", func(t *testing.T) {
 		conformance.RunSweeperProtectsPinnedRows(t, ctx, fixture)
 	})
+	t.Run("ProtectsLabeledRows", func(t *testing.T) {
+		conformance.RunSweeperProtectsLabeledRows(t, ctx, fixture)
+	})
+	t.Run("WithoutProtectedLabelsSweepsLabeledRows", func(t *testing.T) {
+		conformance.RunSweeperWithoutProtectedLabelsSweepsLabeledRows(t, ctx, fixture)
+	})
 	t.Run("HonorsTheCutoffAndThePattern", func(t *testing.T) {
 		conformance.RunSweeperHonorsTheCutoffAndThePattern(t, ctx, fixture)
 	})

--- a/internal/storage/issueops/sweep.go
+++ b/internal/storage/issueops/sweep.go
@@ -36,7 +36,7 @@ func SweepInTx(ctx context.Context, tx *sql.Tx, req publicops.SweepRequest) (pub
 		return publicops.SweepResult{}, fmt.Errorf("listing sweep candidates: %w", err)
 	}
 
-	kept, skips := workapi.FilterSweepCandidates(candidates, req.IDPattern, req.ClosedBefore)
+	kept, skips := workapi.FilterSweepCandidates(candidates, req)
 	result.Skipped = skips
 
 	if req.ProtectReferenced {

--- a/internal/storage/uow/sweeper.go
+++ b/internal/storage/uow/sweeper.go
@@ -41,8 +41,9 @@ var _ publicops.Sweeper = (*sweeper)(nil)
 // This is the genuinely separate body: the two store backends share
 // issueops.SweepInTx, and this one reaches the same questions through the domain
 // use cases. What it must NOT do differently is WHICH ROWS GO — the selection,
-// the pattern, the pinned and closed_at rechecks and the citation rule all run
-// through the same internal/workapi functions the shared body runs.
+// the pattern, the pinned and label protections, the closed_at rechecks and the
+// citation rule all run through the same internal/workapi functions the shared
+// body runs.
 //
 // ONE UNIT OF WORK matters more here than it does for a read. The candidate
 // query and the delete are on the same transaction, so a row closed, unpinned
@@ -81,7 +82,7 @@ func sweepInUOW(ctx context.Context, uw UnitOfWork, req publicops.SweepRequest) 
 		return publicops.SweepResult{}, fmt.Errorf("listing sweep candidates: %w", err)
 	}
 
-	kept, skips := workapi.FilterSweepCandidates(page.Items, req.IDPattern, req.ClosedBefore)
+	kept, skips := workapi.FilterSweepCandidates(page.Items, req)
 	result.Skipped = skips
 
 	if req.ProtectReferenced {

--- a/internal/storage/uow/sweeper_contract_test.go
+++ b/internal/storage/uow/sweeper_contract_test.go
@@ -41,6 +41,12 @@ func TestSweeperContract(t *testing.T) {
 	t.Run("ProtectsPinnedRows", func(t *testing.T) {
 		conformance.RunSweeperProtectsPinnedRows(t, ctx, fixture)
 	})
+	t.Run("ProtectsLabeledRows", func(t *testing.T) {
+		conformance.RunSweeperProtectsLabeledRows(t, ctx, fixture)
+	})
+	t.Run("WithoutProtectedLabelsSweepsLabeledRows", func(t *testing.T) {
+		conformance.RunSweeperWithoutProtectedLabelsSweepsLabeledRows(t, ctx, fixture)
+	})
 	t.Run("HonorsTheCutoffAndThePattern", func(t *testing.T) {
 		conformance.RunSweeperHonorsTheCutoffAndThePattern(t, ctx, fixture)
 	})

--- a/internal/workapi/sweep.go
+++ b/internal/workapi/sweep.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/issueops"
@@ -98,34 +97,89 @@ func MatchesSweepPattern(pattern, id string) bool {
 	return err == nil && ok
 }
 
-// FilterSweepCandidates applies the pattern and then the two protections that
-// hold a candidate back before any reference scan: the pinned flag, and the
-// closed_at recheck.
+// SweepProtectedLabelSet turns a request's ProtectedLabels into the set
+// FilterSweepCandidates matches against. Empty entries are dropped: a label
+// row is never empty, so an empty entry could only ever have come from a
+// caller splitting an empty config value, and admitting it would protect
+// nothing while looking like protection.
+//
+// It is exported so a front door can report what it resolved without
+// re-deriving the rule.
+func SweepProtectedLabelSet(labels []string) map[string]bool {
+	if len(labels) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(labels))
+	for _, l := range labels {
+		if l == "" {
+			continue
+		}
+		set[l] = true
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
+}
+
+// hasProtectedLabel reports whether an issue carries any label in set. A nil
+// set protects nothing, which is the no-opt-in case and must stay a cheap
+// no-op: this runs once per candidate on the delete path.
+func hasProtectedLabel(issue *types.Issue, set map[string]bool) bool {
+	if len(set) == 0 {
+		return false
+	}
+	for _, l := range issue.Labels {
+		if set[l] {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterSweepCandidates applies the pattern and then the protections that hold
+// a candidate back before any reference scan: the pinned flag, the protected
+// labels, and the closed_at recheck.
+//
+// IT TAKES THE WHOLE REQUEST rather than the two or three fields it reads,
+// because every field it reads is a way a candidate can be held back, and the
+// three call sites below the two front doors must not be able to drift on
+// which of them they pass. Handing the request over means a protection added
+// to it reaches every route by construction; handing over a parameter list
+// means a new protection is a signature change that one call site can be
+// updated without.
 //
 // THE ORDER IS PART OF THE ANSWER, and issueops.Sweeper.Sweep states it: the
-// pattern narrows first, so a pinned row the pattern excluded is not counted
-// as protected — it was never a candidate. The three closed_at buckets are
-// defenses against the tier query returning a row it was not asked for, counted
-// rather than dropped so a disagreement between the query and the recheck is
-// visible instead of silent.
+// pattern narrows first, so a pinned or labeled row the pattern excluded is
+// not counted as protected — it was never a candidate. The two protections
+// then come before the three closed_at buckets, which are defenses against the
+// tier query returning a row it was not asked for, counted rather than dropped
+// so a disagreement between the query and the recheck is visible instead of
+// silent. A candidate lands in exactly one bucket.
 //
-// cutoff is the request's ClosedBefore; a nil cutoff performs the presence
-// checks and skips the comparison.
-func FilterSweepCandidates(issues []*types.Issue, pattern string, cutoff *time.Time) ([]*types.Issue, issueops.SweepSkips) {
+// LABEL PROTECTION READS issue.Labels, so a caller that hands over rows from a
+// label-skipping projection (types.IssueFilter.SkipLabels, or Lite) gets a
+// total and SILENT loss of it — every row looks unlabeled and no error is
+// raised. BuildSweepCandidateFilter sets neither, deliberately.
+func FilterSweepCandidates(issues []*types.Issue, req issueops.SweepRequest) ([]*types.Issue, issueops.SweepSkips) {
 	kept := make([]*types.Issue, 0, len(issues))
 	var skips issueops.SweepSkips
+	protected := SweepProtectedLabelSet(req.ProtectedLabels)
+	cutoff := req.ClosedBefore
 
 	for _, issue := range issues {
 		if issue == nil {
 			skips.Unreadable++
 			continue
 		}
-		if !MatchesSweepPattern(pattern, issue.ID) {
+		if !MatchesSweepPattern(req.IDPattern, issue.ID) {
 			continue
 		}
 		switch {
 		case issue.Pinned:
 			skips.Pinned++
+		case hasProtectedLabel(issue, protected):
+			skips.Labeled++
 		case issue.Status != types.StatusClosed:
 			skips.NotClosed++
 		case issue.ClosedAt == nil:

--- a/internal/workapi/sweep_test.go
+++ b/internal/workapi/sweep_test.go
@@ -3,6 +3,7 @@ package workapi
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -129,7 +130,7 @@ func TestFilterSweepCandidatesRechecksClosedAtCutoff(t *testing.T) {
 		nil,
 	}
 
-	filtered, skips := FilterSweepCandidates(candidates, "", &cutoff)
+	filtered, skips := FilterSweepCandidates(candidates, issueops.SweepRequest{ClosedBefore: &cutoff})
 
 	if len(filtered) != 1 || filtered[0].ID != "old-closed" {
 		t.Fatalf("filtered IDs = %v, want only old-closed", sweepCandidateIDs(filtered))
@@ -157,7 +158,7 @@ func TestFilterSweepCandidatesWithoutCutoffStillRequiresClosedAt(t *testing.T) {
 		{ID: "closed-missing-time", Status: types.StatusClosed},
 	}
 
-	filtered, skips := FilterSweepCandidates(candidates, "", nil)
+	filtered, skips := FilterSweepCandidates(candidates, issueops.SweepRequest{})
 
 	if len(filtered) != 1 || filtered[0].ID != "closed" {
 		t.Fatalf("filtered IDs = %v, want only closed", sweepCandidateIDs(filtered))
@@ -181,7 +182,7 @@ func TestFilterSweepCandidatesNarrowsByPatternBeforeProtecting(t *testing.T) {
 		{ID: "other-pinned", Status: types.StatusClosed, ClosedAt: &closedAt, Pinned: true},
 	}
 
-	filtered, skips := FilterSweepCandidates(candidates, "keep-*", nil)
+	filtered, skips := FilterSweepCandidates(candidates, issueops.SweepRequest{IDPattern: "keep-*"})
 
 	if len(filtered) != 1 || filtered[0].ID != "keep-1" {
 		t.Fatalf("filtered IDs = %v, want only keep-1", sweepCandidateIDs(filtered))
@@ -352,4 +353,165 @@ func sweepCandidateIDs(issues []*types.Issue) []string {
 		ids[i] = issue.ID
 	}
 	return ids
+}
+
+// TestFilterSweepCandidatesProtectsLabeledCandidates is the whole of be-edf at
+// the seam every sweep route runs through: a closed ephemeral bead carrying a
+// protected label is HELD BACK and counted, not deleted.
+//
+// The negative control is the load-bearing half. `unlabeled` and `other-label`
+// are identical to `protected` in every field the filter reads except the one
+// under test, so a guard that protected everything — or that resolved its set
+// to "match anything" — fails here rather than passing as a stricter version of
+// the same behavior.
+func TestFilterSweepCandidatesProtectsLabeledCandidates(t *testing.T) {
+	closedAt := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	candidates := []*types.Issue{
+		{ID: "unlabeled", Status: types.StatusClosed, ClosedAt: &closedAt},
+		{ID: "other-label", Status: types.StatusClosed, ClosedAt: &closedAt, Labels: []string{"gt:message"}},
+		{ID: "protected", Status: types.StatusClosed, ClosedAt: &closedAt, Labels: []string{"bd:protected"}},
+		{ID: "protected-among-many", Status: types.StatusClosed, ClosedAt: &closedAt,
+			Labels: []string{"a", "bd:protected", "z"}},
+	}
+
+	filtered, skips := FilterSweepCandidates(candidates, issueops.SweepRequest{
+		ProtectedLabels: []string{"bd:protected"},
+	})
+
+	got := sweepCandidateIDs(filtered)
+	want := []string{"unlabeled", "other-label"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("filtered IDs = %v, want %v", got, want)
+	}
+	if skips.Labeled != 2 {
+		t.Errorf("skips.Labeled = %d, want 2", skips.Labeled)
+	}
+	if skips.Pinned != 0 {
+		t.Errorf("skips.Pinned = %d, want 0 — a labeled row is counted as labeled, in exactly one bucket", skips.Pinned)
+	}
+}
+
+// TestFilterSweepCandidatesWithoutProtectedLabelsProtectsNothing is the
+// no-opt-in control: the rows above, unchanged, all sweep when no labels are
+// requested. Without it the test above could pass against a filter that held
+// back every labeled row regardless of the request.
+func TestFilterSweepCandidatesWithoutProtectedLabelsProtectsNothing(t *testing.T) {
+	closedAt := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	candidates := []*types.Issue{
+		{ID: "protected", Status: types.StatusClosed, ClosedAt: &closedAt, Labels: []string{"bd:protected"}},
+		{ID: "unlabeled", Status: types.StatusClosed, ClosedAt: &closedAt},
+	}
+
+	for _, tc := range []struct {
+		name string
+		req  issueops.SweepRequest
+	}{
+		{"absent", issueops.SweepRequest{}},
+		{"empty slice", issueops.SweepRequest{ProtectedLabels: []string{}}},
+		{"only empty strings", issueops.SweepRequest{ProtectedLabels: []string{"", ""}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			filtered, skips := FilterSweepCandidates(candidates, tc.req)
+			if len(filtered) != 2 {
+				t.Fatalf("filtered IDs = %v, want both", sweepCandidateIDs(filtered))
+			}
+			if skips.Labeled != 0 {
+				t.Errorf("skips.Labeled = %d, want 0", skips.Labeled)
+			}
+		})
+	}
+}
+
+// TestFilterSweepCandidatesMatchesLabelsWholeAndExactly pins that the guard is
+// not a prefix or substring test. A near-miss label must NOT protect: a guard
+// that over-matches silently stops a sweep from ever clearing anything, which
+// presents as `bd purge` quietly doing nothing rather than as an error.
+func TestFilterSweepCandidatesMatchesLabelsWholeAndExactly(t *testing.T) {
+	closedAt := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	candidates := []*types.Issue{
+		{ID: "prefix", Status: types.StatusClosed, ClosedAt: &closedAt, Labels: []string{"bd:protected-ish"}},
+		{ID: "suffix", Status: types.StatusClosed, ClosedAt: &closedAt, Labels: []string{"x-bd:protected"}},
+		{ID: "case", Status: types.StatusClosed, ClosedAt: &closedAt, Labels: []string{"BD:PROTECTED"}},
+	}
+
+	filtered, skips := FilterSweepCandidates(candidates, issueops.SweepRequest{
+		ProtectedLabels: []string{"bd:protected"},
+	})
+
+	if len(filtered) != 3 {
+		t.Fatalf("filtered IDs = %v, want all three — matching is whole-label and exact", sweepCandidateIDs(filtered))
+	}
+	if skips.Labeled != 0 {
+		t.Errorf("skips.Labeled = %d, want 0", skips.Labeled)
+	}
+}
+
+// TestFilterSweepCandidatesNarrowsByPatternBeforeProtectingLabels is the label
+// twin of the pinned ordering pin: a labeled row the pattern EXCLUDED was never
+// a candidate, so it is not counted as a protection.
+func TestFilterSweepCandidatesNarrowsByPatternBeforeProtectingLabels(t *testing.T) {
+	closedAt := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	candidates := []*types.Issue{
+		{ID: "keep-1", Status: types.StatusClosed, ClosedAt: &closedAt},
+		{ID: "keep-labeled", Status: types.StatusClosed, ClosedAt: &closedAt, Labels: []string{"bd:protected"}},
+		{ID: "other-labeled", Status: types.StatusClosed, ClosedAt: &closedAt, Labels: []string{"bd:protected"}},
+	}
+
+	filtered, skips := FilterSweepCandidates(candidates, issueops.SweepRequest{
+		IDPattern:       "keep-*",
+		ProtectedLabels: []string{"bd:protected"},
+	})
+
+	if len(filtered) != 1 || filtered[0].ID != "keep-1" {
+		t.Fatalf("filtered IDs = %v, want only keep-1", sweepCandidateIDs(filtered))
+	}
+	if skips.Labeled != 1 {
+		t.Fatalf("skips.Labeled = %d, want 1 — only the labeled row the pattern ADMITTED is a protection", skips.Labeled)
+	}
+}
+
+// TestFilterSweepCandidatesProtectsLabeledAheadOfTheClosedAtDefenses pins the
+// bucket a row lands in when two reasons apply. The protections run first, so a
+// labeled row that is ALSO not-closed reports as Labeled — the fact its owner
+// needs — and the defense counters stay reserved for rows nothing protected.
+// This is the shape Pinned already had.
+func TestFilterSweepCandidatesProtectsLabeledAheadOfTheClosedAtDefenses(t *testing.T) {
+	candidates := []*types.Issue{
+		{ID: "labeled-open", Status: types.StatusOpen, Labels: []string{"bd:protected"}},
+		{ID: "labeled-no-closed-at", Status: types.StatusClosed, Labels: []string{"bd:protected"}},
+	}
+
+	filtered, skips := FilterSweepCandidates(candidates, issueops.SweepRequest{
+		ProtectedLabels: []string{"bd:protected"},
+	})
+
+	if len(filtered) != 0 {
+		t.Fatalf("filtered IDs = %v, want none", sweepCandidateIDs(filtered))
+	}
+	if skips.Labeled != 2 {
+		t.Errorf("skips.Labeled = %d, want 2", skips.Labeled)
+	}
+	if skips.NotClosed != 0 || skips.UnknownClosedAt != 0 {
+		t.Errorf("defense buckets = NotClosed %d, UnknownClosedAt %d, want 0 — a candidate lands in exactly one bucket",
+			skips.NotClosed, skips.UnknownClosedAt)
+	}
+}
+
+// TestFilterSweepCandidatesPinnedWinsOverLabeled pins the one remaining bucket
+// ambiguity: a row that is both pinned and labeled counts ONCE, as Pinned,
+// because pinned is checked first. Stated so the counters sum to the candidate
+// set rather than double-counting.
+func TestFilterSweepCandidatesPinnedWinsOverLabeled(t *testing.T) {
+	closedAt := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	candidates := []*types.Issue{
+		{ID: "both", Status: types.StatusClosed, ClosedAt: &closedAt, Pinned: true, Labels: []string{"bd:protected"}},
+	}
+
+	_, skips := FilterSweepCandidates(candidates, issueops.SweepRequest{
+		ProtectedLabels: []string{"bd:protected"},
+	})
+
+	if skips.Pinned != 1 || skips.Labeled != 0 {
+		t.Fatalf("Pinned = %d, Labeled = %d, want 1 and 0", skips.Pinned, skips.Labeled)
+	}
 }

--- a/issueops/sweeper.go
+++ b/issueops/sweeper.go
@@ -33,12 +33,20 @@ const (
 // of its closed rows, and whether to do it or only report it.
 //
 // IT IS NOT A FILTER-SHAPED READ REQUEST with a delete attached. The predicate
-// is FIXED at "closed rows of one tier" and the two fields below only narrow
-// it; there is no status, no assignee, no label and no free-text query,
-// because every one of those would be a way to spell a destructive selection
-// that no front door asks for and that a caller could get subtly wrong. What
-// this request can express is exactly what `bd purge` and `bd prune` expose,
-// and widening it is a decision rather than an omission to be filled in.
+// is FIXED at "closed rows of one tier" and the fields below only narrow it;
+// there is no status, no assignee and no free-text query, because every one of
+// those would be a way to spell a destructive selection that no front door
+// asks for and that a caller could get subtly wrong. What this request can
+// express is exactly what `bd purge` and `bd prune` expose, and widening it is
+// a decision rather than an omission to be filled in.
+//
+// THE LABEL FIELD IS NOT A COUNTEREXAMPLE TO THAT, and the direction is what
+// makes it safe: ProtectedLabels can only SUBTRACT rows from the deletion.
+// There is deliberately no label SELECTOR — no way to say "delete the rows
+// carrying this label" — because that would be exactly the spellable
+// destructive selection this paragraph refuses. A field that can only protect
+// fails toward keeping a row; a field that can select fails toward deleting
+// one.
 //
 // Implementations never mutate caller-owned request values: ClosedBefore is
 // read, never written through.
@@ -108,6 +116,28 @@ type SweepRequest struct {
 	// `bd purge` does not, because a wisp's citations are as transient as the
 	// wisp.
 	ProtectReferenced bool
+	// ProtectedLabels skips candidates carrying ANY of these labels. Empty
+	// protects nothing, which is what every caller that does not opt in gets.
+	//
+	// IT IS A REQUEST FIELD RATHER THAN A FIXED RULE because which records are
+	// irreplaceable is the CALLER'S policy, not this package's. An
+	// orchestration layer that stores mail, escalations or any other
+	// write-once record as an ephemeral bead has no status it could set that
+	// would not lie about the record's state — an unread message is genuinely
+	// open — and open is exactly what the ephemeral tier exists to clear. A
+	// label is the only handle that survives that, and the set of labels that
+	// carries the meaning belongs to whoever mints the records.
+	//
+	// IT IS THE SAME PROTECTION `bd mol wisp gc` HONORS, and that is the point
+	// of it being here. The two commands delete the same rows — closed
+	// ephemeral beads — and `bd purge` protected only the pinned flag, so a
+	// workspace that configured the guard got it on one command and not on the
+	// other, with no warning from either.
+	//
+	// Matching is on the WHOLE label, exactly, after the normalization the
+	// caller applies; there is no prefix or glob form, because a destructive
+	// selection is not a place to be clever about matching.
+	ProtectedLabels []string
 	// DryRun reports what the sweep WOULD do and deletes nothing. The result
 	// is otherwise the same result — the same counts, the same skips, the same
 	// refusals — computed against the same snapshot the real sweep would have
@@ -120,9 +150,9 @@ type SweepRequest struct {
 // held back, so the buckets and SweepResult.Swept describe one candidate set.
 //
 // They are separate counters rather than one number because they mean
-// different things to the person reading them: Pinned and Referenced are
-// PROTECTIONS a user can override or re-express, and the other three are the
-// sweep declining to trust its own input.
+// different things to the person reading them: Pinned, Referenced and Labeled
+// are PROTECTIONS a user can override or re-express, and the other three are
+// the sweep declining to trust its own input.
 type SweepSkips struct {
 	// Pinned counts candidates protected by the pinned flag. Pinning is the
 	// workspace's own "never sweep this", and no request field overrides it —
@@ -132,6 +162,10 @@ type SweepSkips struct {
 	// 0 when that field is false; a caller that reads a 0 without having asked
 	// for the protection has learned nothing about whether rows are cited.
 	Referenced int
+	// Labeled counts candidates skipped by ProtectedLabels. Like Referenced it
+	// is always 0 when nothing was asked for, so a 0 read without having set
+	// ProtectedLabels says nothing about whether protected rows exist.
+	Labeled int
 	// NotClosed, UnknownClosedAt and ClosedAtOrAfterCutoff count candidates
 	// the tier's own query returned and the sweep rechecked and rejected: a
 	// status that is not closed, a closed row with no closed_at stamp at all,
@@ -255,10 +289,16 @@ type Sweeper interface {
 	//
 	// THE ORDER THE NARROWING HAPPENS IN IS PART OF THE ANSWER, because the
 	// skip counters are counted along the way: the tier's closed rows, then
-	// IDPattern, then the pinned and closed_at rechecks, then the reference
-	// protection. A pinned row excluded by the pattern is therefore NOT
-	// counted in Skipped.Pinned — it was never a candidate — and the counters
-	// describe the set the request actually reached.
+	// IDPattern, then the pinned and label protections, then the closed_at
+	// rechecks, then the reference protection. A pinned row excluded by the
+	// pattern is therefore NOT counted in Skipped.Pinned — it was never a
+	// candidate — and the counters describe the set the request actually
+	// reached.
+	//
+	// THE TWO CHEAP PROTECTIONS COME BEFORE THE RECHECKS, which is the shape
+	// pinned already had: a protected row is reported as PROTECTED rather than
+	// as a defense firing, because that is the fact its owner needs. A row is
+	// counted in exactly one bucket.
 	//
 	// REFUSALS, all ErrValidation and all before anything is read:
 	//


### PR DESCRIPTION
## What

`bd purge --force` now honors `wisp.protected_labels`, the guard be-mh0 (#6266) gave `bd mol wisp gc`.

The two commands delete the same rows — closed ephemeral beads — and `docs/workflows/wisps.md` presents them as interchangeable: *"Deleted in bulk by `bd purge` or `bd mol wisp gc` once closed."* Before this, a workspace that configured `wisp.protected_labels` got the protection on one command and not the other, with **no warning from either**. An operator who had verified `gc` was safe would run `purge` and lose the records.

## ⚠️ Stacked on #6266

This branch is cut from **#6266's head** (`f3f6da2c6`), not from `main`. Until #6266 merges, the diff shown against `main` includes its three commits; my work is the two commits on top.

```
59ee4d146  fix(purge): honor wisp.protected_labels in bd purge (be-edf)
87fc77b8e  fix(purge): report label and pin skips in the empty JSON result (be-edf)
```

`git diff f3f6da2c6..87fc77b8e` is exactly this change: **19 files, +693/−67**.

**It is stacked deliberately.** #6266 owns the config key, its precedence rule, and `--exclude-label`. Re-deriving those on `main` would put a *second* definition of "which labels are protected" beside the first — which is how the two sibling commands would come to disagree about it, a worse outcome than the gap being closed. `bd purge` calls the same `protectedWispLabelList` `wisp gc` calls: one key, one precedence, one resolution.

## Design

**The guard is a request field, not a rule inside the role.** Which records are irreplaceable is the *caller's* policy — core provides the extension point (`engdocs/PROJECT_CHARTER.md`, Orchestration Boundary). `SweepRequest.ProtectedLabels` can only **subtract** rows from a deletion; there is deliberately no label *selector*, because a field that can only protect fails toward keeping a row, and one that can select fails toward deleting one.

**Filtering lands in `workapi.FilterSweepCandidates`** — the one seam all three sweep bodies run through — so both Dolt stores and the unit-of-work provider inherit it rather than each being taught separately.

That function now takes the whole `SweepRequest` instead of the two fields it read. Every field it reads is a way a candidate can be held back, and a parameter list is a signature that one of the three call sites can be updated without.

**Ordering:** pattern → pinned → labeled → the three `closed_at` defenses → referenced. Protections before defenses, matching the shape `Pinned` already had, so a protected row reports as *protected* rather than as a defense firing. A candidate lands in exactly one bucket.

**`Skipped.Labeled` is reported the way `Skipped.Pinned` is**, in text and JSON, so a scheduled purge can see its sweep was narrowed rather than inferring it from a smaller number than expected.

## Testing

**The contract case is the load-bearing one.** The filter reads `issue.Labels`, and whether those are hydrated onto a sweep candidate is a property of *each backend's query*, not of the pure function. A backend returning nil `Labels` would pass every unit test of the filter and **silently delete every protected wisp in the workspace, with no error to notice.** That is only visible against a real store.

Verified by sabotage rather than asserted — setting `SkipLabels: true` on the candidate filter:

```
--- FAIL: TestSweeperContract/ProtectsLabeledRows
        Skipped.Labeled = 0, want 1
        wisps rows for [swp-label-keep] = 0, want 1
```

Every new case carries a **negative control**, because a guard that protected *everything* would satisfy the positive assertions completely while making `bd purge` quietly unable to purge anything. Each was individually sabotage-checked:

| Sabotage | Caught by |
|---|---|
| guard never fires | 3 workapi cases |
| any label protects | ProtectsLabeledCandidates, MatchesLabelsWholeAndExactly |
| substring / case-insensitive match | MatchesLabelsWholeAndExactly |
| protection moved after the defenses | ProtectsLabeledAheadOfTheClosedAtDefenses |
| label hydration skipped | contract ProtectsLabeledRows |
| purge resolves config but never sends it | all 3 CLI regression tests |
| empty-JSON fix reverted | JSONReportsLabeledSkipsWhenNOTHINGIsSwept |

Coverage added: 6 `workapi` unit cases, 2 `Sweeper` contract cases (run on all three backends), 4 end-to-end CLI regression tests, 1 resolution-ordering test.

## Review round

`codex exec review --base pr6266` (based against #6266's head so it reviews *this* diff, not slit's).

**Round 1 — one P2, real and fixed in `87fc77b8e`:** when *every* candidate carries a protected label, `Swept` is 0 and `bd purge` takes its empty-result branch, whose JSON returned before the skip reporting. A scheduled purge read `{"purged_count": 0, "message": "No closed ephemeral beads to purge"}` — byte-identical to what an empty workspace returns. **The guard doing its job and there being nothing to do were indistinguishable**, and the natural reading of that payload is "my records were never here", the opposite of the truth. That is the empty result which most *needs* the count.

`pinned_skipped` went in beside it (and the matching text line). That gap predates this change, but reporting label protection in the empty payload while staying silent about pin protection would be a new inconsistency of my own making, on the same line.

**Round 2 — clean:** *"No actionable correctness regressions were identified."*

## Gates

| Gate | Result |
|---|---|
| `go build ./...` | pass |
| `go vet ./...` | clean |
| `gofmt -l` on changed files | clean |
| `make build` | pass |
| `generate-cli-docs.sh --check` | `PASS: generated CLI docs are fresh` |
| `workapi` / `issueops` / `httpapi` / `storage/issueops` | pass |
| Sweeper contract (embedded Dolt, all cases) | pass |
| CLI regression tests (embedded Dolt) | pass |
| codex review | clean, round 2 |

**Pre-existing failures, unchanged by this branch.** `cmd/bd` and `internal/storage/dolt` fail in this environment. Compared **set-wise** against an unmodified worktree at `f3f6da2c6`:

```
ONLY IN MINE (regressions):   [none]
ONLY IN BASE:                 [none]
SHARED (pre-existing):        TestConfigValidateReadOnlyIsHermetic
                              TestInitNonInteractiveAutoExportDefaultOffAndOptIn
                              TestPrepareSelectedCommandContext_DoesNotMergeCallerConfigForUnsetKeys
                              TestPrepareSelectedCommandContext_RebindsTargetConfig
```

`internal/storage/dolt` panics on a 10-minute timeout on both trees — tests blocked in `t.Parallel()` waiting on a Dolt server at `127.0.0.1:1`, environmental. `internal/configfile` and `internal/doltserver` also fail identically on both (port 3307/env-var assertions). `internal/testutil` failed only under a large parallel run and passes in isolation on this branch.

## Deliberate scope decisions

**`docs/` is untouched.** The corpus targets pinned release `v1.2.2` (`docs/cli-docs.pin`) and hand-written pages follow the same policy — document what the pinned release does, never main-only features. The `purgeCmd.Long` rewrite therefore does not reach the generated reference until the pin is bumped at release; `generate-cli-docs.sh --check` passes unchanged. `docs/workflows/wisps.md` should gain the protected-label note **at release time**, alongside #6266's.

**The HTTP surface gets the member and the counter, but no config default.** A remote caller that omits `protected_labels` gets no label protection, which is weaker than the local operator gets — a **known asymmetry, recorded on the schema member and in the handler**, not an oversight. Resolving `wisp.protected_labels` in `internal/httpapi` would place the second resolution rule beside the first, one surface over: exactly the divergence this PR exists to close. The fix is to *share* the resolution, not copy it, and changing what an omitted member means is its own decision — see `protect_referenced`, which defaults ON for the same class of reason. Worth a follow-up bead.

**`bd prune` and `bd gc` are unchanged.** They sweep the durable tier, and `wisp.protected_labels` is a wisp-tier key; reading it to decide which durable issues survive would be a guard nobody configured for that purpose. Both pass a request with no `ProtectedLabels`, so their behavior is bit-identical.

Closes be-edf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SvLyohn8xR9tdwz542Y7k
