### PR TITLE
fix(init): preserve user line endings during stealth cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve existing `.gitignore` line endings when removing a managed Beads
+  section whose final line has no terminator ([#6205](https://github.com/gastownhall/beads/issues/6205)).
+
 ### Added
 
 - **`bd count` supports repeatable `--metadata-field key=value` filters**

--- a/cmd/bd/init_stealth.go
+++ b/cmd/bd/init_stealth.go
@@ -183,7 +183,9 @@ func removeBeadsProjectGitignoreSection(repoPath string) (bool, error) {
 		managed[p] = true
 	}
 
-	lines := strings.Split(string(content), "\n")
+	// Keep each line's terminator so removing an unterminated managed tail
+	// cannot remove the newline from the last retained user line.
+	lines := strings.SplitAfter(string(content), "\n")
 	out := make([]string, 0, len(lines))
 	changed := false
 	for i := 0; i < len(lines); i++ {
@@ -207,7 +209,7 @@ func removeBeadsProjectGitignoreSection(repoPath string) (bool, error) {
 		return false, nil
 	}
 
-	newContent := strings.Join(out, "\n")
+	newContent := strings.Join(out, "")
 	if strings.TrimSpace(newContent) == "" {
 		// beads was the only reason this .gitignore existed — remove it for true stealth.
 		if err := os.Remove(gitignorePath); err != nil {

--- a/cmd/bd/init_stealth_test.go
+++ b/cmd/bd/init_stealth_test.go
@@ -339,6 +339,59 @@ func TestRemoveBeadsProjectGitignoreSection_PreservesUserContent(t *testing.T) {
 	}
 }
 
+func TestRemoveBeadsProjectGitignoreSection_PreservesLineEndings(t *testing.T) {
+	section := func(eol string) string {
+		return doctor.ProjectGitignoreHeader + eol + strings.Join(doctor.ProjectGitignorePatterns, eol)
+	}
+	for _, tc := range []struct {
+		name, input, want string
+	}{
+		{
+			name:  "CRLF with final newline",
+			input: "node_modules/\r\n*.log\r\n\r\n" + section("\r\n") + "\r\n",
+			want:  "node_modules/\r\n*.log\r\n",
+		},
+		{
+			name:  "CRLF with unterminated managed tail",
+			input: "node_modules/\r\n*.log\r\n\r\n" + section("\r\n"),
+			want:  "node_modules/\r\n*.log\r\n",
+		},
+		{
+			name:  "LF with unterminated managed tail",
+			input: "node_modules/\n*.log\n\n" + section("\n"),
+			want:  "node_modules/\n*.log\n",
+		},
+		{
+			name:  "mixed endings and unterminated user suffix",
+			input: "node_modules/\r\n*.log\n\r\n" + section("\r\n") + "\r\nuser-tail/",
+			want:  "node_modules/\r\n*.log\nuser-tail/",
+		},
+		{
+			name:  "CRLF user suffix after managed section",
+			input: section("\r\n") + "\r\nuser-tail/\r\n",
+			want:  "user-tail/\r\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, ".gitignore")
+			if err := os.WriteFile(path, []byte(tc.input), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if changed, err := removeBeadsProjectGitignoreSection(dir); err != nil || !changed {
+				t.Fatalf("remove managed section: changed=%v err=%v", changed, err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("retained bytes = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestRemoveBeadsProjectGitignoreSection_DeletesWhenOnlyBeads verifies that a .gitignore beads
 // created solely for its own section is removed entirely, restoring true stealth.
 func TestRemoveBeadsProjectGitignoreSection_DeletesWhenOnlyBeads(t *testing.T) {


### PR DESCRIPTION
## What

Preserve each retained line's original terminator when stealth cleanup removes the Beads-managed `.gitignore` section. An unterminated managed tail currently drops the newline from the preceding user line, leaving a lone CR for CRLF input.

Use `strings.SplitAfter` and join the retained chunks without inserting separators. Header recognition, contiguous managed-pattern removal, the single preceding blank separator, and deletion of a managed-only file keep their existing behavior.

## Why

Fixes #6205, reported by bee-ghosttrack. Ordinary CRLF input already survives the existing implementation; the reproduced defect is the narrower unterminated-tail case. Exact-byte tests also cover mixed line endings and an unterminated unrelated user suffix.

## Validation

- The preserved original function fails exactly the LF and CRLF unterminated-tail cases. The other three controls already pass.
- The candidate passes all five byte-preservation cases plus the existing removal, missing/no-section, managed-only deletion and stealth-doctor checks: six parent tests, five children, no skips.
- Native Windows, Go 1.26.5, CGO enabled; vet, formatting and native/Windows PR lint passed against `c0d8da42d`.
- The original-function overlay was used only for baseline falsification; the passing candidate run used its committed source directly. Required hosted PR Core is pending.

The changelog now records the unterminated managed-tail removal fix. The separate project append problem is tracked by Bee's #6343; it is distinct from this removal change and the worktree append change in #5677. This revision changes the changelog only, retaining the prior explicit source-bound controls. Fresh hosted verification remains required.

Agent-Signature: unknown-model/unknown-reasoning
