### PR TITLE
fix(context): allow non-root service homes under /var/lib

### DIFF
--- a/internal/beads/context.go
+++ b/internal/beads/context.go
@@ -345,6 +345,17 @@ func isPathInSafeBoundary(path string) bool {
 		return resolvedPathWithinRoot(absPath, "/var/tmp")
 	}
 
+	// Non-root service accounts commonly use an account-owned home below
+	// /var/lib (for example, /var/lib/my-service). Treat that specific passwd
+	// home like an ordinary user home before the broad /var deny rule below.
+	// Keep the exception narrow: /var/lib itself is never a home boundary, root
+	// never receives the exception, and both the configured home and requested
+	// path must remain below /var/lib after symlink resolution.
+	if u, err := user.Current(); err == nil &&
+		pathWithinNonRootVarLibHome(absPath, u.Uid, u.HomeDir) {
+		return true
+	}
+
 	for _, prefix := range unsafePrefixes {
 		if strings.HasPrefix(absPath, prefix+"/") || absPath == prefix {
 			return false
@@ -386,6 +397,32 @@ func isPathInSafeBoundary(path string) bool {
 		}
 	}
 	return true
+}
+
+func pathWithinNonRootVarLibHome(absPath, uid, homeDir string) bool {
+	if uid == "" || uid == "0" || homeDir == "" {
+		return false
+	}
+
+	inside := func(path, root string) bool {
+		return path == root || strings.HasPrefix(path, root+"/")
+	}
+
+	const varLibRoot = "/var/lib"
+	home, err := filepath.Abs(homeDir)
+	if err != nil || home == varLibRoot || !inside(home, varLibRoot) {
+		return false
+	}
+	physicalVarLibRoot := resolveLongestExistingAncestor(varLibRoot)
+	physicalHome := resolveLongestExistingAncestor(home)
+	if physicalHome == physicalVarLibRoot || !inside(physicalHome, physicalVarLibRoot) {
+		return false
+	}
+
+	if !inside(absPath, home) && !inside(absPath, physicalHome) {
+		return false
+	}
+	return resolvedPathWithinRoot(absPath, home)
 }
 
 // resolveLongestExistingAncestor canonicalizes path by resolving symlinks on its

--- a/internal/beads/context_test.go
+++ b/internal/beads/context_test.go
@@ -411,6 +411,67 @@ func TestIsPathInSafeBoundary(t *testing.T) {
 	}
 }
 
+func TestPathWithinNonRootVarLibHome(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		uid      string
+		home     string
+		expected bool
+	}{
+		{
+			name:     "service account home",
+			path:     "/var/lib/flow-estate/.beads",
+			uid:      "991",
+			home:     "/var/lib/flow-estate",
+			expected: true,
+		},
+		{
+			name:     "commit addressed release below service home",
+			path:     "/var/lib/flow-estate/releases/abc123/.beads",
+			uid:      "991",
+			home:     "/var/lib/flow-estate",
+			expected: true,
+		},
+		{
+			name:     "sibling service account",
+			path:     "/var/lib/other-service/.beads",
+			uid:      "991",
+			home:     "/var/lib/flow-estate",
+			expected: false,
+		},
+		{
+			name:     "root account",
+			path:     "/var/lib/flow-estate/.beads",
+			uid:      "0",
+			home:     "/var/lib/flow-estate",
+			expected: false,
+		},
+		{
+			name:     "var lib root is too broad",
+			path:     "/var/lib/flow-estate/.beads",
+			uid:      "991",
+			home:     "/var/lib",
+			expected: false,
+		},
+		{
+			name:     "ordinary home does not use service carveout",
+			path:     "/home/alice/.beads",
+			uid:      "1000",
+			home:     "/home/alice",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pathWithinNonRootVarLibHome(tt.path, tt.uid, tt.home); got != tt.expected {
+				t.Fatalf("pathWithinNonRootVarLibHome(%q, %q, %q) = %v, want %v", tt.path, tt.uid, tt.home, got, tt.expected)
+			}
+		})
+	}
+}
+
 // TestResolvedPathWithinRoot exercises the symlink-escape hardening helper added
 // for be-vc1 — the HIGH finding on the /Users/Shared carve-out. The helper must:
 //


### PR DESCRIPTION
## What

Allow `BEADS_DIR` inside the authenticated, non-root current user's passwd home when that home is a specific directory below `/var/lib`.

The exception is deliberately narrow:

- UID 0 is never admitted.
- `/var/lib` itself is never admitted as a home boundary.
- Arbitrary sibling paths below `/var/lib` remain rejected.
- The configured home and requested path must both remain below the physical `/var/lib` root after symlink resolution.
- Existing containment checks still reject a path that escapes the account home.

## Why

Service accounts commonly use `/var/lib/<service>` as their home. Today the broad `/var` SEC-003 denial runs before the current-user home check, and the latter only recognizes `/Users`, `/home`, and `/var/home`. As a result, an account cannot run `bd context` against its own store:

```text
cannot resolve repo context: BEADS_DIR points to unsafe location: /var/lib/flow-estate/releases/<release>/.beads
```

This can make an otherwise healthy Dolt-backed service report a degraded or unavailable repository context. Fixes #6323.

## Verification

- Focused SEC-003 boundary tests: pass.
- `./scripts/test.sh ./internal/beads/...`: pass.
- `make test`: pass; total coverage 39.2%.
- `git diff --check`: pass.
- `make ci-pr-lint`: `gofmt` passes; the wrapper then encounters two pre-existing macOS `gosec` findings on current `main`, recorded separately in #6324. Neither finding touches this PR's files.

## Security notes

The service-home exception derives identity from `os/user.Current`, not the mutable `HOME` environment variable. The physical-root and home-containment checks preserve the symlink-escape protections added for SEC-003.

_codex-unknown-model-unknown-reasoning on behalf of Klas Hesselman_
