### PR TITLE
doctor: gate the classic-artifact filesystem scan behind --scan

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -60,6 +60,7 @@ var (
 	doctorServer                    bool   // run server mode health checks
 	doctorMigration                 string // migration validation mode: "pre" or "post"
 	doctorAgent                     bool   // agent-facing diagnostic mode (ZFC-compliant)
+	doctorScan                      bool   // opt in to the recursive classic-artifact filesystem scan
 )
 
 // ConfigKeyHintsDoctor is the config key for suppressing doctor hints
@@ -105,6 +106,14 @@ Performance Mode (--perf):
 Export Mode (--output):
   Save diagnostics to a JSON file for historical analysis and bug reporting.
   Includes timestamp and platform info for tracking intermittent issues.
+
+Filesystem Scan Mode (--scan):
+  Enable the recursive classic-artifact scan during a regular doctor run.
+  Off by default: the scan walks the whole tree (filepath.Walk + a stat
+  per entry) hunting for nested .beads/ relics from the pre-Dolt era,
+  which is expensive on large checkouts for an advisory check that
+  rarely finds anything outside the top-level .beads/. Use --scan to
+  opt in, or run '--check=artifacts' for a standalone scan (always scans).
 
 Specific Check Mode (--check):
   Run a specific check in detail. Available checks:
@@ -177,6 +186,7 @@ Examples:
   bd doctor --dry-run    # Preview what --fix would do without making changes
   bd doctor --perf       # Performance diagnostics
   bd doctor --output diagnostics.json  # Export diagnostics to file
+  bd doctor --scan            # Include the recursive classic-artifact scan
   bd doctor --check=artifacts           # Show classic artifacts (JSONL, SQLite, cruft dirs)
   bd doctor --check=artifacts --clean  # Delete safe-to-delete artifacts (with confirmation)
   bd doctor --check=conventions        # Convention drift check (lint, stale, orphans)
