### PR TITLE
test(doltremote): pin the s3:// entry and the dotless host:pa@th case

### DIFF
--- a/internal/doltremote/remote.go
+++ b/internal/doltremote/remote.go
@@ -1,6 +1,9 @@
 package doltremote
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 // NativeSchemes are URL schemes that Dolt understands natively and should not
 // be converted through FromGitURL.
@@ -9,6 +12,7 @@ var NativeSchemes = []string{
 	"file://",
 	"aws://",
 	"gs://",
+	"s3://",
 	"git+https://",
 	"git+ssh://",
 	"git+http://",
@@ -62,31 +66,21 @@ func FromGitURL(url string) string {
 	return "git+" + url
 }
 
+var scpStyleGitURLPattern = regexp.MustCompile(`^(?:[a-zA-Z0-9._-]+@[a-zA-Z0-9][a-zA-Z0-9._-]*|[a-zA-Z0-9][a-zA-Z0-9._-]*\.[a-zA-Z0-9._-]*):[^\x00-\x1f\x7f]+$`)
+
 // isSCPStyleGitURL reports whether url looks like an SCP-style git remote:
-// either the classic user form (git@host:path) or the user-less form
-// (host:path). The user-less form is only recognized when the pre-colon
-// token looks like a hostname (contains a ".") so that dotless tokens such
-// as a Windows drive letter ("C:foo") are not mistaken for a host.
+// user@host:path, or host:path when the pre-colon token contains a "." so a
+// Windows drive letter ("C:foo") is not mistaken for a host. Anything that
+// carries a "://" scheme is never SCP-style, whatever else it contains, so a
+// query or path with "@" in it cannot turn an s3:// URL into a git remote.
 //
-// Known limitation: git itself also accepts dotless SSH config aliases in
-// this position (e.g. "github:org/repo.git", "localhost:repo.git"), which
-// the "." check above rejects. Those origins pass through unconverted and
-// won't canonically match an equivalent git+ssh://alias/... or
-// user@alias:path Dolt remote. This is a deliberate trade-off to keep
-// isWindowsDrivePath's single-letter-drive check from being the only guard
-// against misreading "C:foo" as a host; widening the rule (e.g. following
-// git's own convention of treating anything host:path as SCP-style unless
-// the pre-colon token is a single-letter drive) is tracked as a follow-up
-// rather than fixed here.
+// Known limitations: git also accepts dotless SSH config aliases
+// ("github:org/repo.git"); those pass through unconverted and will not
+// canonically match an equivalent git+ssh:// form. User and host are limited
+// to [a-zA-Z0-9._-], so non-ASCII userinfo and IDN hosts are not recognized
+// either.
 func isSCPStyleGitURL(url string) bool {
-	idx := strings.Index(url, ":")
-	if idx <= 0 || strings.Contains(url[:idx], "/") {
-		return false
-	}
-	if strings.Contains(url, "@") {
-		return true
-	}
-	return strings.Contains(url[:idx], ".")
+	return !strings.Contains(url, "://") && scpStyleGitURLPattern.MatchString(url)
 }
 
 // CanonicalForComparison returns a form of url suitable for equality checks

--- a/internal/doltremote/remote.go
+++ b/internal/doltremote/remote.go
@@ -20,7 +20,7 @@ var NativeSchemes = []string{
 }
 
 // Normalize converts a remote URL to a Dolt-compatible format.
-// Dolt-native URLs (dolthub://, file://, aws://, gs://, git+...) are returned
+// Dolt-native URLs (dolthub://, file://, aws://, gs://, s3://, git+...) are returned
 // as-is. Git URLs (https://, ssh://, git@...) are converted via FromGitURL.
 // Unknown schemes are returned as-is and let dolt clone decide.
 func Normalize(url string) string {

--- a/internal/doltremote/remote_invariant_test.go
+++ b/internal/doltremote/remote_invariant_test.go
@@ -1,0 +1,24 @@
+package doltremote_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/doltremote"
+	"github.com/steveyegge/beads/internal/remotecache"
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+)
+
+func TestS3RemotePreservesInternalBoundaries(t *testing.T) {
+	// The "@" in the path is what the old SCP heuristic tripped on.
+	const raw = "s3://bucket/team@prod/db?endpoint=https://acct.r2.example&region=auto&path-style=true"
+
+	if err := remotecache.ValidateRemoteURL(raw); err != nil {
+		t.Fatalf("ValidateRemoteURL(%q): %v", raw, err)
+	}
+	if got := doltremote.Normalize(raw); got != raw {
+		t.Errorf("Normalize(%q) = %q, want unchanged", raw, got)
+	}
+	if doltutil.IsGitProtocolURL(raw) {
+		t.Errorf("IsGitProtocolURL(%q) = true, want false", raw)
+	}
+}

--- a/internal/doltremote/remote_test.go
+++ b/internal/doltremote/remote_test.go
@@ -1,0 +1,47 @@
+package doltremote
+
+import "testing"
+
+func TestIsSCPStyleGitURLRecognizesValidForms(t *testing.T) {
+	tests := []string{
+		"git@github.com:org/repo.git",
+		"deploy@myserver.com:beads/data",
+		"git@github:org/repo.git",
+		"github.com:org/repo.git",
+		// Dots in the user token are inside the accepted charset.
+		"user.name@host.com:path",
+	}
+
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			if !isSCPStyleGitURL(raw) {
+				t.Errorf("isSCPStyleGitURL(%q) = false, want true", raw)
+			}
+		})
+	}
+}
+
+func TestIsSCPStyleGitURLRejectsNonSCPInputs(t *testing.T) {
+	tests := []string{
+		"s3://bucket/team@prod/beads",
+		"s3://bucket/db?endpoint=https://minio.local/api@v1",
+		`C:\Users\alice\beads`,
+		"C:/Users/alice/beads",
+		// Empty path. The "@" alone used to classify this as SCP-style; the
+		// anchored grammar requires at least one path character.
+		"git@host.com:",
+		// Non-ASCII userinfo is outside [a-zA-Z0-9._-]; the URL passes
+		// through unconverted instead of being rewritten to git+ssh://.
+		"usér@host.com:path",
+		// IDN host, same charset limit.
+		"git@bücher.example:repo",
+	}
+
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			if isSCPStyleGitURL(raw) {
+				t.Errorf("isSCPStyleGitURL(%q) = true, want false", raw)
+			}
+		})
+	}
+}

