### PR TITLE
test(cmd/bd): pin the backup URL a URL restore writes back

### DIFF
--- a/cmd/bd/backup.go
+++ b/cmd/bd/backup.go
@@ -24,7 +24,7 @@ and interoperability.
 Commands:
   bd backup init <path>    Set up a backup destination (filesystem or DoltHub)
   bd backup sync           Push to configured backup destination
-  bd backup restore [path] Restore from a backup directory
+  bd backup restore [path] Restore from a backup directory or remote URL
   bd backup remove         Remove backup destination
   bd backup status         Show backup status
 

--- a/cmd/bd/backup_dolt.go
+++ b/cmd/bd/backup_dolt.go
@@ -182,13 +182,11 @@ Run 'bd backup init <path>' first to configure a destination.`,
 }
 
 // resolveDoltBackupURL converts a user-provided path or URL into a Dolt backup URL.
-// Filesystem paths get resolved to absolute and prefixed with file://
-// URLs (https://, http://) are passed through as-is.
+// Recognized backup URLs (versioncontrolops.IsBackupURL) pass through unchanged;
+// anything else is treated as a filesystem path, resolved to absolute and
+// prefixed with file://.
 func resolveDoltBackupURL(raw string) string {
-	// DoltHub or other remote URLs — pass through
-	if strings.HasPrefix(raw, "https://") || strings.HasPrefix(raw, "http://") ||
-		strings.HasPrefix(raw, "file://") || strings.HasPrefix(raw, "aws://") ||
-		strings.HasPrefix(raw, "gs://") {
+	if versioncontrolops.IsBackupURL(raw) {
 		return raw
 	}
 

--- a/cmd/bd/backup_dolt_test.go
+++ b/cmd/bd/backup_dolt_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,46 +23,58 @@ func TestResolveDoltBackupURL(t *testing.T) {
 	// t.TempDir() is absolute and already cleaned on every platform.
 	absBackup := filepath.Join(t.TempDir(), "beads-backup")
 
+	// TODO(#6227): az:// is a valid Dolt backup/remote scheme, but this PR only fixes the s3:// stack. Do not add a green row for today's az:// local-file fallback here.
 	tests := []struct {
-		name      string
-		input     string
-		wantPfx   string // expected prefix
-		wantExact string // exact match (empty = use prefix check)
+		name  string
+		input string
+		want  string
+		// wantRel asserts structure instead of an exact value: cwd can move under a parallel test.
+		wantRel bool
 	}{
 		{
-			name:      "https URL passes through",
-			input:     "https://doltremoteapi.dolthub.com/user/repo",
-			wantExact: "https://doltremoteapi.dolthub.com/user/repo",
+			name:  "https URL passes through",
+			input: "https://doltremoteapi.dolthub.com/user/repo?region=auto",
+			want:  "https://doltremoteapi.dolthub.com/user/repo?region=auto",
 		},
 		{
-			name:      "http URL passes through",
-			input:     "http://localhost:50051/repo",
-			wantExact: "http://localhost:50051/repo",
+			name:  "http URL passes through",
+			input: "http://localhost:50051/repo?endpoint=local",
+			want:  "http://localhost:50051/repo?endpoint=local",
 		},
 		{
-			name:      "file:// URL passes through",
-			input:     "file:///tmp/backup",
-			wantExact: "file:///tmp/backup",
+			name:  "file URL passes through",
+			input: "file:///tmp/backup?version=1",
+			want:  "file:///tmp/backup?version=1",
 		},
 		{
-			name:      "aws:// URL passes through",
-			input:     "aws://[key:secret@]bucket/path",
-			wantExact: "aws://[key:secret@]bucket/path",
+			name:  "aws URL passes through",
+			input: "aws://key:secret@bucket/path?region=auto",
+			want:  "aws://key:secret@bucket/path?region=auto",
 		},
 		{
-			name:      "gs:// URL passes through",
-			input:     "gs://bucket/path",
-			wantExact: "gs://bucket/path",
+			name:  "bracketed aws URL passes through",
+			input: "aws://[key:secret@]bucket/path",
+			want:  "aws://[key:secret@]bucket/path",
 		},
 		{
-			name:      "absolute path gets file:// prefix",
-			input:     absBackup,
-			wantExact: "file://" + absBackup,
+			name:  "gs URL passes through",
+			input: "gs://bucket/path?endpoint=storage.example",
+			want:  "gs://bucket/path?endpoint=storage.example",
+		},
+		{
+			name:  "s3 URL passes through",
+			input: "s3://bucket/path?endpoint=https://minio.example&region=auto&path-style=true",
+			want:  "s3://bucket/path?endpoint=https://minio.example&region=auto&path-style=true",
+		},
+		{
+			name:  "absolute path gets file prefix",
+			input: absBackup,
+			want:  "file://" + absBackup,
 		},
 		{
 			name:    "relative path gets resolved and prefixed",
 			input:   "my-backup",
-			wantPfx: "file://",
+			wantRel: true,
 		},
 	}
 
@@ -69,14 +82,17 @@ func TestResolveDoltBackupURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := resolveDoltBackupURL(tt.input)
-			if tt.wantExact != "" {
-				if got != tt.wantExact {
-					t.Errorf("resolveDoltBackupURL(%q) = %q, want %q", tt.input, got, tt.wantExact)
+			if tt.wantRel {
+				wantSuffix := string(filepath.Separator) + "my-backup"
+				if !strings.HasPrefix(got, "file://") ||
+					!filepath.IsAbs(strings.TrimPrefix(got, "file://")) ||
+					!strings.HasSuffix(got, wantSuffix) {
+					t.Errorf("resolveDoltBackupURL(%q) = %q, want file:// plus an absolute path ending in %q", tt.input, got, wantSuffix)
 				}
-			} else if tt.wantPfx != "" {
-				if len(got) < len(tt.wantPfx) || got[:len(tt.wantPfx)] != tt.wantPfx {
-					t.Errorf("resolveDoltBackupURL(%q) = %q, want prefix %q", tt.input, got, tt.wantPfx)
-				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("resolveDoltBackupURL(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/cmd/bd/backup_dolt_test.go
+++ b/cmd/bd/backup_dolt_test.go
@@ -23,7 +23,9 @@ func TestResolveDoltBackupURL(t *testing.T) {
 	// t.TempDir() is absolute and already cleaned on every platform.
 	absBackup := filepath.Join(t.TempDir(), "beads-backup")
 
-	// TODO(#6227): az:// is a valid Dolt backup/remote scheme, but this PR only fixes the s3:// stack. Do not add a green row for today's az:// local-file fallback here.
+	// TODO(#6227): az:// is a valid Dolt backup/remote scheme, but this PR
+	// only fixes the s3:// stack. Do not add a green row for today's az://
+	// local-file fallback here.
 	tests := []struct {
 		name  string
 		input string

--- a/cmd/bd/backup_restore.go
+++ b/cmd/bd/backup_restore.go
@@ -11,16 +11,17 @@ import (
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
 	"github.com/steveyegge/beads/internal/ui"
 )
 
 var backupRestoreCmd = &cobra.Command{
-	Use:   "restore [path]",
+	Use:   "restore [directory-or-url]",
 	Short: "Restore database from a Dolt backup",
 	Long: `Restore the beads database from a Dolt-native backup.
 
 By default, reads from .beads/backup/ (or the configured backup directory).
