### PR TITLE
feat(sdk): expose native external dependency policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Go embedders can apply Beads' native external-capability dependency
+  policy.** `WithExternalDependencyPolicy` gives long-lived orchestrators the
+  same fail-closed `external:<project>:<capability>` readiness and close guards
+  as the `bd` CLI, without copying the resolver or rewriting dependency edges.
+
 - **`bd count` supports repeatable `--metadata-field key=value` filters**
   ([#6023](https://github.com/gastownhall/beads/issues/6023)), so callers can
   count the same metadata-scoped set `bd list` returns without fetching every

--- a/beads.go
+++ b/beads.go
@@ -26,6 +26,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/externaldeps"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/workspacegate"
 )
@@ -97,6 +98,68 @@ type CommentPageCursor = storage.CommentPageCursor
 // guarded issue mutations. Exported so consumers can match it with errors.As
 // without importing internal/storage.
 type ErrUnsupported = storage.ErrUnsupported
+
+// ExternalProjectLocator resolves the project component of an
+// external:<project>:<capability> dependency to a workspace root. Returning
+// false leaves the dependency blocking.
+type ExternalProjectLocator func(project string) (projectRoot string, ok bool)
+
+// ExternalProjectOpener opens a foreign project for capability lookup. The
+// returned store is closed after each lookup. Returning an error leaves the
+// dependency blocking.
+type ExternalProjectOpener func(ctx context.Context, projectRoot string) (Storage, error)
+
+// WithExternalDependencyPolicy decorates a Dolt-backed public Storage with
+// Beads' canonical query-time policy for external:<project>:<capability>
+// dependencies. A capability is satisfied only when the foreign project has a
+// closed issue labeled provides:<capability>. Malformed references, unknown
+// projects, open failures, and read failures remain blocking; the policy never
+// rewrites dependency edges.
+//
+// The returned store owns store and must be closed exactly once by the caller.
+// Foreign stores returned by openProject are opened read-only by convention and
+// are closed by the policy after each resolution pass. A non-Dolt Storage is
+// rejected with *ErrUnsupported because it cannot expose the dependency and
+// capability queries the policy requires.
+func WithExternalDependencyPolicy(store Storage, locateProject ExternalProjectLocator, openProject ExternalProjectOpener) (Storage, error) {
+	inner, ok := store.(storage.DoltStorage)
+	if !ok {
+		return nil, &storage.ErrUnsupported{
+			Op:      "WithExternalDependencyPolicy",
+			Backend: fmt.Sprintf("%T", store),
+		}
+	}
+
+	var locator externaldeps.ProjectLocator
+	if locateProject != nil {
+		locator = func(project externaldeps.ProjectName) (string, bool) {
+			return locateProject(string(project))
+		}
+	}
+
+	var opener externaldeps.StoreOpener
+	if openProject != nil {
+		opener = func(ctx context.Context, projectRoot string) (storage.DoltStorage, error) {
+			foreign, err := openProject(ctx, projectRoot)
+			if err != nil {
+				return nil, err
+			}
+			foreignDolt, ok := foreign.(storage.DoltStorage)
+			if !ok {
+				if foreign != nil {
+					_ = foreign.Close()
+				}
+				return nil, &storage.ErrUnsupported{
+					Op:      "WithExternalDependencyPolicy.openProject",
+					Backend: fmt.Sprintf("%T", foreign),
+				}
+			}
+			return foreignDolt, nil
+		}
+	}
+
+	return externaldeps.New(inner, locator, opener), nil
+}
 
 // RemoteStore provides dolt remote management and replication operations.
 // Use type assertion on a Storage value to access these methods:

--- a/examples/library-usage/README.md
+++ b/examples/library-usage/README.md
@@ -76,6 +76,34 @@ are empty, the default of `('open', 'in_progress')` applies.
     })
 ```
 
+### External capability dependencies in embedders
+
+`OpenBestAvailable` returns the configured storage implementation. A long-lived
+orchestrator that reads more than one Beads project can add the same
+`external:<project>:<capability>` policy used by the `bd` CLI:
+
+```go
+    store, err = beads.WithExternalDependencyPolicy(
+        store,
+        func(project string) (string, bool) {
+            root, ok := configuredProjectRoots[project]
+            return root, ok
+        },
+        func(ctx context.Context, projectRoot string) (beads.Storage, error) {
+            return beads.OpenBestAvailable(ctx, filepath.Join(projectRoot, ".beads"))
+        },
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+```
+
+The wrapper treats malformed references, unknown projects, and unavailable
+foreign stores as blocking. It considers a capability satisfied only when the
+foreign project has a closed issue labeled `provides:<capability>`. It closes
+each foreign store after the lookup; the caller closes only the returned local
+wrapper.
+
 ## Running This Example
 
 ```bash

--- a/external_dependency_policy_test.go
+++ b/external_dependency_policy_test.go
@@ -1,0 +1,119 @@
+package beads_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	beads "github.com/steveyegge/beads"
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+type externalPolicyStore struct {
+	storage.DoltStorage
+	ready  []*beads.Issue
+	deps   map[string][]*beads.Dependency
+	labels map[string][]*beads.Issue
+	closed bool
+}
+
+func (s *externalPolicyStore) GetExternalBlockingDependencyRecords(context.Context) (map[string][]*beads.Dependency, error) {
+	return s.deps, nil
+}
+
+func (s *externalPolicyStore) GetReadyWork(_ context.Context, filter beads.WorkFilter) ([]*beads.Issue, error) {
+	excluded := make(map[string]struct{}, len(filter.ExcludeIDs))
+	for _, id := range filter.ExcludeIDs {
+		excluded[id] = struct{}{}
+	}
+	result := make([]*beads.Issue, 0, len(s.ready))
+	for _, issue := range s.ready {
+		if _, skip := excluded[issue.ID]; !skip {
+			result = append(result, issue)
+		}
+	}
+	return result, nil
+}
+
+func (s *externalPolicyStore) GetIssuesByLabel(_ context.Context, label string) ([]*beads.Issue, error) {
+	return s.labels[label], nil
+}
+
+func (s *externalPolicyStore) Close() error {
+	s.closed = true
+	return nil
+}
+
+type baseOnlyStore struct {
+	beads.Storage
+}
+
+func TestWithExternalDependencyPolicyResolvesCapabilitiesThroughPublicSDK(t *testing.T) {
+	local := &externalPolicyStore{
+		ready: []*beads.Issue{
+			{ID: "local-blocked", Status: beads.StatusOpen, IssueType: beads.TypeTask},
+			{ID: "local-ready", Status: beads.StatusOpen, IssueType: beads.TypeTask},
+		},
+		deps: map[string][]*beads.Dependency{
+			"local-blocked": {{IssueID: "local-blocked", DependsOnID: "external:payments:api", Type: beads.DepBlocks}},
+		},
+	}
+	foreign := &externalPolicyStore{
+		labels: map[string][]*beads.Issue{
+			"provides:api": {{ID: "provider", Status: beads.StatusOpen, IssueType: beads.TypeTask}},
+		},
+	}
+
+	wrapped, err := beads.WithExternalDependencyPolicy(
+		local,
+		func(project string) (string, bool) {
+			return "/projects/" + project, project == "payments"
+		},
+		func(_ context.Context, projectRoot string) (beads.Storage, error) {
+			if projectRoot != "/projects/payments" {
+				t.Fatalf("project root = %q, want /projects/payments", projectRoot)
+			}
+			return foreign, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("WithExternalDependencyPolicy: %v", err)
+	}
+
+	ready, err := wrapped.GetReadyWork(t.Context(), beads.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetReadyWork with open provider: %v", err)
+	}
+	if got := issueIDs(ready); len(got) != 1 || got[0] != "local-ready" {
+		t.Fatalf("ready with open provider = %v, want [local-ready]", got)
+	}
+	if !foreign.closed {
+		t.Fatal("foreign store was not closed after capability resolution")
+	}
+
+	foreign.closed = false
+	foreign.labels["provides:api"][0].Status = beads.StatusClosed
+	ready, err = wrapped.GetReadyWork(t.Context(), beads.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetReadyWork with closed provider: %v", err)
+	}
+	if got := issueIDs(ready); len(got) != 2 || got[0] != "local-blocked" || got[1] != "local-ready" {
+		t.Fatalf("ready with closed provider = %v, want [local-blocked local-ready]", got)
+	}
+}
+
+func TestWithExternalDependencyPolicyRejectsNonDoltStorage(t *testing.T) {
+	_, err := beads.WithExternalDependencyPolicy(&baseOnlyStore{}, nil, nil)
+	var unsupported *beads.ErrUnsupported
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("error = %v, want *beads.ErrUnsupported", err)
+	}
+}
+
+func issueIDs(issues []*beads.Issue) []string {
+	ids := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		ids = append(ids, issue.ID)
+	}
+	return ids
+}


### PR DESCRIPTION
`OpenBestAvailable` returns the raw configured store, while the `bd` CLI applies external capability dependency policy only inside `cmd/bd`. Long-lived Go embedders therefore can treat a bead blocked by `external:<project>:<capability>` as ready even though the CLI correctly keeps it blocked.

This change exposes `WithExternalDependencyPolicy`, a narrow public wrapper around Beads' existing resolver. It keeps malformed references, missing projects, and foreign read failures blocking; accepts only a closed `provides:<capability>` issue; closes foreign stores after each lookup; and never rewrites dependency edges. The library usage guide and changelog document the ownership and failure contract.

Validation:
- `CGO_ENABLED=0 go test . -count=1`
- `CGO_ENABLED=0 go test ./internal/storage/externaldeps -count=1`
- public API test covers open and closed providers plus non-Dolt refusal
- `CGO_ENABLED=0 make test` passed all affected packages; the existing `cmd/bd TestTestServerConnection/unreachable_host` failed because `192.0.2.1:3307` answered in this host environment
- `make ci-pr-lint` reaches the existing upstream formatting failures in `internal/storage/{dolt,embeddeddolt,uow}/role_fixture_kit_test.go`; the changed Go files pass `gofmt` and `git diff --check`
