### PR TITLE
fix(show): disclose dependency edges the listing cannot represent (be-lpi)

### DIFF
--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -245,6 +245,14 @@ var showCmd = &cobra.Command{
 				}
 			}
 
+			// Both listings above drop every edge whose far end has no row in
+			// this database, so a cross-repo or `external:` dependency renders
+			// as no dependency at all — indistinguishable from having none
+			// (be-lpi). --json says so in unresolvable_dependencies; say it
+			// here too, or `bd dep add x liveop-y` reports success and then
+			// `bd show x` shows nothing.
+			warnUnresolvableDepEdges(ctx, issueStore, issue.ID, len(depsWithMeta), len(dependentsWithMeta))
+
 			printRelatedSection(relatedSeen)
 
 			// Show comments

--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -231,13 +231,16 @@ var showCmd = &cobra.Command{
 			relatedSeen := make(map[string]*types.IssueWithDependencyMetadata)
 
 			// Show dependencies - grouped by dependency type for clarity
-			depsWithMeta, _ := issueStore.GetDependenciesWithMetadata(ctx, issue.ID) // Best effort: show issue even if deps unavailable
+			// The errors are KEPT, not discarded: rendering stays best
+			// effort, but a FAILED listing and a SHORT one both leave the
+			// slice empty, and only the second is an unresolvable edge.
+			depsWithMeta, depsErr := issueStore.GetDependenciesWithMetadata(ctx, issue.ID) // Best effort: show issue even if deps unavailable
 			for _, sec := range groupDepSections(depsWithMeta, true, relatedSeen) {
 				printDepSection(sec)
 			}
 
 			// Show dependents - grouped by dependency type for clarity
-			dependentsWithMeta, _ := issueStore.GetDependentsWithMetadata(ctx, issue.ID) // Best effort: show issue even if dependents unavailable
+			dependentsWithMeta, dependentsErr := issueStore.GetDependentsWithMetadata(ctx, issue.ID) // Best effort: show issue even if dependents unavailable
 			for _, sec := range groupDepSections(dependentsWithMeta, false, relatedSeen) {
 				printDepSection(sec)
 				if sec.Type == types.DepParentChild && issue.IssueType == types.TypeEpic {
@@ -251,7 +254,9 @@ var showCmd = &cobra.Command{
 			// (be-lpi). --json says so in unresolvable_dependencies; say it
 			// here too, or `bd dep add x liveop-y` reports success and then
 			// `bd show x` shows nothing.
-			warnUnresolvableDepEdges(ctx, issueStore, issue.ID, len(depsWithMeta), len(dependentsWithMeta))
+			warnUnresolvableDepEdges(ctx, issueStore, issue.ID,
+				depListing{rows: len(depsWithMeta), err: depsErr},
+				depListing{rows: len(dependentsWithMeta), err: dependentsErr})
 
 			printRelatedSection(relatedSeen)
 

--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -231,6 +231,8 @@ var showCmd = &cobra.Command{
 			relatedSeen := make(map[string]*types.IssueWithDependencyMetadata)
 
 			// Show dependencies - grouped by dependency type for clarity
+			// Counts first — see readDepCounts for why the order matters.
+			depCountsSnapshot := readDepCounts(ctx, issueStore, issue.ID)
 			// The errors are KEPT, not discarded: rendering stays best
 			// effort, but a FAILED listing and a SHORT one both leave the
 			// slice empty, and only the second is an unresolvable edge.
@@ -254,7 +256,7 @@ var showCmd = &cobra.Command{
 			// (be-lpi). --json says so in unresolvable_dependencies; say it
 			// here too, or `bd dep add x liveop-y` reports success and then
 			// `bd show x` shows nothing.
-			warnUnresolvableDepEdges(ctx, issueStore, issue.ID,
+			warnUnresolvableDepEdges(issue.ID, depCountsSnapshot,
 				depListing{rows: len(depsWithMeta), err: depsErr},
 				depListing{rows: len(dependentsWithMeta), err: dependentsErr})
 

--- a/cmd/bd/show_display.go
+++ b/cmd/bd/show_display.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -123,6 +124,8 @@ func displayShowIssueReturn(ctx context.Context, issueID string) *types.Issue {
 
 	// Dependencies (what this issue depends on)
 	relatedSeen := make(map[string]*types.IssueWithDependencyMetadata)
+	// Counts first — see readDepCounts for why the order matters.
+	depCountsSnapshot := readDepCounts(ctx, issueStore, issue.ID)
 	depsWithMeta, depsErr := issueStore.GetDependenciesWithMetadata(ctx, issue.ID)
 	for _, sec := range groupDepSections(depsWithMeta, true, relatedSeen) {
 		printDepSection(sec)
@@ -136,7 +139,7 @@ func displayShowIssueReturn(ctx context.Context, issueID string) *types.Issue {
 
 	// Shared with the non-watch path in show.go so the two renders cannot
 	// drift apart in what they disclose (be-lpi).
-	warnUnresolvableDepEdges(ctx, issueStore, issue.ID,
+	warnUnresolvableDepEdges(issue.ID, depCountsSnapshot,
 		depListing{rows: len(depsWithMeta), err: depsErr},
 		depListing{rows: len(dependentsWithMeta), err: dependentsErr})
 
@@ -171,11 +174,36 @@ type depListing struct {
 	err  error
 }
 
+// depCount is one direction's aggregate, carried with its own error for the
+// same reason depListing is.
+type depCount struct {
+	n   int64
+	err error
+}
+
+type depCounts struct {
+	deps       depCount
+	dependents depCount
+}
+
+var errNoDepCounter = errors.New("no dependency counter available")
+
 type unresolvableDepCounter interface {
 	CountDependencies(ctx context.Context, issueID string) (int64, error)
 	CountDependents(ctx context.Context, issueID string) (int64, error)
 }
 
+// readDepCounts and warnUnresolvableDepEdges are split so the COUNTS ARE READ
+// BEFORE THE ROW LISTINGS, which the callers do. The store issues a connection
+// per call, so a concurrent write can land between the count and the listing;
+// counting first puts that skew on the safe side, because an edge ADDED in the
+// window leaves the count stale-LOW and the difference goes negative and is
+// suppressed. Counting afterwards would announce a freshly added local edge as
+// unresolvable. A concurrent DELETE still produces a spurious notice — the
+// residual, and the reason this is an ordering mitigation rather than a fix
+// (be-lpi; the real fix is a shared snapshot or a direct count of edges whose
+// target has no row).
+//
 // warnUnresolvableDepEdges prints a stderr-only notice when an issue has
 // dependency edges that the rendered listings could not show.
 //
@@ -197,10 +225,17 @@ type unresolvableDepCounter interface {
 // common fully-local case — the same choice warnDroppedDepEdges makes in
 // dep.go for the same reason. Best effort: a count error is swallowed, since
 // the issue has already been rendered successfully by the time this runs.
-func warnUnresolvableDepEdges(ctx context.Context, store unresolvableDepCounter, issueID string, deps, dependents depListing) {
+func readDepCounts(ctx context.Context, store unresolvableDepCounter, issueID string) depCounts {
 	if store == nil {
-		return
+		return depCounts{deps: depCount{err: errNoDepCounter}, dependents: depCount{err: errNoDepCounter}}
 	}
+	var c depCounts
+	c.deps.n, c.deps.err = store.CountDependencies(ctx, issueID)
+	c.dependents.n, c.dependents.err = store.CountDependents(ctx, issueID)
+	return c
+}
+
+func warnUnresolvableDepEdges(issueID string, counts depCounts, deps, dependents depListing) {
 	reported := false
 	report := func(kind string, count int64, countErr error, listing depListing) {
 		// BOTH reads have to have succeeded. The count alone cannot tell a
@@ -218,10 +253,8 @@ func warnUnresolvableDepEdges(ctx context.Context, store unresolvableDepCounter,
 		fmt.Fprintf(os.Stderr, "warning: %s has %d %s edge(s) whose far end has no row in this database (cross-repo/external) and are not shown above\n",
 			issueID, missing, kind)
 	}
-	depCount, depErr := store.CountDependencies(ctx, issueID)
-	report("dependency", depCount, depErr, deps)
-	rdepCount, rdepErr := store.CountDependents(ctx, issueID)
-	report("dependent", rdepCount, rdepErr, dependents)
+	report("dependency", counts.deps.n, counts.deps.err, deps)
+	report("dependent", counts.dependents.n, counts.dependents.err, dependents)
 	if reported {
 		// Named once, after both directions, so an issue short on each gets
 		// one pointer rather than two.

--- a/cmd/bd/show_display.go
+++ b/cmd/bd/show_display.go
@@ -123,20 +123,22 @@ func displayShowIssueReturn(ctx context.Context, issueID string) *types.Issue {
 
 	// Dependencies (what this issue depends on)
 	relatedSeen := make(map[string]*types.IssueWithDependencyMetadata)
-	depsWithMeta, _ := issueStore.GetDependenciesWithMetadata(ctx, issue.ID)
+	depsWithMeta, depsErr := issueStore.GetDependenciesWithMetadata(ctx, issue.ID)
 	for _, sec := range groupDepSections(depsWithMeta, true, relatedSeen) {
 		printDepSection(sec)
 	}
 
 	// Dependents (what depends on this issue)
-	dependentsWithMeta, _ := issueStore.GetDependentsWithMetadata(ctx, issue.ID)
+	dependentsWithMeta, dependentsErr := issueStore.GetDependentsWithMetadata(ctx, issue.ID)
 	for _, sec := range groupDepSections(dependentsWithMeta, false, relatedSeen) {
 		printDepSection(sec)
 	}
 
 	// Shared with the non-watch path in show.go so the two renders cannot
 	// drift apart in what they disclose (be-lpi).
-	warnUnresolvableDepEdges(ctx, issueStore, issue.ID, len(depsWithMeta), len(dependentsWithMeta))
+	warnUnresolvableDepEdges(ctx, issueStore, issue.ID,
+		depListing{rows: len(depsWithMeta), err: depsErr},
+		depListing{rows: len(dependentsWithMeta), err: dependentsErr})
 
 	// Related (bidirectional, deduplicated)
 	printRelatedSection(relatedSeen)
@@ -160,6 +162,15 @@ func displayShowIssueReturn(ctx context.Context, issueID string) *types.Issue {
 
 // unresolvableDepCounter is the slice of the store warnUnresolvableDepEdges
 // reads. Both counts are O(1) aggregate queries over the dependency tables.
+// depListing is one direction's rendered edge list: how many rows reached the
+// screen, and whether the read that produced them succeeded. The error is the
+// load-bearing half — a failed read and a genuinely short one are both an
+// empty slice, and only the second means an edge could not be represented.
+type depListing struct {
+	rows int
+	err  error
+}
+
 type unresolvableDepCounter interface {
 	CountDependencies(ctx context.Context, issueID string) (int64, error)
 	CountDependents(ctx context.Context, issueID string) (int64, error)
@@ -186,16 +197,20 @@ type unresolvableDepCounter interface {
 // common fully-local case — the same choice warnDroppedDepEdges makes in
 // dep.go for the same reason. Best effort: a count error is swallowed, since
 // the issue has already been rendered successfully by the time this runs.
-func warnUnresolvableDepEdges(ctx context.Context, store unresolvableDepCounter, issueID string, shownDeps, shownDependents int) {
+func warnUnresolvableDepEdges(ctx context.Context, store unresolvableDepCounter, issueID string, deps, dependents depListing) {
 	if store == nil {
 		return
 	}
 	reported := false
-	report := func(kind string, count int64, err error, shown int) {
-		if err != nil {
+	report := func(kind string, count int64, countErr error, listing depListing) {
+		// BOTH reads have to have succeeded. The count alone cannot tell a
+		// SHORT listing from a FAILED one — each leaves an empty slice — and
+		// warning on the second turns a transient backend error into a claim
+		// about the data, which is the more expensive of the two mistakes.
+		if countErr != nil || listing.err != nil {
 			return
 		}
-		missing := count - int64(shown)
+		missing := count - int64(listing.rows)
 		if missing <= 0 {
 			return
 		}
@@ -204,9 +219,9 @@ func warnUnresolvableDepEdges(ctx context.Context, store unresolvableDepCounter,
 			issueID, missing, kind)
 	}
 	depCount, depErr := store.CountDependencies(ctx, issueID)
-	report("dependency", depCount, depErr, shownDeps)
+	report("dependency", depCount, depErr, deps)
 	rdepCount, rdepErr := store.CountDependents(ctx, issueID)
-	report("dependent", rdepCount, rdepErr, shownDependents)
+	report("dependent", rdepCount, rdepErr, dependents)
 	if reported {
 		// Named once, after both directions, so an issue short on each gets
 		// one pointer rather than two.

--- a/cmd/bd/show_display.go
+++ b/cmd/bd/show_display.go
@@ -134,6 +134,10 @@ func displayShowIssueReturn(ctx context.Context, issueID string) *types.Issue {
 		printDepSection(sec)
 	}
 
+	// Shared with the non-watch path in show.go so the two renders cannot
+	// drift apart in what they disclose (be-lpi).
+	warnUnresolvableDepEdges(ctx, issueStore, issue.ID, len(depsWithMeta), len(dependentsWithMeta))
+
 	// Related (bidirectional, deduplicated)
 	printRelatedSection(relatedSeen)
 
@@ -152,4 +156,60 @@ func displayShowIssueReturn(ctx context.Context, issueID string) *types.Issue {
 
 	fmt.Println()
 	return issue
+}
+
+// unresolvableDepCounter is the slice of the store warnUnresolvableDepEdges
+// reads. Both counts are O(1) aggregate queries over the dependency tables.
+type unresolvableDepCounter interface {
+	CountDependencies(ctx context.Context, issueID string) (int64, error)
+	CountDependents(ctx context.Context, issueID string) (int64, error)
+}
+
+// warnUnresolvableDepEdges prints a stderr-only notice when an issue has
+// dependency edges that the rendered listings could not show.
+//
+// GetDependenciesWithMetadata and GetDependentsWithMetadata answer with the
+// ISSUES on the far end of each edge and skip any whose id has no row in this
+// database — a cross-repo id or an `external:` reference, both of which live
+// in depends_on_external, the one target column carrying no foreign key into
+// issues (issueops.IsExternalDepTarget). The count queries have no such join,
+// so they keep those edges. The difference is exactly the set of edges that
+// are real, stored, and unrenderable from here.
+//
+// Until be-lpi this difference was silent, and `bd dep add x liveop-y`
+// reported success while the `bd show x` a caller ran straight after showed
+// no dependency at all — indistinguishable from the edge never having been
+// written. The JSON detail view publishes the same fact as
+// unresolvable_dependencies / unresolvable_dependents.
+//
+// stderr only, so the rendered issue on stdout is byte-identical for the
+// common fully-local case — the same choice warnDroppedDepEdges makes in
+// dep.go for the same reason. Best effort: a count error is swallowed, since
+// the issue has already been rendered successfully by the time this runs.
+func warnUnresolvableDepEdges(ctx context.Context, store unresolvableDepCounter, issueID string, shownDeps, shownDependents int) {
+	if store == nil {
+		return
+	}
+	reported := false
+	report := func(kind string, count int64, err error, shown int) {
+		if err != nil {
+			return
+		}
+		missing := count - int64(shown)
+		if missing <= 0 {
+			return
+		}
+		reported = true
+		fmt.Fprintf(os.Stderr, "warning: %s has %d %s edge(s) whose far end has no row in this database (cross-repo/external) and are not shown above\n",
+			issueID, missing, kind)
+	}
+	depCount, depErr := store.CountDependencies(ctx, issueID)
+	report("dependency", depCount, depErr, shownDeps)
+	rdepCount, rdepErr := store.CountDependents(ctx, issueID)
+	report("dependent", rdepCount, rdepErr, shownDependents)
+	if reported {
+		// Named once, after both directions, so an issue short on each gets
+		// one pointer rather than two.
+		fmt.Fprintf(os.Stderr, "For raw edge records, run: bd dep list %s %s\n", issueID, issueID)
+	}
 }

--- a/cmd/bd/show_unresolvable_deps_embedded_test.go
+++ b/cmd/bd/show_unresolvable_deps_embedded_test.go
@@ -1,0 +1,120 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestEmbeddedShowUnresolvableDeps drives the PRODUCTION path for be-lpi:
+// `bd dep add` writing a real edge, then `bd show` reading it back. The unit
+// coverage in internal/workapi constructs the count/row skew directly, which
+// proves the arithmetic and says nothing about whether any real command can
+// produce that state — this does the opposite, and the two together are the
+// claim.
+//
+// The stored shape being pinned is the one the town's convoy beads carry:
+// depends_on_external holds a target this database has no row for, so every
+// listing path drops it (issueops.GetDependenciesWithMetadataInTx) while every
+// count keeps it. Before the fix that left `dependency_count: 1` beside
+// `dependencies: null` with nothing saying why, and `bd show` in text mode
+// rendered no dependency section at all.
+func TestEmbeddedShowUnresolvableDeps(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "ud")
+
+	anchor := bdCreate(t, bd, dir, "Anchor with an external edge", "--type", "task")
+	local := bdCreate(t, bd, dir, "Fully local blocker", "--type", "task")
+
+	// Both target shapes IsExternalDepTarget classifies as external: an
+	// explicit `external:` reference, and a bare id whose prefix names
+	// another repository. They land in the same column and fail the same
+	// way, so pinning only one would leave the commoner of the two —
+	// `bd dep add ud-x liveop-y` — uncovered.
+	for _, tc := range []struct {
+		name   string
+		target string
+		depTyp string
+	}{
+		{"external_reference", "external:liveop:liveop-kmf", "tracks"},
+		{"cross_repo_prefix", "liveop-kmf", "blocks"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			subject := bdCreate(t, bd, dir, "Subject "+tc.name, "--type", "task")
+			bdDep(t, bd, dir, "add", subject.ID, tc.target, "--type", tc.depTyp)
+
+			details := bdShowDetails(t, bd, dir, subject.ID)
+			depCount, ok := details["dependency_count"].(float64)
+			if !ok || depCount != 1 {
+				t.Fatalf("dependency_count = %v, want 1 — the edge must still be counted",
+					details["dependency_count"])
+			}
+			if deps, present := details["dependencies"]; present && deps != nil {
+				if list, isList := deps.([]interface{}); isList && len(list) != 0 {
+					t.Fatalf("dependencies = %v, want empty: the target has no row in this database", deps)
+				}
+			}
+			unresolvable, ok := details["unresolvable_dependencies"].(float64)
+			if !ok || unresolvable != 1 {
+				t.Fatalf("unresolvable_dependencies = %v, want 1 — a count the caller cannot enumerate must say so (be-lpi)",
+					details["unresolvable_dependencies"])
+			}
+
+			// Text mode: the notice goes to stderr, so stdout stays
+			// byte-identical for scripts. Assert on stderr alone, or
+			// this passes on a build that prints nothing anywhere.
+			stdout, stderr := runShowSplit(t, bd, dir, subject.ID)
+			if !strings.Contains(stderr, "no row in this database") {
+				t.Errorf("bd show stderr did not disclose the unrenderable edge:\nstderr:\n%s", stderr)
+			}
+			if strings.Contains(stdout, "no row in this database") {
+				t.Errorf("the notice reached stdout, which must stay unchanged:\n%s", stdout)
+			}
+		})
+	}
+
+	// NEGATIVE CONTROL, and it is the load-bearing half: a fully local edge
+	// must leave the field unset and stderr silent. Without it every
+	// assertion above is satisfied by a build that reports every issue as
+	// having unresolvable edges.
+	t.Run("fully_local_control", func(t *testing.T) {
+		bdDep(t, bd, dir, "add", anchor.ID, local.ID, "--type", "blocks")
+
+		details := bdShowDetails(t, bd, dir, anchor.ID)
+		if v, present := details["unresolvable_dependencies"]; present {
+			t.Errorf("unresolvable_dependencies = %v on a fully local edge, want absent", v)
+		}
+		deps, _ := details["dependencies"].([]interface{})
+		if len(deps) != 1 {
+			t.Errorf("dependencies = %v, want the one local edge", details["dependencies"])
+		}
+
+		_, stderr := runShowSplit(t, bd, dir, anchor.ID)
+		if strings.Contains(stderr, "no row in this database") {
+			t.Errorf("bd show warned about a fully local edge:\nstderr:\n%s", stderr)
+		}
+	})
+}
+
+// runShowSplit runs `bd show <id>` keeping stdout and stderr apart, which the
+// shared helpers deliberately merge. The split is the whole point here: the
+// notice's contract is that it appears on stderr and nowhere else.
+func runShowSplit(t *testing.T, bd, dir, id string) (stdout, stderr string) {
+	t.Helper()
+	cmd := exec.Command(bd, "show", id)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	outBuf, errBuf, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd show %s failed: %v\nstdout:\n%s\nstderr:\n%s", id, err, outBuf.String(), errBuf.String())
+	}
+	return outBuf.String(), errBuf.String()
+}

--- a/cmd/bd/show_unresolvable_deps_unit_test.go
+++ b/cmd/bd/show_unresolvable_deps_unit_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeDepCounter answers the two aggregate queries warnUnresolvableDepEdges
+// makes, independently of any listing.
+type fakeDepCounter struct {
+	depCount  int64
+	depErr    error
+	rdepCount int64
+	rdepErr   error
+}
+
+func (f fakeDepCounter) CountDependencies(_ context.Context, _ string) (int64, error) {
+	return f.depCount, f.depErr
+}
+func (f fakeDepCounter) CountDependents(_ context.Context, _ string) (int64, error) {
+	return f.rdepCount, f.rdepErr
+}
+
+// TestWarnUnresolvableDepEdges covers the text-mode disclosure, and in
+// particular the case a codex review caught on the first cut of this change:
+// `bd show` renders dependencies best effort and discarded the listing error,
+// so a FAILED listing beside a SUCCEEDING count reported every edge the issue
+// has as cross-repo/external. That turns a transient backend error into a
+// claim about the data, which is worse than staying quiet — the same
+// distinction BuildIssueDetails draws with depsErr on the JSON side, and the
+// text path did not draw at all.
+func TestWarnUnresolvableDepEdges(t *testing.T) {
+	boom := errors.New("backend down")
+
+	tests := []struct {
+		name       string
+		counter    fakeDepCounter
+		deps       depListing
+		dependents depListing
+		wantWarn   bool
+		wantText   string
+	}{
+		{
+			name:     "one unrenderable outgoing edge",
+			counter:  fakeDepCounter{depCount: 1},
+			deps:     depListing{rows: 0},
+			wantWarn: true,
+			wantText: "1 dependency edge(s)",
+		},
+		{
+			name:       "one unrenderable incoming edge",
+			counter:    fakeDepCounter{rdepCount: 3},
+			dependents: depListing{rows: 1},
+			wantWarn:   true,
+			wantText:   "2 dependent edge(s)",
+		},
+		{
+			// The negative control. Without it every assertion above is
+			// satisfied by a build that warns unconditionally.
+			name:       "fully local, counts match the rows",
+			counter:    fakeDepCounter{depCount: 2, rdepCount: 1},
+			deps:       depListing{rows: 2},
+			dependents: depListing{rows: 1},
+			wantWarn:   false,
+		},
+		{
+			name:     "nothing at all",
+			counter:  fakeDepCounter{},
+			wantWarn: false,
+		},
+		{
+			// The codex finding. The count is honest and the listing never
+			// ran; staying silent is the only correct answer.
+			name:     "listing read FAILED, count succeeded",
+			counter:  fakeDepCounter{depCount: 5},
+			deps:     depListing{rows: 0, err: boom},
+			wantWarn: false,
+		},
+		{
+			name:       "dependents listing FAILED, count succeeded",
+			counter:    fakeDepCounter{rdepCount: 5},
+			dependents: depListing{rows: 0, err: boom},
+			wantWarn:   false,
+		},
+		{
+			// Symmetric: the count is what failed. It yields 0, which cannot
+			// exceed any row total, but assert it rather than lean on the sign.
+			name:     "count read FAILED",
+			counter:  fakeDepCounter{depErr: boom},
+			deps:     depListing{rows: 0},
+			wantWarn: false,
+		},
+		{
+			// One direction is diagnosable and the other is not: the healthy
+			// half must still be reported.
+			name:       "outgoing failed, incoming still reportable",
+			counter:    fakeDepCounter{depCount: 4, rdepCount: 2},
+			deps:       depListing{rows: 0, err: boom},
+			dependents: depListing{rows: 0},
+			wantWarn:   true,
+			wantText:   "2 dependent edge(s)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := captureStderr(t, func() {
+				warnUnresolvableDepEdges(context.Background(), tc.counter, "rp-1", tc.deps, tc.dependents)
+			})
+			if tc.wantWarn {
+				if !strings.Contains(out, "no row in this database") {
+					t.Errorf("expected a warning, got:\n%q", out)
+				}
+				if tc.wantText != "" && !strings.Contains(out, tc.wantText) {
+					t.Errorf("warning did not mention %q, got:\n%q", tc.wantText, out)
+				}
+				if !strings.Contains(out, "bd dep list rp-1 rp-1") {
+					t.Errorf("warning did not name the recovery command, got:\n%q", out)
+				}
+				// The pointer is printed once however many directions warn.
+				if n := strings.Count(out, "For raw edge records"); n != 1 {
+					t.Errorf("recovery pointer printed %d times, want 1:\n%q", n, out)
+				}
+			} else if out != "" {
+				t.Errorf("expected silence, got:\n%q", out)
+			}
+		})
+	}
+
+	t.Run("both directions warn but the pointer is printed once", func(t *testing.T) {
+		out := captureStderr(t, func() {
+			warnUnresolvableDepEdges(context.Background(),
+				fakeDepCounter{depCount: 1, rdepCount: 1}, "rp-1",
+				depListing{rows: 0}, depListing{rows: 0})
+		})
+		if n := strings.Count(out, "no row in this database"); n != 2 {
+			t.Errorf("expected two warnings, got %d:\n%q", n, out)
+		}
+		if n := strings.Count(out, "For raw edge records"); n != 1 {
+			t.Errorf("recovery pointer printed %d times, want 1:\n%q", n, out)
+		}
+	})
+
+	t.Run("nil store is a no-op", func(t *testing.T) {
+		out := captureStderr(t, func() {
+			warnUnresolvableDepEdges(context.Background(), nil, "rp-1", depListing{}, depListing{})
+		})
+		if out != "" {
+			t.Errorf("expected silence, got:\n%q", out)
+		}
+	})
+}

--- a/cmd/bd/show_unresolvable_deps_unit_test.go
+++ b/cmd/bd/show_unresolvable_deps_unit_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 )
 
-// fakeDepCounter answers the two aggregate queries warnUnresolvableDepEdges
-// makes, independently of any listing.
+// fakeDepCounter answers the two aggregate queries readDepCounts makes,
+// independently of any listing.
 type fakeDepCounter struct {
 	depCount  int64
 	depErr    error
@@ -106,8 +106,9 @@ func TestWarnUnresolvableDepEdges(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			counts := readDepCounts(context.Background(), tc.counter, "rp-1")
 			out := captureStderr(t, func() {
-				warnUnresolvableDepEdges(context.Background(), tc.counter, "rp-1", tc.deps, tc.dependents)
+				warnUnresolvableDepEdges("rp-1", counts, tc.deps, tc.dependents)
 			})
 			if tc.wantWarn {
 				if !strings.Contains(out, "no row in this database") {
@@ -130,10 +131,9 @@ func TestWarnUnresolvableDepEdges(t *testing.T) {
 	}
 
 	t.Run("both directions warn but the pointer is printed once", func(t *testing.T) {
+		counts := readDepCounts(context.Background(), fakeDepCounter{depCount: 1, rdepCount: 1}, "rp-1")
 		out := captureStderr(t, func() {
-			warnUnresolvableDepEdges(context.Background(),
-				fakeDepCounter{depCount: 1, rdepCount: 1}, "rp-1",
-				depListing{rows: 0}, depListing{rows: 0})
+			warnUnresolvableDepEdges("rp-1", counts, depListing{rows: 0}, depListing{rows: 0})
 		})
 		if n := strings.Count(out, "no row in this database"); n != 2 {
 			t.Errorf("expected two warnings, got %d:\n%q", n, out)
@@ -143,12 +143,38 @@ func TestWarnUnresolvableDepEdges(t *testing.T) {
 		}
 	})
 
+	// A nil store yields counts carrying errNoDepCounter in both directions,
+	// which the report gate treats exactly like any other failed count read.
 	t.Run("nil store is a no-op", func(t *testing.T) {
+		counts := readDepCounts(context.Background(), nil, "rp-1")
 		out := captureStderr(t, func() {
-			warnUnresolvableDepEdges(context.Background(), nil, "rp-1", depListing{}, depListing{})
+			warnUnresolvableDepEdges("rp-1", counts, depListing{rows: 0}, depListing{rows: 0})
 		})
 		if out != "" {
 			t.Errorf("expected silence, got:\n%q", out)
+		}
+	})
+
+	// The arithmetic half of the concurrency mitigation: a count that is
+	// stale-LOW relative to the listing — what a count read BEFORE a
+	// concurrent add looks like — must be suppressed rather than reported.
+	//
+	// SCOPE, stated because it would otherwise read as more than it is: this
+	// pins the SUBTRACTION only. The call-site ORDER that produces the
+	// stale-low count lives in show.go and show_display.go, which this test
+	// does not exercise; the split into readDepCounts plus
+	// warnUnresolvableDepEdges is what makes that order visible at those call
+	// sites, and TestBuildIssueDetails_ConcurrentAddIsNotReportedAsUnresolvable
+	// is the case that actually fails when an order is reversed.
+	t.Run("a stale-low count is suppressed, not reported", func(t *testing.T) {
+		counts := readDepCounts(context.Background(), fakeDepCounter{depCount: 1}, "rp-1")
+		out := captureStderr(t, func() {
+			// The listing observed the edge the count predates, plus one more
+			// added in the window.
+			warnUnresolvableDepEdges("rp-1", counts, depListing{rows: 2}, depListing{})
+		})
+		if out != "" {
+			t.Errorf("a concurrent add must not be reported as unresolvable, got:\n%q", out)
 		}
 	})
 }

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -6606,6 +6606,41 @@ components:
             every such issue on a request that did not set `include_comments`.
             Without it, an absent `comments` key is ambiguous between "no
             comments" and "comments not included in this response".
+        unresolvable_dependencies:
+          type: integer
+          format: int64
+          description: >-
+            How many of `dependency_count`'s edges `dependencies` could not
+            represent, because the issue on the far end has no row in this
+            database — a cross-repo id or an `external:` reference. The edge is
+            real and correctly stored; only its far end is unreachable from
+            here, so the listing drops it while the count keeps it.
+
+
+            Without it the count reads as phantom: a caller sees
+            `dependency_count: 1` beside an absent `dependencies`, finds
+            nothing under that id anywhere, and concludes the count is wrong.
+            It is not — the edge record itself is readable, and on the CLI
+            `bd dep list <id> <id>` prints it.
+
+
+            ABSENT, NEVER ZERO, WHEN THERE IS NOTHING TO REPORT, and absent
+            too when the dependency read FAILED rather than came back short.
+            "Could not be represented" and "was never fetched" are different
+            facts and do not collapse into one member — the same distinction
+            `comments_omitted` draws.
+        unresolvable_dependents:
+          type: integer
+          format: int64
+          description: >-
+            The inbound counterpart of `unresolvable_dependencies`, on the same
+            terms.
+
+
+            Present only on a request that set `include_dependents`. Without
+            those rows `dependents` is absent by design, so a difference taken
+            against it would report every dependent the issue has as
+            unresolvable.
         epic_total_children:
           type: integer
         epic_closed_children:

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1166,6 +1166,30 @@ type IssueDetails struct {
 	// Comments slice or a zero count: a true empty stays plain omission.
 	CommentsOmitted *bool `json:"comments_omitted,omitempty"`
 
+	// UnresolvableDependencies / UnresolvableDependents count the edges
+	// DependencyCount / DependentCount include that the Dependencies /
+	// Dependents slices could not represent, because the issue on the far
+	// end has no row in this database: a cross-repo id or an `external:`
+	// reference, both of which live in the one dependency target column
+	// carrying no foreign key into issues (issueops.IsExternalDepTarget).
+	// The edge is real and correctly stored; only its far end is
+	// unreachable from here, so the enumeration drops it while the count
+	// keeps it.
+	//
+	// Without these, the count is a number with no referent (be-lpi): a
+	// caller reads `dependency_count: 1` beside `dependencies: null`,
+	// finds nothing in `bd dep list`, and concludes the count is phantom.
+	// It is not — `bd dep list <id> <id>` shows the raw edge record.
+	//
+	// Set only when the slice was actually READ and came back short. A
+	// failed or skipped read leaves them unset, because "could not be
+	// represented" and "was never fetched" must not collapse into one
+	// signal — the same distinction CommentsOmitted draws above.
+	// UnresolvableDependents is therefore set only under
+	// DetailOptions.IncludeDependents, where the rows are collected.
+	UnresolvableDependencies *int64 `json:"unresolvable_dependencies,omitempty"`
+	UnresolvableDependents   *int64 `json:"unresolvable_dependents,omitempty"`
+
 	// Epic progress fields (populated only for issue_type=epic with children)
 	EpicTotalChildren  *int  `json:"epic_total_children,omitempty"`
 	EpicClosedChildren *int  `json:"epic_closed_children,omitempty"`

--- a/internal/workapi/detail.go
+++ b/internal/workapi/detail.go
@@ -117,15 +117,30 @@ func BuildIssueDetails(ctx context.Context, src DetailSource, issue *types.Issue
 	details := types.NewIssueDetails(*issue)
 
 	details.Labels, _ = src.Labels(ctx, id, isWisp)
-	details.Dependencies, _ = src.Dependencies(ctx, id, isWisp)
+	// depsErr is kept rather than discarded: it is what separates "the edge
+	// list came back short" from "the edge list never came back", and the
+	// unresolvable-edge delta below is only meaningful in the first case.
+	deps, depsErr := src.Dependencies(ctx, id, isWisp)
+	details.Dependencies = deps
 
 	// Aggregate counts - O(1) queries, no row materialization.
-	dependentCount, _ := src.CountDependents(ctx, id, isWisp)
+	dependentCount, dependentCountErr := src.CountDependents(ctx, id, isWisp)
 	details.DependentCount = &dependentCount
-	dependencyCount, _ := src.CountDependencies(ctx, id, isWisp)
+	dependencyCount, dependencyCountErr := src.CountDependencies(ctx, id, isWisp)
 	details.DependencyCount = &dependencyCount
 	commentCount, _ := src.CountComments(ctx, id, isWisp)
 	details.CommentCount = &commentCount
+
+	// The count counts edge ROWS; the slice carries the issues on the far
+	// end, and drops any whose id has no row in this database. The two
+	// therefore disagree by exactly the cross-repo and `external:` edges,
+	// which is real stored data rather than a phantom count (be-lpi).
+	// Publish the difference instead of leaving the caller to infer it.
+	if depsErr == nil && dependencyCountErr == nil {
+		if n := dependencyCount - int64(len(details.Dependencies)); n > 0 {
+			details.UnresolvableDependencies = &n
+		}
+	}
 
 	if opts.IncludeDependents {
 		dependents, err := collectDependents(ctx, src, id, isWisp)
@@ -134,6 +149,14 @@ func BuildIssueDetails(ctx context.Context, src DetailSource, issue *types.Issue
 		}
 		details.Dependents = dependents
 		applyEpicProgress(details, dependents)
+		// Same asymmetry as the outgoing side, and only computable here:
+		// without IncludeDependents the slice is nil by design, so a delta
+		// against it would report the whole count as unresolvable.
+		if dependentCountErr == nil {
+			if n := dependentCount - int64(len(dependents)); n > 0 {
+				details.UnresolvableDependents = &n
+			}
+		}
 	}
 
 	if opts.IncludeComments {

--- a/internal/workapi/detail.go
+++ b/internal/workapi/detail.go
@@ -117,19 +117,33 @@ func BuildIssueDetails(ctx context.Context, src DetailSource, issue *types.Issue
 	details := types.NewIssueDetails(*issue)
 
 	details.Labels, _ = src.Labels(ctx, id, isWisp)
-	// depsErr is kept rather than discarded: it is what separates "the edge
-	// list came back short" from "the edge list never came back", and the
-	// unresolvable-edge delta below is only meaningful in the first case.
-	deps, depsErr := src.Dependencies(ctx, id, isWisp)
-	details.Dependencies = deps
 
 	// Aggregate counts - O(1) queries, no row materialization.
+	//
+	// THE COUNTS ARE READ BEFORE THE ROW LISTS, and the order is load-bearing
+	// wherever the source is not snapshot-consistent. The UOW source runs the
+	// whole build inside one read transaction and is immune; the store-backed
+	// source issues a connection per call, so a concurrent write can land
+	// between the two reads and skew the delta below. Counting first puts that
+	// skew on the safe side: an edge ADDED in the window leaves the count
+	// stale-LOW, so the delta goes negative and is suppressed, where the
+	// reverse order would have announced a fresh local edge as unresolvable.
+	// A concurrent DELETE still produces a spurious report, which is the
+	// residual and is why this is an ordering mitigation rather than a fix —
+	// only a shared snapshot or a direct count of unresolvable edges closes
+	// it (be-lpi).
 	dependentCount, dependentCountErr := src.CountDependents(ctx, id, isWisp)
 	details.DependentCount = &dependentCount
 	dependencyCount, dependencyCountErr := src.CountDependencies(ctx, id, isWisp)
 	details.DependencyCount = &dependencyCount
 	commentCount, _ := src.CountComments(ctx, id, isWisp)
 	details.CommentCount = &commentCount
+
+	// depsErr is kept rather than discarded: it is what separates "the edge
+	// list came back short" from "the edge list never came back", and the
+	// unresolvable-edge delta below is only meaningful in the first case.
+	deps, depsErr := src.Dependencies(ctx, id, isWisp)
+	details.Dependencies = deps
 
 	// The count counts edge ROWS; the slice carries the issues on the far
 	// end, and drops any whose id has no row in this database. The two

--- a/internal/workapi/detail_unresolvable_test.go
+++ b/internal/workapi/detail_unresolvable_test.go
@@ -3,6 +3,7 @@ package workapi
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/storage"
@@ -201,6 +202,91 @@ func TestBuildIssueDetails_UnresolvableDependents(t *testing.T) {
 	}
 	if got.UnresolvableDependents != nil {
 		t.Errorf("UnresolvableDependents = %d on a fully local store, want unset", *got.UnresolvableDependents)
+	}
+}
+
+// mutatingSource models a write landing BETWEEN the two reads
+// BuildIssueDetails makes: whichever of Dependencies/CountDependencies runs
+// first observes one edge, and whichever runs second observes two.
+//
+// This is what makes the ordering testable at all. A source returning fixed
+// values cannot distinguish the two orders — the first version of this test
+// used one, and reverting the fix under it still passed, which is a test that
+// pins arithmetic while claiming to pin an order.
+type mutatingSource struct {
+	issue  *types.Issue
+	edges  int
+	before int
+}
+
+func (m *mutatingSource) observe() int {
+	if m.before == 0 {
+		m.before = 1
+		return m.edges // the first reader sees the pre-write state
+	}
+	return m.edges + 1 // by the second read, an edge has been added
+}
+
+func (m *mutatingSource) GetIssue(_ context.Context, _ string) (*types.Issue, error) {
+	return m.issue, nil
+}
+func (m *mutatingSource) GetWisp(_ context.Context, id string) (*types.Issue, error) {
+	return nil, notFound(id)
+}
+func (m *mutatingSource) Labels(_ context.Context, _ string, _ bool) ([]string, error) {
+	return nil, nil
+}
+func (m *mutatingSource) Dependencies(_ context.Context, _ string, _ bool) ([]*types.IssueWithDependencyMetadata, error) {
+	n := m.observe()
+	out := make([]*types.IssueWithDependencyMetadata, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, depRow(fmt.Sprintf("rp-%d", i+2), types.DepBlocks))
+	}
+	return out, nil
+}
+func (m *mutatingSource) CountDependencies(_ context.Context, _ string, _ bool) (int64, error) {
+	return int64(m.observe()), nil
+}
+func (m *mutatingSource) CountDependents(_ context.Context, _ string, _ bool) (int64, error) {
+	return 0, nil
+}
+func (m *mutatingSource) CountComments(_ context.Context, _ string, _ bool) (int64, error) {
+	return 0, nil
+}
+func (m *mutatingSource) IterDependents(_ context.Context, _ string, _ bool) (storage.Iter[types.IssueWithDependencyMetadata], error) {
+	return storage.NewSliceIter[types.IssueWithDependencyMetadata](nil), nil
+}
+func (m *mutatingSource) IterComments(_ context.Context, _ string, _ bool) (storage.Iter[types.Comment], error) {
+	return storage.NewSliceIter[types.Comment](nil), nil
+}
+
+// TestBuildIssueDetails_ConcurrentAddIsNotReportedAsUnresolvable pins the
+// ORDER of the two reads, which is the only defence the store-backed source
+// has against a write landing between them. (The UOW source runs the whole
+// build inside one read transaction and needs none.)
+//
+// The count is read FIRST, so an edge added in the window leaves it
+// stale-LOW: the difference goes negative and nothing is reported. Read
+// afterwards it would be stale-HIGH, and a freshly added, perfectly ordinary
+// local edge would be published as unresolvable — a false claim about the
+// data, which is the expensive direction. Found by a codex review of the
+// first cut of this change.
+//
+// The source above mutates between calls, so swapping the two reads in
+// BuildIssueDetails turns this red. That is the control; without it the case
+// passes under either order.
+func TestBuildIssueDetails_ConcurrentAddIsNotReportedAsUnresolvable(t *testing.T) {
+	ctx := context.Background()
+	issue := &types.Issue{ID: "rp-1"}
+	src := &mutatingSource{issue: issue, edges: 1}
+
+	details, err := BuildIssueDetails(ctx, src, issue, false, DetailOptions{})
+	if err != nil {
+		t.Fatalf("BuildIssueDetails: %v", err)
+	}
+	if details.UnresolvableDependencies != nil {
+		t.Errorf("UnresolvableDependencies = %d, want unset — a count read before a concurrent add is stale-low, not evidence of an unrenderable edge; are the two reads still in count-then-listing order?",
+			*details.UnresolvableDependencies)
 	}
 }
 

--- a/internal/workapi/detail_unresolvable_test.go
+++ b/internal/workapi/detail_unresolvable_test.go
@@ -1,0 +1,207 @@
+package workapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// skewSource is a DetailSource whose COUNTS and ROWS are set independently.
+//
+// The shared fakeStoreReader derives both from one slice, so it can only ever
+// produce a store where they agree — which is exactly the state this test has
+// to move away from. A real backend derives them from two different queries:
+// the counts are a plain COUNT(*) over the dependency tables, while the rows
+// are the issues on the far end and silently omit any id with no row in this
+// database (issueops.GetDependenciesWithMetadataInTx's `continue`). A
+// cross-repo or `external:` target hits that gap by construction, since
+// depends_on_external is the one target column carrying no foreign key into
+// issues.
+type skewSource struct {
+	issue *types.Issue
+
+	deps    []*types.IssueWithDependencyMetadata
+	depsErr error
+
+	dependents []*types.IssueWithDependencyMetadata
+
+	depCount     int64
+	depCountErr  error
+	rdepCount    int64
+	rdepCountErr error
+}
+
+func (s skewSource) GetIssue(_ context.Context, _ string) (*types.Issue, error) { return s.issue, nil }
+func (s skewSource) GetWisp(_ context.Context, id string) (*types.Issue, error) {
+	return nil, notFound(id)
+}
+func (s skewSource) Labels(_ context.Context, _ string, _ bool) ([]string, error) { return nil, nil }
+func (s skewSource) Dependencies(_ context.Context, _ string, _ bool) ([]*types.IssueWithDependencyMetadata, error) {
+	return s.deps, s.depsErr
+}
+func (s skewSource) CountDependencies(_ context.Context, _ string, _ bool) (int64, error) {
+	return s.depCount, s.depCountErr
+}
+func (s skewSource) CountDependents(_ context.Context, _ string, _ bool) (int64, error) {
+	return s.rdepCount, s.rdepCountErr
+}
+func (s skewSource) CountComments(_ context.Context, _ string, _ bool) (int64, error) {
+	return 0, nil
+}
+func (s skewSource) IterDependents(_ context.Context, _ string, _ bool) (storage.Iter[types.IssueWithDependencyMetadata], error) {
+	return storage.NewSliceIter(s.dependents), nil
+}
+func (s skewSource) IterComments(_ context.Context, _ string, _ bool) (storage.Iter[types.Comment], error) {
+	return storage.NewSliceIter[types.Comment](nil), nil
+}
+
+func depRow(id string, t types.DependencyType) *types.IssueWithDependencyMetadata {
+	return &types.IssueWithDependencyMetadata{Issue: types.Issue{ID: id}, DependencyType: t}
+}
+
+// TestBuildIssueDetails_UnresolvableDependencies pins be-lpi: a dependency
+// edge whose target has no row in this database counts toward
+// dependency_count and cannot appear in the dependencies slice, and that
+// difference must be published rather than left for the caller to infer.
+//
+// The convoy case that produced the report is the one-edge, zero-row row:
+// hq-cv-ftcra carries a single `tracks` edge to
+// external:liveop:liveop-kmf, so bd show --json answered
+// dependency_count 1 beside dependencies:null and every enumeration path
+// agreed the edge did not exist.
+func TestBuildIssueDetails_UnresolvableDependencies(t *testing.T) {
+	ctx := context.Background()
+	issue := &types.Issue{ID: "rp-1"}
+
+	tests := []struct {
+		name  string
+		src   skewSource
+		want  *int64
+		count int64
+	}{
+		{
+			name:  "all edges unresolvable",
+			src:   skewSource{issue: issue, deps: nil, depCount: 1},
+			want:  ptr64(1),
+			count: 1,
+		},
+		{
+			name: "one of two edges unresolvable",
+			src: skewSource{
+				issue:    issue,
+				deps:     []*types.IssueWithDependencyMetadata{depRow("rp-2", types.DepBlocks)},
+				depCount: 2,
+			},
+			want:  ptr64(1),
+			count: 2,
+		},
+		{
+			// The negative control. A fully local store must be
+			// byte-identical to before the fix, or every caller that
+			// checks the field starts seeing it on healthy rows.
+			name: "fully local, nothing unresolvable",
+			src: skewSource{
+				issue:    issue,
+				deps:     []*types.IssueWithDependencyMetadata{depRow("rp-2", types.DepBlocks)},
+				depCount: 1,
+			},
+			want:  nil,
+			count: 1,
+		},
+		{
+			name:  "no dependencies at all",
+			src:   skewSource{issue: issue, depCount: 0},
+			want:  nil,
+			count: 0,
+		},
+		{
+			// A FAILED read and a SHORT read both leave the slice
+			// empty. Only the first must stay silent: reporting it
+			// would announce a data property on the strength of a
+			// query that never ran.
+			name:  "dependency read failed, not merely short",
+			src:   skewSource{issue: issue, depsErr: errors.New("backend down"), depCount: 3},
+			want:  nil,
+			count: 3,
+		},
+		{
+			// Symmetric: a failed COUNT yields 0, and 0 minus a
+			// populated slice is negative, but say so explicitly
+			// rather than relying on the sign.
+			name: "count read failed",
+			src: skewSource{
+				issue:       issue,
+				deps:        []*types.IssueWithDependencyMetadata{depRow("rp-2", types.DepBlocks)},
+				depCountErr: errors.New("backend down"),
+			},
+			want:  nil,
+			count: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			details, err := BuildIssueDetails(ctx, tc.src, issue, false, DetailOptions{})
+			if err != nil {
+				t.Fatalf("BuildIssueDetails: %v", err)
+			}
+			if details.DependencyCount == nil || *details.DependencyCount != tc.count {
+				t.Errorf("DependencyCount = %v, want %d", details.DependencyCount, tc.count)
+			}
+			switch {
+			case tc.want == nil && details.UnresolvableDependencies != nil:
+				t.Errorf("UnresolvableDependencies = %d, want unset", *details.UnresolvableDependencies)
+			case tc.want != nil && details.UnresolvableDependencies == nil:
+				t.Errorf("UnresolvableDependencies unset, want %d", *tc.want)
+			case tc.want != nil && *details.UnresolvableDependencies != *tc.want:
+				t.Errorf("UnresolvableDependencies = %d, want %d", *details.UnresolvableDependencies, *tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildIssueDetails_UnresolvableDependents pins the inbound half, and in
+// particular that it stays silent in count-only mode. Dependents is nil by
+// design without IncludeDependents (be-ijck6q), so a delta taken against it
+// there would report every dependent an issue has as unresolvable.
+func TestBuildIssueDetails_UnresolvableDependents(t *testing.T) {
+	ctx := context.Background()
+	issue := &types.Issue{ID: "rp-1"}
+	src := skewSource{issue: issue, dependents: nil, rdepCount: 2}
+
+	countOnly, err := BuildIssueDetails(ctx, src, issue, false, DetailOptions{})
+	if err != nil {
+		t.Fatalf("BuildIssueDetails count-only: %v", err)
+	}
+	if countOnly.UnresolvableDependents != nil {
+		t.Errorf("count-only UnresolvableDependents = %d, want unset — the rows were never fetched",
+			*countOnly.UnresolvableDependents)
+	}
+
+	included, err := BuildIssueDetails(ctx, src, issue, false, DetailOptions{IncludeDependents: true})
+	if err != nil {
+		t.Fatalf("BuildIssueDetails include-dependents: %v", err)
+	}
+	if included.UnresolvableDependents == nil || *included.UnresolvableDependents != 2 {
+		t.Errorf("UnresolvableDependents = %v, want 2", included.UnresolvableDependents)
+	}
+
+	// Negative control on the same path: every dependent resolvable.
+	local := skewSource{
+		issue:      issue,
+		dependents: []*types.IssueWithDependencyMetadata{depRow("rp-2", types.DepBlocks)},
+		rdepCount:  1,
+	}
+	got, err := BuildIssueDetails(ctx, local, issue, false, DetailOptions{IncludeDependents: true})
+	if err != nil {
+		t.Fatalf("BuildIssueDetails local: %v", err)
+	}
+	if got.UnresolvableDependents != nil {
+		t.Errorf("UnresolvableDependents = %d on a fully local store, want unset", *got.UnresolvableDependents)
+	}
+}
+
+func ptr64(v int64) *int64 { return &v }


### PR DESCRIPTION
## The bug

`bd show --json` emitted a self-contradicting payload on any issue with a cross-repo or `external:` dependency:

```json
{"id":"hq-cv-ftcra","dependency_count":1,"dependencies":null}
```

and `bd show` in text mode rendered no dependency section at all — so `bd dep add x liveop-y` reported success and the `bd show x` you ran straight after was indistinguishable from the edge never having been written.

## The count is correct. The enumeration is the defect.

Reported as a *phantom* `dependency_count` on convoy beads. It is neither phantom nor convoy-specific. Read out of the store:

```
issue_id     depends_on_issue_id  depends_on_wisp_id  depends_on_external           type
hq-cv-ftcra  NULL                 NULL                external:liveop:liveop-kmf    tracks
```

`GetDependenciesWithMetadataInTx` reads the edge rows, resolves each far end, then `continue`s past any id with no local row. An `external:` or cross-repo target **has** no local row by construction — `IsExternalDepTarget` routes exactly the ids this database cannot hold into `depends_on_external`, the one target column with no foreign key into `issues`. The count queries have no such join. So the count keeps the edge and every listing drops it.

The `bd list --json` zero the report also cites is **correct by design and unrelated**: that count is blocks-only per `SearchCountsSQL`, and the edge is `tracks`. Two independent facts were conflated in the report; only the second was a bug.

This matters beyond tidiness: under the "phantom count" framing the natural fix is to make the count agree with the listing — i.e. zero it — which would delete the only signal that these edges exist (77 of them in the store where this was found, all `tracks`).

## The fix

Publish the difference instead of leaving the caller to infer it, following the `comments_omitted` precedent (ga-clgh):

- `IssueDetails` gains `unresolvable_dependencies` / `unresolvable_dependents`
- `BuildIssueDetails` sets them, so CLI `--json` and the HTTP detail view get it at once
- text mode says the same on **stderr, never stdout**, so the rendered issue is byte-identical for the common fully-local case — the choice `warnDroppedDepEdges` already made in `dep.go` for this same gap
- the notice helper is shared with the watch-mode render so the two cannot drift

Set **only** when the row list was actually read and came back short. `unresolvable_dependents` only under `IncludeDependents`, where the rows exist.

`bd dep list` needed no change: bd-mtla already warns there and points at `bd dep list <id> <id>`, which prints the raw edge record.

## Deliberately not done

- **Zeroing the count.** It is right and the edge is real.
- **Synthesising placeholder issues** for external targets in `GetDependenciesWithMetadata`. It has 14 non-test call sites including the Linear, GitLab, Jira and ADO sync paths, which would then map a fabricated issue onto a remote tracker.
- **`docs/reference/json-schema.md`.** Hand-written, and documents the pinned release (`docs/cli-docs.pin` is v1.2.2), not main. Follow-up filed.

## Review findings, both fixed in this branch

`codex exec review` found two real defects in the first cut. Both are the same class as the bug being fixed — a signal that cannot tell *absent* from *unread*.

1. **The text path discarded the listing error.** A failing listing beside a succeeding count reported every counted edge as external: a transient backend error rendered as a claim about the data. Fixed by carrying rows and error together and requiring both reads to have succeeded.
2. **The difference is inferred across two non-atomic reads.** Only the store-backed path is exposed — `uow.issueReader.Get` wraps the build in `RunTxRead`, while `storereader` (what `bd show` runs on) opens a connection per call. Mitigated by reading the **counts first**, so an edge added in the window leaves the count stale-low and the difference is suppressed rather than announced. A concurrent *delete* still reports spuriously; that residual is filed separately with two ways to close it properly.

**My first test for (2) could not fail** — it used a source returning fixed values, so reversing the reads still passed. The sabotage run caught it by staying green. Replaced with a source that mutates between calls; swapping the reads now fails with exactly the false report the review described.

Codex is clean on the final head.

## Verification

| tier | what |
|---|---|
| unit | `internal/workapi/detail_unresolvable_test.go` — arithmetic + negative controls (fully local, failed row read, failed count read, count-only mode) + the order-sensitive concurrency case |
| unit | `cmd/bd/show_unresolvable_deps_unit_test.go` — 11 cases for the text notice, incl. both read-failure directions and one-direction-fails-other-still-reports |
| e2e | `cmd/bd/show_unresolvable_deps_embedded_test.go` — drives `bd init` → `create` → `dep add` → `show` for both target shapes plus a fully-local control; asserts the notice reaches stderr and **not** stdout |

The e2e tier exists because the unit tier constructs the count/row skew directly and so proves the arithmetic while saying nothing about whether a real command can produce that state. Verified the scratch fixture's stored columns are byte-identical in shape to the production row rather than merely similar.

**Sabotage control run on every guard**; each turns its tests red, negative controls stay green.

`make test`: failure set identical to a clean checkout of `c0d8da42d` — `TestPrepareSelectedCommandContext_RebindsTargetConfig` and `TestInitNonInteractiveAutoExportDefaultOffAndOptIn`, both pre-existing and both reproduced on the baseline worktree. `go vet ./...`, `make api-check`, `make ci-pr-lint` (its three gofmt failures are also pre-existing and in files this branch does not touch), and `cmd/bd/protocol` golden corpus all clean.

## Preflight

`scripts/pr-preflight.sh` flagged five open PRs on a broad keyword search; **none shares a file with this branch** (checked with positive and negative controls on the overlap test). The nearest by name, #6315 *"expose native external dependency policy"*, is about SDK readiness semantics for `external:` targets and does not touch the detail view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017B2Z4eQi2a9Cgfumj2RRnR