-Optionally specify a path to a directory containing a Dolt backup.
+Optionally specify a directory containing a Dolt backup or a remote backup URL.
 
 This restores a full database backup created by 'bd backup sync' or an
 equivalent Dolt backup. JSONL files produced by 'bd export' are issue exports,
@@ -28,7 +29,7 @@ not restore targets for this command.
 
 Use --force to overwrite an existing database with the backup contents.
 
-The database must already be initialized (run 'bd init' first if needed).
+Restore requires a freshly initialized database. Run 'bd init' first if needed.
 To initialize and restore in one step, use: bd init && bd backup restore`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -55,8 +56,10 @@ To initialize and restore in one step, use: bd init && bd backup restore`,
 			}
 		}
 
-		if err := validateBackupRestoreDir(dir); err != nil {
-			return err
+		if !versioncontrolops.IsBackupURL(dir) {
+			if err := validateBackupRestoreDir(dir); err != nil {
+				return err
+			}
 		}
 
 		force, _ := cmd.Flags().GetBool("force")

--- a/cmd/bd/backup_restore_url_test.go
+++ b/cmd/bd/backup_restore_url_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+var errBackupRestoreReachedStorage = errors.New("backup restore reached storage")
+
+type backupRestoreRecordingStore struct {
+	storage.DoltStorage
+	restoreCalls  int
+	restoreSource string
+}
+
+func (s *backupRestoreRecordingStore) BackupAdd(context.Context, string, string) error { return nil }
+func (s *backupRestoreRecordingStore) BackupSync(context.Context, string) error        { return nil }
+func (s *backupRestoreRecordingStore) BackupRemove(context.Context, string) error      { return nil }
+func (s *backupRestoreRecordingStore) BackupDatabase(context.Context, string) error    { return nil }
+func (s *backupRestoreRecordingStore) RestoreDatabase(_ context.Context, source string, _ bool) error {
+	s.restoreCalls++
+	s.restoreSource = source
+	return errBackupRestoreReachedStorage
+}
+func (s *backupRestoreRecordingStore) Commit(context.Context, string) error { return nil }
+
+var _ storage.BackupStore = (*backupRestoreRecordingStore)(nil)
+
+func TestBackupRestoreCommandRoutesBackupURLToStorage(t *testing.T) {
+	oldStore := store
+	oldRootCtx := rootCtx
+	oldProxiedServerMode := proxiedServerMode
+	t.Cleanup(func() {
+		store = oldStore
+		rootCtx = oldRootCtx
+		proxiedServerMode = oldProxiedServerMode
+	})
+
+	fake := &backupRestoreRecordingStore{}
+	store = fake
+	rootCtx = context.Background()
+	proxiedServerMode = false
+
+	const source = "s3://bucket/path?endpoint=https://minio.example&region=auto&path-style=true"
+	err := backupRestoreCmd.RunE(backupRestoreCmd, []string{source})
+	if !errors.Is(err, errBackupRestoreReachedStorage) {
+		t.Fatalf("backup restore error = %v, want storage error", err)
+	}
+	if fake.restoreCalls != 1 {
+		t.Fatalf("RestoreDatabase calls = %d, want 1", fake.restoreCalls)
+	}
+	if fake.restoreSource != source {
+		t.Fatalf("RestoreDatabase source = %q, want %q", fake.restoreSource, source)
+	}
+}
+
+func TestBackupRestoreCommandKeepsDirectoryValidation(t *testing.T) {
+	oldStore := store
+	oldRootCtx := rootCtx
+	oldProxiedServerMode := proxiedServerMode
+	t.Cleanup(func() {
+		store = oldStore
+		rootCtx = oldRootCtx
+		proxiedServerMode = oldProxiedServerMode
+	})
+
+	fake := &backupRestoreRecordingStore{}
+	store = fake
+	rootCtx = context.Background()
+	proxiedServerMode = false
+
+	source := filepath.Join(t.TempDir(), "missing")
+	err := backupRestoreCmd.RunE(backupRestoreCmd, []string{source})
+	want := fmt.Sprintf("backup directory not found: %s\nRun 'bd backup' first to create a backup", source)
+	if err == nil || err.Error() != want {
+		t.Fatalf("backup restore error = %q, want %q", err, want)
+	}
+	if fake.restoreCalls != 0 {
+		t.Fatalf("RestoreDatabase calls = %d, want 0", fake.restoreCalls)
+	}
+}

--- a/cmd/bd/backup_restore_url_test.go
+++ b/cmd/bd/backup_restore_url_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -14,18 +16,23 @@ var errBackupRestoreReachedStorage = errors.New("backup restore reached storage"
 
 type backupRestoreRecordingStore struct {
 	storage.DoltStorage
+	restoreErr    error
 	restoreCalls  int
 	restoreSource string
+	backupAddURL  string
 }
 
-func (s *backupRestoreRecordingStore) BackupAdd(context.Context, string, string) error { return nil }
-func (s *backupRestoreRecordingStore) BackupSync(context.Context, string) error        { return nil }
-func (s *backupRestoreRecordingStore) BackupRemove(context.Context, string) error      { return nil }
-func (s *backupRestoreRecordingStore) BackupDatabase(context.Context, string) error    { return nil }
+func (s *backupRestoreRecordingStore) BackupAdd(_ context.Context, _ string, url string) error {
+	s.backupAddURL = url
+	return nil
+}
+func (s *backupRestoreRecordingStore) BackupSync(context.Context, string) error     { return nil }
+func (s *backupRestoreRecordingStore) BackupRemove(context.Context, string) error   { return nil }
+func (s *backupRestoreRecordingStore) BackupDatabase(context.Context, string) error { return nil }
 func (s *backupRestoreRecordingStore) RestoreDatabase(_ context.Context, source string, _ bool) error {
 	s.restoreCalls++
 	s.restoreSource = source
-	return errBackupRestoreReachedStorage
+	return s.restoreErr
 }
 func (s *backupRestoreRecordingStore) Commit(context.Context, string) error { return nil }
 
@@ -41,7 +48,7 @@ func TestBackupRestoreCommandRoutesBackupURLToStorage(t *testing.T) {
 		proxiedServerMode = oldProxiedServerMode
 	})
 
-	fake := &backupRestoreRecordingStore{}
+	fake := &backupRestoreRecordingStore{restoreErr: errBackupRestoreReachedStorage}
 	store = fake
 	rootCtx = context.Background()
 	proxiedServerMode = false
@@ -69,7 +76,7 @@ func TestBackupRestoreCommandKeepsDirectoryValidation(t *testing.T) {
 		proxiedServerMode = oldProxiedServerMode
 	})
 
