### PR TITLE
fix(make): check docs against the configured build binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ fmt-check:
 check-docs:
 	@echo "Building bd for docs checks..."
 	@CGO_ENABLED=0 go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd ./cmd/bd
-	@./scripts/check-doc-flags.sh ./bd
+	@./scripts/check-doc-flags.sh "$(BUILD_DIR)/bd"
 	@./scripts/check-doc-freshness.sh
 	@go test -tags=gms_pure_go ./test/docsync
 


### PR DESCRIPTION
Pass `"$(BUILD_DIR)/bd"` to `check-doc-flags.sh` from `make check-docs`, matching the binary that target just built.

With a nondefault BUILD_DIR, the old operand passes ./bd even though the build writes elsewhere. That can select a stale root binary or fail when it is absent. The checker's normal v1.2.2 documentation pin takes precedence over the supplied binary, so this operand matters when BD_DOCS_IGNORE_PIN=1 or the documentation pin selects HEAD. That existing precedence is preserved.

The full Make recipe was exercised on native Windows with explicit builder/checker stand-ins. Default-directory behavior passed before and after. For a nondefault directory, the old operand failed stale-root and missing-root controls; the revised operand consumed the freshly generated file in both cases. Those controls establish Make wiring when the supplied binary is consumed, without claiming real compilation or pinned-checker semantics. Native/Windows PR lint passed.

#5667 owns quoting the build producer's paths, including spaces. Both complementary changes need composed validation when the second is integrated. Bee's separate #6340 tracks the analogous candidate paths in test-upgrade, test-cross-version and test-migration; those targets are outside this one-operand change.

This review update changes the description only; the published source head and its completed hosted verification are unchanged.

Fixes #6197, reported by bee-ghosttrack.

Agent-Signature: unknown-model/unknown-reasoning
