### PR TITLE
fix(config): identify native config environment in path errors

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -483,6 +483,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            expected_goos: linux
+          - os: macos-latest
+            expected_goos: darwin
+          - os: windows-latest
+            expected_goos: windows
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
@@ -503,6 +510,12 @@ jobs:
       - name: Exercise the real Bash process boundary
         shell: bash
         run: go test '-tags=integration,gms_pure_go' -count=1 -run '^TestPRPreflight' ./scripts
+
+      - name: Check native user config diagnostics
+        shell: bash
+        env:
+          CGO_ENABLED: "0"
+        run: bash scripts/ci/test-user-config-diagnostic.sh '${{ matrix.expected_goos }}'
 
       - name: Exercise test.sh prebuilt binary path
         shell: bash

--- a/internal/config/user_config_path.go
+++ b/internal/config/user_config_path.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 const userConfigYamlDisplayFallback = "~/.config/bd/config.yaml"
@@ -24,7 +25,29 @@ type userConfigYamlCandidates struct {
 func currentUserConfigYamlCandidates() userConfigYamlCandidates {
 	homeDir, homeErr := os.UserHomeDir()
 	nativeConfigDir, nativeErr := os.UserConfigDir()
-	return buildUserConfigYamlCandidates(homeDir, homeErr, nativeConfigDir, nativeErr)
+	candidates := buildUserConfigYamlCandidates(homeDir, homeErr, nativeConfigDir, nativeErr)
+	if candidates.nativeErr != nil {
+		candidates.nativeErr = fmt.Errorf("%s: %w", nativeUserConfigEnvironmentSource(), candidates.nativeErr)
+	}
+	return candidates
+}
+
+// nativeUserConfigEnvironmentSource names the source selected by os.UserConfigDir.
+// This labels errors only; os.UserConfigDir still owns path resolution.
+func nativeUserConfigEnvironmentSource() string {
+	switch runtime.GOOS {
+	case "windows":
+		return "APPDATA"
+	case "darwin", "ios":
+		return "HOME"
+	case "plan9":
+		return "home"
+	default:
+		if os.Getenv("XDG_CONFIG_HOME") != "" {
+			return "XDG_CONFIG_HOME"
+		}
+		return "HOME"
+	}
 }
 
 func buildUserConfigYamlCandidates(homeDir string, homeErr error, nativeConfigDir string, nativeErr error) userConfigYamlCandidates {

--- a/internal/config/user_config_path.go
+++ b/internal/config/user_config_path.go
@@ -25,27 +25,19 @@ type userConfigYamlCandidates struct {
 func currentUserConfigYamlCandidates() userConfigYamlCandidates {
 	homeDir, homeErr := os.UserHomeDir()
 	nativeConfigDir, nativeErr := os.UserConfigDir()
-	candidates := buildUserConfigYamlCandidates(homeDir, homeErr, nativeConfigDir, nativeErr)
-	if candidates.nativeErr != nil {
-		candidates.nativeErr = fmt.Errorf("%s: %w", nativeUserConfigEnvironmentSource(), candidates.nativeErr)
-	}
-	return candidates
+	return buildUserConfigYamlCandidates(homeDir, homeErr, nativeConfigDir, nativeErr)
 }
 
-// nativeUserConfigEnvironmentSource names the source selected by os.UserConfigDir.
-// This labels errors only; os.UserConfigDir still owns path resolution.
-func nativeUserConfigEnvironmentSource() string {
+// nativeUserConfigValidationSource names the source of a relative directory
+// returned without a resolver error. On Unix, os.UserConfigDir already rejects
+// relative XDG_CONFIG_HOME values itself; only HOME can reach our validation.
+func nativeUserConfigValidationSource() string {
 	switch runtime.GOOS {
 	case "windows":
 		return "APPDATA"
-	case "darwin", "ios":
-		return "HOME"
 	case "plan9":
 		return "home"
 	default:
-		if os.Getenv("XDG_CONFIG_HOME") != "" {
-			return "XDG_CONFIG_HOME"
-		}
 		return "HOME"
 	}
 }
@@ -60,7 +52,13 @@ func buildUserConfigYamlCandidates(homeDir string, homeErr error, nativeConfigDi
 		candidates.documented = filepath.Clean(filepath.Join(home, ".config", "bd", "config.yaml"))
 	}
 
-	if nativeDir, err := cleanAbsoluteUserDirectory("native user config directory", nativeConfigDir, nativeErr); err != nil {
+	nativeLabel := "native user config directory"
+	if nativeErr == nil {
+		nativeLabel += " (" + nativeUserConfigValidationSource() + ")"
+	}
+	// Resolver errors already identify their source; retain that diagnostic
+	// without inferring it from a later read of the process environment.
+	if nativeDir, err := cleanAbsoluteUserDirectory(nativeLabel, nativeConfigDir, nativeErr); err != nil {
 		candidates.nativeErr = err
 	} else {
 		candidates.native = filepath.Clean(filepath.Join(nativeDir, "bd", "config.yaml"))

--- a/internal/config/user_config_path_test.go
+++ b/internal/config/user_config_path_test.go
@@ -4,8 +4,42 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
+
+func TestUserConfigYamlPathNamesNativeEnvironmentSource(t *testing.T) {
+	t.Setenv("HOME", "~")
+	t.Setenv("USERPROFILE", "~")
+	t.Setenv("home", "~")
+	t.Setenv("APPDATA", "relative-appdata")
+	for _, xdg := range []string{"relative-xdg", ""} {
+		name := "XDG configured"
+		wantSource := "XDG_CONFIG_HOME"
+		if xdg == "" {
+			name, wantSource = "XDG absent", "HOME"
+		}
+		switch runtime.GOOS {
+		case "windows":
+			wantSource = "APPDATA"
+		case "darwin", "ios":
+			wantSource = "HOME"
+		case "plan9":
+			wantSource = "home"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", xdg)
+			path, err := UserConfigYamlPath()
+			if err == nil || path != "" {
+				t.Fatalf("unsafe roots produced path %q, err=%v", path, err)
+			}
+			if !strings.Contains(err.Error(), wantSource+": native user config directory") {
+				t.Errorf("native config error %q does not identify %s", err, wantSource)
+			}
+		})
+	}
+}
 
 func TestSelectUserConfigYamlPathPrecedence(t *testing.T) {
 	t.Run("existing documented path wins", func(t *testing.T) {

--- a/internal/config/user_config_path_test.go
+++ b/internal/config/user_config_path_test.go
@@ -34,11 +34,43 @@ func TestUserConfigYamlPathNamesNativeEnvironmentSource(t *testing.T) {
 			if err == nil || path != "" {
 				t.Fatalf("unsafe roots produced path %q, err=%v", path, err)
 			}
-			if !strings.Contains(err.Error(), wantSource+": native user config directory") {
+			wantLabel := "native user config directory (" + wantSource + ")"
+			if wantSource == "XDG_CONFIG_HOME" {
+				// Go rejects relative XDG roots before returning a directory;
+				// preserve its source-bearing error under the generic label.
+				wantLabel = "native user config directory: "
+			}
+			if !strings.Contains(err.Error(), wantLabel) || !strings.Contains(err.Error(), wantSource) {
 				t.Errorf("native config error %q does not identify %s", err, wantSource)
 			}
 		})
 	}
+}
+
+func TestUserConfigYamlCandidatesOwnNativeDiagnostics(t *testing.T) {
+	wantSource := "HOME"
+	if runtime.GOOS == "windows" {
+		wantSource = "APPDATA"
+	} else if runtime.GOOS == "plan9" {
+		wantSource = "home"
+	}
+	t.Run("validation identifies its source", func(t *testing.T) {
+		candidates := buildUserConfigYamlCandidates(t.TempDir(), nil, "relative-native", nil)
+		want := "native user config directory (" + wantSource + ")"
+		if candidates.nativeErr == nil || !strings.Contains(candidates.nativeErr.Error(), want) {
+			t.Fatalf("builder native error = %v, want label %q", candidates.nativeErr, want)
+		}
+	})
+	t.Run("resolver diagnostic and identity are preserved", func(t *testing.T) {
+		resolverErr := errors.New("XDG_CONFIG_HOME resolver diagnostic")
+		candidates := buildUserConfigYamlCandidates(t.TempDir(), nil, "", resolverErr)
+		if !errors.Is(candidates.nativeErr, resolverErr) {
+			t.Fatalf("builder native error = %v, want original resolver error", candidates.nativeErr)
+		}
+		if got, want := candidates.nativeErr.Error(), "native user config directory: "+resolverErr.Error(); got != want {
+			t.Fatalf("builder native error = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestSelectUserConfigYamlPathPrecedence(t *testing.T) {

--- a/scripts/ci/test-user-config-diagnostic.sh
+++ b/scripts/ci/test-user-config-diagnostic.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Exercise the native config source label, including both XDG states.
+# Compatible with macOS Bash 3.2; run with linux, darwin, or windows.
+set -euo pipefail
+
+[[ $# -eq 1 ]] || { echo 'Expected one native Go OS' >&2; exit 1; }
+expected_os="$1"
+case "$(uname -s)" in
+    Linux) actual_os=linux ;;
+    Darwin) actual_os=darwin ;;
+    MINGW*|MSYS*) actual_os=windows ;;
+    *) echo 'Unsupported native Bash host' >&2; exit 1 ;;
+esac
+[[ "$expected_os" = "$actual_os" ]] || {
+    echo "Expected $expected_os, running on $actual_os" >&2; exit 1;
+}
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+# shellcheck source=../../.buildflags
+source "$repo_root/.buildflags"
+export CGO_ENABLED=0
+go_executable="$(type -P go)"
+[[ "$go_executable" = /* && -x "$go_executable" ]] || {
+    echo 'Go must resolve to an absolute application' >&2; exit 1;
+}
+host_info="$("$go_executable" env GOHOSTOS GOOS)"
+[[ "$host_info" = "$expected_os"$'\n'"$expected_os" ]] || {
+    echo "Expected native $expected_os Go host and target" >&2; exit 1;
+}
+parent=TestUserConfigYamlPathNamesNativeEnvironmentSource
+expected=("$parent" "$parent/XDG_configured" "$parent/XDG_absent")
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+status=0
+"$go_executable" test -tags "$BEADS_BUILD_TAGS" -v -count=1 -timeout 3m \
+    -run "^$parent$" ./internal/config >"$log" 2>&1 || status=$?
+cat "$log"
+[[ $status -eq 0 ]] || exit "$status"
+if grep -Eq -- '^[[:space:]]*--- (FAIL|SKIP):' "$log"; then
+    echo 'Native config diagnostic tests must pass without skips' >&2
+    exit 1
+fi
+passes="$(grep -Ec -- '^[[:space:]]*--- PASS:' "$log" || true)"
+[[ "$passes" = "${#expected[@]}" ]] || {
+    echo 'Expected exactly one parent and two child passes' >&2; exit 1;
+}
+for name in "${expected[@]}"; do
+    passes="$(grep -Ec -- "^[[:space:]]*--- PASS: $name( |$)" "$log" || true)"
+    [[ "$passes" = 1 ]] || {
+        echo "Expected exactly one PASS for $name, got $passes" >&2; exit 1;
+    }
+done

--- a/scripts/ci/test-user-config-diagnostic.sh
+++ b/scripts/ci/test-user-config-diagnostic.sh
@@ -40,10 +40,6 @@ if grep -Eq -- '^[[:space:]]*--- (FAIL|SKIP):' "$log"; then
     echo 'Native config diagnostic tests must pass without skips' >&2
     exit 1
 fi
-passes="$(grep -Ec -- '^[[:space:]]*--- PASS:' "$log" || true)"
-[[ "$passes" = "${#expected[@]}" ]] || {
-    echo 'Expected exactly one parent and two child passes' >&2; exit 1;
-}
 for name in "${expected[@]}"; do
     passes="$(grep -Ec -- "^[[:space:]]*--- PASS: $name( |$)" "$log" || true)"
     [[ "$passes" = 1 ]] || {

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -94,6 +94,41 @@ func TestPRComplexityReportIsAdvisoryAndBestEffort(t *testing.T) {
 	}
 }
 
+func TestPRWorkflowExercisesNativeUserConfigDiagnostics(t *testing.T) {
+	workflow := readCIWorkflow(t, "pr.yml")
+	job := workflow.job(t, "pr-preflight-platforms")
+	if job.RunsOn != "${{ matrix.os }}" || job.If != "" || job.ContinueOnError || job.TimeoutMinutes != 20 {
+		t.Fatal("native config diagnostic lane must remain required on the existing platform matrix")
+	}
+	if !equalStrings(job.Strategy.Matrix.OS, []string{"ubuntu-latest", "macos-latest", "windows-latest"}) {
+		t.Fatalf("unexpected platform matrix: %v", job.Strategy.Matrix.OS)
+	}
+	wantHosts := map[string]string{"ubuntu-latest": "linux", "macos-latest": "darwin", "windows-latest": "windows"}
+	if len(job.Strategy.Matrix.Include) != len(wantHosts) {
+		t.Fatalf("unexpected native host tuples: %v", job.Strategy.Matrix.Include)
+	}
+	for _, tuple := range job.Strategy.Matrix.Include {
+		if want, ok := wantHosts[tuple.OS]; !ok || tuple.ExpectedGOOS != want {
+			t.Fatalf("unexpected native host tuple: %+v", tuple)
+		}
+		delete(wantHosts, tuple.OS)
+	}
+	step := job.step(t, "Check native user config diagnostics")
+	if step.If != "" || step.Shell != "bash" || step.Env["CGO_ENABLED"] != "0" ||
+		(step.ContinueOnError != nil && step.ContinueOnError != false) {
+		t.Fatalf("native diagnostic step is conditional, optional, or uses the wrong host: %+v", step)
+	}
+	assertStepRunsExactly(t, job, step.Name, "bash scripts/ci/test-user-config-diagnostic.sh '${{ matrix.expected_goos }}'")
+	assertStepsBefore(t, job, []string{"Set up Go", "Restore Go module cache"}, []string{step.Name})
+	gate := workflow.job(t, "ci-gate")
+	gateEnv := gate.step(t, "Evaluate CI gate").Env
+	if !contains(gate.Needs, "pr-preflight-platforms") ||
+		gateEnv["PR_PREFLIGHT_PLATFORMS"] != "${{ needs.pr-preflight-platforms.result }}" ||
+		!contains(strings.Fields(gateEnv["CI_GATE_REQUIRED"]), "PR_PREFLIGHT_PLATFORMS") {
+		t.Fatal("native diagnostic platform results must feed the required aggregate gate")
+	}
+}
+
 func TestPRWorkflowExercisesWindowsBenchmarkEnvScrubbing(t *testing.T) {
 	workflow := readCIWorkflow(t, "pr.yml")
 	job := workflow.job(t, "pr-preflight-platforms")

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -97,21 +97,16 @@ func TestPRComplexityReportIsAdvisoryAndBestEffort(t *testing.T) {
 func TestPRWorkflowExercisesNativeUserConfigDiagnostics(t *testing.T) {
 	workflow := readCIWorkflow(t, "pr.yml")
 	job := workflow.job(t, "pr-preflight-platforms")
-	if job.RunsOn != "${{ matrix.os }}" || job.If != "" || job.ContinueOnError || job.TimeoutMinutes != 20 {
-		t.Fatal("native config diagnostic lane must remain required on the existing platform matrix")
-	}
-	if !equalStrings(job.Strategy.Matrix.OS, []string{"ubuntu-latest", "macos-latest", "windows-latest"}) {
-		t.Fatalf("unexpected platform matrix: %v", job.Strategy.Matrix.OS)
-	}
+	// The benchmark-environment test owns the shared job and matrix shape.
 	wantHosts := map[string]string{"ubuntu-latest": "linux", "macos-latest": "darwin", "windows-latest": "windows"}
-	if len(job.Strategy.Matrix.Include) != len(wantHosts) {
-		t.Fatalf("unexpected native host tuples: %v", job.Strategy.Matrix.Include)
-	}
+	gotHosts := make(map[string][]string)
 	for _, tuple := range job.Strategy.Matrix.Include {
-		if want, ok := wantHosts[tuple.OS]; !ok || tuple.ExpectedGOOS != want {
-			t.Fatalf("unexpected native host tuple: %+v", tuple)
+		gotHosts[tuple.OS] = append(gotHosts[tuple.OS], tuple.ExpectedGOOS)
+	}
+	for host, want := range wantHosts {
+		if got := gotHosts[host]; len(got) != 1 || got[0] != want {
+			t.Fatalf("native host %s = %v, want exactly one %s", host, got, want)
 		}
-		delete(wantHosts, tuple.OS)
 	}
 	step := job.step(t, "Check native user config diagnostics")
 	if step.If != "" || step.Shell != "bash" || step.Env["CGO_ENABLED"] != "0" ||


### PR DESCRIPTION
Unsafe native user-config diagnostics identify the environment source used by Go. On Windows, a rejected APPDATA directory is named even when XDG_CONFIG_HOME is set. The candidate builder owns its validation label; native resolver errors retain their original source-bearing diagnostic and error identity. It does not reread mutable environment state after resolution or reconstruct Go's paths.

Paths still come from os.UserConfigDir, with unchanged precedence and refusal of unsafe roots. On Unix, Go rejects a relative XDG_CONFIG_HOME itself; a relative directory returned without a resolver error comes from HOME. Builder validation labels use APPDATA on Windows, home on Plan 9, and HOME elsewhere.

The existing required Linux, macOS and Windows preflight matrix exercises configured and absent XDG cases on each real host. Its Bash driver binds the outer host and Go host/target and preserves the Go exit status. Each required parent and child must pass exactly once, with no failure or skip; additional passing tests are allowed. The native diagnostic test verifies its host mappings and step while the existing benchmark-environment test owns shared job/matrix shape.

Local validation passed the actual Windows driver with CGO disabled, seven focused config parents normally and with the race detector, workflow tests, actionlint, vet and native PR lint. Seventeen driver controls cover accepted extra passes and refusal of missing, duplicated, skipped, failed or wrong-host evidence. Restoring the prior production file fails the new public/builder diagnostic assertions.

An exploratory full-package config run has four failures also reproduced with the exact prior production file: two worktree fallback fixtures, ancestor-workspace discovery and JSON environment isolation. They are retained as separate evidence; this PR does not claim a clean full-package run. Linux/macOS native execution and fresh required hosted checks remain required.

#5676 edits the same test import area; whichever lands second needs the composed config tests. No new CI job or weakened required gate is introduced.

Fixes #6314

_unknown-model/unknown-reasoning on behalf of Ewen Cuthiell_