-	fake := &backupRestoreRecordingStore{}
+	fake := &backupRestoreRecordingStore{restoreErr: errBackupRestoreReachedStorage}
 	store = fake
 	rootCtx = context.Background()
 	proxiedServerMode = false
@@ -82,5 +89,51 @@ func TestBackupRestoreCommandKeepsDirectoryValidation(t *testing.T) {
 	}
 	if fake.restoreCalls != 0 {
 		t.Fatalf("RestoreDatabase calls = %d, want 0", fake.restoreCalls)
+	}
+}
+
+func TestBackupRestoreCommandRegistersBackupURLAfterRestore(t *testing.T) {
+	oldStore := store
+	oldRootCtx := rootCtx
+	oldProxiedServerMode := proxiedServerMode
+	t.Cleanup(func() {
+		store = oldStore
+		rootCtx = oldRootCtx
+		proxiedServerMode = oldProxiedServerMode
+	})
+
+	// A successful restore re-registers the source as the backup remote and
+	// saves .beads/dolt-backup.json via beads.FindBeadsDir, so point BEADS_DIR
+	// at a throwaway workspace (embeddeddolt/ is the marker FindBeadsDir
+	// accepts) rather than whatever .beads is ambient.
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDir, "embeddeddolt"), 0o700); err != nil {
+		t.Fatalf("create workspace marker: %v", err)
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+
+	fake := &backupRestoreRecordingStore{}
+	store = fake
+	rootCtx = context.Background()
+	proxiedServerMode = false
+
+	const source = "s3://bucket/path?endpoint=https://minio.example&region=auto&path-style=true"
+	if err := backupRestoreCmd.RunE(backupRestoreCmd, []string{source}); err != nil {
+		t.Fatalf("backup restore error = %v, want nil", err)
+	}
+	if fake.backupAddURL != source {
+		t.Fatalf("BackupAdd url = %q, want %q", fake.backupAddURL, source)
+	}
+
+	data, err := os.ReadFile(filepath.Join(beadsDir, "dolt-backup.json"))
+	if err != nil {
+		t.Fatalf("read saved backup config: %v", err)
+	}
+	var cfg doltBackupConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal saved backup config: %v", err)
+	}
+	if cfg.BackupURL != source {
+		t.Fatalf("saved backup_url = %q, want %q", cfg.BackupURL, source)
 	}
 }