@@ -352,6 +362,7 @@ func init() {
 	doctorCmd.Flags().BoolVar(&doctorServer, "server", false, "Run Dolt server mode health checks (connectivity, version, schema)")
 	doctorCmd.Flags().StringVar(&doctorMigration, "migration", "", "Run legacy Dolt-server migration diagnostics: 'pre' or 'post'")
 	doctorCmd.Flags().BoolVar(&doctorAgent, "agent", false, "Agent-facing diagnostic mode: rich context for AI agents (ZFC-compliant)")
+	doctorCmd.Flags().BoolVar(&doctorScan, "scan", false, "Opt in to the recursive filesystem scan for classic artifacts (otherwise skipped to avoid stat-ing the whole tree)")
 }
 
 func shouldSkipDoctorNetworkChecks() bool {
@@ -963,10 +974,18 @@ func runDiagnostics(path string) doctorResult {
 	result.Checks = append(result.Checks, doltLocksCheck)
 	// Don't fail overall check for Dolt locks, just warn
 
-	// Check 33: Classic artifacts (post-Dolt-migration cleanup)
-	classicArtifactsCheck := convertDoctorCheck(doctor.CheckClassicArtifacts(path))
-	result.Checks = append(result.Checks, classicArtifactsCheck)
-	// Don't fail overall check for classic artifacts, just warn
+	// Check 33: Classic artifacts (post-Dolt-migration cleanup).
+	// Skipped unless --scan is set: CheckClassicArtifacts recurses the whole
+	// tree (filepath.Walk + per-entry Lstat) hunting for nested .beads/
+	// relics. On large checkouts that stat storm dominates doctor runtime for
+	// an advisory check that rarely finds anything outside the top-level
+	// .beads/. Opt in with --scan, or use --check=artifacts for an explicit
+	// standalone scan (always scans).
+	if doctorScan {
+		classicArtifactsCheck := convertDoctorCheck(doctor.CheckClassicArtifacts(path))
+		result.Checks = append(result.Checks, classicArtifactsCheck)
+		// Don't fail overall check for classic artifacts, just warn
+	}
 
 	// Check 34: Linux btrfs NoCOW on .beads/ (GH nocow-beads-dolt-init)
 	// Warns when the dolt data directory sits on btrfs without FS_NOCOW_FL,

--- a/cmd/bd/doctor_test.go
+++ b/cmd/bd/doctor_test.go
@@ -957,3 +957,51 @@ func TestDoctor_ExplicitPathOverridesBEADS_DIR(t *testing.T) {
 		t.Error("Expected to find explicit-marker in chosen path - wrong directory was selected")
 	}
 }
+
+// TestRunDiagnostics_ClassicArtifactsScanGated verifies that the recursive
+// classic-artifact filesystem scan (Check 33) is opt-in via --scan: it is
+// omitted from a bare doctor run (no whole-tree stat storm) and included
+// only when doctorScan is set. --check=artifacts exercises the standalone
+// scan path separately and is not asserted here.
+func TestRunDiagnostics_ClassicArtifactsScanGated(t *testing.T) {
+	setup := func(t *testing.T) string {
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.Mkdir(beadsDir, 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"backend":"sqlite"}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+		return tmpDir
+	}
+
+	hasClassicArtifacts := func(result doctorResult) bool {
+		for _, c := range result.Checks {
+			if c.Name == "Classic Artifacts" {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Restore the global toggle after the test so other tests are unaffected.
+	prevScan := doctorScan
+	defer func() { doctorScan = prevScan }()
+
+	t.Run("default omits scan", func(t *testing.T) {
+		doctorScan = false
+		result := runDiagnostics(setup(t))
+		if hasClassicArtifacts(result) {
+			t.Error("bare doctor ran the recursive classic-artifact scan; it must be opt-in via --scan")
+		}
+	})
+
+	t.Run("--scan includes scan", func(t *testing.T) {
+		doctorScan = true
+		result := runDiagnostics(setup(t))
+		if !hasClassicArtifacts(result) {
+			t.Error("--scan did not include the Classic Artifacts check")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

`bd doctor` runs **Check 33 ("Classic Artifacts")** on every invocation. `CheckClassicArtifacts` → `ScanForArtifacts` drives `filepath.Walk` over the entire tree, which `Lstat`s every entry only to discard nearly all of them — the callback only ever acts on directories literally named `.beads`. On large checkouts that stat storm dominates `doctor` runtime for an advisory check that almost never finds anything outside the top-level `.beads/`.

The only prune logic covers `.git`, `node_modules`, `vendor`, `__pycache__`; everything else (`dist`, `build`, `target`, `.venv`, generated asset trees, vendored toolchains, …) is `lstat`'d purely to be ignored.

## Change

Make the recursive scan **opt-in** via a new `--scan` flag:

- `bd doctor` — scan skipped (no whole-tree walk).
- `bd doctor --scan` — scan restored to prior behavior.
- `bd doctor --check=artifacts` — unchanged; still scans unconditionally (it is an explicit scan request).

This follows the existing house idiom: `runDiagnostics` already reads the package-global `doctorOrchestrator`, so a `doctorScan` global fits the established pattern. Help text documents the new flag and explains the trade-off.

## Behavior verified

Smoke test against a throwaway repo:
- Default `bd doctor`: `"Classic Artifacts"` absent from JSON output (no walk).
- `bd doctor --scan`: check present.
- `bd doctor --check=artifacts`: still scans (regressed to neither).

## Tests

Added `TestRunDiagnostics_ClassicArtifactsScanGated` mirroring the existing global-toggle idiom used for `jsonOutput` — asserts the check is omitted by default and included with `--scan`.

```
./scripts/test.sh -run '^TestRunDiagnostics_ClassicArtifactsScanGated$' ./cmd/bd/   # green
./scripts/test.sh ./cmd/bd/ ./cmd/bd/doctor/                                          # green
```

Affected-package suites pass. `gofmt` clean on the two changed files.

## Notes / honesty

- Generated CLI docs (`docs/cli-reference/doctor.md`) are **deliberately not** hand-edited: they are frozen to a release tag via `docs/cli-docs.pin` (currently `v1.2.2`) and regenerated at release time. Editing them by hand would introduce drift. `scripts/check-cli-docs-drift.sh --check` and `scripts/check-doc-flags.sh` both PASS.
- `make ci-pr-lint` currently fails on **three pre-existing files** under `internal/storage/{dolt,embeddeddolt,uow}/role_fixture_kit_test.go` due to a `gofmt` disagreement with the local Go 1.27 toolchain. Those files are **untouched by this PR** (`git diff origin/main` is empty for them) and are not addressed here per the "one issue per PR, no riders" guideline. Happy to file a separate chore PR if maintainers prefer.
- The local `golangci-lint` binary (v2.10.1, built with go1.27) hits a stdlib export-data-version mismatch ("export data version 4 is greater than maximum supported version 2") on untouched files — environmental, not introduced by this change. CI uses its own pinned toolchain and is authoritative.

## Checklist

- [x] Branch `fix/fs-scan` off `origin/main`
- [x] `--scan` flag added, scan gated (opt-in)
- [x] Unit test added
- [x] Affected-package tests green
- [x] Doc-drift gates pass
- [x] Committed, pushed to fork
- [ ] CI on this PR