--- a/internal/doltremote/remote_test.go
+++ b/internal/doltremote/remote_test.go
@@ -1,6 +1,9 @@
 package doltremote
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestIsSCPStyleGitURLRecognizesValidForms(t *testing.T) {
 	tests := []string{
@@ -30,6 +33,11 @@ func TestIsSCPStyleGitURLRejectsNonSCPInputs(t *testing.T) {
 		// Empty path. The "@" alone used to classify this as SCP-style; the
 		// anchored grammar requires at least one path character.
 		"git@host.com:",
+		// Dotless host with the only "@" after the colon. The "@" alone used
+		// to classify these as SCP-style (host:pa@th -> git+ssh://host/pa@th);
+		// the anchored grammar wants user@host or a dotted host before the colon.
+		"host:pa@th",
+		"alias:repo@v1",
 		// Non-ASCII userinfo is outside [a-zA-Z0-9._-]; the URL passes
 		// through unconverted instead of being rewritten to git+ssh://.
 		"usér@host.com:path",
@@ -41,6 +49,30 @@ func TestIsSCPStyleGitURLRejectsNonSCPInputs(t *testing.T) {
 		t.Run(raw, func(t *testing.T) {
 			if isSCPStyleGitURL(raw) {
 				t.Errorf("isSCPStyleGitURL(%q) = true, want false", raw)
+			}
+		})
+	}
+}
+
+func TestNativeSchemesContainsEachNativeScheme(t *testing.T) {
+	tests := []string{
+		"dolthub://",
+		"file://",
+		"aws://",
+		"gs://",
+		// s3 URLs must take the native fast path rather than survive
+		// Normalize by falling through past the git heuristics.
+		"s3://",
+		"git+https://",
+		"git+ssh://",
+		"git+http://",
+		"git+file://",
+	}
+
+	for _, scheme := range tests {
+		t.Run(scheme, func(t *testing.T) {
+			if !slices.Contains(NativeSchemes, scheme) {
+				t.Errorf("slices.Contains(NativeSchemes, %q) = false, want true", scheme)
 			}
 		})
 	}


### PR DESCRIPTION
**Stacked on #5948** (`6d749bb92`); the increment is the last commit. **Layer**: `internal/doltremote` only. **Diff**: 2 files, +34/-2 (`remote.go` one doc-comment line, the rest `remote_test.go`).

---

## What

Follow-up to the round-2 review of #5948. It closes the three non-blocking items without touching the approved head.

- MINOR-1: `TestNativeSchemesContainsEachNativeScheme` asserts `slices.Contains(NativeSchemes, scheme)` for every entry the list holds. With the `"s3://"` line deleted from `remote.go`, the mutation from the review, its `s3://` subtest fails and the other eight pass.
- NIT-1: `host:pa@th` and `alias:repo@v1` are reject rows in `TestIsSCPStyleGitURLRejectsNonSCPInputs`. On `origin/main`'s `remote.go` they classify true and normalize to `git+ssh://host/pa@th` and `git+ssh://alias/repo@v1`; on #5948's head they classify false and pass through unchanged. The #5948 description now lists this as the fourth behavior change.
- NIT-2: the `Normalize` doc comment lists `s3://` with the other native schemes.

## Verification

- `go test ./internal/doltremote/... ./internal/remotecache/... -count=1`: ok (macOS, go 1.26.5, `gms_pure_go`, CGO on).
- `make ci-pr-lint` with `BD_LINT_NEW_FROM_MERGE_BASE=origin/main`: 0 issues on the native and Windows lanes.
- Red/green: `"s3://"` removed from `NativeSchemes` fails only the `s3://` subtest; `origin/main`'s `remote.go` fails the two new rows, plus the five rows #5948 already pins.

Existing tests: additions only, zero modified assertions.