--- a/internal/storage/dolt/restore_source_test.go
+++ b/internal/storage/dolt/restore_source_test.go
@@ -1,0 +1,79 @@
+package dolt
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
+)
+
+func TestRestoreDatabaseRoutesBackupURLWithoutStat(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	const source = "s3://backup-bucket/beads"
+	mock.ExpectExec("CALL DOLT_BACKUP('restore', ?, ?)").
+		WithArgs(source, "beads").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	store := &DoltStore{database: "beads"}
+	err = store.restoreDatabase(t.Context(), source, false, func(time.Duration) (*sql.DB, error) {
+		return db, nil
+	})
+	if err != nil {
+		t.Fatalf("RestoreDatabase: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestRestoreDatabaseKeepsDirectorySourceBehavior(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	source := t.TempDir()
+	want, err := versioncontrolops.DirToFileURL(source)
+	if err != nil {
+		t.Fatalf("DirToFileURL(%q): %v", source, err)
+	}
+	mock.ExpectExec("CALL DOLT_BACKUP('restore', ?, ?)").
+		WithArgs(want, "beads").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	store := &DoltStore{database: "beads"}
+	err = store.restoreDatabase(t.Context(), source, false, func(time.Duration) (*sql.DB, error) {
+		return db, nil
+	})
+	if err != nil {
+		t.Fatalf("RestoreDatabase: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestRestoreDatabaseStatsDirectorySource(t *testing.T) {
+	source := t.TempDir() + "/missing"
+	store := &DoltStore{database: "beads"}
+	err := store.restoreDatabase(t.Context(), source, false, func(time.Duration) (*sql.DB, error) {
+		t.Fatal("RestoreDatabase opened a connection for a missing directory")
+		return nil, nil
+	})
+	if err == nil {
+		t.Fatal("RestoreDatabase returned nil for a missing directory")
+	}
+	if !strings.Contains(err.Error(), "backup source does not exist") {
+		t.Fatalf("RestoreDatabase error %q does not report a missing backup source", err)
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1338,22 +1338,20 @@ func (s *DoltStore) BackupDatabase(ctx context.Context, dir string) error {
 	return nil
 }
 
-// RestoreDatabase restores the database from a Dolt backup at dir.
+// RestoreDatabase restores the database from a local backup directory or a
+// backup URL accepted by DOLT_BACKUP (see versioncontrolops.ResolveBackupSource).
 // When force is true, an existing database is overwritten.
-func (s *DoltStore) RestoreDatabase(ctx context.Context, dir string, force bool) error {
-	info, err := os.Stat(dir)
-	if err != nil {
-		return fmt.Errorf("backup source does not exist: %w", err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("backup source is not a directory: %s", dir)
-	}
+func (s *DoltStore) RestoreDatabase(ctx context.Context, source string, force bool) error {
+	return s.restoreDatabase(ctx, source, force, s.oneShotConn)
+}
 
-	backupURL, err := versioncontrolops.DirToFileURL(dir)
+func (s *DoltStore) restoreDatabase(ctx context.Context, source string, force bool, openConn func(time.Duration) (*sql.DB, error)) error {
+	backupURL, err := versioncontrolops.ResolveBackupSource(source)
 	if err != nil {
 		return err
 	}
-	db, err := s.oneShotConn(0)
+
+	db, err := openConn(0)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/embeddeddolt/restore_source_test.go
+++ b/internal/storage/embeddeddolt/restore_source_test.go
@@ -1,0 +1,49 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A backup URL must reach DOLT_BACKUP unchanged instead of being stat'ed as a
+// directory. A file:// URL whose path sits under a regular file is
+// deterministic: Dolt cannot create that directory (root included), the
+// restore fails, and the error carries versioncontrolops.BackupRestore's
+// "restore from backup <url>" wrapper, which proves the URL was passed to
+// CALL DOLT_BACKUP('restore', ...) byte-for-byte.
+func TestRestoreDatabaseRoutesBackupURLWithoutStat(t *testing.T) {
+	env := newTestEnv(t, "test")
+	blocker := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blocker, nil, 0o600); err != nil {
+		t.Fatalf("write %q: %v", blocker, err)
+	}
+	source := "file://" + filepath.Join(blocker, "backup")
+
+	err := env.store.RestoreDatabase(t.Context(), source, false)
+	if err == nil {
+		t.Fatalf("RestoreDatabase(%q) returned nil for a backup that cannot exist", source)
+	}
+	if !strings.Contains(err.Error(), "restore from backup "+source) {
+		t.Fatalf("RestoreDatabase error %q does not show the URL reaching DOLT_BACKUP unchanged", err)
+	}
+	if strings.Contains(err.Error(), "backup source does not exist") {
+		t.Fatalf("RestoreDatabase stat'ed a backup URL: %v", err)
+	}
+}
+
+func TestRestoreDatabaseStatsDirectorySource(t *testing.T) {
+	env := newTestEnv(t, "test")
+	source := filepath.Join(t.TempDir(), "missing")
+
+	err := env.store.RestoreDatabase(t.Context(), source, false)
+	if err == nil {
+		t.Fatal("RestoreDatabase returned nil for a missing directory")
+	}
+	if !strings.Contains(err.Error(), "backup source does not exist") {
+		t.Fatalf("RestoreDatabase error %q does not report a missing backup source", err)
+	}
+}

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -765,19 +765,11 @@ func (s *EmbeddedDoltStore) BackupDatabase(ctx context.Context, dir string) erro
 	})
 }
 
-// RestoreDatabase restores the database from a Dolt backup at dir.
-// The dir must exist locally and contain a valid Dolt backup.
+// RestoreDatabase restores the database from a local backup directory or a
+// backup URL accepted by DOLT_BACKUP (see versioncontrolops.ResolveBackupSource).
 // When force is true, an existing database is overwritten.
-func (s *EmbeddedDoltStore) RestoreDatabase(ctx context.Context, dir string, force bool) error {
-	info, err := os.Stat(dir)
-	if err != nil {
-		return fmt.Errorf("backup source does not exist: %w", err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("backup source is not a directory: %s", dir)
-	}
-
-	backupURL, err := versioncontrolops.DirToFileURL(dir)
+func (s *EmbeddedDoltStore) RestoreDatabase(ctx context.Context, source string, force bool) error {
+	backupURL, err := versioncontrolops.ResolveBackupSource(source)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -851,9 +851,12 @@ type BackupStore interface {
 	// BackupDatabase registers dir as a file:// Dolt backup remote and syncs
 	// the full database to it, preserving complete commit history.
 	BackupDatabase(ctx context.Context, dir string) error
-	// RestoreDatabase restores the database from a Dolt backup at dir.
+	// RestoreDatabase restores the database from a Dolt backup at source, which
+	// is either a local backup directory or a backup URL that DOLT_BACKUP accepts
+	// (versioncontrolops.IsBackupURL). Implementations must not require the source
+	// to exist on the local filesystem when it is a URL.
 	// When force is true, the existing database is dropped before restoring.
-	RestoreDatabase(ctx context.Context, dir string, force bool) error
+	RestoreDatabase(ctx context.Context, source string, force bool) error
 }
 
 // ReadyWorkCounter sizes the total ready-work count for a filter without

--- a/internal/storage/versioncontrolops/backup.go
+++ b/internal/storage/versioncontrolops/backup.go
@@ -3,6 +3,7 @@ package versioncontrolops
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -54,6 +55,49 @@ func DirToFileURL(dir string) (string, error) {
 		return "", fmt.Errorf("resolve absolute path: %w", err)
 	}
 	return "file://" + abs, nil
+}
+
+// backupSchemes are the URL schemes DOLT_BACKUP accepts as a destination or
+// restore source. Deliberately not doltremote.NativeSchemes: that list is the
+// clone/push vocabulary, excludes the http(s) backups bd already supports and
+// includes git+ schemes that are not backup targets.
+// az:// is a valid Dolt scheme (dbfactory/az.go) but is missing here and in
+// NativeSchemes alike; tracked in #6227.
+var backupSchemes = map[string]bool{
+	"http": true, "https": true, "file": true, "aws": true, "gs": true, "s3": true,
+}
+
+// IsBackupURL reports whether raw carries a scheme DOLT_BACKUP accepts. It
+// classifies by scheme token only (everything before the first "://",
+// lowercased) and does not validate the URL: Go 1.25.2+ url.Parse rejects
+// Dolt's bracketed aws://[dynamo_table:bucket]/db form (Dolt itself carries a
+// shim for it, earl.ParseRawWithAWSSupport), so parse-validity is the wrong
+// signal. URL validity stays Dolt's job.
+func IsBackupURL(raw string) bool {
+	sep := strings.Index(raw, "://")
+	if sep <= 0 {
+		return false
+	}
+	return backupSchemes[strings.ToLower(raw[:sep])]
+}
+
+// ResolveBackupSource turns a restore source into the URL passed to
+// DOLT_BACKUP('restore', ...). Recognized backup URLs pass through unchanged
+// and are never stat'ed; anything else must be an existing local directory
+// and is converted with DirToFileURL. The error strings are load-bearing:
+// the resolver and store tests assert them.
+func ResolveBackupSource(source string) (string, error) {
+	if IsBackupURL(source) {
+		return source, nil
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		return "", fmt.Errorf("backup source does not exist: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("backup source is not a directory: %s", source)
+	}
+	return DirToFileURL(source)
 }
 
 // ExtractAddressConflictName parses the conflicting remote name from a Dolt

--- a/internal/storage/versioncontrolops/backup_test.go
+++ b/internal/storage/versioncontrolops/backup_test.go
@@ -2,6 +2,9 @@ package versioncontrolops
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -41,6 +44,84 @@ func TestExtractAddressConflictName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ExtractAddressConflictName(tt.err); got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsBackupURL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "http", raw: "http://backup.example/beads", want: true},
+		{name: "https", raw: "https://backup.example/beads", want: true},
+		{name: "file", raw: "file:///var/backups/beads", want: true},
+		{name: "aws", raw: "aws://backup-bucket/beads", want: true},
+		{name: "bracketed aws", raw: "aws://[dolt_table:my_bucket]/db", want: true},
+		{name: "gs", raw: "gs://backup-bucket/beads", want: true},
+		{name: "s3", raw: "s3://backup-bucket/beads", want: true},
+		{name: "git ssh", raw: "git+ssh://git@example.com/org/repo.git", want: false},
+		{name: "git https", raw: "git+https://example.com/org/repo.git", want: false},
+		{name: "relative path", raw: "backups/beads", want: false},
+		{name: "absolute path", raw: "/var/backups/beads", want: false},
+		{name: "empty", raw: "", want: false},
+		{name: "scp style", raw: "git@example.com:org/repo.git", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsBackupURL(tt.raw); got != tt.want {
+				t.Errorf("IsBackupURL(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveBackupSource(t *testing.T) {
+	dir := t.TempDir()
+	dirURL, err := DirToFileURL(dir)
+	if err != nil {
+		t.Fatalf("DirToFileURL(%q): %v", dir, err)
+	}
+	file := filepath.Join(dir, "not-a-directory")
+	if err := os.WriteFile(file, nil, 0o600); err != nil {
+		t.Fatalf("write %q: %v", file, err)
+	}
+
+	tests := []struct {
+		name    string
+		source  string
+		want    string
+		wantErr string
+	}{
+		// A URL whose path does not exist locally: a stat would fail, so a
+		// verbatim return proves the URL was never stat'ed.
+		{name: "s3 URL passes through without stat", source: "s3://backup-bucket/beads", want: "s3://backup-bucket/beads"},
+		{name: "bracketed aws URL passes through", source: "aws://[dolt_table:my_bucket]/db", want: "aws://[dolt_table:my_bucket]/db"},
+		{name: "existing directory converts to file URL", source: dir, want: dirURL},
+		{name: "missing directory", source: filepath.Join(dir, "missing"), wantErr: "backup source does not exist"},
+		{name: "regular file", source: file, wantErr: "backup source is not a directory"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveBackupSource(tt.source)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ResolveBackupSource(%q) = %q, want error containing %q", tt.source, got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ResolveBackupSource(%q) error %q does not contain %q", tt.source, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveBackupSource(%q): %v", tt.source, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveBackupSource(%q) = %q, want %q", tt.source, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
**Stacked on #5950** (`874c53da9`, on #5949's `0447b0b70`); the increment is the last commit. **Layer**: `cmd/bd` tests only, no non-test code changes. **Diff**: 2 files, +63/-8.

---

## What

Follow-up to the round-2 review of #5950. It closes both nits without touching the approved head.

- NIT-1: `TestBackupRestoreCommandRegistersBackupURLAfterRestore` runs `bd backup restore` with the fake `RestoreDatabase` succeeding and asserts that the URL reaching `BackupAdd`, and the `backup_url` saved to `.beads/dolt-backup.json`, both equal `s3://bucket/path?endpoint=https://minio.example&region=auto&path-style=true` byte-for-byte. `BEADS_DIR` points at a throwaway workspace with an `embeddeddolt/` marker, the isolation `backup_status_test.go` already uses, so the config write never lands in an ambient `.beads`. The fake gained a `restoreErr` field and records the `BackupAdd` URL; the two existing tests construct it with the error they returned before, and their assertions are unchanged.
- NIT-2: the `TODO(#6227)` comment is rewrapped to the file's column width, wording unchanged.

## Verification

- `go test ./cmd/bd/ -run 'TestResolveDoltBackupURL|TestBackupRestoreCommand' -count=1`: ok (macOS, go 1.26.5, `gms_pure_go`, CGO on).
- `make ci-pr-lint` with `BD_LINT_NEW_FROM_MERGE_BASE=origin/main`: 0 issues on the native and Windows lanes.
- Red/green: with the post-restore step handing `"file://" + dir` to `registerBackupRemote` instead of `resolveDoltBackupURL(dir)`, the new test fails with `BackupAdd url = "file://s3://bucket/path?..."`. The other four tests pass under the same mutation because they never reach that step. Restored, all pass.
