### PR TITLE
Phase 2 (draft, stacked on #6304 and #6147): dual-write history behind a flag (#6135)

### DIFF
--- a/backend/conformance/cross_record_invariant_contract.go
+++ b/backend/conformance/cross_record_invariant_contract.go
@@ -153,12 +153,40 @@ func RunStoreInvariantTransactionScopesExactlyTheSpanningRecords(t *testing.T, c
 		{ID: fixture.IssuePrefix + "-crossrec-scope-a", Patch: map[string]any{"alias": shared}},
 		{ID: fixture.IssuePrefix + "-crossrec-scope-b", Patch: map[string]any{"alias": shared}},
 	}
+
+	var beforeA, beforeB int
+	if fixture.CountHistoryForSubject != nil {
+		var err error
+		beforeA, err = fixture.CountHistoryForSubject(ctx, spanning[0].ID)
+		if err != nil {
+			t.Fatalf("CountHistoryForSubject(%s) before the refused batch: %v", spanning[0].ID, err)
+		}
+		beforeB, err = fixture.CountHistoryForSubject(ctx, spanning[1].ID)
+		if err != nil {
+			t.Fatalf("CountHistoryForSubject(%s) before the refused batch: %v", spanning[1].ID, err)
+		}
+	}
+
 	result, err := fixture.EnforceCrossRecordInvariant(ctx, spanning)
 	if err != nil {
 		t.Fatalf("EnforceCrossRecordInvariant(spanning): %v", err)
 	}
 	if result.Accepted {
 		t.Fatal("EnforceCrossRecordInvariant accepted two writes that jointly violate the shared-alias invariant")
+	}
+
+	if fixture.CountHistoryForSubject != nil {
+		afterA, err := fixture.CountHistoryForSubject(ctx, spanning[0].ID)
+		if err != nil {
+			t.Fatalf("CountHistoryForSubject(%s) after the refused batch: %v", spanning[0].ID, err)
+		}
+		afterB, err := fixture.CountHistoryForSubject(ctx, spanning[1].ID)
+		if err != nil {
+			t.Fatalf("CountHistoryForSubject(%s) after the refused batch: %v", spanning[1].ID, err)
+		}
+		if afterA != beforeA || afterB != beforeB {
+			t.Errorf("a refused batch left a trace: history count for %s went %d->%d, for %s went %d->%d; a refusal must be atomic — the whole batch takes no effect, not just the record that individually triggered it", spanning[0].ID, beforeA, afterA, spanning[1].ID, beforeB, afterB)
+		}
 	}
 
 	unrelated := []RecordWrite{

--- a/backend/conformance/cross_record_invariant_contract.go
+++ b/backend/conformance/cross_record_invariant_contract.go
@@ -1,0 +1,340 @@
+package conformance
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// This file holds the contract for R16.1 (gastownhall/beads#6133,
+// be-hs42e.1 §5-§7, FR-02, FR-03): enforcement that spans more than one
+// record, which ExpectedRevisionFixture's per-record CompareAndSetVersion
+// structurally cannot see.
+//
+// GuardedWrite AND ExpectedRevisionFixture.CompareAndSetVersion SHARE THE
+// EXACT SAME TYPE, PerRecordCASWrite, declared once in
+// expected_revision_contract.go. R16.1-a's boundary claim is literally that
+// the second is the first, called twice against records that individually
+// pass but jointly violate a store invariant — sharing the type makes that
+// claim structural, checked by the compiler, rather than merely asserted in
+// a doc comment.
+//
+// TWO CONCRETE SUBJECTS ARE REQUIRED BY FR-02 RATHER THAN INVENTED HERE:
+// Memory key/alias uniqueness (#5877 R2) and graph-edge
+// MaximumEndpointMultiplicity. MemoryKeyAliasWrite and GraphEdgeWrite exist
+// so the cases named for them construct a REAL joint violation in each
+// subject's own vocabulary, rather than a synthetic one this file made up.
+//
+// EVERY HOOK BELOW IS INDEPENDENTLY NILABLE — see the package-level note in
+// expected_revision_contract.go. Every case nil-checks every hook it uses
+// and SKIPS BY NAME when one is missing.
+
+// RecordWrite is one record's half of a multi-record write submitted to
+// EnforceCrossRecordInvariant.
+type RecordWrite struct {
+	ID       string
+	Expected *Address
+	Patch    map[string]any
+}
+
+// InvariantResult is the outcome of a call to EnforceCrossRecordInvariant.
+type InvariantResult struct {
+	Accepted         bool
+	InvariantRefusal *InvariantRefusal
+}
+
+// InvariantRefusal names the specific store invariant a multi-record write
+// violated (R16.1-c) — never a bare boolean, so a caller (and a test) can
+// tell which invariant fired.
+type InvariantRefusal struct {
+	InvariantName string
+}
+
+// LeaseHandle is an advisory lease over subject. It is observed by
+// convention only (FR-03): holding one does not, by itself, change what any
+// per-record or invariant-enforcing write accepts.
+type LeaseHandle struct {
+	Subject   string
+	ExpiresAt time.Time
+	// Release ends the lease early. A nil Release means the fixture expects
+	// the lease to simply expire; cases treat a nil Release as optional
+	// cleanup, not a required call.
+	Release func(ctx context.Context) error
+}
+
+// CrossRecordInvariantFixture supplies the capabilities under test for
+// R16.1: enforcement that spans more than one record, and the advisory
+// lease primitive FR-03 says is insufficient on its own to provide it.
+type CrossRecordInvariantFixture struct {
+	IssuePrefix string
+
+	// GuardedWrite is a per-record CAS write over the SAME type as
+	// ExpectedRevisionFixture.CompareAndSetVersion (PerRecordCASWrite) — see
+	// this file's package doc comment for why. A nil hook means this
+	// backend exposes no per-record guard to construct the boundary case
+	// against, and cases that need one skip with that reason.
+	GuardedWrite PerRecordCASWrite
+
+	// EnforceCrossRecordInvariant evaluates writes as one joint operation
+	// and refuses the whole batch, with a named InvariantRefusal, if
+	// accepting it would violate a store invariant spanning more than one
+	// of the given records. A nil hook means this backend has not wired
+	// store-invariant enforcement yet, and cases that need one skip with
+	// that reason.
+	EnforceCrossRecordInvariant func(ctx context.Context, writes []RecordWrite) (InvariantResult, error)
+
+	// AcquireAdvisoryLease acquires a convention-only lease over subject for
+	// up to ttl. A nil hook means this backend has no lease primitive to
+	// test as an insufficient guard, and cases that need one skip with that
+	// reason.
+	AcquireAdvisoryLease func(ctx context.Context, subject string, ttl time.Duration) (LeaseHandle, error)
+
+	// CountHistoryForSubject reports how many durable history entries exist
+	// for subject. A nil hook means this backend cannot observe history by
+	// subject, and cases that need one skip with that reason.
+	CountHistoryForSubject func(ctx context.Context, subject string) (int, error)
+
+	// MemoryKeyAliasWrite writes memoryID's key/alias pair unconditionally,
+	// in the shape of a per-record write (FR-02's first named subject,
+	// #5877 R2). A nil hook means this backend exposes no Memory key/alias
+	// write to probe, and the case that needs it skips with that reason.
+	MemoryKeyAliasWrite func(ctx context.Context, memoryID, key, alias string) (ExpectedRevisionResult, error)
+
+	// GraphEdgeWrite writes a graph edge unconditionally, in the shape of a
+	// per-record write (FR-02's second named subject,
+	// MaximumEndpointMultiplicity). A nil hook means this backend exposes no
+	// graph edge write to probe, and the case that needs it skips with that
+	// reason.
+	GraphEdgeWrite func(ctx context.Context, fromID, toID, edgeType string) (ExpectedRevisionResult, error)
+}
+
+// RunCrossRecordInvariantSurvivesTwoPassingPerRecordGuards pins R16.1-a's
+// boundary claim directly: two writes, each individually valid under
+// GuardedWrite (== CompareAndSetVersion), that JOINTLY violate a store
+// invariant neither call's own precondition can see. Both must be Accepted
+// through GuardedWrite alone — the whole point of R16.1 is that this
+// per-record guard cannot catch what only spans records.
+func RunCrossRecordInvariantSurvivesTwoPassingPerRecordGuards(t *testing.T, ctx context.Context, fixture CrossRecordInvariantFixture) {
+	t.Helper()
+	if fixture.GuardedWrite == nil {
+		t.Skip("this backend exposes no per-record guard to construct the boundary case against (GuardedWrite is nil)")
+	}
+	shared := fixture.IssuePrefix + "-crossrec-shared-alias"
+
+	first, err := fixture.GuardedWrite(ctx, fixture.IssuePrefix+"-crossrec-a", nil, map[string]any{"alias": shared})
+	if err != nil {
+		t.Fatalf("GuardedWrite(a): %v", err)
+	}
+	if !first.Accepted {
+		t.Fatalf("GuardedWrite(a) claiming alias %q was refused (Refusal=%+v), want Accepted: a per-record guard cannot see a joint violation", shared, first.Refusal)
+	}
+
+	second, err := fixture.GuardedWrite(ctx, fixture.IssuePrefix+"-crossrec-b", nil, map[string]any{"alias": shared})
+	if err != nil {
+		t.Fatalf("GuardedWrite(b): %v", err)
+	}
+	if !second.Accepted {
+		t.Fatalf("GuardedWrite(b) claiming the SAME alias %q was refused (Refusal=%+v), want Accepted (R16.1-a: per-record CAS structurally cannot catch a cross-record conflict)", shared, second.Refusal)
+	}
+}
+
+// RunStoreInvariantTransactionScopesExactlyTheSpanningRecords pins R16.1-b:
+// EnforceCrossRecordInvariant refuses a batch that jointly violates an
+// invariant, and — checked against an unrelated, non-conflicting write in
+// the same call shape — must not refuse more broadly than the records that
+// actually span the violation.
+func RunStoreInvariantTransactionScopesExactlyTheSpanningRecords(t *testing.T, ctx context.Context, fixture CrossRecordInvariantFixture) {
+	t.Helper()
+	if fixture.EnforceCrossRecordInvariant == nil {
+		t.Skip("this backend has not wired store-invariant enforcement yet (EnforceCrossRecordInvariant is nil)")
+	}
+	shared := fixture.IssuePrefix + "-crossrec-scope-alias"
+	spanning := []RecordWrite{
+		{ID: fixture.IssuePrefix + "-crossrec-scope-a", Patch: map[string]any{"alias": shared}},
+		{ID: fixture.IssuePrefix + "-crossrec-scope-b", Patch: map[string]any{"alias": shared}},
+	}
+	result, err := fixture.EnforceCrossRecordInvariant(ctx, spanning)
+	if err != nil {
+		t.Fatalf("EnforceCrossRecordInvariant(spanning): %v", err)
+	}
+	if result.Accepted {
+		t.Fatal("EnforceCrossRecordInvariant accepted two writes that jointly violate the shared-alias invariant")
+	}
+
+	unrelated := []RecordWrite{
+		{ID: fixture.IssuePrefix + "-crossrec-scope-unrelated", Patch: map[string]any{"alias": fixture.IssuePrefix + "-crossrec-scope-unrelated-alias"}},
+	}
+	independent, err := fixture.EnforceCrossRecordInvariant(ctx, unrelated)
+	if err != nil {
+		t.Fatalf("EnforceCrossRecordInvariant(unrelated): %v", err)
+	}
+	if !independent.Accepted {
+		t.Fatalf("EnforceCrossRecordInvariant refused an unrelated, non-conflicting write (InvariantRefusal=%+v); the invariant transaction must scope exactly the spanning records, not more", independent.InvariantRefusal)
+	}
+}
+
+// RunInvariantRefusalNamesTheViolatedInvariant pins R16.1-c: a refused batch
+// carries an InvariantRefusal naming the specific invariant that fired, not
+// a bare boolean.
+func RunInvariantRefusalNamesTheViolatedInvariant(t *testing.T, ctx context.Context, fixture CrossRecordInvariantFixture) {
+	t.Helper()
+	if fixture.EnforceCrossRecordInvariant == nil {
+		t.Skip("this backend has not wired store-invariant enforcement yet (EnforceCrossRecordInvariant is nil)")
+	}
+	shared := fixture.IssuePrefix + "-crossrec-named-alias"
+	result, err := fixture.EnforceCrossRecordInvariant(ctx, []RecordWrite{
+		{ID: fixture.IssuePrefix + "-crossrec-named-a", Patch: map[string]any{"alias": shared}},
+		{ID: fixture.IssuePrefix + "-crossrec-named-b", Patch: map[string]any{"alias": shared}},
+	})
+	if err != nil {
+		t.Fatalf("EnforceCrossRecordInvariant: %v", err)
+	}
+	if result.Accepted {
+		t.Fatal("EnforceCrossRecordInvariant accepted a joint violation; cannot check the refusal's InvariantName")
+	}
+	if result.InvariantRefusal == nil {
+		t.Fatal("InvariantRefusal = nil on a non-accepted result")
+	}
+	if result.InvariantRefusal.InvariantName == "" {
+		t.Error("InvariantRefusal.InvariantName is empty, want a specific invariant name (R16.1-c)")
+	}
+}
+
+// RunMemoryKeyAliasUniquenessIsAStoreInvariantNotACAS pins FR-02's first
+// required subject: Memory key/alias uniqueness (#5877 R2) is a STORE
+// invariant, not row-level CAS, so two memories independently claiming the
+// same alias each succeed when checked one at a time through a
+// per-record-shaped call.
+func RunMemoryKeyAliasUniquenessIsAStoreInvariantNotACAS(t *testing.T, ctx context.Context, fixture CrossRecordInvariantFixture) {
+	t.Helper()
+	if fixture.MemoryKeyAliasWrite == nil {
+		t.Skip("this backend exposes no Memory key/alias write to probe (MemoryKeyAliasWrite is nil)")
+	}
+	alias := fixture.IssuePrefix + "-crossrec-memalias"
+
+	first, err := fixture.MemoryKeyAliasWrite(ctx, fixture.IssuePrefix+"-crossrec-mem-a", "key-a", alias)
+	if err != nil {
+		t.Fatalf("MemoryKeyAliasWrite(a): %v", err)
+	}
+	if !first.Accepted {
+		t.Fatalf("MemoryKeyAliasWrite(a) was refused (Refusal=%+v), want Accepted", first.Refusal)
+	}
+
+	second, err := fixture.MemoryKeyAliasWrite(ctx, fixture.IssuePrefix+"-crossrec-mem-b", "key-b", alias)
+	if err != nil {
+		t.Fatalf("MemoryKeyAliasWrite(b): %v", err)
+	}
+	if !second.Accepted {
+		t.Fatalf("MemoryKeyAliasWrite(b) claiming the SAME alias %q was refused (Refusal=%+v); alias uniqueness (#5877 R2) is a store invariant, so a per-record write cannot enforce it and must be Accepted here", alias, second.Refusal)
+	}
+}
+
+// RunMaximumEndpointMultiplicityIsAStoreInvariantNotACAS pins FR-02's second
+// required subject: MaximumEndpointMultiplicity is a STORE invariant, not
+// row-level CAS, so two edges independently claiming the same endpoint each
+// succeed when checked one at a time through a per-record-shaped call.
+func RunMaximumEndpointMultiplicityIsAStoreInvariantNotACAS(t *testing.T, ctx context.Context, fixture CrossRecordInvariantFixture) {
+	t.Helper()
+	if fixture.GraphEdgeWrite == nil {
+		t.Skip("this backend exposes no graph edge write to probe (GraphEdgeWrite is nil)")
+	}
+	from := fixture.IssuePrefix + "-crossrec-edge-from"
+
+	first, err := fixture.GraphEdgeWrite(ctx, from, fixture.IssuePrefix+"-crossrec-edge-to-a", "depends-on")
+	if err != nil {
+		t.Fatalf("GraphEdgeWrite(a): %v", err)
+	}
+	if !first.Accepted {
+		t.Fatalf("GraphEdgeWrite(a) was refused (Refusal=%+v), want Accepted", first.Refusal)
+	}
+
+	second, err := fixture.GraphEdgeWrite(ctx, from, fixture.IssuePrefix+"-crossrec-edge-to-b", "depends-on")
+	if err != nil {
+		t.Fatalf("GraphEdgeWrite(b): %v", err)
+	}
+	if !second.Accepted {
+		t.Fatalf("GraphEdgeWrite(b) from the SAME endpoint %q was refused (Refusal=%+v); MaximumEndpointMultiplicity is a store invariant, so a per-record write cannot enforce it and must be Accepted here", from, second.Refusal)
+	}
+}
+
+// RunAdvisoryLeaseAloneDoesNotPreventTheInvariantViolation pins FR-03's
+// negative case: an advisory lease is observed BY CONVENTION ONLY, so
+// holding one over the shared subject does not, by itself, stop the same
+// per-record violation RunCrossRecordInvariantSurvivesTwoPassingPerRecordGuards
+// constructs.
+func RunAdvisoryLeaseAloneDoesNotPreventTheInvariantViolation(t *testing.T, ctx context.Context, fixture CrossRecordInvariantFixture) {
+	t.Helper()
+	if fixture.AcquireAdvisoryLease == nil {
+		t.Skip("this backend has no lease primitive to test as an insufficient guard (AcquireAdvisoryLease is nil)")
+	}
+	if fixture.GuardedWrite == nil {
+		t.Skip("this backend exposes no per-record guard to construct the boundary case against (GuardedWrite is nil)")
+	}
+	shared := fixture.IssuePrefix + "-crossrec-leased-alias"
+	crossRecordInvariantAcquireLease(t, ctx, fixture, shared, time.Minute)
+
+	first, err := fixture.GuardedWrite(ctx, fixture.IssuePrefix+"-crossrec-leased-a", nil, map[string]any{"alias": shared})
+	if err != nil {
+		t.Fatalf("GuardedWrite(a) under a held lease: %v", err)
+	}
+	second, err := fixture.GuardedWrite(ctx, fixture.IssuePrefix+"-crossrec-leased-b", nil, map[string]any{"alias": shared})
+	if err != nil {
+		t.Fatalf("GuardedWrite(b) under a held lease: %v", err)
+	}
+	if !first.Accepted || !second.Accepted {
+		t.Fatalf("holding an advisory lease changed a per-record GuardedWrite's own verdict (first.Accepted=%v second.Accepted=%v); the lease is observed by convention only and GuardedWrite must not consult it (FR-03)", first.Accepted, second.Accepted)
+	}
+}
+
+// RunLeaseAcquisitionRecordsNoHistoryEntry mirrors
+// RunMetadataCASAWispSwapRecordsNoDurableHistory's delta-around-the-call
+// shape (metadata_cas_contract.go, history_matching.go): acquiring an
+// advisory lease is bookkeeping, not a durable state change, so it must
+// record no history entry for its subject.
+func RunLeaseAcquisitionRecordsNoHistoryEntry(t *testing.T, ctx context.Context, fixture CrossRecordInvariantFixture) {
+	t.Helper()
+	if fixture.AcquireAdvisoryLease == nil {
+		t.Skip("this backend has no lease primitive to test (AcquireAdvisoryLease is nil)")
+	}
+	if fixture.CountHistoryForSubject == nil {
+		t.Skip("this backend cannot observe history by subject (CountHistoryForSubject is nil)")
+	}
+	subject := fixture.IssuePrefix + "-crossrec-lease-history"
+
+	before, err := fixture.CountHistoryForSubject(ctx, subject)
+	if err != nil {
+		t.Fatalf("CountHistoryForSubject(before): %v", err)
+	}
+
+	crossRecordInvariantAcquireLease(t, ctx, fixture, subject, time.Minute)
+
+	after, err := fixture.CountHistoryForSubject(ctx, subject)
+	if err != nil {
+		t.Fatalf("CountHistoryForSubject(after): %v", err)
+	}
+	if got := after - before; got != 0 {
+		t.Errorf("acquiring an advisory lease recorded %d history entries for %q, want none", got, subject)
+	}
+}
+
+// --- fixture helpers -------------------------------------------------------
+
+// crossRecordInvariantAcquireLease acquires an advisory lease and registers
+// its Release (when the fixture provides one) as a test cleanup, so a case
+// does not have to thread a defer through its own body. No caller needs the
+// handle itself — both cases only need a lease held over the subject — so
+// this does not return one.
+func crossRecordInvariantAcquireLease(t *testing.T, ctx context.Context, fixture CrossRecordInvariantFixture, subject string, ttl time.Duration) {
+	t.Helper()
+	lease, err := fixture.AcquireAdvisoryLease(ctx, subject, ttl)
+	if err != nil {
+		t.Fatalf("AcquireAdvisoryLease(%s): %v", subject, err)
+	}
+	if lease.Release != nil {
+		t.Cleanup(func() {
+			if err := lease.Release(ctx); err != nil {
+				t.Errorf("releasing the advisory lease on %q: %v", subject, err)
+			}
+		})
+	}
+}

--- a/backend/conformance/cross_record_invariant_contract.go
+++ b/backend/conformance/cross_record_invariant_contract.go
@@ -165,6 +165,8 @@ func RunStoreInvariantTransactionScopesExactlyTheSpanningRecords(t *testing.T, c
 		if err != nil {
 			t.Fatalf("CountHistoryForSubject(%s) before the refused batch: %v", spanning[1].ID, err)
 		}
+	} else {
+		t.Logf("this backend cannot observe history by subject (CountHistoryForSubject is nil): the before-batch history counts for %s and %s go uncaptured", spanning[0].ID, spanning[1].ID)
 	}
 
 	result, err := fixture.EnforceCrossRecordInvariant(ctx, spanning)
@@ -187,6 +189,8 @@ func RunStoreInvariantTransactionScopesExactlyTheSpanningRecords(t *testing.T, c
 		if afterA != beforeA || afterB != beforeB {
 			t.Errorf("a refused batch left a trace: history count for %s went %d->%d, for %s went %d->%d; a refusal must be atomic — the whole batch takes no effect, not just the record that individually triggered it", spanning[0].ID, beforeA, afterA, spanning[1].ID, beforeB, afterB)
 		}
+	} else {
+		t.Logf("this backend cannot observe history by subject (CountHistoryForSubject is nil): the refused batch's atomicity (no partial trace left behind for %s or %s) goes unverified", spanning[0].ID, spanning[1].ID)
 	}
 
 	unrelated := []RecordWrite{

--- a/backend/conformance/dualwrite_history_contract.go
+++ b/backend/conformance/dualwrite_history_contract.go
@@ -1,0 +1,344 @@
+package conformance
+
+import (
+	"context"
+	"testing"
+)
+
+// This file holds the contract Phase 2's dual-write history mechanism must
+// satisfy: FR-1, FR-2, FR-3, FR-5 and FR-7 of be-hs42e.3 (gastownhall/beads#6135)
+// directly, plus FR-6 per leg (see below). FR-4 and FR-8 are this phase's
+// requirements too but are not testable through this fixture's five closures
+// — see the exclusion list below for why. FR-9 is deliberately NOT this
+// file's job: it is the differential test harness task 4 builds separately
+// (flag-off-vs-recorded-baseline plus flag-on-perturbs-nothing-but-
+// current_revision), not a property a per-mutation fixture case can express.
+// This is the phase that starts populating
+// issue_versions/current_revision/store_epoch behind
+// storage.VersionedHistoryConfigurer while every read path still answers from
+// the durable issues/wisps rows exactly as before. Nothing here asserts that a
+// dual-written value is ever READ back through a query surface — that CAS
+// enforcement and read-path switch is Phase 3/4 (#6136), unbuilt at this
+// phase — only that the write side mints what it promises, and only when it
+// promises to.
+//
+// WHY THIS IS A DEDICATED FIXTURE RATHER THAN AN EXTENSION OF AN EXISTING ONE.
+// An earlier design iteration proposed folding these cases into the
+// pre-existing RetentionFixture/CrossRecordInvariantFixture pair. That
+// approach was withdrawn (be-q0w1q) after review surfaced a version-row
+// identity gap those fixtures' cases would have exercised before it was
+// resolved: (issue_id, revision) was the only key issue_versions had, which
+// cannot express a third write racing the same revision the way a
+// content-addressed or generated identity can. be-hs42e.3 design §15
+// resolves the identity question with a dedicated version_id (migration
+// 0068, landing after this contract exists — see the task-1 half of this
+// bead), and this contract is written against §15's resolved shape, not the
+// one the withdrawn approach would have extended.
+//
+// THE FIXTURE'S FIVE CLOSURES ARE THE OBSERVABLE SURFACE, NOT THE SCHEMA. A
+// case here never reads issue_versions or store_epoch directly — that would
+// make the contract a second copy of one leg's SQL rather than a promise
+// every leg keeps in its own idiom (raw SQL against the dolt leg's own
+// *sql.DB, an exported accessor on the embedded store, RawSQLUseCase through
+// a unit of work). Mutate and MutateAsNoOp drive the same front door every
+// other conformance fixture in this package drives — CreateIssue and
+// UpdateIssue, or their unit-of-work equivalents — never the version table:
+// emission lives at the RecordVersionInTx seam beneath all of them, so a
+// closure that inserted a row directly would be asserting that this test can
+// write a row, not that the engine does.
+//
+// WHAT THIS CONTRACT DELIBERATELY DOES NOT PIN, and the reason, so a later
+// reader does not mistake the gap for an oversight:
+//
+//   - THE EXACT BYTES OF durable_state. Design §15's R5.1 artifact is a
+//     verbatim marshal of the mutated issue, and its shape is pinned where it
+//     is produced, not here: a byte-for-byte assertion in a cross-leg
+//     contract would break every time a field is added to types.Issue for
+//     reasons that have nothing to do with dual-write correctness. What IS
+//     pinned (RunDualWriteAttributionIsRecordedWithTheMutation) is that a row
+//     exists and its attribution columns are populated the moment the
+//     mutation that produced it returns — the externally observable proxy
+//     for "atomic with the mutation" a black-box fixture can actually check.
+//   - store_epoch AND issue_versions.epoch (FR-6, "stamped, never bumped").
+//     None of this fixture's five closures can see either: CurrentRevision
+//     reads issues.current_revision, and VersionRowCount and
+//     LatestVersionAttribution read issue_versions but never its epoch
+//     column. Adding a sixth closure just to reach one column — one two of
+//     three legs would have to invent white-box access for — would make the
+//     shared surface bespoke to a single requirement. FR-6 is instead pinned
+//     per leg, where a leg already has (or can cheaply grow) the access: see
+//     the dolt leg's TestDualWriteStampsTheCurrentStoreEpochOnEachVersionRow.
+//   - PARTICIPATION-GENERATION GATING (design §16.2b). Whether an
+//     update-shaped mutation on a legacy (participation_generation IS NULL)
+//     row is correctly skipped is Phase 2 behavior this bead also owns, but
+//     it depends on migration 0068's participation_generation column, which
+//     does not exist when this contract is first written (0068 lands last in
+//     this bead's build order, by the mayor's explicit sequencing). It gets
+//     its own dedicated cases once 0068 lands, beside this file rather than
+//     inside it.
+//   - CONCURRENT WRITERS. Every case here is one writer, one issue, one
+//     mutation at a time — the same restriction journal_contract.go states
+//     for the same reason: a single-threaded case cannot exercise what only
+//     concurrency can break, and faking it with sleeps buys a flaky suite
+//     instead of a guarantee.
+//   - FR-4 ("attribution is metadata: never compared when deciding whether
+//     two versions' durable state differs, never included in any future
+//     digest/equality check"). This is a constraint on code that does not
+//     exist in Phase 2 — no digest or equality check over durable_state is
+//     built by this phase — so there is nothing yet for a case to run
+//     against. FR-4 has no dedicated case here for that reason, not because
+//     it was missed.
+//   - FR-8 (`wisps.current_revision`/`wisps.participation_generation` are
+//     never read or written by this phase). None of this fixture's five
+//     closures can express it: Mutate's front door is CreateIssue against
+//     the issues table, so this fixture has no wisp-routed id to check in
+//     the first place. FR-8 is a routing exclusion, not a property of a
+//     mutated issue's own version history, and belongs beside the explicit
+//     test design §9 item 5 already calls for (task 1's responsibility, not
+//     this contract's).
+//
+// SEEDING DISCIPLINE: EVERY CASE CREATES ITS OWN ISSUE. Unlike the journal —
+// append-only and workspace-global, so every case rebaselines off the live
+// head — a version history is PER ISSUE, and Mutate's front door is create,
+// which cannot run twice against the same id. So every case mints its own id
+// from fixture.IssuePrefix plus a marker naming the case, and no case may
+// assume anything about another id's history.
+type DualWriteFixture struct {
+	// IssuePrefix namespaces the id each case mints. Ids are global to a
+	// workspace, so two cases sharing one would read each other's version
+	// history.
+	IssuePrefix string
+	// Mutate performs one ACCEPTED mutation against a not-yet-existing id:
+	// the fixture's chosen front door for "a mutation this phase must
+	// version" is CreateIssue (or its unit-of-work equivalent), because
+	// create is one of the call sites RecordVersionInTx wires into and the
+	// one every leg can drive without first needing a row to exist.
+	Mutate func(ctx context.Context, id string) error
+	// MutateAsNoOp performs a mutation against an id Mutate already created
+	// that existing production code (issueops.DiscardNoopIssueUpdates)
+	// recognizes as a no-op before it ever reaches RecordVersionInTx — the
+	// fixture's chosen shape is an update that re-sets a field to the value
+	// Mutate already gave it. It is a DIFFERENT call than Mutate on purpose:
+	// FR-2 is a claim about the engine's no-op skip, and a fixture that used
+	// the same closure for both could not tell a real skip from Mutate
+	// simply never having run.
+	MutateAsNoOp func(ctx context.Context, id string) error
+	// CurrentRevision reads issues.current_revision for id.
+	CurrentRevision func(ctx context.Context, id string) (int64, error)
+	// VersionRowCount reads how many issue_versions rows exist for id.
+	VersionRowCount func(ctx context.Context, id string) (int, error)
+	// LatestVersionAttribution reads change_actor, change_agent and
+	// change_message off the highest-revision issue_versions row for id.
+	// Columns the schema allows NULL come back as "": this fixture answers
+	// "what did the mutation record", and a leg that recorded nothing for a
+	// column answers that question with an empty string, not a sentinel a
+	// case would have to special-case around.
+	LatestVersionAttribution func(ctx context.Context, id string) (actor, agent, message string, err error)
+}
+
+// RunDualWriteMintsOneVersionRowPerAcceptedMutation pins FR-1: an accepted
+// mutation mints EXACTLY one issue_versions row, not zero and not more than
+// one.
+//
+// Zero would mean the phase built the flag and never wired the seam behind
+// it — every other case in this file would still read a functioning store,
+// because nothing about ordinary issue mutation depends on versioning
+// existing. More than one is the other silent failure this phase has to
+// avoid: a seam invoked twice for one caller-visible mutation (once from the
+// front door's own transaction and once from a retry or a decorator wrapping
+// it a second time) would double the history of every issue in the store
+// without a single ordinary read ever noticing, since nothing reads
+// issue_versions yet.
+func RunDualWriteMintsOneVersionRowPerAcceptedMutation(t *testing.T, ctx context.Context, fixture DualWriteFixture) {
+	t.Helper()
+	id := fixture.IssuePrefix + "-mints-one"
+	if err := fixture.Mutate(ctx, id); err != nil {
+		t.Fatalf("mutating %s: %v", id, err)
+	}
+	count, err := fixture.VersionRowCount(ctx, id)
+	if err != nil {
+		t.Fatalf("counting version rows for %s: %v", id, err)
+	}
+	if count != 1 {
+		t.Errorf("version row count for %s = %d, want exactly 1: one accepted mutation mints one row, "+
+			"not zero (the seam never fired) and not more than one (it fired twice for a single "+
+			"caller-visible mutation)", id, count)
+	}
+}
+
+// RunDualWriteNoOpMutationMintsNoRow pins FR-2: a mutation
+// issueops.DiscardNoopIssueUpdates already discards before it reaches any
+// write mints NO version row.
+//
+// This is the inheritance the task-1 design calls for explicitly:
+// RecordVersionInTx sits inside the same already-short-circuited function
+// bodies as RecordEventInTx, so a no-op never reaches it, and this case is
+// what would catch a future refactor that moved the call ABOVE that
+// short-circuit — versioning an update that changed nothing, which would
+// make current_revision (and FR-5's identity between it and the row count)
+// diverge from "the number of times this issue's durable state actually
+// changed" for every issue anyone re-saves without editing.
+func RunDualWriteNoOpMutationMintsNoRow(t *testing.T, ctx context.Context, fixture DualWriteFixture) {
+	t.Helper()
+	id := fixture.IssuePrefix + "-noop-mints-none"
+	if err := fixture.Mutate(ctx, id); err != nil {
+		t.Fatalf("mutating %s: %v", id, err)
+	}
+	before, err := fixture.VersionRowCount(ctx, id)
+	if err != nil {
+		t.Fatalf("counting version rows for %s before the no-op: %v", id, err)
+	}
+
+	if err := fixture.MutateAsNoOp(ctx, id); err != nil {
+		t.Fatalf("no-op mutating %s: %v", id, err)
+	}
+	after, err := fixture.VersionRowCount(ctx, id)
+	if err != nil {
+		t.Fatalf("counting version rows for %s after the no-op: %v", id, err)
+	}
+	if after != before {
+		t.Errorf("version row count for %s went from %d to %d across a no-op mutation, want unchanged: "+
+			"a mutation the engine already discards as a no-op must never reach RecordVersionInTx",
+			id, before, after)
+	}
+}
+
+// RunDualWriteAttributionIsRecordedWithTheMutation pins FR-3 and FR-4: the
+// version row minted for an accepted mutation carries that mutation's
+// attribution, visible the instant the mutation's own call returns.
+//
+// "Visible the instant the call returns" is the load-bearing half: this
+// contract cannot see two writes land in the same database transaction, but
+// it CAN see whether a caller has to do anything extra — flush, commit
+// separately, poll — before the attribution it just supplied shows up beside
+// the row it mutated. A dual-write seam that recorded the version
+// asynchronously, or in a transaction of its own committed after the
+// caller's, would still pass every other case in this file and fail this one.
+func RunDualWriteAttributionIsRecordedWithTheMutation(t *testing.T, ctx context.Context, fixture DualWriteFixture) {
+	t.Helper()
+	id := fixture.IssuePrefix + "-attribution"
+	if err := fixture.Mutate(ctx, id); err != nil {
+		t.Fatalf("mutating %s: %v", id, err)
+	}
+	actor, _, _, err := fixture.LatestVersionAttribution(ctx, id)
+	if err != nil {
+		t.Fatalf("reading attribution for %s immediately after the mutation that must have minted it: %v", id, err)
+	}
+	if actor == "" {
+		t.Errorf("change_actor for %s is empty immediately after an accepted mutation: FR-3/FR-4 require "+
+			"the version row to carry the mutation's attribution, and an actor is the one attribution "+
+			"input every leg's Mutate closure supplies", id)
+	}
+}
+
+// RunDualWriteCurrentRevisionMatchesTheNewVersionRow pins FR-5: after any
+// accepted mutation, issues.current_revision agrees with how many version
+// rows the issue actually has.
+//
+// This restates the bead's task-1 description — bump current_revision by a
+// plain +1 on the row already carrying the mutation, in the same transaction
+// as the version row it accompanies — as something a black-box fixture can
+// check without seeing either write: current_revision IS a count of the
+// version rows RecordVersionInTx has minted for this issue, never ahead of
+// it and never behind. Divergence in either direction is a real bug this
+// phase must not ship: current_revision racing ahead of the row count would
+// tell Phase 3/4's future CAS check to expect a revision that was never
+// durably recorded, and falling behind would let a second writer believe it
+// observed the latest version when a row past it already exists.
+func RunDualWriteCurrentRevisionMatchesTheNewVersionRow(t *testing.T, ctx context.Context, fixture DualWriteFixture) {
+	t.Helper()
+	id := fixture.IssuePrefix + "-revision-matches"
+	if err := fixture.Mutate(ctx, id); err != nil {
+		t.Fatalf("mutating %s: %v", id, err)
+	}
+	revision, err := fixture.CurrentRevision(ctx, id)
+	if err != nil {
+		t.Fatalf("reading current_revision for %s: %v", id, err)
+	}
+	count, err := fixture.VersionRowCount(ctx, id)
+	if err != nil {
+		t.Fatalf("counting version rows for %s: %v", id, err)
+	}
+	if revision != int64(count) {
+		t.Errorf("current_revision for %s = %d but it has %d version row(s): the two must always agree — "+
+			"current_revision is nothing but a count of the rows RecordVersionInTx has minted for this "+
+			"issue", id, revision, count)
+	}
+}
+
+// RunDualWriteFlagOffProducesNoVersionRows pins FR-7: with
+// storage.VersionedHistoryConfigurer left off, an otherwise-identical
+// mutation mints no version row and leaves current_revision at its untouched
+// schema default.
+//
+// This is the phase's core safety property, restated from the write side:
+// every store this bead ships to already runs with the flag off, so a
+// dual-write engine that fired regardless of the switch would start writing
+// issue_versions rows nobody asked for, in every workspace, the moment this
+// PR merges. The fixture this case is called against must be constructed
+// with the flag OFF from the start — see each leg's flag-off constructor —
+// so the case cannot pass by accident against a fixture that happens to
+// share state with a flag-on one.
+func RunDualWriteFlagOffProducesNoVersionRows(t *testing.T, ctx context.Context, fixture DualWriteFixture) {
+	t.Helper()
+	id := fixture.IssuePrefix + "-flag-off"
+	if err := fixture.Mutate(ctx, id); err != nil {
+		t.Fatalf("mutating %s with the flag off: %v", id, err)
+	}
+	count, err := fixture.VersionRowCount(ctx, id)
+	if err != nil {
+		t.Fatalf("counting version rows for %s: %v", id, err)
+	}
+	if count != 0 {
+		t.Errorf("version row count for %s = %d with storage.VersionedHistoryConfigurer OFF, want 0: a "+
+			"disabled flag must produce byte-identical writes to the pre-Phase-2 engine, and a row minted "+
+			"anyway means every existing workspace starts accumulating history nobody enabled", id, count)
+	}
+	revision, err := fixture.CurrentRevision(ctx, id)
+	if err != nil {
+		t.Fatalf("reading current_revision for %s: %v", id, err)
+	}
+	if revision != 1 {
+		t.Errorf("current_revision for %s = %d with the flag off, want 1 (the column's own schema "+
+			"default, untouched): a flag-off store must never execute the bump half of RecordVersionInTx "+
+			"either", id, revision)
+	}
+}
+
+// RunDualWriteNoOpMutationLeavesThePriorVersionRowUnperturbed strengthens
+// FR-2 from the one angle RunDualWriteNoOpMutationMintsNoRow does not reach:
+// that case pins that a no-op mints no NEW row; this pins that a no-op does
+// not silently rewrite the row already there.
+//
+// A dual-write seam that mistakenly ran an UPDATE instead of an
+// insert-or-skip — reusing the prior row's primary key because the no-op
+// path recomputed "the current version" instead of being skipped before it
+// got there — would pass RunDualWriteNoOpMutationMintsNoRow outright: the row
+// count never changes when an UPDATE overwrites in place. Comparing the
+// attribution byte-for-byte across the no-op is what catches that failure
+// mode instead.
+func RunDualWriteNoOpMutationLeavesThePriorVersionRowUnperturbed(t *testing.T, ctx context.Context, fixture DualWriteFixture) {
+	t.Helper()
+	id := fixture.IssuePrefix + "-noop-unperturbed"
+	if err := fixture.Mutate(ctx, id); err != nil {
+		t.Fatalf("mutating %s: %v", id, err)
+	}
+	beforeActor, beforeAgent, beforeMessage, err := fixture.LatestVersionAttribution(ctx, id)
+	if err != nil {
+		t.Fatalf("reading attribution for %s before the no-op: %v", id, err)
+	}
+
+	if err := fixture.MutateAsNoOp(ctx, id); err != nil {
+		t.Fatalf("no-op mutating %s: %v", id, err)
+	}
+	afterActor, afterAgent, afterMessage, err := fixture.LatestVersionAttribution(ctx, id)
+	if err != nil {
+		t.Fatalf("reading attribution for %s after the no-op: %v", id, err)
+	}
+	if beforeActor != afterActor || beforeAgent != afterAgent || beforeMessage != afterMessage {
+		t.Errorf("attribution for %s changed across a no-op mutation, (%q,%q,%q) -> (%q,%q,%q): a mutation "+
+			"that mints no new row must also leave the existing one exactly as the accepted mutation "+
+			"before it left it, not silently rewritten in place",
+			id, beforeActor, beforeAgent, beforeMessage, afterActor, afterAgent, afterMessage)
+	}
+}

--- a/backend/conformance/expected_revision_contract.go
+++ b/backend/conformance/expected_revision_contract.go
@@ -44,6 +44,49 @@ import (
 // backend has independently closed the row_lock partial-coverage gap the
 // architecture doc's own §10 risk table names. That is deliberate — see the
 // function's own doc comment — not a bug to relax the assertion around.
+//
+// DEFERRALS RECORDED HERE, NOT ACTED ON IN PHASE 0 (bee-ghosttrack's PR
+// #6147 round-1 review; kept as ONE note so a later phase does not have to
+// reconstruct these from PR comment history):
+//
+//  - UNRETAINED AND DISCLOSURE-GATING ARE A FUTURE AUTHORIZATION AXIS, NOT A
+//    SIXTH Restriction VALUE. R11's bounded-window edge (an Address old
+//    enough to have fallen outside a retention window, distinct from Gone)
+//    and disclosure-gating (a store that presents a Gone or Unretained
+//    Address as Unknown to a caller not authorized to learn it existed at
+//    all) both layer an AUTHORIZATION dimension over the five states this
+//    file already defines — WHO is asking, not WHAT the store knows. Adding
+//    either as a sixth Restriction constant would conflate those two
+//    dimensions; a later phase should model authorization as an orthogonal
+//    axis instead.
+//  - INVARIANT-DECLARATION DISCOVERABILITY: nothing in this suite lets a
+//    caller enumerate which store invariants EnforceCrossRecordInvariant
+//    knows about ahead of a refusal — InvariantRefusal.InvariantName is
+//    only ever observed reactively. Deferred to whatever phase gives
+//    invariants a first-class registry.
+//  - LEASE TTL SELF-EXPIRY: LeaseHandle carries ExpiresAt
+//    (cross_record_invariant_contract.go) but nothing in this suite
+//    exercises a lease actually expiring on its own — only explicit
+//    Release. Deferred until a real lease primitive exists to observe
+//    timing against.
+//  - R20-j's DURABILITY IS NOT PROVEN ACROSS A RESTART in this suite —
+//    RunAStoreThatRemovesStateStillAnswersGoneDurably (retention_epoch_
+//    contract.go) reads twice in the same process, which cannot
+//    distinguish real durability from an in-memory cache that merely
+//    outlives two calls. Deferred to the E2E tier, which can actually
+//    restart a backend between reads.
+//  - ERASURE'S GONE-RECORD TOKEN RETENTION (R5.1 machinery) is out of
+//    scope here: RunErasureMintsACorrectedVersionRatherThanEditingInPlace
+//    (retention_epoch_contract.go) checks that the original resolves
+//    GoneErasure and the correction resolves Live, not what token or
+//    tombstone content backs that GoneErasure answer. Deferred to the
+//    later phase that specifies R5.1's erasure-record shape.
+//
+// THE "_attribution" PATCH-KEY CONVENTION (expectedRevisionAttributionPatch,
+// this file) IS THE CANONICAL WAY TO THREAD A ChangeAttribution THROUGH A
+// PerRecordCASWrite's generic patch parameter. Phase 3's hook documentation
+// should point implementers at this convention explicitly, so no backend
+// invents a second one.
 
 // Address opaquely identifies one Version. It names no physical column — per
 // be-hs42e.1 §5, this is conceptual vocabulary that any future backend's hook
@@ -118,6 +161,17 @@ type ExpectedRevisionResult struct {
 // Refusal is R17's typed, machine-readable outcome for a write that named a
 // version no longer current — never a generic error, never indistinguishable
 // from an accepted write (R17-c/d1).
+//
+// THE FIXTURE KIT IS THE TRANSLATION BOUNDARY, NOT A SHAPE MANDATE ON REAL
+// BACKENDS: R17 itself permits either of two shipped refusal shapes — a
+// (result, nil-error) pair carrying a populated Refusal, or a typed native
+// error a backend already returns for this case. ExpectedRevisionFixture's
+// CompareAndSetVersion hook normalizes whichever shape a real backend ships
+// to this ONE Refusal-populated-result shape for the suite to assert
+// against uniformly. Nothing here should be read as banning a native
+// typed-error refusal shape at the backend level — only as saying the
+// fixture adapter that wires a backend into this suite must translate it
+// into this shape before handing it back.
 type Refusal struct {
 	// RefusingVersion is the Address that was actually current when the
 	// write was evaluated (R17-a).

--- a/backend/conformance/expected_revision_contract.go
+++ b/backend/conformance/expected_revision_contract.go
@@ -1,0 +1,545 @@
+package conformance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// This file holds the vocabulary every one of the three new versioned-history
+// contract files shares (Address, ChangeAttribution, Restriction,
+// RetainedWindow, the PerRecordCASWrite hook shape, and the sentinel errors),
+// plus the contract for R16/R17 (gastownhall/beads#6133, be-hs42e.1 §5-§7):
+// the whole-of-state expectedRevision CAS write and its typed Refusal.
+//
+// THE SHARED VOCABULARY LIVES HERE, NOT IN A FOURTH FILE. All three contract
+// files declare `package conformance`, so Go same-package visibility already
+// gives cross-file access with no import; the architecture doc names exactly
+// three contract files and does not say where their shared types live. This
+// file's own §4a choice is to keep them beside R16/R17 rather than split out
+// a vocabulary-only file with no tests of its own — R16/R17 is the first
+// contract that needs them, so a reader asking "what is an Address" starts
+// here.
+//
+// EVERY HOOK ON EVERY FIXTURE IN ALL THREE NEW FILES IS INDEPENDENTLY
+// NILABLE — unlike metadata_cas_contract.go, where MetadataCAS itself is
+// required and only two hooks are optional. Phase 0 ships zero real
+// implementations of any of these capabilities in any backend's fixture kit
+// (architecture §12: "every new hook is nil in every backend's fixture
+// kit"), so every case below nil-checks every hook it uses and SKIPS BY NAME
+// when one is missing — the same idiom history_matching.go uses for
+// CountHistoryMatching.
+//
+// THIS SUITE DEFINES INTERFACES AND TESTS ONLY. Nothing introduced by this
+// phase implements real CAS, invariant, retention, or epoch enforcement. The
+// positive-path body of every Run function below is a complete, realistic
+// assertion of what Phase 3's real hooks must do — because this suite IS the
+// spec Phase 3 implements against (NFR-03) — but none of it runs today,
+// since versioned_history_wiring_test.go wires every hook nil.
+//
+// RunExpectedRevisionCoversFieldsOutsideAnyWatchedSubset (R16-c) IS EXPECTED
+// TO FAIL the moment a real backend wires CompareAndSetVersion, unless that
+// backend has independently closed the row_lock partial-coverage gap the
+// architecture doc's own §10 risk table names. That is deliberate — see the
+// function's own doc comment — not a bug to relax the assertion around.
+
+// Address opaquely identifies one Version. It names no physical column — per
+// be-hs42e.1 §5, this is conceptual vocabulary that any future backend's hook
+// translates to and from whatever it actually stores.
+type Address string
+
+// ChangeAttribution is who/what/why/when produced a Version, as observed by
+// the transaction that produced it (be-hs42e.1 §5). Actor, Agent, and
+// Message are independently nullable.
+type ChangeAttribution struct {
+	Actor   *string
+	Agent   *string
+	Message *string
+	At      time.Time
+}
+
+// Restriction is one of the five states a store may report for an Address
+// (be-hs42e.1 §5, FR-05). Gone and Unknown are deliberately distinct values,
+// never conflated: Gone means the store once held this Version and no longer
+// does; Unknown means the store has no knowledge of the lineage at all
+// (FR-06) — e.g. it never synced far enough back to have an opinion.
+type Restriction int
+
+const (
+	RestrictionLive Restriction = iota
+	RestrictionGoneRetention
+	RestrictionGoneErasure
+	RestrictionGoneReorganization
+	RestrictionUnknown
+)
+
+func (r Restriction) String() string {
+	switch r {
+	case RestrictionLive:
+		return "live"
+	case RestrictionGoneRetention:
+		return "gone-retention"
+	case RestrictionGoneErasure:
+		return "gone-erasure"
+	case RestrictionGoneReorganization:
+		return "gone-reorganization"
+	case RestrictionUnknown:
+		return "unknown"
+	default:
+		return fmt.Sprintf("Restriction(%d)", int(r))
+	}
+}
+
+// RetainedWindow is the surviving range a store reports once some Addresses
+// within a lineage have gone (be-hs42e.1 §5, R20-c/h).
+type RetainedWindow struct {
+	LowerBound Address
+	UpperBound Address
+}
+
+// PerRecordCASWrite is the shape every per-record whole-of-state CAS write
+// takes. ExpectedRevisionFixture.CompareAndSetVersion and
+// CrossRecordInvariantFixture.GuardedWrite share this EXACT type on purpose:
+// R16.1-a's boundary claim is literally that the second is the first, called
+// twice — sharing the type makes that claim structural, not just asserted.
+type PerRecordCASWrite func(ctx context.Context, id string, expected *Address, patch map[string]any) (ExpectedRevisionResult, error)
+
+// ExpectedRevisionResult is the outcome of a PerRecordCASWrite call. Accepted
+// and Refusal are mutually exclusive: read Refusal only when Accepted is
+// false, read NewVersion only when it is true.
+type ExpectedRevisionResult struct {
+	Accepted   bool
+	NewVersion Address
+	Refusal    *Refusal
+}
+
+// Refusal is R17's typed, machine-readable outcome for a write that named a
+// version no longer current — never a generic error, never indistinguishable
+// from an accepted write (R17-c/d1).
+type Refusal struct {
+	// RefusingVersion is the Address that was actually current when the
+	// write was evaluated (R17-a).
+	RefusingVersion Address
+	// Attribution is RefusingVersion's ChangeAttribution, as observed by the
+	// refusing transaction (R17-b).
+	Attribution ChangeAttribution
+}
+
+// ErrRevisionNotFound means the write named an id with no current version at
+// all — distinct from a Refusal, which requires a current version to refuse
+// against (R17-d2).
+var ErrRevisionNotFound = errors.New("expected-revision: id has no current version")
+
+// ErrRevisionValidation means the write itself was malformed, independent of
+// whether its expectation held (R17-d3).
+var ErrRevisionValidation = errors.New("expected-revision: request is invalid")
+
+// ExpectedRevisionFixture supplies the whole-of-state CAS capability under
+// test (R16, R17): a write that names the Version it expects to be current,
+// accepted only while that expectation holds, refused with a typed Refusal
+// otherwise.
+type ExpectedRevisionFixture struct {
+	IssuePrefix string
+
+	// CompareAndSetVersion performs a whole-of-state CAS write: it is
+	// accepted only while expected (nil meaning "no version named", i.e. an
+	// unconditional write, R16-b) names the currently-current Address. A nil
+	// hook means this backend does not yet implement expectedRevision CAS,
+	// and every case in this file SKIPS with that reason.
+	CompareAndSetVersion PerRecordCASWrite
+
+	// CurrentVersion reports the Address currently current for id. A nil
+	// hook means this backend cannot independently confirm the current
+	// Address, and cases that need one skip with that reason.
+	CurrentVersion func(ctx context.Context, id string) (Address, error)
+
+	// MutateOutsideExpectedRevision writes to id through a path R16-c
+	// specifically targets: one NOT gated by the whole-of-state precondition
+	// (the architecture doc names row_lock's documented partial-coverage gap
+	// as the concrete probe — see §7 risk, §10 risk table). A nil hook means
+	// this backend exposes no such out-of-band path, and the one case that
+	// needs it skips with that reason.
+	MutateOutsideExpectedRevision func(ctx context.Context, id string, field, value string) error
+}
+
+// RunExpectedRevisionAcceptsAWriteNamingTheCurrentVersion pins R16's
+// baseline: a write naming the Address that is actually current must be
+// accepted.
+func RunExpectedRevisionAcceptsAWriteNamingTheCurrentVersion(t *testing.T, ctx context.Context, fixture ExpectedRevisionFixture) {
+	t.Helper()
+	if fixture.CompareAndSetVersion == nil {
+		t.Skip("this backend does not implement expectedRevision CAS (CompareAndSetVersion is nil)")
+	}
+	if fixture.CurrentVersion == nil {
+		t.Skip("this backend cannot independently confirm the current Address (CurrentVersion is nil)")
+	}
+	id, seeded := expectedRevisionSeed(t, ctx, fixture, "current", map[string]any{"phase": "start"})
+
+	current, err := fixture.CurrentVersion(ctx, id)
+	if err != nil {
+		t.Fatalf("CurrentVersion(%s): %v", id, err)
+	}
+	if current != seeded.NewVersion {
+		t.Fatalf("CurrentVersion(%s) = %s, want the seed's NewVersion %s", id, current, seeded.NewVersion)
+	}
+
+	result, err := fixture.CompareAndSetVersion(ctx, id, &current, map[string]any{"phase": "advanced"})
+	if err != nil {
+		t.Fatalf("CompareAndSetVersion(%s, expected=current): %v", id, err)
+	}
+	if !result.Accepted {
+		t.Fatalf("CompareAndSetVersion naming the true current Address was refused (Refusal=%+v), want Accepted (R16: a write naming the current Version must be accepted)", result.Refusal)
+	}
+}
+
+// RunExpectedRevisionAcceptsAWriteNamingNoVersion pins R16-b's paraphrase: a
+// nil expectation means an unconditional write, not "the key must be
+// absent" — the unconditional path must still exist over a record that
+// already has a current Version.
+func RunExpectedRevisionAcceptsAWriteNamingNoVersion(t *testing.T, ctx context.Context, fixture ExpectedRevisionFixture) {
+	t.Helper()
+	if fixture.CompareAndSetVersion == nil {
+		t.Skip("this backend does not implement expectedRevision CAS (CompareAndSetVersion is nil)")
+	}
+	id, _ := expectedRevisionSeed(t, ctx, fixture, "unconditional", map[string]any{"phase": "start"})
+
+	result, err := fixture.CompareAndSetVersion(ctx, id, nil, map[string]any{"phase": "overwritten"})
+	if err != nil {
+		t.Fatalf("CompareAndSetVersion(%s, expected=nil) over an existing record: %v", id, err)
+	}
+	if !result.Accepted {
+		t.Fatal("CompareAndSetVersion(expected=nil) over an existing record was refused, want Accepted (R16-b: nil means an unconditional write, not \"must be absent\")")
+	}
+}
+
+// RunExpectedRevisionCoversFieldsOutsideAnyWatchedSubset pins R16's
+// whole-of-state promise against the concrete gap the architecture doc names
+// (§7 risk, §10 risk table): row_lock's documented partial-coverage leaves
+// some fields writable without reminting the Version those fields belong to.
+// A write through MutateOutsideExpectedRevision must still count as a change
+// against the expectation — otherwise a caller's CAS can silently observe a
+// stale precondition as current.
+//
+// THIS CASE IS EXPECTED TO FAIL the moment a real backend wires
+// CompareAndSetVersion, UNLESS that backend has independently closed the
+// row_lock gap first (architecture §10 risk table: "this suite existing and
+// failing loudly against that gap IS THE POINT"). It is not a bug in this
+// test if it starts failing against a real hook — it is the suite doing its
+// job. Do not weaken this assertion to make a real backend pass; close the
+// gap instead.
+func RunExpectedRevisionCoversFieldsOutsideAnyWatchedSubset(t *testing.T, ctx context.Context, fixture ExpectedRevisionFixture) {
+	t.Helper()
+	if fixture.CompareAndSetVersion == nil {
+		t.Skip("this backend does not implement expectedRevision CAS (CompareAndSetVersion is nil)")
+	}
+	if fixture.MutateOutsideExpectedRevision == nil {
+		t.Skip("this backend exposes no out-of-band mutation path to probe the whole-of-state boundary with (MutateOutsideExpectedRevision is nil)")
+	}
+	id, seeded := expectedRevisionSeed(t, ctx, fixture, "outofband", map[string]any{"phase": "start"})
+	staleExpected := seeded.NewVersion
+
+	if err := fixture.MutateOutsideExpectedRevision(ctx, id, "side_channel", "changed"); err != nil {
+		t.Fatalf("MutateOutsideExpectedRevision(%s): %v", id, err)
+	}
+
+	result, err := fixture.CompareAndSetVersion(ctx, id, &staleExpected, map[string]any{"phase": "advanced"})
+	if err != nil {
+		t.Fatalf("CompareAndSetVersion(%s, expected=pre-mutation version): %v", id, err)
+	}
+	if result.Accepted {
+		t.Fatal("CompareAndSetVersion naming the pre-mutation Address was accepted after an out-of-band field write; " +
+			"R16's whole-of-state precondition must cover fields outside any single watched subset")
+	}
+}
+
+// RunRefusalReportsTheRefusingVersionAddress pins R17-a: a Refusal names the
+// Address that was actually current when the write was evaluated, read here
+// independently via CurrentVersion rather than trusted from the caller's own
+// stale value.
+func RunRefusalReportsTheRefusingVersionAddress(t *testing.T, ctx context.Context, fixture ExpectedRevisionFixture) {
+	t.Helper()
+	if fixture.CompareAndSetVersion == nil {
+		t.Skip("this backend does not implement expectedRevision CAS (CompareAndSetVersion is nil)")
+	}
+	if fixture.CurrentVersion == nil {
+		t.Skip("this backend cannot independently confirm the current Address (CurrentVersion is nil)")
+	}
+	id, stale := expectedRevisionSeedStale(t, ctx, fixture, "refaddr")
+
+	result, err := fixture.CompareAndSetVersion(ctx, id, &stale, map[string]any{"phase": "clobber"})
+	if err != nil {
+		t.Fatalf("CompareAndSetVersion(%s, stale expected): %v", id, err)
+	}
+	if result.Accepted || result.Refusal == nil {
+		t.Fatalf("CompareAndSetVersion over a stale expectation = %+v, want a Refusal", result)
+	}
+
+	real, err := fixture.CurrentVersion(ctx, id)
+	if err != nil {
+		t.Fatalf("CurrentVersion(%s): %v", id, err)
+	}
+	if result.Refusal.RefusingVersion != real {
+		t.Errorf("Refusal.RefusingVersion = %s, want the real current Address %s (R17-a)", result.Refusal.RefusingVersion, real)
+	}
+}
+
+// RunRefusalReportsTheRefusingVersionsChangeAttribution pins R17-b: a
+// Refusal carries the ChangeAttribution the refusing transaction observed
+// for the version that beat the caller.
+//
+// §4a: PerRecordCASWrite's patch is a generic map[string]any with no
+// dedicated attribution field, so this case threads a ChangeAttribution
+// through the documented patch["_attribution"] convention
+// (expectedRevisionAttributionPatch) — this file's own choice, since the
+// architecture doc does not pin how a caller supplies attribution on a
+// per-record write, only that the backend must observe and later report it.
+func RunRefusalReportsTheRefusingVersionsChangeAttribution(t *testing.T, ctx context.Context, fixture ExpectedRevisionFixture) {
+	t.Helper()
+	if fixture.CompareAndSetVersion == nil {
+		t.Skip("this backend does not implement expectedRevision CAS (CompareAndSetVersion is nil)")
+	}
+	actor := "cas-winner"
+	wantAttribution := ChangeAttribution{Actor: &actor, At: time.Now().UTC()}
+
+	id, seeded := expectedRevisionSeed(t, ctx, fixture, "refattr", map[string]any{"phase": "start"})
+	staleAddr := seeded.NewVersion
+	advanced, err := fixture.CompareAndSetVersion(ctx, id, &staleAddr,
+		expectedRevisionAttributionPatch(map[string]any{"phase": "moved-on"}, wantAttribution))
+	if err != nil {
+		t.Fatalf("advancing %s with a known attribution: %v", id, err)
+	}
+	if !advanced.Accepted {
+		t.Fatalf("advancing %s with a known attribution was refused", id)
+	}
+
+	result, err := fixture.CompareAndSetVersion(ctx, id, &staleAddr, map[string]any{"phase": "clobber"})
+	if err != nil {
+		t.Fatalf("CompareAndSetVersion(%s, stale expected): %v", id, err)
+	}
+	if result.Accepted || result.Refusal == nil {
+		t.Fatalf("CompareAndSetVersion over a stale expectation = %+v, want a Refusal", result)
+	}
+	if !sameAttribution(result.Refusal.Attribution, wantAttribution) {
+		t.Errorf("Refusal.Attribution = %+v, want %+v (R17-b: the attribution the refusing transaction observed)", result.Refusal.Attribution, wantAttribution)
+	}
+}
+
+// RunRefusalIsATypedOutcomeNotAGenericError pins R17-c/d1: a stale
+// expectation comes back as a populated Refusal with a nil error, never as a
+// generic Go error.
+func RunRefusalIsATypedOutcomeNotAGenericError(t *testing.T, ctx context.Context, fixture ExpectedRevisionFixture) {
+	t.Helper()
+	if fixture.CompareAndSetVersion == nil {
+		t.Skip("this backend does not implement expectedRevision CAS (CompareAndSetVersion is nil)")
+	}
+	id, stale := expectedRevisionSeedStale(t, ctx, fixture, "typedoutcome")
+
+	result, err := fixture.CompareAndSetVersion(ctx, id, &stale, map[string]any{"phase": "clobber"})
+	if err != nil {
+		t.Fatalf("a stale expectation returned error = %v, want nil: R17 reports a refusal, not an error (R17-c)", err)
+	}
+	if result.Accepted {
+		t.Fatal("a stale expectation was accepted")
+	}
+	if result.Refusal == nil {
+		t.Fatal("Refusal = nil on a non-accepted result, want a populated Refusal (R17-d1)")
+	}
+}
+
+// RunRefusalIsDistinguishableFromAnAcceptedWrite runs an accepted and a
+// refused case side by side and pins that Accepted is the only signal a
+// caller needs: Refusal and NewVersion are never both populated, and never
+// both empty.
+func RunRefusalIsDistinguishableFromAnAcceptedWrite(t *testing.T, ctx context.Context, fixture ExpectedRevisionFixture) {
+	t.Helper()
+	if fixture.CompareAndSetVersion == nil {
+		t.Skip("this backend does not implement expectedRevision CAS (CompareAndSetVersion is nil)")
+	}
+
+	for _, test := range []struct {
+		name    string
+		prepare func(t *testing.T) (string, Address)
+	}{
+		{"accepted", func(t *testing.T) (string, Address) {
+			id, seeded := expectedRevisionSeed(t, ctx, fixture, "distinguish-accept", map[string]any{"phase": "start"})
+			return id, seeded.NewVersion
+		}},
+		{"refused", func(t *testing.T) (string, Address) {
+			return expectedRevisionSeedStale(t, ctx, fixture, "distinguish-refuse")
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			id, expected := test.prepare(t)
+			result, err := fixture.CompareAndSetVersion(ctx, id, &expected, map[string]any{"phase": "attempt"})
+			if err != nil {
+				t.Fatalf("CompareAndSetVersion(%s): %v", id, err)
+			}
+			if result.Accepted && result.Refusal != nil {
+				t.Fatalf("result = %+v, want Refusal populated only when Accepted is false", result)
+			}
+			if !result.Accepted && result.Refusal == nil {
+				t.Fatalf("result = %+v, want Refusal populated when Accepted is false", result)
+			}
+			if result.Accepted && result.NewVersion == "" {
+				t.Error("Accepted = true but NewVersion is empty")
+			}
+		})
+	}
+}
+
+// RunRefusalIsDistinguishableFromNotFound pins R17-d2: an id with no current
+// version at all is ErrRevisionNotFound, never a Refusal — a Refusal
+// requires a current version to refuse against.
+func RunRefusalIsDistinguishableFromNotFound(t *testing.T, ctx context.Context, fixture ExpectedRevisionFixture) {
+	t.Helper()
+	if fixture.CompareAndSetVersion == nil {
+		t.Skip("this backend does not implement expectedRevision CAS (CompareAndSetVersion is nil)")
+	}
+	ghost := Address("ghost-version")
+	id := fixture.IssuePrefix + "-exprev-neverseeded"
+
+	result, err := fixture.CompareAndSetVersion(ctx, id, &ghost, map[string]any{"phase": "attempt"})
+	if !errors.Is(err, ErrRevisionNotFound) {
+		t.Fatalf("CompareAndSetVersion on a never-seeded id error = %v, want ErrRevisionNotFound (R17-d2)", err)
+	}
+	if result.Accepted || result.Refusal != nil {
+		t.Errorf("result = %+v, want neither Accepted nor a Refusal for a not-found id", result)
+	}
+}
+
+// RunRefusalIsDistinguishableFromValidationFailure pins R17-d3: a malformed
+// request is ErrRevisionValidation, independent of whether its expectation
+// would have held.
+func RunRefusalIsDistinguishableFromValidationFailure(t *testing.T, ctx context.Context, fixture ExpectedRevisionFixture) {
+	t.Helper()
+	if fixture.CompareAndSetVersion == nil {
+		t.Skip("this backend does not implement expectedRevision CAS (CompareAndSetVersion is nil)")
+	}
+	result, err := fixture.CompareAndSetVersion(ctx, "", nil, map[string]any{"phase": "attempt"})
+	if !errors.Is(err, ErrRevisionValidation) {
+		t.Fatalf("CompareAndSetVersion with an empty id error = %v, want ErrRevisionValidation (R17-d3)", err)
+	}
+	if result.Accepted || result.Refusal != nil {
+		t.Errorf("result = %+v, want neither Accepted nor a Refusal for a malformed request", result)
+	}
+}
+
+// RunRefusalNeverSilentlyPicksAWinner pins the race shape underneath R17:
+// two writes competing over the same stale expectation must produce exactly
+// one Accepted and one real Refusal — never both accepted, never a merged or
+// silently overwritten result — and the Address left current afterward must
+// be the winner's, read independently.
+func RunRefusalNeverSilentlyPicksAWinner(t *testing.T, ctx context.Context, fixture ExpectedRevisionFixture) {
+	t.Helper()
+	if fixture.CompareAndSetVersion == nil {
+		t.Skip("this backend does not implement expectedRevision CAS (CompareAndSetVersion is nil)")
+	}
+	if fixture.CurrentVersion == nil {
+		t.Skip("this backend cannot independently confirm the current Address (CurrentVersion is nil)")
+	}
+	id, seeded := expectedRevisionSeed(t, ctx, fixture, "competing", map[string]any{"phase": "start"})
+	shared := seeded.NewVersion
+
+	first, err := fixture.CompareAndSetVersion(ctx, id, &shared, map[string]any{"phase": "writer-a"})
+	if err != nil {
+		t.Fatalf("writer A: CompareAndSetVersion(%s): %v", id, err)
+	}
+	second, err := fixture.CompareAndSetVersion(ctx, id, &shared, map[string]any{"phase": "writer-b"})
+	if err != nil {
+		t.Fatalf("writer B: CompareAndSetVersion(%s): %v", id, err)
+	}
+
+	if first.Accepted == second.Accepted {
+		t.Fatalf("two competing writes against the same expectation both reported Accepted=%v, want exactly one to win", first.Accepted)
+	}
+	winner, loser := first, second
+	if second.Accepted {
+		winner, loser = second, first
+	}
+	if loser.Refusal == nil {
+		t.Fatal("the losing write carries no Refusal")
+	}
+
+	real, err := fixture.CurrentVersion(ctx, id)
+	if err != nil {
+		t.Fatalf("CurrentVersion(%s): %v", id, err)
+	}
+	if real != winner.NewVersion {
+		t.Errorf("CurrentVersion(%s) = %s after the race, want the winner's NewVersion %s: a third value means the race was decided somewhere other than the two calls made here", id, real, winner.NewVersion)
+	}
+}
+
+// --- fixture helpers -------------------------------------------------------
+
+// expectedRevisionSeed performs an unconditional (expected=nil) write to
+// mint id's first Version, and fatals unless the fixture accepts it — every
+// case in this file needs a live record to test a whole-of-state CAS
+// against, and CompareAndSetVersion(expected=nil) is the only write path
+// this fixture exposes to make one.
+func expectedRevisionSeed(t *testing.T, ctx context.Context, fixture ExpectedRevisionFixture, tag string, patch map[string]any) (string, ExpectedRevisionResult) {
+	t.Helper()
+	id := fixture.IssuePrefix + "-exprev-" + tag
+	if patch == nil {
+		patch = map[string]any{}
+	}
+	result, err := fixture.CompareAndSetVersion(ctx, id, nil, patch)
+	if err != nil {
+		t.Fatalf("seeding %s: CompareAndSetVersion(expected=nil) error = %v", id, err)
+	}
+	if !result.Accepted {
+		t.Fatalf("seeding %s: CompareAndSetVersion(expected=nil) Accepted = false, want true (R16-b: an unconditional write to a fresh id must be accepted)", id)
+	}
+	return id, result
+}
+
+// expectedRevisionSeedStale seeds id, advances it once more, and returns the
+// Address from BEFORE that second write — a caller naming this Address as
+// Expected has a stale expectation, because the second write has since
+// moved the current Version on.
+func expectedRevisionSeedStale(t *testing.T, ctx context.Context, fixture ExpectedRevisionFixture, tag string) (string, Address) {
+	t.Helper()
+	id, seeded := expectedRevisionSeed(t, ctx, fixture, tag, map[string]any{"phase": "start"})
+	staleAddr := seeded.NewVersion
+	advanced, err := fixture.CompareAndSetVersion(ctx, id, &staleAddr, map[string]any{"phase": "moved-on"})
+	if err != nil {
+		t.Fatalf("advancing %s past the address a later case will treat as stale: %v", id, err)
+	}
+	if !advanced.Accepted {
+		t.Fatalf("advancing %s past the address a later case will treat as stale was refused", id)
+	}
+	return id, staleAddr
+}
+
+// expectedRevisionAttributionPatch adds attribution to patch under the
+// "_attribution" key — the convention this file uses to thread a
+// ChangeAttribution through PerRecordCASWrite's generic patch parameter. See
+// RunRefusalReportsTheRefusingVersionsChangeAttribution's doc comment for
+// why this convention exists.
+func expectedRevisionAttributionPatch(patch map[string]any, attribution ChangeAttribution) map[string]any {
+	if patch == nil {
+		patch = map[string]any{}
+	}
+	patch["_attribution"] = attribution
+	return patch
+}
+
+// sameAttribution compares two ChangeAttribution values by content. It does
+// not use reflect.DeepEqual: comparing time.Time by its internal
+// representation is fragile (monotonic readings can differ for an otherwise
+// equal instant), so At is compared with time.Time.Equal and the nullable
+// string fields are compared by dereferenced value.
+func sameAttribution(a, b ChangeAttribution) bool {
+	return samePtrString(a.Actor, b.Actor) &&
+		samePtrString(a.Agent, b.Agent) &&
+		samePtrString(a.Message, b.Message) &&
+		a.At.Equal(b.At)
+}
+
+func samePtrString(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}

--- a/backend/conformance/retention_epoch_contract.go
+++ b/backend/conformance/retention_epoch_contract.go
@@ -26,7 +26,11 @@ import (
 // per-store promise, not a global one: a Reorganization can leave one store
 // still serving an Address that another has moved past.
 //
-// THREE §4a CHOICES THIS FILE MAKES THAT THE ARCHITECTURE DOC DOES NOT PIN:
+// THIS FILE ORIGINALLY MADE THREE §4a CHOICES THE ARCHITECTURE DOC DOES NOT
+// PIN. Two have since DIED — retired by fixes made within this same PR,
+// before merge, in response to review. Kept here, marked DIED, so a reader
+// tracing why RetentionAnswer/RetentionFixture look the way they do does not
+// have to reconstruct the history from git log or PR comments:
 //
 //  1. Remove/Commit's refusal under an active Hold is a typed error,
 //     ErrRetentionHeld, rather than a non-accepted-shaped RetentionAnswer —
@@ -37,24 +41,25 @@ import (
 //     worked" and "the removal happened" look like the same kind of value.
 //     (R17's Refusal reasons about the same tradeoff the other way, because
 //     R17 already had a typed non-error outcome shape to reuse — Remove has
-//     no such sibling shape to reuse here.)
-//  2. ForceRemove's attribution is asserted only for shape, not content:
-//     RetentionAnswer carries no attribution field and this contract adds no
-//     dedicated read-back hook for one, so RunForcingAHeldRemovalRecordsWhoWhenWhy
-//     cannot mechanically verify WHERE who/when/why land — only that
-//     ForceRemove accepts them as real parameters and succeeds despite the
-//     Hold. See that function's own doc comment.
-//  3. AN ADDRESS THAT NO OPERATION HAS TOUCHED RESOLVES RestrictionLive BY
-//     DEFAULT, within the one store a case otherwise uses consistently. The
-//     architecture doc defines what removal, erasure, and reorganization DO
-//     but does not separately spell out the baseline for an address a store
-//     tracks but has not yet acted on. This file reserves RestrictionUnknown
-//     for a DIFFERENT store asked about an Address it has no lineage
-//     relationship with at all (FR-06) — see
+//     no such sibling shape to reuse here.) STILL STANDS.
+//  2. DIED. ForceRemove's attribution used to be asserted only for shape,
+//     not content, because RetentionAnswer carried no attribution field.
+//     RetentionAnswer.Attribution now carries it, and
+//     RunForcingAHeldRemovalRecordsWhoWhenWhy asserts real content — see
+//     that function's own doc comment.
+//  3. DIED. An address that no operation had touched used to resolve
+//     RestrictionLive BY DEFAULT, purely by naming convention — a fabricated
+//     Address, from the retired retentionAddress helper, that no store had
+//     ever actually minted. Every case that needs a real, live Address now
+//     mints one for real via RetentionFixture.Mint (see retentionMint).
+//     RestrictionUnknown for a foreign store (FR-06) is UNCHANGED by this:
 //     RunAStoreWithNoLineageKnowledgeAnswersUnknownNotGone and
-//     RunGoneIsDistinguishableFromUnknown, both of which test the Unknown
-//     case via a second, foreign storeID rather than an untouched address on
-//     the primary one.
+//     RunGoneIsDistinguishableFromUnknown still test the Unknown case via a
+//     second, foreign storeID that genuinely never saw the Address — not via
+//     an untouched-but-fabricated address on the primary one, which is the
+//     part that died. retentionAddress itself survives as the one helper
+//     those two cases still use, precisely because Unknown requires an
+//     Address no store ever minted.
 //
 // EVERY HOOK ON BOTH FIXTURES BELOW IS INDEPENDENTLY NILABLE — see the
 // package-level note in expected_revision_contract.go. Every case
@@ -64,11 +69,27 @@ import (
 type RetentionAnswer struct {
 	Restriction Restriction
 	// RetainedWindow is populated once some Addresses within the lineage
-	// have gone, naming the surviving range (R20-c). Nil means no window
-	// applies (e.g. Restriction is Live or Unknown).
+	// have gone, naming the surviving range (R20-c) — AND, independently,
+	// whenever a Hold is protecting an Address from removal, naming that
+	// Address within the range it protects (R20-h). Nil means neither
+	// applies (e.g. Restriction is Live with no Hold in effect, or
+	// Unknown).
 	RetainedWindow *RetainedWindow
 	// ProducingStore names the store that produced this answer (R20-i).
 	ProducingStore string
+	// Attribution records who, when, and why produced this answer, for the
+	// operations that force their way past an ordinary refusal — currently
+	// just ForceRemove (R20-h2). Nil means this answer did not come from an
+	// attributed forcing operation (e.g. an ordinary Remove/Commit, or a
+	// Live/Unknown answer never touched by one).
+	Attribution *ChangeAttribution
+	// Epoch names the store-epoch generation this answer was evaluated
+	// under, so a caller can tell WHICH epoch a GoneReorganization answer
+	// belongs to, not just that reorganization is why the Address is gone
+	// (R20-n). Nil means this answer did not involve epoch reasoning (e.g.
+	// an ordinary Remove/Commit under R20-a..R20-l, evaluated by a store
+	// with no epoch concept at all).
+	Epoch *int
 }
 
 // RemovalReason is why an Address was removed: R20 requires the three
@@ -146,6 +167,15 @@ type RetentionFixture struct {
 	// hook means this backend has no erasure primitive, and the case that
 	// needs it skips with that reason.
 	Erase func(ctx context.Context, storeID string, address Address, correctedState string, attribution ChangeAttribution) (Address, error)
+
+	// Mint mints a fresh Version for id under storeID, returning its
+	// Address — analogous to EpochFixture.MintUnderEpoch, without an epoch
+	// to peg it to. A nil hook means this backend has no way to mint a
+	// real, resolvable Address to test retention against, and cases that
+	// need one skip with that reason. Replaces the retired convention that
+	// a fabricated, never-minted Address defaults to RestrictionLive (see
+	// this file's package doc comment, formerly §4a choice 3).
+	Mint func(ctx context.Context, storeID, id string) (Address, error)
 }
 
 // RunRemovalLeavesTheAddressAbleToAnswer pins R20-a/b: after a committed
@@ -159,8 +189,11 @@ func RunRemovalLeavesTheAddressAbleToAnswer(t *testing.T, ctx context.Context, f
 	if fixture.Resolve == nil {
 		t.Skip("this backend does not yet report retention state (Resolve is nil)")
 	}
+	if fixture.Mint == nil {
+		t.Skip("this backend has no way to mint a real Address to test retention against (Mint is nil)")
+	}
 	store := retentionStore(fixture, "answerable")
-	address := retentionAddress(fixture, "answerable")
+	address := retentionMint(t, ctx, fixture, store, "answerable")
 
 	preview, err := fixture.Remove(ctx, store, address, RemovalReasonRetention)
 	if err != nil {
@@ -191,6 +224,9 @@ func RunRemovalReasonIsRetentionErasureOrReorganizationDistinctly(t *testing.T, 
 	if fixture.Resolve == nil {
 		t.Skip("this backend does not yet report retention state (Resolve is nil)")
 	}
+	if fixture.Mint == nil {
+		t.Skip("this backend has no way to mint a real Address to test retention against (Mint is nil)")
+	}
 	store := retentionStore(fixture, "reasons")
 	cases := []struct {
 		reason RemovalReason
@@ -202,7 +238,7 @@ func RunRemovalReasonIsRetentionErasureOrReorganizationDistinctly(t *testing.T, 
 	}
 	seen := map[Restriction]bool{}
 	for _, c := range cases {
-		address := retentionAddress(fixture, "reason-"+c.reason.String())
+		address := retentionMint(t, ctx, fixture, store, "reason-"+c.reason.String())
 		preview, err := fixture.Remove(ctx, store, address, c.reason)
 		if err != nil {
 			t.Fatalf("Remove(%s, reason=%s): %v", address, c.reason, err)
@@ -231,8 +267,11 @@ func RunRemovalReportsTheSurvivingRetainedWindow(t *testing.T, ctx context.Conte
 	if fixture.Remove == nil {
 		t.Skip("this backend has no removal primitive (Remove is nil)")
 	}
+	if fixture.Mint == nil {
+		t.Skip("this backend has no way to mint a real Address to test retention against (Mint is nil)")
+	}
 	store := retentionStore(fixture, "window")
-	address := retentionAddress(fixture, "window")
+	address := retentionMint(t, ctx, fixture, store, "window")
 
 	preview, err := fixture.Remove(ctx, store, address, RemovalReasonRetention)
 	if err != nil {
@@ -260,9 +299,12 @@ func RunRemovalNeverReassignsASurvivingAddress(t *testing.T, ctx context.Context
 	if fixture.Resolve == nil {
 		t.Skip("this backend does not yet report retention state (Resolve is nil)")
 	}
+	if fixture.Mint == nil {
+		t.Skip("this backend has no way to mint a real Address to test retention against (Mint is nil)")
+	}
 	store := retentionStore(fixture, "survivor")
-	removed := retentionAddress(fixture, "survivor-removed")
-	survivor := retentionAddress(fixture, "survivor-kept")
+	removed := retentionMint(t, ctx, fixture, store, "survivor-removed")
+	survivor := retentionMint(t, ctx, fixture, store, "survivor-kept")
 
 	before, err := fixture.Resolve(ctx, store, survivor)
 	if err != nil {
@@ -298,9 +340,12 @@ func RunGoneIsDistinguishableFromUnknown(t *testing.T, ctx context.Context, fixt
 	if fixture.Resolve == nil {
 		t.Skip("this backend does not yet report retention state (Resolve is nil)")
 	}
+	if fixture.Mint == nil {
+		t.Skip("this backend has no way to mint a real Address to test retention against (Mint is nil)")
+	}
 	store := retentionStore(fixture, "gonevunknown")
 	strangerStore := retentionStore(fixture, "gonevunknown-stranger")
-	gone := retentionAddress(fixture, "gonevunknown-gone")
+	gone := retentionMint(t, ctx, fixture, store, "gonevunknown-gone")
 
 	preview, err := fixture.Remove(ctx, store, gone, RemovalReasonRetention)
 	if err != nil {
@@ -338,9 +383,12 @@ func RunAnAddressNeverResolvesToADifferentState(t *testing.T, ctx context.Contex
 	if fixture.Resolve == nil {
 		t.Skip("this backend does not yet report retention state (Resolve is nil)")
 	}
+	if fixture.Mint == nil {
+		t.Skip("this backend has no way to mint a real Address to test retention against (Mint is nil)")
+	}
 	store := retentionStore(fixture, "nomixup")
-	removedAddr := retentionAddress(fixture, "nomixup-removed")
-	liveAddr := retentionAddress(fixture, "nomixup-live")
+	removedAddr := retentionMint(t, ctx, fixture, store, "nomixup-removed")
+	liveAddr := retentionMint(t, ctx, fixture, store, "nomixup-live")
 
 	preview, err := fixture.Remove(ctx, store, removedAddr, RemovalReasonRetention)
 	if err != nil {
@@ -383,8 +431,11 @@ func RunADestructiveOperationEnumeratesAffectedAddressesFirst(t *testing.T, ctx 
 	if fixture.Resolve == nil {
 		t.Skip("this backend does not yet report retention state (Resolve is nil)")
 	}
+	if fixture.Mint == nil {
+		t.Skip("this backend has no way to mint a real Address to test retention against (Mint is nil)")
+	}
 	store := retentionStore(fixture, "enumeratefirst")
-	address := retentionAddress(fixture, "enumeratefirst")
+	address := retentionMint(t, ctx, fixture, store, "enumeratefirst")
 
 	before, err := fixture.Resolve(ctx, store, address)
 	if err != nil {
@@ -410,8 +461,9 @@ func RunADestructiveOperationEnumeratesAffectedAddressesFirst(t *testing.T, ctx 
 }
 
 // RunAHoldPreventsRemovalAndReportsInRetainedBounds pins R20-h: an active
-// Hold makes Remove/Commit refuse, and the Address stays out of any Gone
-// restriction.
+// Hold makes Remove/Commit refuse, AND the held Address must show up
+// positively in the reported RetainedWindow bounds — not merely be inferred
+// from the absence of a Gone restriction.
 //
 // §4a choice 1 (see this file's package doc comment): Commit's refusal is
 // the typed ErrRetentionHeld rather than a non-accepted-shaped
@@ -427,8 +479,11 @@ func RunAHoldPreventsRemovalAndReportsInRetainedBounds(t *testing.T, ctx context
 	if fixture.Resolve == nil {
 		t.Skip("this backend does not yet report retention state (Resolve is nil)")
 	}
+	if fixture.Mint == nil {
+		t.Skip("this backend has no way to mint a real Address to test retention against (Mint is nil)")
+	}
 	store := retentionStore(fixture, "held")
-	address := retentionAddress(fixture, "held")
+	address := retentionMint(t, ctx, fixture, store, "held")
 
 	if err := fixture.Hold(ctx, store, address); err != nil {
 		t.Fatalf("Hold(%s): %v", address, err)
@@ -449,19 +504,18 @@ func RunAHoldPreventsRemovalAndReportsInRetainedBounds(t *testing.T, ctx context
 	if answer.Restriction == RestrictionGoneRetention || answer.Restriction == RestrictionGoneErasure || answer.Restriction == RestrictionGoneReorganization {
 		t.Errorf("Resolve(%s) reports %s after Commit was refused for being held, want it to remain out of any Gone restriction", address, answer.Restriction)
 	}
+	if answer.RetainedWindow == nil {
+		t.Fatalf("Resolve(%s) after a refused, held removal reports RetainedWindow = nil, want a populated window: R20-h's promise is that a Hold shows up IN the retained bounds, not merely as an absence of a Gone restriction", address)
+	}
+	if answer.RetainedWindow.LowerBound != address || answer.RetainedWindow.UpperBound != address {
+		t.Errorf("Resolve(%s).RetainedWindow = %+v, want both bounds naming the held Address itself: nothing else was ever minted in this store, so the range the Hold protects is exactly this one Address", address, answer.RetainedWindow)
+	}
 }
 
 // RunForcingAHeldRemovalRecordsWhoWhenWhy pins R20-h2: ForceRemove crosses an
-// active Hold and must record who, when, and why.
-//
-// §4a choice 2 (see this file's package doc comment): RetentionAnswer
-// carries no attribution field and this contract adds no dedicated
-// read-back hook for one, so this case cannot mechanically verify WHERE the
-// attribution and reason land — only that ForceRemove accepts them as real
-// parameters and succeeds despite the Hold. A future revision that adds a
-// read-back hook (mirroring how
-// RunRefusalReportsTheRefusingVersionsChangeAttribution verifies R17's
-// attribution) should tighten this case to assert content, not just shape.
+// active Hold and must record who, when, and why — read back via
+// RetentionAnswer.Attribution, not just accepted as parameters (formerly
+// §4a choice 2, now DIED; see this file's package doc comment).
 func RunForcingAHeldRemovalRecordsWhoWhenWhy(t *testing.T, ctx context.Context, fixture RetentionFixture) {
 	t.Helper()
 	if fixture.Hold == nil {
@@ -470,8 +524,11 @@ func RunForcingAHeldRemovalRecordsWhoWhenWhy(t *testing.T, ctx context.Context, 
 	if fixture.ForceRemove == nil {
 		t.Skip("this backend has no forced-removal primitive (ForceRemove is nil)")
 	}
+	if fixture.Mint == nil {
+		t.Skip("this backend has no way to mint a real Address to test retention against (Mint is nil)")
+	}
 	store := retentionStore(fixture, "forced")
-	address := retentionAddress(fixture, "forced")
+	address := retentionMint(t, ctx, fixture, store, "forced")
 
 	if err := fixture.Hold(ctx, store, address); err != nil {
 		t.Fatalf("Hold(%s): %v", address, err)
@@ -491,6 +548,12 @@ func RunForcingAHeldRemovalRecordsWhoWhenWhy(t *testing.T, ctx context.Context, 
 	if answer.ProducingStore != store {
 		t.Errorf("ForceRemove(%s).ProducingStore = %q, want %q", address, answer.ProducingStore, store)
 	}
+	if answer.Attribution == nil {
+		t.Fatalf("ForceRemove(%s).Attribution = nil, want the who/when/why recorded for this forced removal (R20-h2)", address)
+	}
+	if !sameAttribution(*answer.Attribution, attribution) {
+		t.Errorf("ForceRemove(%s).Attribution = %+v, want %+v (R20-h2: who/when/why must be recorded, not just accepted as parameters)", address, *answer.Attribution, attribution)
+	}
 }
 
 // RunEveryRetentionAnswerNamesItsProducingStore pins R20-i for both a live
@@ -504,10 +567,13 @@ func RunEveryRetentionAnswerNamesItsProducingStore(t *testing.T, ctx context.Con
 	if fixture.Remove == nil {
 		t.Skip("this backend has no removal primitive (Remove is nil)")
 	}
+	if fixture.Mint == nil {
+		t.Skip("this backend has no way to mint a real Address to test retention against (Mint is nil)")
+	}
 	storeA := retentionStore(fixture, "namesA")
 	storeB := retentionStore(fixture, "namesB")
-	liveAddr := retentionAddress(fixture, "names-live")
-	goneAddr := retentionAddress(fixture, "names-gone")
+	liveAddr := retentionMint(t, ctx, fixture, storeA, "names-live")
+	goneAddr := retentionMint(t, ctx, fixture, storeB, "names-gone")
 
 	preview, err := fixture.Remove(ctx, storeB, goneAddr, RemovalReasonRetention)
 	if err != nil {
@@ -566,8 +632,11 @@ func RunAStoreThatRemovesStateStillAnswersGoneDurably(t *testing.T, ctx context.
 	if fixture.Resolve == nil {
 		t.Skip("this backend does not yet report retention state (Resolve is nil)")
 	}
+	if fixture.Mint == nil {
+		t.Skip("this backend has no way to mint a real Address to test retention against (Mint is nil)")
+	}
 	store := retentionStore(fixture, "durable")
-	address := retentionAddress(fixture, "durable")
+	address := retentionMint(t, ctx, fixture, store, "durable")
 
 	preview, err := fixture.Remove(ctx, store, address, RemovalReasonErasure)
 	if err != nil {
@@ -605,8 +674,11 @@ func RunErasureMintsACorrectedVersionRatherThanEditingInPlace(t *testing.T, ctx 
 	if fixture.Resolve == nil {
 		t.Skip("this backend does not yet report retention state (Resolve is nil)")
 	}
+	if fixture.Mint == nil {
+		t.Skip("this backend has no way to mint a real Address to test retention against (Mint is nil)")
+	}
 	store := retentionStore(fixture, "erasure")
-	original := retentionAddress(fixture, "erasure-original")
+	original := retentionMint(t, ctx, fixture, store, "erasure-original")
 	actor := "retention-operator"
 	attribution := ChangeAttribution{Actor: &actor, At: time.Now().UTC()}
 
@@ -785,7 +857,8 @@ func RunEpochBumpVoidsOnlyAddressesOfVersionsNoLongerServed(t *testing.T, ctx co
 		t.Fatalf("MintUnderEpoch(record-b): %v", err)
 	}
 
-	if _, err := fixture.BumpEpoch(ctx, store, EpochBumpTriggerRestore); err != nil {
+	newEpoch, err := fixture.BumpEpoch(ctx, store, EpochBumpTriggerRestore)
+	if err != nil {
 		t.Fatalf("BumpEpoch: %v", err)
 	}
 
@@ -812,6 +885,11 @@ func RunEpochBumpVoidsOnlyAddressesOfVersionsNoLongerServed(t *testing.T, ctx co
 	}
 	if voidedAnswer.Restriction != RestrictionGoneReorganization {
 		t.Errorf("Resolve(a prior-epoch Address no longer served) = %s, want RestrictionGoneReorganization (R20-n)", voidedAnswer.Restriction)
+	}
+	if voidedAnswer.Epoch == nil {
+		t.Fatal("Resolve(a prior-epoch Address no longer served).Epoch = nil, want the current epoch populated (R20-n: the answer must name the current epoch, not just Restriction alone)")
+	} else if *voidedAnswer.Epoch != newEpoch {
+		t.Errorf("Resolve(a prior-epoch Address no longer served).Epoch = %d, want the current epoch %d", *voidedAnswer.Epoch, newEpoch)
 	}
 
 	keptAnswer, err := fixture.Resolve(ctx, store, stillServed)
@@ -841,13 +919,33 @@ func retentionStore(fixture RetentionFixture, tag string) string {
 }
 
 // retentionAddress builds a fresh, syntactically valid Address namespaced by
-// the fixture's IssuePrefix and tag. RetentionFixture has no hook to mint an
-// Address — Remove, Hold, ForceRemove, and Erase are the only per-Address
-// operations it exposes — so every case names its own Address directly. See
-// this file's package doc comment, §4a choice 3, for the Live/Unknown
-// baseline convention this relies on.
+// the fixture's IssuePrefix and tag, WITHOUT ever giving it to any store.
+// RunAStoreWithNoLineageKnowledgeAnswersUnknownNotGone is the only remaining
+// caller: Unknown specifically means a store with no lineage knowledge of
+// the Address at all (FR-06), so fabricating one that no store has ever
+// seen is the correct construction here, not a shortcut — unlike every
+// other case in this file, which now mints a real Address via
+// fixture.Mint/retentionMint instead of relying on the retired
+// Live-baseline convention (see this file's package doc comment, formerly
+// §4a choice 3).
 func retentionAddress(fixture RetentionFixture, tag string) Address {
 	return Address(fixture.IssuePrefix + "-retention-address-" + tag)
+}
+
+// retentionMint mints a fresh Address for tag on store via fixture.Mint,
+// fataling the case if minting fails — analogous to how
+// EpochFixture.MintUnderEpoch is called directly in this file's Epoch
+// cases, without its own wrapper. Cases use this in place of the retired
+// retentionAddress convention (formerly §4a choice 3, now DIED — see this
+// file's package doc comment) for any Address that must resolve as a real,
+// store-established Version.
+func retentionMint(t *testing.T, ctx context.Context, fixture RetentionFixture, store, tag string) Address {
+	t.Helper()
+	address, err := fixture.Mint(ctx, store, tag)
+	if err != nil {
+		t.Fatalf("Mint(%s, %s): %v", store, tag, err)
+	}
+	return address
 }
 
 // epochStore names a storeID namespaced by the fixture's IssuePrefix and tag.
@@ -861,7 +959,23 @@ func epochStore(fixture EpochFixture, tag string) string {
 func sameRetentionAnswer(a, b RetentionAnswer) bool {
 	return a.Restriction == b.Restriction &&
 		a.ProducingStore == b.ProducingStore &&
-		sameRetainedWindow(a.RetainedWindow, b.RetainedWindow)
+		sameRetainedWindow(a.RetainedWindow, b.RetainedWindow) &&
+		sameAttributionPtr(a.Attribution, b.Attribution) &&
+		sameIntPtr(a.Epoch, b.Epoch)
+}
+
+func sameAttributionPtr(a, b *ChangeAttribution) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return sameAttribution(*a, *b)
+}
+
+func sameIntPtr(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 func sameRetainedWindow(a, b *RetainedWindow) bool {

--- a/backend/conformance/retention_epoch_contract.go
+++ b/backend/conformance/retention_epoch_contract.go
@@ -1,0 +1,872 @@
+package conformance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// This file holds the contract for R20 (gastownhall/beads#6133, be-hs42e.1
+// §5-§9): what a store reports about an Address once retention, erasure, or
+// reorganization has stopped it resolving to live state (R20-a..R20-l), and
+// the store-epoch generation counter that selectively voids addresses minted
+// under an earlier one (R20-m/n).
+//
+// RESTRICTION AND RETAINEDWINDOW ARE DECLARED IN expected_revision_contract.go
+// — see that file's package-level note on where this suite's shared
+// vocabulary lives and why.
+//
+// GONE AND UNKNOWN ARE NEVER CONFLATED (FR-05, FR-06): Gone means the store
+// once held this Version and no longer does; Unknown means the store has no
+// lineage knowledge of the Address at all. Every RetentionAnswer names its
+// PRODUCING STORE (R20-i) so a case can catch a backend that silently
+// answers for the wrong store — this matters because R20 is explicitly a
+// per-store promise, not a global one: a Reorganization can leave one store
+// still serving an Address that another has moved past.
+//
+// THREE §4a CHOICES THIS FILE MAKES THAT THE ARCHITECTURE DOC DOES NOT PIN:
+//
+//  1. Remove/Commit's refusal under an active Hold is a typed error,
+//     ErrRetentionHeld, rather than a non-accepted-shaped RetentionAnswer —
+//     the doc names the promise ("must refuse ... unless forced", R20-h) but
+//     not its shape. An error was chosen because Commit's success path
+//     already returns a RetentionAnswer describing a Version that is now
+//     GONE; reusing that same shape for a refusal would make "the hold
+//     worked" and "the removal happened" look like the same kind of value.
+//     (R17's Refusal reasons about the same tradeoff the other way, because
+//     R17 already had a typed non-error outcome shape to reuse — Remove has
+//     no such sibling shape to reuse here.)
+//  2. ForceRemove's attribution is asserted only for shape, not content:
+//     RetentionAnswer carries no attribution field and this contract adds no
+//     dedicated read-back hook for one, so RunForcingAHeldRemovalRecordsWhoWhenWhy
+//     cannot mechanically verify WHERE who/when/why land — only that
+//     ForceRemove accepts them as real parameters and succeeds despite the
+//     Hold. See that function's own doc comment.
+//  3. AN ADDRESS THAT NO OPERATION HAS TOUCHED RESOLVES RestrictionLive BY
+//     DEFAULT, within the one store a case otherwise uses consistently. The
+//     architecture doc defines what removal, erasure, and reorganization DO
+//     but does not separately spell out the baseline for an address a store
+//     tracks but has not yet acted on. This file reserves RestrictionUnknown
+//     for a DIFFERENT store asked about an Address it has no lineage
+//     relationship with at all (FR-06) — see
+//     RunAStoreWithNoLineageKnowledgeAnswersUnknownNotGone and
+//     RunGoneIsDistinguishableFromUnknown, both of which test the Unknown
+//     case via a second, foreign storeID rather than an untouched address on
+//     the primary one.
+//
+// EVERY HOOK ON BOTH FIXTURES BELOW IS INDEPENDENTLY NILABLE — see the
+// package-level note in expected_revision_contract.go. Every case
+// nil-checks every hook it uses and SKIPS BY NAME when one is missing.
+
+// RetentionAnswer is what a store reports when asked about an Address.
+type RetentionAnswer struct {
+	Restriction Restriction
+	// RetainedWindow is populated once some Addresses within the lineage
+	// have gone, naming the surviving range (R20-c). Nil means no window
+	// applies (e.g. Restriction is Live or Unknown).
+	RetainedWindow *RetainedWindow
+	// ProducingStore names the store that produced this answer (R20-i).
+	ProducingStore string
+}
+
+// RemovalReason is why an Address was removed: R20 requires the three
+// reasons stay pairwise distinguishable in the Restriction they produce.
+type RemovalReason int
+
+const (
+	RemovalReasonRetention RemovalReason = iota
+	RemovalReasonErasure
+	RemovalReasonReorganization
+)
+
+func (r RemovalReason) String() string {
+	switch r {
+	case RemovalReasonRetention:
+		return "retention"
+	case RemovalReasonErasure:
+		return "erasure"
+	case RemovalReasonReorganization:
+		return "reorganization"
+	default:
+		return fmt.Sprintf("RemovalReason(%d)", int(r))
+	}
+}
+
+// RemovalPreview is Remove's enumerate-before-you-change half (R20-g): the
+// Addresses about to be affected are reported before Commit makes the
+// change real.
+type RemovalPreview struct {
+	AffectedAddresses []Address
+	Commit            func(ctx context.Context) (RetentionAnswer, error)
+}
+
+// ErrRetentionHeld means a RemovalPreview's Commit was refused because an
+// active Hold covers the Address (R20-h). See this file's package doc
+// comment, §4a choice 1, for why this is a typed error rather than a
+// non-accepted-shaped RetentionAnswer.
+var ErrRetentionHeld = errors.New("retention: address is held")
+
+// RetentionResolve answers what a store currently reports for address. It is
+// shared verbatim between RetentionFixture and EpochFixture: an epoch bump's
+// effect on an Address (R20-n) is observed through the exact same read path
+// as an ordinary removal's effect (R20-a..R20-l).
+type RetentionResolve func(ctx context.Context, storeID string, address Address) (RetentionAnswer, error)
+
+// RetentionFixture supplies the capabilities under test for R20's removal,
+// hold, forced-removal, and erasure semantics.
+type RetentionFixture struct {
+	IssuePrefix string
+
+	// Resolve reports storeID's current answer for address. A nil hook
+	// means this backend does not yet report retention state, and cases
+	// that need one skip with that reason.
+	Resolve RetentionResolve
+
+	// Remove reports the Addresses a removal is about to affect
+	// (RemovalPreview.AffectedAddresses) before Commit makes the change
+	// real (R20-g). A nil hook means this backend has no removal primitive,
+	// and cases that need one skip with that reason.
+	Remove func(ctx context.Context, storeID string, address Address, reason RemovalReason) (RemovalPreview, error)
+
+	// Hold prevents Remove/Commit from taking effect against address until
+	// released (R20-h). A nil hook means this backend has no hold
+	// primitive, and cases that need one skip with that reason.
+	Hold func(ctx context.Context, storeID string, address Address) error
+
+	// ForceRemove removes address despite an active Hold, recording who,
+	// when, and why in the resulting Gone record (R20-h2). A nil hook means
+	// this backend has no forced-removal primitive, and the cases that need
+	// one skip with that reason.
+	ForceRemove func(ctx context.Context, storeID string, address Address, attribution ChangeAttribution, reason string) (RetentionAnswer, error)
+
+	// Erase mints a corrected replacement Version for address rather than
+	// editing it in place (R20-l), returning the corrected Address. A nil
+	// hook means this backend has no erasure primitive, and the case that
+	// needs it skips with that reason.
+	Erase func(ctx context.Context, storeID string, address Address, correctedState string, attribution ChangeAttribution) (Address, error)
+}
+
+// RunRemovalLeavesTheAddressAbleToAnswer pins R20-a/b: after a committed
+// removal, the Address can still be resolved — it must answer, just not
+// live.
+func RunRemovalLeavesTheAddressAbleToAnswer(t *testing.T, ctx context.Context, fixture RetentionFixture) {
+	t.Helper()
+	if fixture.Remove == nil {
+		t.Skip("this backend has no removal primitive (Remove is nil)")
+	}
+	if fixture.Resolve == nil {
+		t.Skip("this backend does not yet report retention state (Resolve is nil)")
+	}
+	store := retentionStore(fixture, "answerable")
+	address := retentionAddress(fixture, "answerable")
+
+	preview, err := fixture.Remove(ctx, store, address, RemovalReasonRetention)
+	if err != nil {
+		t.Fatalf("Remove(%s, %s): %v", store, address, err)
+	}
+	if _, err := preview.Commit(ctx); err != nil {
+		t.Fatalf("Commit removing %s: %v", address, err)
+	}
+
+	answer, err := fixture.Resolve(ctx, store, address)
+	if err != nil {
+		t.Fatalf("Resolve(%s, %s) after removal: %v", store, address, err)
+	}
+	if answer.Restriction == RestrictionLive {
+		t.Fatalf("Resolve(%s) after Remove+Commit reports RestrictionLive, want a non-live Restriction: removal must leave the address able to answer, just not live", address)
+	}
+}
+
+// RunRemovalReasonIsRetentionErasureOrReorganizationDistinctly pins R20-d:
+// the three RemovalReasons produce pairwise-distinct Restrictions, so a
+// caller can tell which kind of removal it is looking at from the answer
+// alone.
+func RunRemovalReasonIsRetentionErasureOrReorganizationDistinctly(t *testing.T, ctx context.Context, fixture RetentionFixture) {
+	t.Helper()
+	if fixture.Remove == nil {
+		t.Skip("this backend has no removal primitive (Remove is nil)")
+	}
+	if fixture.Resolve == nil {
+		t.Skip("this backend does not yet report retention state (Resolve is nil)")
+	}
+	store := retentionStore(fixture, "reasons")
+	cases := []struct {
+		reason RemovalReason
+		want   Restriction
+	}{
+		{RemovalReasonRetention, RestrictionGoneRetention},
+		{RemovalReasonErasure, RestrictionGoneErasure},
+		{RemovalReasonReorganization, RestrictionGoneReorganization},
+	}
+	seen := map[Restriction]bool{}
+	for _, c := range cases {
+		address := retentionAddress(fixture, "reason-"+c.reason.String())
+		preview, err := fixture.Remove(ctx, store, address, c.reason)
+		if err != nil {
+			t.Fatalf("Remove(%s, reason=%s): %v", address, c.reason, err)
+		}
+		if _, err := preview.Commit(ctx); err != nil {
+			t.Fatalf("Commit(%s, reason=%s): %v", address, c.reason, err)
+		}
+		answer, err := fixture.Resolve(ctx, store, address)
+		if err != nil {
+			t.Fatalf("Resolve(%s) after Remove(reason=%s): %v", address, c.reason, err)
+		}
+		if answer.Restriction != c.want {
+			t.Errorf("Remove(reason=%s) then Resolve = %s, want %s", c.reason, answer.Restriction, c.want)
+		}
+		if seen[answer.Restriction] {
+			t.Errorf("Restriction %s was already reported for a different RemovalReason; the three reasons must map to pairwise-distinct Restrictions", answer.Restriction)
+		}
+		seen[answer.Restriction] = true
+	}
+}
+
+// RunRemovalReportsTheSurvivingRetainedWindow pins R20-c: a removal's answer
+// carries a populated RetainedWindow naming the surviving range.
+func RunRemovalReportsTheSurvivingRetainedWindow(t *testing.T, ctx context.Context, fixture RetentionFixture) {
+	t.Helper()
+	if fixture.Remove == nil {
+		t.Skip("this backend has no removal primitive (Remove is nil)")
+	}
+	store := retentionStore(fixture, "window")
+	address := retentionAddress(fixture, "window")
+
+	preview, err := fixture.Remove(ctx, store, address, RemovalReasonRetention)
+	if err != nil {
+		t.Fatalf("Remove(%s): %v", address, err)
+	}
+	answer, err := preview.Commit(ctx)
+	if err != nil {
+		t.Fatalf("Commit(%s): %v", address, err)
+	}
+	if answer.RetainedWindow == nil {
+		t.Fatal("RetainedWindow = nil after a removal, want a populated window (R20-c)")
+	}
+	if answer.RetainedWindow.LowerBound == "" || answer.RetainedWindow.UpperBound == "" {
+		t.Errorf("RetainedWindow = %+v, want both bounds non-empty", answer.RetainedWindow)
+	}
+}
+
+// RunRemovalNeverReassignsASurvivingAddress pins R20-f: removing one Address
+// must never alter or reassign a different, surviving Address's own answer.
+func RunRemovalNeverReassignsASurvivingAddress(t *testing.T, ctx context.Context, fixture RetentionFixture) {
+	t.Helper()
+	if fixture.Remove == nil {
+		t.Skip("this backend has no removal primitive (Remove is nil)")
+	}
+	if fixture.Resolve == nil {
+		t.Skip("this backend does not yet report retention state (Resolve is nil)")
+	}
+	store := retentionStore(fixture, "survivor")
+	removed := retentionAddress(fixture, "survivor-removed")
+	survivor := retentionAddress(fixture, "survivor-kept")
+
+	before, err := fixture.Resolve(ctx, store, survivor)
+	if err != nil {
+		t.Fatalf("Resolve(survivor) before removing its neighbor: %v", err)
+	}
+
+	preview, err := fixture.Remove(ctx, store, removed, RemovalReasonRetention)
+	if err != nil {
+		t.Fatalf("Remove(%s): %v", removed, err)
+	}
+	if _, err := preview.Commit(ctx); err != nil {
+		t.Fatalf("Commit(%s): %v", removed, err)
+	}
+
+	after, err := fixture.Resolve(ctx, store, survivor)
+	if err != nil {
+		t.Fatalf("Resolve(survivor) after removing its neighbor: %v", err)
+	}
+	if !sameRetentionAnswer(before, after) {
+		t.Errorf("removing a neighbor changed the survivor's own answer from %+v to %+v; removing one Address must never reassign or alter another", before, after)
+	}
+}
+
+// RunGoneIsDistinguishableFromUnknown pins FR-05's core claim: the SAME
+// Address, asked of the store that removed it versus a store that never
+// held it, must not resolve identically — Gone (once held, now removed) and
+// Unknown (no lineage knowledge at all) are never conflated.
+func RunGoneIsDistinguishableFromUnknown(t *testing.T, ctx context.Context, fixture RetentionFixture) {
+	t.Helper()
+	if fixture.Remove == nil {
+		t.Skip("this backend has no removal primitive (Remove is nil)")
+	}
+	if fixture.Resolve == nil {
+		t.Skip("this backend does not yet report retention state (Resolve is nil)")
+	}
+	store := retentionStore(fixture, "gonevunknown")
+	strangerStore := retentionStore(fixture, "gonevunknown-stranger")
+	gone := retentionAddress(fixture, "gonevunknown-gone")
+
+	preview, err := fixture.Remove(ctx, store, gone, RemovalReasonRetention)
+	if err != nil {
+		t.Fatalf("Remove(%s): %v", gone, err)
+	}
+	if _, err := preview.Commit(ctx); err != nil {
+		t.Fatalf("Commit(%s): %v", gone, err)
+	}
+
+	goneAnswer, err := fixture.Resolve(ctx, store, gone)
+	if err != nil {
+		t.Fatalf("Resolve(gone, its own store): %v", err)
+	}
+	unknownAnswer, err := fixture.Resolve(ctx, strangerStore, gone)
+	if err != nil {
+		t.Fatalf("Resolve(gone's address, a store that never held it): %v", err)
+	}
+	if goneAnswer.Restriction == RestrictionLive || unknownAnswer.Restriction == RestrictionLive {
+		t.Fatalf("Live leaked into a Gone/Unknown comparison: gone=%s unknown=%s", goneAnswer.Restriction, unknownAnswer.Restriction)
+	}
+	if goneAnswer.Restriction == unknownAnswer.Restriction {
+		t.Errorf("the SAME Address resolved identically (%s) whether asked of the store that removed it or a store that never held it; FR-05 requires Gone and Unknown stay distinct", goneAnswer.Restriction)
+	}
+}
+
+// RunAnAddressNeverResolvesToADifferentState guards against a mixed-up
+// lookup key: two distinct Addresses on the same store, deliberately left
+// in different Restrictions, must never have their answers cross-
+// contaminate.
+func RunAnAddressNeverResolvesToADifferentState(t *testing.T, ctx context.Context, fixture RetentionFixture) {
+	t.Helper()
+	if fixture.Remove == nil {
+		t.Skip("this backend has no removal primitive (Remove is nil)")
+	}
+	if fixture.Resolve == nil {
+		t.Skip("this backend does not yet report retention state (Resolve is nil)")
+	}
+	store := retentionStore(fixture, "nomixup")
+	removedAddr := retentionAddress(fixture, "nomixup-removed")
+	liveAddr := retentionAddress(fixture, "nomixup-live")
+
+	preview, err := fixture.Remove(ctx, store, removedAddr, RemovalReasonRetention)
+	if err != nil {
+		t.Fatalf("Remove(%s): %v", removedAddr, err)
+	}
+	if _, err := preview.Commit(ctx); err != nil {
+		t.Fatalf("Commit(%s): %v", removedAddr, err)
+	}
+
+	removedAnswer, err := fixture.Resolve(ctx, store, removedAddr)
+	if err != nil {
+		t.Fatalf("Resolve(removed): %v", err)
+	}
+	liveAnswer, err := fixture.Resolve(ctx, store, liveAddr)
+	if err != nil {
+		t.Fatalf("Resolve(live): %v", err)
+	}
+
+	if liveAnswer.Restriction != RestrictionLive {
+		t.Fatalf("Resolve(an address nothing ever removed) = %s, want RestrictionLive", liveAnswer.Restriction)
+	}
+	if removedAnswer.Restriction == RestrictionLive {
+		t.Fatal("Resolve(a removed address) = RestrictionLive, want a Gone restriction")
+	}
+	if sameRetentionAnswer(removedAnswer, liveAnswer) {
+		t.Errorf("Resolve(%s) and Resolve(%s) returned identical answers %+v; a mixed-up lookup key would look exactly like this", removedAddr, liveAddr, removedAnswer)
+	}
+}
+
+// RunADestructiveOperationEnumeratesAffectedAddressesFirst pins R20-g:
+// Remove reports the Addresses it is about to affect BEFORE anything
+// changes. Checked by confirming that obtaining the preview alone — without
+// calling Commit — leaves the address's own answer untouched, regardless of
+// what that answer is.
+func RunADestructiveOperationEnumeratesAffectedAddressesFirst(t *testing.T, ctx context.Context, fixture RetentionFixture) {
+	t.Helper()
+	if fixture.Remove == nil {
+		t.Skip("this backend has no removal primitive (Remove is nil)")
+	}
+	if fixture.Resolve == nil {
+		t.Skip("this backend does not yet report retention state (Resolve is nil)")
+	}
+	store := retentionStore(fixture, "enumeratefirst")
+	address := retentionAddress(fixture, "enumeratefirst")
+
+	before, err := fixture.Resolve(ctx, store, address)
+	if err != nil {
+		t.Fatalf("Resolve before Remove: %v", err)
+	}
+
+	preview, err := fixture.Remove(ctx, store, address, RemovalReasonRetention)
+	if err != nil {
+		t.Fatalf("Remove(%s): %v", address, err)
+	}
+	if len(preview.AffectedAddresses) == 0 {
+		t.Fatal("RemovalPreview.AffectedAddresses is empty, want the addresses this removal is about to affect (R20-g)")
+	}
+
+	// Commit is deliberately NOT called yet.
+	after, err := fixture.Resolve(ctx, store, address)
+	if err != nil {
+		t.Fatalf("Resolve after Remove but before Commit: %v", err)
+	}
+	if !sameRetentionAnswer(before, after) {
+		t.Errorf("Resolve changed from %+v to %+v after Remove but before Commit; enumeration must precede the change, not cause it", before, after)
+	}
+}
+
+// RunAHoldPreventsRemovalAndReportsInRetainedBounds pins R20-h: an active
+// Hold makes Remove/Commit refuse, and the Address stays out of any Gone
+// restriction.
+//
+// §4a choice 1 (see this file's package doc comment): Commit's refusal is
+// the typed ErrRetentionHeld rather than a non-accepted-shaped
+// RetentionAnswer.
+func RunAHoldPreventsRemovalAndReportsInRetainedBounds(t *testing.T, ctx context.Context, fixture RetentionFixture) {
+	t.Helper()
+	if fixture.Hold == nil {
+		t.Skip("this backend has no hold primitive (Hold is nil)")
+	}
+	if fixture.Remove == nil {
+		t.Skip("this backend has no removal primitive (Remove is nil)")
+	}
+	if fixture.Resolve == nil {
+		t.Skip("this backend does not yet report retention state (Resolve is nil)")
+	}
+	store := retentionStore(fixture, "held")
+	address := retentionAddress(fixture, "held")
+
+	if err := fixture.Hold(ctx, store, address); err != nil {
+		t.Fatalf("Hold(%s): %v", address, err)
+	}
+
+	preview, err := fixture.Remove(ctx, store, address, RemovalReasonRetention)
+	if err != nil {
+		t.Fatalf("Remove(%s) under a hold: %v", address, err)
+	}
+	if _, err := preview.Commit(ctx); !errors.Is(err, ErrRetentionHeld) {
+		t.Fatalf("Commit(%s) under a hold error = %v, want ErrRetentionHeld", address, err)
+	}
+
+	answer, err := fixture.Resolve(ctx, store, address)
+	if err != nil {
+		t.Fatalf("Resolve(%s) after a refused, held removal: %v", address, err)
+	}
+	if answer.Restriction == RestrictionGoneRetention || answer.Restriction == RestrictionGoneErasure || answer.Restriction == RestrictionGoneReorganization {
+		t.Errorf("Resolve(%s) reports %s after Commit was refused for being held, want it to remain out of any Gone restriction", address, answer.Restriction)
+	}
+}
+
+// RunForcingAHeldRemovalRecordsWhoWhenWhy pins R20-h2: ForceRemove crosses an
+// active Hold and must record who, when, and why.
+//
+// §4a choice 2 (see this file's package doc comment): RetentionAnswer
+// carries no attribution field and this contract adds no dedicated
+// read-back hook for one, so this case cannot mechanically verify WHERE the
+// attribution and reason land — only that ForceRemove accepts them as real
+// parameters and succeeds despite the Hold. A future revision that adds a
+// read-back hook (mirroring how
+// RunRefusalReportsTheRefusingVersionsChangeAttribution verifies R17's
+// attribution) should tighten this case to assert content, not just shape.
+func RunForcingAHeldRemovalRecordsWhoWhenWhy(t *testing.T, ctx context.Context, fixture RetentionFixture) {
+	t.Helper()
+	if fixture.Hold == nil {
+		t.Skip("this backend has no hold primitive (Hold is nil)")
+	}
+	if fixture.ForceRemove == nil {
+		t.Skip("this backend has no forced-removal primitive (ForceRemove is nil)")
+	}
+	store := retentionStore(fixture, "forced")
+	address := retentionAddress(fixture, "forced")
+
+	if err := fixture.Hold(ctx, store, address); err != nil {
+		t.Fatalf("Hold(%s): %v", address, err)
+	}
+
+	actor := "retention-operator"
+	message := "legal hold expired"
+	attribution := ChangeAttribution{Actor: &actor, Message: &message, At: time.Now().UTC()}
+
+	answer, err := fixture.ForceRemove(ctx, store, address, attribution, "hold-expired")
+	if err != nil {
+		t.Fatalf("ForceRemove(%s) despite an active hold: %v", address, err)
+	}
+	if answer.Restriction == RestrictionLive {
+		t.Errorf("ForceRemove(%s) reports RestrictionLive, want a Gone restriction", address)
+	}
+	if answer.ProducingStore != store {
+		t.Errorf("ForceRemove(%s).ProducingStore = %q, want %q", address, answer.ProducingStore, store)
+	}
+}
+
+// RunEveryRetentionAnswerNamesItsProducingStore pins R20-i for both a live
+// and a non-live answer: ProducingStore always names the store that
+// actually produced the answer.
+func RunEveryRetentionAnswerNamesItsProducingStore(t *testing.T, ctx context.Context, fixture RetentionFixture) {
+	t.Helper()
+	if fixture.Resolve == nil {
+		t.Skip("this backend does not yet report retention state (Resolve is nil)")
+	}
+	if fixture.Remove == nil {
+		t.Skip("this backend has no removal primitive (Remove is nil)")
+	}
+	storeA := retentionStore(fixture, "namesA")
+	storeB := retentionStore(fixture, "namesB")
+	liveAddr := retentionAddress(fixture, "names-live")
+	goneAddr := retentionAddress(fixture, "names-gone")
+
+	preview, err := fixture.Remove(ctx, storeB, goneAddr, RemovalReasonRetention)
+	if err != nil {
+		t.Fatalf("Remove(%s): %v", goneAddr, err)
+	}
+	if _, err := preview.Commit(ctx); err != nil {
+		t.Fatalf("Commit(%s): %v", goneAddr, err)
+	}
+
+	liveAnswer, err := fixture.Resolve(ctx, storeA, liveAddr)
+	if err != nil {
+		t.Fatalf("Resolve(%s, %s): %v", storeA, liveAddr, err)
+	}
+	if liveAnswer.ProducingStore != storeA {
+		t.Errorf("Resolve(%s, ...).ProducingStore = %q, want %q (R20-i: live answer)", storeA, liveAnswer.ProducingStore, storeA)
+	}
+
+	goneAnswer, err := fixture.Resolve(ctx, storeB, goneAddr)
+	if err != nil {
+		t.Fatalf("Resolve(%s, %s): %v", storeB, goneAddr, err)
+	}
+	if goneAnswer.ProducingStore != storeB {
+		t.Errorf("Resolve(%s, ...).ProducingStore = %q, want %q (R20-i: non-live answer)", storeB, goneAnswer.ProducingStore, storeB)
+	}
+}
+
+// RunAStoreWithNoLineageKnowledgeAnswersUnknownNotGone pins FR-06: a store
+// asked about a store/Address pair it has no lineage relationship with at
+// all — never received it, never removed it — must answer Unknown, not one
+// of the Gone restrictions.
+func RunAStoreWithNoLineageKnowledgeAnswersUnknownNotGone(t *testing.T, ctx context.Context, fixture RetentionFixture) {
+	t.Helper()
+	if fixture.Resolve == nil {
+		t.Skip("this backend does not yet report retention state (Resolve is nil)")
+	}
+	store := retentionStore(fixture, "nolineage")
+	address := retentionAddress(fixture, "nolineage-nevertracked")
+
+	answer, err := fixture.Resolve(ctx, store, address)
+	if err != nil {
+		t.Fatalf("Resolve(%s, %s): %v", store, address, err)
+	}
+	if answer.Restriction != RestrictionUnknown {
+		t.Errorf("Resolve on a store/address pair with no lineage relationship = %s, want RestrictionUnknown (FR-06)", answer.Restriction)
+	}
+}
+
+// RunAStoreThatRemovesStateStillAnswersGoneDurably pins R20-j: a removed
+// Address's Gone answer is durable — two successive reads must agree, not
+// merely happen to agree once.
+func RunAStoreThatRemovesStateStillAnswersGoneDurably(t *testing.T, ctx context.Context, fixture RetentionFixture) {
+	t.Helper()
+	if fixture.Remove == nil {
+		t.Skip("this backend has no removal primitive (Remove is nil)")
+	}
+	if fixture.Resolve == nil {
+		t.Skip("this backend does not yet report retention state (Resolve is nil)")
+	}
+	store := retentionStore(fixture, "durable")
+	address := retentionAddress(fixture, "durable")
+
+	preview, err := fixture.Remove(ctx, store, address, RemovalReasonErasure)
+	if err != nil {
+		t.Fatalf("Remove(%s): %v", address, err)
+	}
+	if _, err := preview.Commit(ctx); err != nil {
+		t.Fatalf("Commit(%s): %v", address, err)
+	}
+
+	first, err := fixture.Resolve(ctx, store, address)
+	if err != nil {
+		t.Fatalf("Resolve(%s), first read: %v", address, err)
+	}
+	second, err := fixture.Resolve(ctx, store, address)
+	if err != nil {
+		t.Fatalf("Resolve(%s), second read: %v", address, err)
+	}
+	if first.Restriction == RestrictionLive {
+		t.Fatalf("Resolve(%s) after removal = RestrictionLive, want a Gone restriction", address)
+	}
+	if !sameRetentionAnswer(first, second) {
+		t.Errorf("two successive Resolve(%s) calls disagreed: %+v vs %+v; a removal must answer Gone DURABLY, not from a cache that can revert", address, first, second)
+	}
+}
+
+// RunErasureMintsACorrectedVersionRatherThanEditingInPlace pins R20-l: Erase
+// returns a NEW Address for the corrected state rather than editing the
+// original in place — the original resolves GoneErasure, the corrected
+// replacement resolves Live.
+func RunErasureMintsACorrectedVersionRatherThanEditingInPlace(t *testing.T, ctx context.Context, fixture RetentionFixture) {
+	t.Helper()
+	if fixture.Erase == nil {
+		t.Skip("this backend has no erasure primitive (Erase is nil)")
+	}
+	if fixture.Resolve == nil {
+		t.Skip("this backend does not yet report retention state (Resolve is nil)")
+	}
+	store := retentionStore(fixture, "erasure")
+	original := retentionAddress(fixture, "erasure-original")
+	actor := "retention-operator"
+	attribution := ChangeAttribution{Actor: &actor, At: time.Now().UTC()}
+
+	corrected, err := fixture.Erase(ctx, store, original, `{"corrected":true}`, attribution)
+	if err != nil {
+		t.Fatalf("Erase(%s): %v", original, err)
+	}
+	if corrected == original {
+		t.Fatalf("Erase(%s) returned the SAME Address, want a NEW one (R20-l: erasure mints a corrected version rather than editing in place)", original)
+	}
+
+	originalAnswer, err := fixture.Resolve(ctx, store, original)
+	if err != nil {
+		t.Fatalf("Resolve(original): %v", err)
+	}
+	if originalAnswer.Restriction != RestrictionGoneErasure {
+		t.Errorf("Resolve(the erased original) = %s, want RestrictionGoneErasure", originalAnswer.Restriction)
+	}
+
+	correctedAnswer, err := fixture.Resolve(ctx, store, corrected)
+	if err != nil {
+		t.Fatalf("Resolve(corrected): %v", err)
+	}
+	if correctedAnswer.Restriction != RestrictionLive {
+		t.Errorf("Resolve(the corrected replacement) = %s, want RestrictionLive", correctedAnswer.Restriction)
+	}
+}
+
+// EpochBumpTrigger enumerates the only three events R20-m allows to advance
+// a store's epoch.
+type EpochBumpTrigger int
+
+const (
+	EpochBumpTriggerRestore EpochBumpTrigger = iota
+	EpochBumpTriggerDestructiveReinit
+	EpochBumpTriggerTokenSchemeChange
+)
+
+func (tr EpochBumpTrigger) String() string {
+	switch tr {
+	case EpochBumpTriggerRestore:
+		return "restore"
+	case EpochBumpTriggerDestructiveReinit:
+		return "destructive-reinit"
+	case EpochBumpTriggerTokenSchemeChange:
+		return "token-scheme-change"
+	default:
+		return fmt.Sprintf("EpochBumpTrigger(%d)", int(tr))
+	}
+}
+
+// EpochFixture supplies the capabilities under test for R20-m/n: the
+// store-epoch generation counter and its selective effect on addresses
+// minted under an earlier epoch.
+type EpochFixture struct {
+	IssuePrefix string
+
+	// CurrentEpoch reports storeID's current epoch generation. A nil hook
+	// means this backend has no epoch concept yet, and cases that need one
+	// skip with that reason.
+	CurrentEpoch func(ctx context.Context, storeID string) (int, error)
+
+	// BumpEpoch advances storeID's epoch for the given trigger, returning
+	// the new epoch. A nil hook means this backend has no epoch concept
+	// yet, and cases that need one skip with that reason.
+	BumpEpoch func(ctx context.Context, storeID string, trigger EpochBumpTrigger) (int, error)
+
+	// MintUnderEpoch mints a fresh Version for id under storeID's current
+	// epoch, returning its Address. A nil hook means this backend has no
+	// way to mint a Version under a known epoch, and cases that need one
+	// skip with that reason.
+	MintUnderEpoch func(ctx context.Context, storeID, id string) (Address, error)
+
+	// StillServes reports whether storeID still serves the Version named by
+	// a prior-epoch address, despite the epoch having moved on. A nil hook
+	// means this backend cannot report that, and the case that needs it
+	// skips with that reason.
+	StillServes func(ctx context.Context, storeID string, address Address) (bool, error)
+
+	// Resolve is the SAME RetentionResolve type RetentionFixture uses — an
+	// epoch bump's effect on an Address is observed through the identical
+	// read path as an ordinary removal. A nil hook means this backend does
+	// not yet report retention state, and cases that need one skip with
+	// that reason.
+	Resolve RetentionResolve
+
+	// CurrentAddressFor reports the Address a still-served, prior-epoch
+	// Version now resolves to under the new epoch. A nil hook means this
+	// backend cannot report that, and the case that needs it skips with
+	// that reason.
+	CurrentAddressFor func(ctx context.Context, storeID string, oldAddress Address) (Address, error)
+}
+
+// RunAnEpochBumpIsTriggeredOnlyByRestoreReinitOrSchemeChange pins R20-m: a
+// store's epoch advances for exactly the three named triggers.
+//
+// THIS CASE CANNOT PROVE A FOURTH, UNINVITED TRIGGER NEVER BUMPS THE EPOCH
+// in some real backend — enumerating "never" over an open set of possible
+// call sites is not something an interface-level test can do. That is
+// Phase 3's implementation discipline to hold, not something this suite can
+// enforce (NFR-03's blind spot, mirroring canonicalizeForContract's stated
+// blind spot in metadata_cas_contract.go).
+func RunAnEpochBumpIsTriggeredOnlyByRestoreReinitOrSchemeChange(t *testing.T, ctx context.Context, fixture EpochFixture) {
+	t.Helper()
+	if fixture.BumpEpoch == nil {
+		t.Skip("this backend has no epoch concept yet (BumpEpoch is nil)")
+	}
+	if fixture.CurrentEpoch == nil {
+		t.Skip("this backend cannot report its current epoch (CurrentEpoch is nil)")
+	}
+	store := epochStore(fixture, "triggers")
+
+	for _, trigger := range []EpochBumpTrigger{
+		EpochBumpTriggerRestore,
+		EpochBumpTriggerDestructiveReinit,
+		EpochBumpTriggerTokenSchemeChange,
+	} {
+		before, err := fixture.CurrentEpoch(ctx, store)
+		if err != nil {
+			t.Fatalf("CurrentEpoch before %s: %v", trigger, err)
+		}
+		after, err := fixture.BumpEpoch(ctx, store, trigger)
+		if err != nil {
+			t.Fatalf("BumpEpoch(%s): %v", trigger, err)
+		}
+		if after <= before {
+			t.Errorf("BumpEpoch(%s) = %d, want an epoch greater than the pre-bump value %d", trigger, after, before)
+		}
+		observed, err := fixture.CurrentEpoch(ctx, store)
+		if err != nil {
+			t.Fatalf("CurrentEpoch after %s: %v", trigger, err)
+		}
+		if observed != after {
+			t.Errorf("CurrentEpoch after BumpEpoch(%s) = %d, want the bumped value %d", trigger, observed, after)
+		}
+	}
+}
+
+// RunEpochBumpVoidsOnlyAddressesOfVersionsNoLongerServed pins R20-n — "Rev7
+// tightening... the clause most likely to be gotten wrong" in the
+// architecture doc's own words. A prior-epoch Address goes
+// GoneReorganization UNLESS the backend still serves that Version, in which
+// case it must stay Live AND additionally report the Address it now
+// resolves to under the new epoch.
+//
+// StillServes is an ORACLE here, not a control: this case cannot make a real
+// backend keep serving one address and drop another, since Phase 0 wires no
+// real backend. It asks StillServes what the fixture (once real) decided,
+// and checks the rest of the contract's promise against that decision for
+// both outcomes.
+func RunEpochBumpVoidsOnlyAddressesOfVersionsNoLongerServed(t *testing.T, ctx context.Context, fixture EpochFixture) {
+	t.Helper()
+	if fixture.MintUnderEpoch == nil {
+		t.Skip("this backend has no way to mint a Version under a known epoch (MintUnderEpoch is nil)")
+	}
+	if fixture.BumpEpoch == nil {
+		t.Skip("this backend has no epoch concept yet (BumpEpoch is nil)")
+	}
+	if fixture.StillServes == nil {
+		t.Skip("this backend cannot report whether it still serves a prior-epoch Version (StillServes is nil)")
+	}
+	if fixture.Resolve == nil {
+		t.Skip("this backend does not yet report retention state (Resolve is nil)")
+	}
+	if fixture.CurrentAddressFor == nil {
+		t.Skip("this backend cannot report a still-served Version's new Address (CurrentAddressFor is nil)")
+	}
+	store := epochStore(fixture, "voids")
+
+	addrA, err := fixture.MintUnderEpoch(ctx, store, "record-a")
+	if err != nil {
+		t.Fatalf("MintUnderEpoch(record-a): %v", err)
+	}
+	addrB, err := fixture.MintUnderEpoch(ctx, store, "record-b")
+	if err != nil {
+		t.Fatalf("MintUnderEpoch(record-b): %v", err)
+	}
+
+	if _, err := fixture.BumpEpoch(ctx, store, EpochBumpTriggerRestore); err != nil {
+		t.Fatalf("BumpEpoch: %v", err)
+	}
+
+	servesA, err := fixture.StillServes(ctx, store, addrA)
+	if err != nil {
+		t.Fatalf("StillServes(%s): %v", addrA, err)
+	}
+	servesB, err := fixture.StillServes(ctx, store, addrB)
+	if err != nil {
+		t.Fatalf("StillServes(%s): %v", addrB, err)
+	}
+	if servesA == servesB {
+		t.Skip("this scenario needs one still-served and one no-longer-served address to exercise both halves of R20-n; StillServes reported the same answer for both, so this fixture gives this case nothing to contrast")
+	}
+
+	stillServed, noLongerServed := addrA, addrB
+	if servesB && !servesA {
+		stillServed, noLongerServed = addrB, addrA
+	}
+
+	voidedAnswer, err := fixture.Resolve(ctx, store, noLongerServed)
+	if err != nil {
+		t.Fatalf("Resolve(no-longer-served): %v", err)
+	}
+	if voidedAnswer.Restriction != RestrictionGoneReorganization {
+		t.Errorf("Resolve(a prior-epoch Address no longer served) = %s, want RestrictionGoneReorganization (R20-n)", voidedAnswer.Restriction)
+	}
+
+	keptAnswer, err := fixture.Resolve(ctx, store, stillServed)
+	if err != nil {
+		t.Fatalf("Resolve(still-served): %v", err)
+	}
+	if keptAnswer.Restriction != RestrictionLive {
+		t.Errorf("Resolve(a prior-epoch Address the backend still serves) = %s, want RestrictionLive (R20-n's exception)", keptAnswer.Restriction)
+	}
+
+	newAddr, err := fixture.CurrentAddressFor(ctx, store, stillServed)
+	if err != nil {
+		t.Fatalf("CurrentAddressFor(%s): %v", stillServed, err)
+	}
+	if newAddr == "" {
+		t.Error("CurrentAddressFor(a still-served prior-epoch Address) returned an empty Address, want a real one under the new epoch")
+	}
+}
+
+// --- fixture helpers -------------------------------------------------------
+
+// retentionStore names a storeID namespaced by the fixture's IssuePrefix and
+// tag, so cases that need more than one store (e.g. to probe FR-06's
+// no-lineage-knowledge case) get independent ones.
+func retentionStore(fixture RetentionFixture, tag string) string {
+	return fixture.IssuePrefix + "-retention-store-" + tag
+}
+
+// retentionAddress builds a fresh, syntactically valid Address namespaced by
+// the fixture's IssuePrefix and tag. RetentionFixture has no hook to mint an
+// Address — Remove, Hold, ForceRemove, and Erase are the only per-Address
+// operations it exposes — so every case names its own Address directly. See
+// this file's package doc comment, §4a choice 3, for the Live/Unknown
+// baseline convention this relies on.
+func retentionAddress(fixture RetentionFixture, tag string) Address {
+	return Address(fixture.IssuePrefix + "-retention-address-" + tag)
+}
+
+// epochStore names a storeID namespaced by the fixture's IssuePrefix and tag.
+func epochStore(fixture EpochFixture, tag string) string {
+	return fixture.IssuePrefix + "-epoch-store-" + tag
+}
+
+// sameRetentionAnswer compares two RetentionAnswer values by content rather
+// than identity, so a case can assert "this did not change" without
+// depending on the concrete Restriction the backend happened to pick.
+func sameRetentionAnswer(a, b RetentionAnswer) bool {
+	return a.Restriction == b.Restriction &&
+		a.ProducingStore == b.ProducingStore &&
+		sameRetainedWindow(a.RetainedWindow, b.RetainedWindow)
+}
+
+func sameRetainedWindow(a, b *RetainedWindow) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}

--- a/backend/conformance/retention_epoch_contract.go
+++ b/backend/conformance/retention_epoch_contract.go
@@ -58,8 +58,8 @@ import (
 //     second, foreign storeID that genuinely never saw the Address — not via
 //     an untouched-but-fabricated address on the primary one, which is the
 //     part that died. retentionAddress itself survives as the one helper
-//     those two cases still use, precisely because Unknown requires an
-//     Address no store ever minted.
+//     RunAStoreWithNoLineageKnowledgeAnswersUnknownNotGone still uses,
+//     precisely because Unknown requires an Address no store ever minted.
 //
 // EVERY HOOK ON BOTH FIXTURES BELOW IS INDEPENDENTLY NILABLE — see the
 // package-level note in expected_revision_contract.go. Every case
@@ -507,8 +507,8 @@ func RunAHoldPreventsRemovalAndReportsInRetainedBounds(t *testing.T, ctx context
 	if answer.RetainedWindow == nil {
 		t.Fatalf("Resolve(%s) after a refused, held removal reports RetainedWindow = nil, want a populated window: R20-h's promise is that a Hold shows up IN the retained bounds, not merely as an absence of a Gone restriction", address)
 	}
-	if answer.RetainedWindow.LowerBound != address || answer.RetainedWindow.UpperBound != address {
-		t.Errorf("Resolve(%s).RetainedWindow = %+v, want both bounds naming the held Address itself: nothing else was ever minted in this store, so the range the Hold protects is exactly this one Address", address, answer.RetainedWindow)
+	if answer.RetainedWindow.LowerBound != address && answer.RetainedWindow.UpperBound != address {
+		t.Errorf("Resolve(%s).RetainedWindow = %+v, want at least one bound naming the held Address itself: R20-h's promise is that a Hold shows up IN the retained bounds, but this fixture's store name is not guaranteed fresh across runs on a persistent backend, so a prior run's Addresses may widen the window and only one edge is guaranteed to be exactly this Address", address, answer.RetainedWindow)
 	}
 }
 

--- a/backend/conformance/role_bundle.go
+++ b/backend/conformance/role_bundle.go
@@ -89,6 +89,7 @@ type RoleContractBundle struct {
 	CycleDetector        func(t *testing.T) *CycleDetectorFixture
 	Deleter              func(t *testing.T) *DeleterFixture
 	DependencyEditor     func(t *testing.T) *DependencyEditorFixture
+	DualWrite            func(t *testing.T) *DualWriteFixture
 	EdgeReader           func(t *testing.T) *EdgeReaderFixture
 	GraphCounter         func(t *testing.T) *GraphCounterFixture
 	Importer             func(t *testing.T) *ImporterFixture

--- a/backend/conformance/role_bundle_cases.go
+++ b/backend/conformance/role_bundle_cases.go
@@ -279,6 +279,24 @@ var roleContractCases = []roleContract{
 		RunDependencyEditorAcceptsBlockingAcrossIssueTypes,
 	),
 
+	// The accessor named here is not an accessor at all, alone among these
+	// rows except Journal: storage.VersionedHistoryConfigurer is reached by
+	// TYPE ASSERTION, either on a store (the dolt and embedded-dolt legs) or
+	// on a unit-of-work provider (the uow leg), because enabling dual-write
+	// history is engine configuration rather than an issue-shaped operation
+	// storage.Storage publishes. A backend that does not implement Phase 2's
+	// dual-write mechanism leaves this field nil; see
+	// dualwrite_history_contract.go's header.
+	roleCases("DualWrite", "the storage.VersionedHistoryConfigurer type assertion", oncePerRole,
+		func(b RoleContractBundle) func(t *testing.T) *DualWriteFixture { return b.DualWrite },
+		RunDualWriteMintsOneVersionRowPerAcceptedMutation,
+		RunDualWriteNoOpMutationMintsNoRow,
+		RunDualWriteAttributionIsRecordedWithTheMutation,
+		RunDualWriteCurrentRevisionMatchesTheNewVersionRow,
+		RunDualWriteFlagOffProducesNoVersionRows,
+		RunDualWriteNoOpMutationLeavesThePriorVersionRowUnperturbed,
+	),
+
 	roleCases("EdgeReader", "EdgeReader()", oncePerRole,
 		func(b RoleContractBundle) func(t *testing.T) *EdgeReaderFixture { return b.EdgeReader },
 		RunEdgeReaderAnswersOnePerAnchorInRequestOrder,

--- a/backend/conformance/role_bundle_test.go
+++ b/backend/conformance/role_bundle_test.go
@@ -27,9 +27,16 @@ import (
 // which is the same defect class as a test with correct assertions on a fixture
 // that cannot fail, one level up. So the expected set is DERIVED from the
 // package source rather than written down: every top-level func named Run* that
-// takes (*testing.T, context.Context, <name>Fixture) is a role-tier case, and
-// the entry points that take a Factory instead — RunAll, RunAudit and friends,
-// RunPortableMethods, RunSearchPaging, RunDeferredReads — are not.
+// takes (*testing.T, context.Context, <name>Fixture) where <name>Fixture is one
+// of RoleContractBundle's own field types is a role-tier case. That bundle-field
+// check is what keeps this scoped to the role tier specifically: the package
+// also holds other conformance tiers (e.g. the history-semantics contracts that
+// versioned_history_wiring_test.go wires directly, with no RoleContractBundle
+// field of their own — see that file's header) whose Run*Fixture-shaped
+// functions must NOT be swept in here, since nothing in RoleContractBundle ever
+// calls them. The entry points that take a Factory instead — RunAll, RunAudit
+// and friends, RunPortableMethods, RunSearchPaging, RunDeferredReads — are not
+// role-tier cases either.
 //
 // The table's own half of the comparison is derived too: roleCases resolves
 // each function VALUE back to its declared name (runFuncName), so a row cannot
@@ -314,9 +321,13 @@ func runProbeChild(t *testing.T, mode string) (string, error) {
 
 // parseRoleContractCases returns every role-tier case declared in this
 // package's non-test sources, in filename then declaration order — the order
-// roleContractCases is written in.
+// roleContractCases is written in. A Run*Fixture-shaped function whose Fixture
+// type is not one of RoleContractBundle's own field types belongs to a
+// different conformance tier and is not a role-tier case; see
+// roleTierFixtureNames.
 func parseRoleContractCases(t *testing.T) []string {
 	t.Helper()
+	roleFixtures := roleTierFixtureNames()
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {
 		t.Fatal("runtime.Caller failed")
@@ -341,7 +352,7 @@ func parseRoleContractCases(t *testing.T) []string {
 				if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "Run") {
 					continue
 				}
-				if takesFixture(fn) {
+				if fixtureName, ok := takesFixture(fn); ok && roleFixtures[fixtureName] {
 					cases = append(cases, fn.Name.Name)
 				}
 			}
@@ -350,22 +361,54 @@ func parseRoleContractCases(t *testing.T) []string {
 	return cases
 }
 
+// roleTierFixtureNames returns the pointee type name of every *XxxFixture a
+// RoleContractBundle field produces. This is the role tier's actual membership
+// test: a Run*Fixture-shaped function is a role-tier case only if its Fixture
+// type appears here, because that is the only way RunRoleContracts could ever
+// reach it. Other conformance tiers in this package (e.g. Phase 0's
+// history-semantics contracts, wired directly by
+// versioned_history_wiring_test.go rather than through this bundle) mint their
+// own *Fixture types that intentionally never appear here.
+func roleTierFixtureNames() map[string]bool {
+	names := map[string]bool{}
+	bundleType := reflect.TypeOf(RoleContractBundle{})
+	for i := range bundleType.NumField() {
+		field := bundleType.Field(i).Type
+		if field.Kind() != reflect.Func || field.NumOut() != 1 {
+			continue
+		}
+		out := field.Out(0)
+		if out.Kind() != reflect.Ptr {
+			continue
+		}
+		names[out.Elem().Name()] = true
+	}
+	return names
+}
+
 // takesFixture reports whether fn has the role-tier case signature:
-// (t *testing.T, ctx context.Context, fixture <name>Fixture).
-func takesFixture(fn *ast.FuncDecl) bool {
+// (t *testing.T, ctx context.Context, fixture <name>Fixture), returning the
+// Fixture type's name so the caller can check it against the role tier's
+// actual membership (roleTierFixtureNames) rather than the signature shape
+// alone — the shape is necessary but not sufficient, since other conformance
+// tiers use it too.
+func takesFixture(fn *ast.FuncDecl) (fixtureName string, ok bool) {
 	if fn.Type.Params == nil || len(fn.Type.Params.List) != 3 {
-		return false
+		return "", false
 	}
 	params := fn.Type.Params.List
-	star, ok := params[0].Type.(*ast.StarExpr)
-	if !ok || !isQualified(star.X, "testing", "T") {
-		return false
+	star, starOk := params[0].Type.(*ast.StarExpr)
+	if !starOk || !isQualified(star.X, "testing", "T") {
+		return "", false
 	}
 	if !isQualified(params[1].Type, "context", "Context") {
-		return false
+		return "", false
 	}
-	fixture, ok := params[2].Type.(*ast.Ident)
-	return ok && strings.HasSuffix(fixture.Name, "Fixture")
+	fixture, identOk := params[2].Type.(*ast.Ident)
+	if !identOk || !strings.HasSuffix(fixture.Name, "Fixture") {
+		return "", false
+	}
+	return fixture.Name, true
 }
 
 func isQualified(expr ast.Expr, pkg, name string) bool {

--- a/backend/conformance/versioned_history_wiring_test.go
+++ b/backend/conformance/versioned_history_wiring_test.go
@@ -1,0 +1,134 @@
+package conformance
+
+import (
+	"context"
+	"testing"
+)
+
+// TestVersionedHistoryPhase0RunsInFullSkipMode is Phase 0's own wiring: it
+// constructs each of the three new Fixtures with every hook nil — exactly
+// the state every backend's real fixture kit is in as of this phase's merge
+// (architecture §12: "every new hook is nil in every backend's fixture kit")
+// — and runs every R16/R16.1/R17/R20 case once each, proving the whole suite
+// compiles and skips cleanly under today's CI (NFR-01).
+//
+// This is NOT a per-backend wiring file like internal/storage/dolt's — there
+// is no real per-backend accessor for any of these capabilities yet, so a
+// real per-backend fixture would be indistinguishable, all-nil boilerplate
+// repeated three times. This one local test stands in for that until Phase 3
+// gives a real backend something non-nil to wire here instead.
+func TestVersionedHistoryPhase0RunsInFullSkipMode(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ExpectedRevision", func(t *testing.T) {
+		fixture := ExpectedRevisionFixture{IssuePrefix: "vh0"}
+		t.Run("AcceptsAWriteNamingTheCurrentVersion", func(t *testing.T) {
+			RunExpectedRevisionAcceptsAWriteNamingTheCurrentVersion(t, ctx, fixture)
+		})
+		t.Run("AcceptsAWriteNamingNoVersion", func(t *testing.T) {
+			RunExpectedRevisionAcceptsAWriteNamingNoVersion(t, ctx, fixture)
+		})
+		t.Run("CoversFieldsOutsideAnyWatchedSubset", func(t *testing.T) {
+			RunExpectedRevisionCoversFieldsOutsideAnyWatchedSubset(t, ctx, fixture)
+		})
+		t.Run("RefusalReportsTheRefusingVersionAddress", func(t *testing.T) {
+			RunRefusalReportsTheRefusingVersionAddress(t, ctx, fixture)
+		})
+		t.Run("RefusalReportsTheRefusingVersionsChangeAttribution", func(t *testing.T) {
+			RunRefusalReportsTheRefusingVersionsChangeAttribution(t, ctx, fixture)
+		})
+		t.Run("RefusalIsATypedOutcomeNotAGenericError", func(t *testing.T) {
+			RunRefusalIsATypedOutcomeNotAGenericError(t, ctx, fixture)
+		})
+		t.Run("RefusalIsDistinguishableFromAnAcceptedWrite", func(t *testing.T) {
+			RunRefusalIsDistinguishableFromAnAcceptedWrite(t, ctx, fixture)
+		})
+		t.Run("RefusalIsDistinguishableFromNotFound", func(t *testing.T) {
+			RunRefusalIsDistinguishableFromNotFound(t, ctx, fixture)
+		})
+		t.Run("RefusalIsDistinguishableFromValidationFailure", func(t *testing.T) {
+			RunRefusalIsDistinguishableFromValidationFailure(t, ctx, fixture)
+		})
+		t.Run("RefusalNeverSilentlyPicksAWinner", func(t *testing.T) {
+			RunRefusalNeverSilentlyPicksAWinner(t, ctx, fixture)
+		})
+	})
+
+	t.Run("CrossRecordInvariant", func(t *testing.T) {
+		fixture := CrossRecordInvariantFixture{IssuePrefix: "vh0"}
+		t.Run("SurvivesTwoPassingPerRecordGuards", func(t *testing.T) {
+			RunCrossRecordInvariantSurvivesTwoPassingPerRecordGuards(t, ctx, fixture)
+		})
+		t.Run("StoreInvariantTransactionScopesExactlyTheSpanningRecords", func(t *testing.T) {
+			RunStoreInvariantTransactionScopesExactlyTheSpanningRecords(t, ctx, fixture)
+		})
+		t.Run("InvariantRefusalNamesTheViolatedInvariant", func(t *testing.T) {
+			RunInvariantRefusalNamesTheViolatedInvariant(t, ctx, fixture)
+		})
+		t.Run("MemoryKeyAliasUniquenessIsAStoreInvariantNotACAS", func(t *testing.T) {
+			RunMemoryKeyAliasUniquenessIsAStoreInvariantNotACAS(t, ctx, fixture)
+		})
+		t.Run("MaximumEndpointMultiplicityIsAStoreInvariantNotACAS", func(t *testing.T) {
+			RunMaximumEndpointMultiplicityIsAStoreInvariantNotACAS(t, ctx, fixture)
+		})
+		t.Run("AdvisoryLeaseAloneDoesNotPreventTheInvariantViolation", func(t *testing.T) {
+			RunAdvisoryLeaseAloneDoesNotPreventTheInvariantViolation(t, ctx, fixture)
+		})
+		t.Run("LeaseAcquisitionRecordsNoHistoryEntry", func(t *testing.T) {
+			RunLeaseAcquisitionRecordsNoHistoryEntry(t, ctx, fixture)
+		})
+	})
+
+	t.Run("Retention", func(t *testing.T) {
+		fixture := RetentionFixture{IssuePrefix: "vh0"}
+		t.Run("RemovalLeavesTheAddressAbleToAnswer", func(t *testing.T) {
+			RunRemovalLeavesTheAddressAbleToAnswer(t, ctx, fixture)
+		})
+		t.Run("RemovalReasonIsRetentionErasureOrReorganizationDistinctly", func(t *testing.T) {
+			RunRemovalReasonIsRetentionErasureOrReorganizationDistinctly(t, ctx, fixture)
+		})
+		t.Run("RemovalReportsTheSurvivingRetainedWindow", func(t *testing.T) {
+			RunRemovalReportsTheSurvivingRetainedWindow(t, ctx, fixture)
+		})
+		t.Run("RemovalNeverReassignsASurvivingAddress", func(t *testing.T) {
+			RunRemovalNeverReassignsASurvivingAddress(t, ctx, fixture)
+		})
+		t.Run("GoneIsDistinguishableFromUnknown", func(t *testing.T) {
+			RunGoneIsDistinguishableFromUnknown(t, ctx, fixture)
+		})
+		t.Run("AnAddressNeverResolvesToADifferentState", func(t *testing.T) {
+			RunAnAddressNeverResolvesToADifferentState(t, ctx, fixture)
+		})
+		t.Run("ADestructiveOperationEnumeratesAffectedAddressesFirst", func(t *testing.T) {
+			RunADestructiveOperationEnumeratesAffectedAddressesFirst(t, ctx, fixture)
+		})
+		t.Run("AHoldPreventsRemovalAndReportsInRetainedBounds", func(t *testing.T) {
+			RunAHoldPreventsRemovalAndReportsInRetainedBounds(t, ctx, fixture)
+		})
+		t.Run("ForcingAHeldRemovalRecordsWhoWhenWhy", func(t *testing.T) {
+			RunForcingAHeldRemovalRecordsWhoWhenWhy(t, ctx, fixture)
+		})
+		t.Run("EveryRetentionAnswerNamesItsProducingStore", func(t *testing.T) {
+			RunEveryRetentionAnswerNamesItsProducingStore(t, ctx, fixture)
+		})
+		t.Run("AStoreWithNoLineageKnowledgeAnswersUnknownNotGone", func(t *testing.T) {
+			RunAStoreWithNoLineageKnowledgeAnswersUnknownNotGone(t, ctx, fixture)
+		})
+		t.Run("AStoreThatRemovesStateStillAnswersGoneDurably", func(t *testing.T) {
+			RunAStoreThatRemovesStateStillAnswersGoneDurably(t, ctx, fixture)
+		})
+		t.Run("ErasureMintsACorrectedVersionRatherThanEditingInPlace", func(t *testing.T) {
+			RunErasureMintsACorrectedVersionRatherThanEditingInPlace(t, ctx, fixture)
+		})
+	})
+
+	t.Run("Epoch", func(t *testing.T) {
+		fixture := EpochFixture{IssuePrefix: "vh0"}
+		t.Run("AnEpochBumpIsTriggeredOnlyByRestoreReinitOrSchemeChange", func(t *testing.T) {
+			RunAnEpochBumpIsTriggeredOnlyByRestoreReinitOrSchemeChange(t, ctx, fixture)
+		})
+		t.Run("EpochBumpVoidsOnlyAddressesOfVersionsNoLongerServed", func(t *testing.T) {
+			RunEpochBumpVoidsOnlyAddressesOfVersionsNoLongerServed(t, ctx, fixture)
+		})
+	})
+}

--- a/backend/conformance/versioned_history_wiring_test.go
+++ b/backend/conformance/versioned_history_wiring_test.go
@@ -12,11 +12,10 @@ import (
 // — and runs every R16/R16.1/R17/R20 case once each, proving the whole suite
 // compiles and skips cleanly under today's CI (NFR-01).
 //
-// This is NOT a per-backend wiring file like internal/storage/dolt's — there
-// is no real per-backend accessor for any of these capabilities yet, so a
-// real per-backend fixture would be indistinguishable, all-nil boilerplate
-// repeated three times. This one local test stands in for that until Phase 3
-// gives a real backend something non-nil to wire here instead.
+// Each leg under internal/storage wires these same entrypoints, with the same
+// all-nil fixtures, so TestEveryLegWiresEveryRoleContract counts them; this
+// local copy is not a substitute for those, it just proves the all-skip
+// behavior once without needing to build all three legs to see it.
 func TestVersionedHistoryPhase0RunsInFullSkipMode(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/storage/dolt/cross_record_invariant_contract_test.go
+++ b/internal/storage/dolt/cross_record_invariant_contract_test.go
@@ -1,0 +1,41 @@
+package dolt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+)
+
+// TestCrossRecordInvariantContract wires this leg into the R16.1
+// cross-record invariant contract. Phase 0 leaves every hook nil in every
+// backend's fixture kit (architecture §12), so each case below skips by
+// name; this file exists so TestEveryLegWiresEveryRoleContract counts this
+// leg, and so the cases start running for real the moment this leg's fixture
+// kit grows a non-nil hook.
+func TestCrossRecordInvariantContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := conformance.CrossRecordInvariantFixture{IssuePrefix: "xrec"}
+
+	t.Run("SurvivesTwoPassingPerRecordGuards", func(t *testing.T) {
+		conformance.RunCrossRecordInvariantSurvivesTwoPassingPerRecordGuards(t, ctx, fixture)
+	})
+	t.Run("StoreInvariantTransactionScopesExactlyTheSpanningRecords", func(t *testing.T) {
+		conformance.RunStoreInvariantTransactionScopesExactlyTheSpanningRecords(t, ctx, fixture)
+	})
+	t.Run("InvariantRefusalNamesTheViolatedInvariant", func(t *testing.T) {
+		conformance.RunInvariantRefusalNamesTheViolatedInvariant(t, ctx, fixture)
+	})
+	t.Run("MemoryKeyAliasUniquenessIsAStoreInvariantNotACAS", func(t *testing.T) {
+		conformance.RunMemoryKeyAliasUniquenessIsAStoreInvariantNotACAS(t, ctx, fixture)
+	})
+	t.Run("MaximumEndpointMultiplicityIsAStoreInvariantNotACAS", func(t *testing.T) {
+		conformance.RunMaximumEndpointMultiplicityIsAStoreInvariantNotACAS(t, ctx, fixture)
+	})
+	t.Run("AdvisoryLeaseAloneDoesNotPreventTheInvariantViolation", func(t *testing.T) {
+		conformance.RunAdvisoryLeaseAloneDoesNotPreventTheInvariantViolation(t, ctx, fixture)
+	})
+	t.Run("LeaseAcquisitionRecordsNoHistoryEntry", func(t *testing.T) {
+		conformance.RunLeaseAcquisitionRecordsNoHistoryEntry(t, ctx, fixture)
+	})
+}

--- a/internal/storage/dolt/dualwrite_history_contract_test.go
+++ b/internal/storage/dolt/dualwrite_history_contract_test.go
@@ -1,0 +1,226 @@
+package dolt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestDualWriteContract runs the dual-write history contract with
+// storage.VersionedHistoryConfigurer ON. Like TestJournalContract, this is an
+// engine check rather than an independent per-leg vote: all three legs share
+// RecordVersionInTx, and the dolt leg is where a write that escaped its
+// transaction, or a read that raced it, would have somewhere to go wrong.
+func TestDualWriteContract(t *testing.T) {
+	fixture, ctx, cleanup := newDoltDualWriteFixture(t, "dwc", true)
+	defer cleanup()
+
+	t.Run("MintsOneVersionRowPerAcceptedMutation", func(t *testing.T) {
+		conformance.RunDualWriteMintsOneVersionRowPerAcceptedMutation(t, ctx, fixture)
+	})
+	t.Run("NoOpMutationMintsNoRow", func(t *testing.T) {
+		conformance.RunDualWriteNoOpMutationMintsNoRow(t, ctx, fixture)
+	})
+	t.Run("AttributionIsRecordedWithTheMutation", func(t *testing.T) {
+		conformance.RunDualWriteAttributionIsRecordedWithTheMutation(t, ctx, fixture)
+	})
+	t.Run("CurrentRevisionMatchesTheNewVersionRow", func(t *testing.T) {
+		conformance.RunDualWriteCurrentRevisionMatchesTheNewVersionRow(t, ctx, fixture)
+	})
+	t.Run("NoOpMutationLeavesThePriorVersionRowUnperturbed", func(t *testing.T) {
+		conformance.RunDualWriteNoOpMutationLeavesThePriorVersionRowUnperturbed(t, ctx, fixture)
+	})
+}
+
+// TestDualWriteContractFlagOff runs FR-7 against a fixture constructed with
+// the flag OFF from the start. It is a separate top-level test, not a subtest
+// of TestDualWriteContract, because sharing one store between a flag-on and a
+// flag-off case would make "flag off" mean "flag not yet turned on this
+// session" rather than the thing FR-7 actually promises.
+func TestDualWriteContractFlagOff(t *testing.T) {
+	fixture, ctx, cleanup := newDoltDualWriteFixture(t, "dwcoff", false)
+	defer cleanup()
+
+	t.Run("FlagOffProducesNoVersionRows", func(t *testing.T) {
+		conformance.RunDualWriteFlagOffProducesNoVersionRows(t, ctx, fixture)
+	})
+}
+
+// TestDualWriteFixtureKitIsWired is the explicit per-leg guardrail design
+// §8.5 calls for in place of AST auto-discovery: DualWriteFixture's type name
+// ends in "Fixture" like every other role fixture, so
+// TestEveryLegWiresEveryRoleContract's scan of backend/conformance DOES
+// enumerate its six RunDualWriteXxx functions as entrypoints — but that scan
+// is satisfied the moment this leg's own test files reference all six by
+// name, which TestDualWriteContract and TestDualWriteContractFlagOff already
+// do between them. What that satisfied scan cannot catch is a fixture built
+// with a nil closure that happens to never run in this leg's own case list —
+// silent by construction, since a nil func field only panics the one time
+// something calls it. This test exists to make that failure loud instead:
+// it fails the moment any of the five closures is nil, independent of
+// whether any case above happens to exercise it.
+func TestDualWriteFixtureKitIsWired(t *testing.T) {
+	fixture, _, cleanup := newDoltDualWriteFixture(t, "dwk", true)
+	defer cleanup()
+
+	if fixture.Mutate == nil {
+		t.Error("DualWriteFixture.Mutate is nil")
+	}
+	if fixture.MutateAsNoOp == nil {
+		t.Error("DualWriteFixture.MutateAsNoOp is nil")
+	}
+	if fixture.CurrentRevision == nil {
+		t.Error("DualWriteFixture.CurrentRevision is nil")
+	}
+	if fixture.VersionRowCount == nil {
+		t.Error("DualWriteFixture.VersionRowCount is nil")
+	}
+	if fixture.LatestVersionAttribution == nil {
+		t.Error("DualWriteFixture.LatestVersionAttribution is nil")
+	}
+}
+
+// TestDualWriteStampsTheCurrentStoreEpochOnEachVersionRow pins FR-6, the one
+// dual-write requirement DualWriteFixture cannot reach: every issue_versions
+// row this phase inserts carries the CURRENT store_epoch.epoch value (design
+// §16's "stamped"), and inserting that row must never itself change
+// store_epoch.epoch (design's "never bumped" — that bump belongs to a later,
+// unbuilt phase, not to RecordVersionInTx). This lives on the dolt leg only,
+// not because the property is dolt-specific, but because none of
+// DualWriteFixture's five closures expose either epoch column — see
+// dualwrite_history_contract.go's "WHAT THIS CONTRACT DELIBERATELY DOES NOT
+// PIN" — and the dolt leg is the one with a plain *sql.DB to read them from
+// directly.
+func TestDualWriteStampsTheCurrentStoreEpochOnEachVersionRow(t *testing.T) {
+	store, storeCleanup := setupTestStore(t)
+	defer storeCleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+	configurer, ok := any(store).(storage.VersionedHistoryConfigurer)
+	if !ok {
+		t.Fatalf("%T does not implement storage.VersionedHistoryConfigurer", store)
+	}
+	configurer.SetVersionedHistoryEnabled(true)
+	defer configurer.SetVersionedHistoryEnabled(false)
+
+	create := func(id string) error {
+		return store.CreateIssue(ctx, &types.Issue{
+			ID: id, Title: "t-" + id, IssueType: types.TypeTask, Status: types.StatusOpen,
+		}, "actor")
+	}
+	storeEpoch := func() (int, error) {
+		var epoch int
+		err := store.db.QueryRowContext(ctx, `SELECT epoch FROM store_epoch WHERE id = 1`).Scan(&epoch)
+		return epoch, err
+	}
+	versionEpoch := func(id string) (int, error) {
+		var epoch int
+		err := store.db.QueryRowContext(ctx,
+			`SELECT epoch FROM issue_versions WHERE issue_id = ? ORDER BY revision DESC LIMIT 1`, id).
+			Scan(&epoch)
+		return epoch, err
+	}
+
+	const first, second = "dwe-stamp-first", "dwe-stamp-second"
+	if err := create(first); err != nil {
+		t.Fatalf("creating %s: %v", first, err)
+	}
+	epochAfterFirst, err := storeEpoch()
+	if err != nil {
+		t.Fatalf("reading store_epoch after the first mutation: %v", err)
+	}
+	firstVersionEpoch, err := versionEpoch(first)
+	if err != nil {
+		t.Fatalf("reading issue_versions.epoch for %s: %v", first, err)
+	}
+	if firstVersionEpoch != epochAfterFirst {
+		t.Errorf("issue_versions.epoch for %s = %d, want the current store_epoch.epoch %d: FR-6 requires "+
+			"every version row to be stamped with the store's current epoch at the moment it is minted",
+			first, firstVersionEpoch, epochAfterFirst)
+	}
+
+	if err := create(second); err != nil {
+		t.Fatalf("creating %s: %v", second, err)
+	}
+	epochAfterSecond, err := storeEpoch()
+	if err != nil {
+		t.Fatalf("reading store_epoch after the second mutation: %v", err)
+	}
+	if epochAfterSecond != epochAfterFirst {
+		t.Errorf("store_epoch.epoch went from %d to %d across an ordinary accepted mutation, want "+
+			"unchanged: FR-6 requires RecordVersionInTx to stamp the epoch onto the version row, never "+
+			"to bump store_epoch.epoch itself — that bump belongs to a later, unbuilt phase",
+			epochAfterFirst, epochAfterSecond)
+	}
+	secondVersionEpoch, err := versionEpoch(second)
+	if err != nil {
+		t.Fatalf("reading issue_versions.epoch for %s: %v", second, err)
+	}
+	if secondVersionEpoch != epochAfterSecond {
+		t.Errorf("issue_versions.epoch for %s = %d, want the current store_epoch.epoch %d",
+			second, secondVersionEpoch, epochAfterSecond)
+	}
+}
+
+func newDoltDualWriteFixture(t *testing.T, prefix string, enabled bool) (conformance.DualWriteFixture, context.Context, func()) {
+	t.Helper()
+	store, storeCleanup := setupTestStore(t)
+	ctx, cancel := testContext(t)
+	// Through the type assertion `bd serve` makes, never the concrete method
+	// set: dual-write history is not on storage.DoltStorage, so publishing it
+	// IS implementing this interface, matching newDoltJournalFixture's own
+	// discipline for storage.EventsJournalCursor above.
+	configurer, ok := any(store).(storage.VersionedHistoryConfigurer)
+	if !ok {
+		cancel()
+		storeCleanup()
+		t.Fatalf("%T does not implement storage.VersionedHistoryConfigurer", store)
+	}
+	configurer.SetVersionedHistoryEnabled(enabled)
+	fixture := conformance.DualWriteFixture{
+		IssuePrefix: prefix,
+		Mutate: func(ctx context.Context, id string) error {
+			return store.CreateIssue(ctx, &types.Issue{
+				ID: id, Title: "t-" + id, IssueType: types.TypeTask, Status: types.StatusOpen,
+			}, "actor")
+		},
+		MutateAsNoOp: func(ctx context.Context, id string) error {
+			// Re-sets title to the exact value Mutate already gave it, so
+			// issueops.DiscardNoopIssueUpdates discards it before it ever
+			// reaches RecordVersionInTx.
+			return store.UpdateIssue(ctx, id, map[string]any{"title": "t-" + id}, "actor")
+		},
+		CurrentRevision: func(ctx context.Context, id string) (int64, error) {
+			var revision int64
+			err := store.db.QueryRowContext(ctx, `SELECT current_revision FROM issues WHERE id = ?`, id).
+				Scan(&revision)
+			return revision, err
+		},
+		VersionRowCount: func(ctx context.Context, id string) (int, error) {
+			var count int
+			err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM issue_versions WHERE issue_id = ?`, id).
+				Scan(&count)
+			return count, err
+		},
+		LatestVersionAttribution: func(ctx context.Context, id string) (actor, agent, message string, err error) {
+			err = store.db.QueryRowContext(ctx, `
+				SELECT COALESCE(change_actor, ''), COALESCE(change_agent, ''), COALESCE(change_message, '')
+				FROM issue_versions
+				WHERE issue_id = ?
+				ORDER BY revision DESC
+				LIMIT 1`, id).Scan(&actor, &agent, &message)
+			return actor, agent, message, err
+		},
+	}
+	return fixture, ctx, func() {
+		// Dual-write is instance-scoped, and this store outlives the fixture
+		// in the shared-database harness. Leaving it on would version every
+		// mutation a later test in this package makes.
+		configurer.SetVersionedHistoryEnabled(false)
+		cancel()
+		storeCleanup()
+	}
+}

--- a/internal/storage/dolt/expected_revision_contract_test.go
+++ b/internal/storage/dolt/expected_revision_contract_test.go
@@ -1,0 +1,50 @@
+package dolt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+)
+
+// TestExpectedRevisionContract wires this leg into the R16/R17
+// expected-revision contract. Phase 0 leaves every hook nil in every
+// backend's fixture kit (architecture §12), so each case below skips by
+// name; this file exists so TestEveryLegWiresEveryRoleContract counts this
+// leg, and so the cases start running for real the moment this leg's fixture
+// kit grows a non-nil hook.
+func TestExpectedRevisionContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := conformance.ExpectedRevisionFixture{IssuePrefix: "erev"}
+
+	t.Run("AcceptsAWriteNamingTheCurrentVersion", func(t *testing.T) {
+		conformance.RunExpectedRevisionAcceptsAWriteNamingTheCurrentVersion(t, ctx, fixture)
+	})
+	t.Run("AcceptsAWriteNamingNoVersion", func(t *testing.T) {
+		conformance.RunExpectedRevisionAcceptsAWriteNamingNoVersion(t, ctx, fixture)
+	})
+	t.Run("CoversFieldsOutsideAnyWatchedSubset", func(t *testing.T) {
+		conformance.RunExpectedRevisionCoversFieldsOutsideAnyWatchedSubset(t, ctx, fixture)
+	})
+	t.Run("RefusalReportsTheRefusingVersionAddress", func(t *testing.T) {
+		conformance.RunRefusalReportsTheRefusingVersionAddress(t, ctx, fixture)
+	})
+	t.Run("RefusalReportsTheRefusingVersionsChangeAttribution", func(t *testing.T) {
+		conformance.RunRefusalReportsTheRefusingVersionsChangeAttribution(t, ctx, fixture)
+	})
+	t.Run("RefusalIsATypedOutcomeNotAGenericError", func(t *testing.T) {
+		conformance.RunRefusalIsATypedOutcomeNotAGenericError(t, ctx, fixture)
+	})
+	t.Run("RefusalIsDistinguishableFromAnAcceptedWrite", func(t *testing.T) {
+		conformance.RunRefusalIsDistinguishableFromAnAcceptedWrite(t, ctx, fixture)
+	})
+	t.Run("RefusalIsDistinguishableFromNotFound", func(t *testing.T) {
+		conformance.RunRefusalIsDistinguishableFromNotFound(t, ctx, fixture)
+	})
+	t.Run("RefusalIsDistinguishableFromValidationFailure", func(t *testing.T) {
+		conformance.RunRefusalIsDistinguishableFromValidationFailure(t, ctx, fixture)
+	})
+	t.Run("RefusalNeverSilentlyPicksAWinner", func(t *testing.T) {
+		conformance.RunRefusalNeverSilentlyPicksAWinner(t, ctx, fixture)
+	})
+}

--- a/internal/storage/dolt/initschema_0067_versioned_beads_replay_test.go
+++ b/internal/storage/dolt/initschema_0067_versioned_beads_replay_test.go
@@ -1,0 +1,106 @@
+//go:build integration && !windows
+
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing reproduces,
+// against a real shared dolt sql-server, the designated-migrator replay
+// scenario for migration 0067 (issue_versions, store_epoch,
+// issues.current_revision): the schema_migrations bookkeeping row for version
+// 67 is missing, but the physical tables and column already exist from the
+// original init — the same state stageBehindRemoteBackedDB
+// (cmd/bd/protocol/versioning_contract_test.go) forges before
+// TestProtocol_V2_DesignatedMigratorOverride runs `bd create` with
+// BD_ALLOW_REMOTE_MIGRATE=1.
+//
+// Before the fix, replaying migration 67's frozen CREATE TABLE issue_versions
+// dies with Error 1105 ("table with name issue_versions already exists");
+// once that's guarded, CREATE TABLE store_epoch would die the same way, and
+// once both are guarded, ALTER TABLE issues ADD COLUMN current_revision would
+// die on a duplicate-column error. Editing the shipped, content-hashed 0067
+// SQL bytes is constrained the same way 0040/0041 were (see
+// TestSchemaInitRecoversFromPartialNonlocalMigration above): CREATE TABLE IF
+// NOT EXISTS is safe, ordinary MySQL-flavored DDL, but MySQL (which Dolt
+// follows) has no ADD COLUMN IF NOT EXISTS — that is a MariaDB-only extension
+// — so the column guard must come from elsewhere in the runtime migration
+// path, not from the frozen file text itself.
+func TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing(t *testing.T) {
+	skipIfNoDolt(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	if testServerPort == 0 {
+		t.Skip("no Dolt test server available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	rootDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: testServerPort, User: "root"}.String()
+	rootDB, err := sql.Open("mysql", rootDSN)
+	if err != nil {
+		t.Fatalf("open root connection: %v", err)
+	}
+	defer rootDB.Close()
+
+	dbName := uniqueTestDBName(t)
+	if _, err := rootDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+dbName+"`"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	dbDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: testServerPort, User: "root", Database: dbName}.String()
+	db, err := sql.Open("mysql", dbDSN)
+	if err != nil {
+		t.Fatalf("open db connection: %v", err)
+	}
+	defer db.Close()
+
+	// 1. Fully initialize to the latest schema — issue_versions, store_epoch,
+	//    and issues.current_revision all physically exist afterward.
+	if _, err := initSchemaOnDB(ctx, db); err != nil {
+		t.Fatalf("initial initSchemaOnDB: %v", err)
+	}
+	latest := schema.LatestVersion()
+	assertSchemaVersionAtLeast(ctx, t, db, latest)
+
+	// 2. Forge the exact state stageBehindRemoteBackedDB puts a clone in: the
+	//    version-67 bookkeeping row is gone, but nothing about the physical
+	//    tables/column changed. Commit the delete so it is not left staged —
+	//    an uncommitted schema_migrations write would instead trip the
+	//    unrelated "pending migration alters a dirty table" guard
+	//    (gastownhall/beads#4566) before the replay is ever reached, same as
+	//    the 0040/0041 forges above.
+	if _, err := db.ExecContext(ctx, "DELETE FROM schema_migrations WHERE version = 67"); err != nil {
+		t.Fatalf("rewind schema_migrations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		"CALL DOLT_COMMIT('-Am', 'forge missing 0067 bookkeeping row, tables/column already applied')"); err != nil {
+		t.Fatalf("commit forged partial state: %v", err)
+	}
+
+	// 3. Re-init replays migration 67 against a database that already has its
+	//    tables and column. RED (pre-fix): dies on Error 1105, "table with
+	//    name issue_versions already exists" — the same failure
+	//    TestProtocol_V2_DesignatedMigratorOverride hits at the full
+	//    bd-binary integration level. GREEN (post-fix): CREATE TABLE IF NOT
+	//    EXISTS plus the ADD COLUMN idempotency guard make the replay a clean
+	//    no-op, and the chain reaches latest again.
+	if _, err := initSchemaOnDB(ctx, db); err != nil {
+		if !strings.Contains(err.Error(), "already exists") {
+			t.Fatalf("re-init after forged missing 0067 bookkeeping row failed, but not with the expected Error 1105 \"already exists\" shape — want the same failure TestProtocol_V2_DesignatedMigratorOverride hits: %v", err)
+		}
+		t.Fatalf("re-init after forged missing 0067 bookkeeping row (this is the designated-migrator replay bug, be-xrl84): %v", err)
+	}
+	assertSchemaVersionAtLeast(ctx, t, db, latest)
+}

--- a/internal/storage/dolt/initschema_0067_versioned_beads_replay_test.go
+++ b/internal/storage/dolt/initschema_0067_versioned_beads_replay_test.go
@@ -28,13 +28,14 @@ import (
 // dies with Error 1105 ("table with name issue_versions already exists");
 // once that's guarded, CREATE TABLE store_epoch would die the same way, and
 // once both are guarded, ALTER TABLE issues ADD COLUMN current_revision would
-// die on a duplicate-column error. Editing the shipped, content-hashed 0067
-// SQL bytes is constrained the same way 0040/0041 were (see
-// TestSchemaInitRecoversFromPartialNonlocalMigration above): CREATE TABLE IF
-// NOT EXISTS is safe, ordinary MySQL-flavored DDL, but MySQL (which Dolt
-// follows) has no ADD COLUMN IF NOT EXISTS — that is a MariaDB-only extension
-// — so the column guard must come from elsewhere in the runtime migration
-// path, not from the frozen file text itself.
+// die on a duplicate-column error. All four guards now live in the frozen
+// file itself: CREATE TABLE IF NOT EXISTS for the tables, and an
+// INFORMATION_SCHEMA-probed PREPARE for each plane's ADD COLUMN (MySQL, which
+// Dolt follows, has no ADD COLUMN IF NOT EXISTS — that is a MariaDB-only
+// extension). Keeping the guard in the SQL rather than in the Go runtime path
+// is what makes the file idempotent for callers that execute its bytes
+// directly, which is the shape
+// TestPR4107Migration0067ReplaysIdempotentlyAsRawSQL exercises.
 func TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing(t *testing.T) {
 	skipIfNoDolt(t)
 	acquireTestSlot()
@@ -90,11 +91,11 @@ func TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing(t *testing.T) {
 	}
 
 	// 3. Re-init replays migration 67 against a database that already has its
-	//    tables and column. RED (pre-fix): dies on Error 1105, "table with
+	//    tables and columns. RED (pre-fix): dies on Error 1105, "table with
 	//    name issue_versions already exists" — the same failure
 	//    TestProtocol_V2_DesignatedMigratorOverride hits at the full
 	//    bd-binary integration level. GREEN (post-fix): CREATE TABLE IF NOT
-	//    EXISTS plus the ADD COLUMN idempotency guard make the replay a clean
+	//    EXISTS plus the two guarded ADD COLUMNs make the replay a clean
 	//    no-op, and the chain reaches latest again.
 	if _, err := initSchemaOnDB(ctx, db); err != nil {
 		if !strings.Contains(err.Error(), "already exists") {
@@ -103,4 +104,90 @@ func TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing(t *testing.T) {
 		t.Fatalf("re-init after forged missing 0067 bookkeeping row (this is the designated-migrator replay bug, be-xrl84): %v", err)
 	}
 	assertSchemaVersionAtLeast(ctx, t, db, latest)
+}
+
+// TestMigration0067ReplaysIdempotentlyAsRawSQLThroughPR4107Harness is the
+// raw-SQL half of the same guarantee, and the half no Go-side guard can
+// provide.
+//
+// pr4107_corruption_test.go's runMigrationSQLFilesFrom re-executes the frozen
+// .up.sql bytes from 0046 onward straight through the driver, against a store
+// setupTestStore has already migrated to latest. Nothing in
+// internal/storage/schema is in that path — not execMigrationBody, not any
+// filename-keyed override — so every migration >= 0046 has to be idempotent
+// as raw SQL on its own. 0067's two ADD COLUMNs are guarded on
+// INFORMATION_SCHEMA for exactly this, and this test is the proof, run
+// through that harness rather than a hand-written double-apply: the same call
+// TestPR4107IssueIsBlockedMigrationMatchesRuntimeMixedGraphSemantics makes,
+// made twice.
+//
+// It also pins that the guard NO-OPS rather than re-applies: a column whose
+// replay silently dropped and re-added it would pass a mere "the column
+// exists" check while resetting every row to the DEFAULT. Phase 1 writes no
+// revisions, so the seeded value below is the only way to see that
+// difference from here.
+func TestMigration0067ReplaysIdempotentlyAsRawSQLThroughPR4107Harness(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mig0067-replay-subject")
+	if _, err := store.db.ExecContext(ctx,
+		"UPDATE issues SET current_revision = 42 WHERE id = 'mig0067-replay-subject'"); err != nil {
+		t.Fatalf("seed current_revision: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO issue_versions (issue_id, revision, epoch, change_at)
+		VALUES ('mig0067-replay-subject', 42, 1, '2026-09-05 00:00:00')`); err != nil {
+		t.Fatalf("seed issue_versions row: %v", err)
+	}
+
+	for pass := 1; pass <= 2; pass++ {
+		runMigrationSQLFilesFrom(t, ctx, store, "../schema/migrations", 46)
+
+		for _, table := range []string{"issues", "wisps"} {
+			if got := countColumn(t, ctx, store, table, "current_revision"); got != 1 {
+				t.Fatalf("pass %d: %s.current_revision column count = %d, want exactly 1", pass, table, got)
+			}
+		}
+
+		var revision int64
+		if err := store.db.QueryRowContext(ctx,
+			"SELECT current_revision FROM issues WHERE id = 'mig0067-replay-subject'").Scan(&revision); err != nil {
+			t.Fatalf("pass %d: read back current_revision: %v", pass, err)
+		}
+		if revision != 42 {
+			t.Fatalf("pass %d: issues.current_revision = %d, want the seeded 42 — the replay re-applied the ADD COLUMN instead of no-opping", pass, revision)
+		}
+
+		var versionRows int
+		if err := store.db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM issue_versions WHERE issue_id = 'mig0067-replay-subject'").Scan(&versionRows); err != nil {
+			t.Fatalf("pass %d: count issue_versions: %v", pass, err)
+		}
+		if versionRows != 1 {
+			t.Fatalf("pass %d: issue_versions row count = %d, want 1 — CREATE TABLE IF NOT EXISTS must not recreate the table", pass, versionRows)
+		}
+
+		if got := countColumn(t, ctx, store, "store_epoch", "epoch"); got != 1 {
+			t.Fatalf("pass %d: store_epoch.epoch column count = %d, want 1", pass, got)
+		}
+	}
+}
+
+// countColumn returns how many INFORMATION_SCHEMA.COLUMNS rows table.column
+// has in the current database — 0 or 1 in practice, and the assertion that
+// distinguishes "the guard held" from "the replay added a second one".
+func countColumn(t *testing.T, ctx context.Context, store *DoltStore, table, column string) int {
+	t.Helper()
+	var n int
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+		table, column).Scan(&n); err != nil {
+		t.Fatalf("count %s.%s: %v", table, column, err)
+	}
+	return n
 }

--- a/internal/storage/dolt/initschema_0067_versioned_beads_replay_test.go
+++ b/internal/storage/dolt/initschema_0067_versioned_beads_replay_test.go
@@ -139,8 +139,8 @@ func TestMigration0067ReplaysIdempotentlyAsRawSQLThroughPR4107Harness(t *testing
 		t.Fatalf("seed current_revision: %v", err)
 	}
 	if _, err := store.db.ExecContext(ctx, `
-		INSERT INTO issue_versions (issue_id, revision, epoch, change_at)
-		VALUES ('mig0067-replay-subject', 42, 1, '2026-09-05 00:00:00')`); err != nil {
+		INSERT INTO issue_versions (issue_id, revision, epoch, change_at, attribution_status)
+		VALUES ('mig0067-replay-subject', 42, 1, '2026-09-05 00:00:00', 'undetermined')`); err != nil {
 		t.Fatalf("seed issue_versions row: %v", err)
 	}
 

--- a/internal/storage/dolt/retention_epoch_contract_test.go
+++ b/internal/storage/dolt/retention_epoch_contract_test.go
@@ -1,0 +1,72 @@
+package dolt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+)
+
+// TestRetentionContract wires this leg into the R20 retention contract.
+// Phase 0 leaves every hook nil in every backend's fixture kit (architecture
+// §12), so each case below skips by name; this file exists so
+// TestEveryLegWiresEveryRoleContract counts this leg, and so the cases start
+// running for real the moment this leg's fixture kit grows a non-nil hook.
+func TestRetentionContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := conformance.RetentionFixture{IssuePrefix: "rete"}
+
+	t.Run("RemovalLeavesTheAddressAbleToAnswer", func(t *testing.T) {
+		conformance.RunRemovalLeavesTheAddressAbleToAnswer(t, ctx, fixture)
+	})
+	t.Run("RemovalReasonIsRetentionErasureOrReorganizationDistinctly", func(t *testing.T) {
+		conformance.RunRemovalReasonIsRetentionErasureOrReorganizationDistinctly(t, ctx, fixture)
+	})
+	t.Run("RemovalReportsTheSurvivingRetainedWindow", func(t *testing.T) {
+		conformance.RunRemovalReportsTheSurvivingRetainedWindow(t, ctx, fixture)
+	})
+	t.Run("RemovalNeverReassignsASurvivingAddress", func(t *testing.T) {
+		conformance.RunRemovalNeverReassignsASurvivingAddress(t, ctx, fixture)
+	})
+	t.Run("GoneIsDistinguishableFromUnknown", func(t *testing.T) {
+		conformance.RunGoneIsDistinguishableFromUnknown(t, ctx, fixture)
+	})
+	t.Run("AnAddressNeverResolvesToADifferentState", func(t *testing.T) {
+		conformance.RunAnAddressNeverResolvesToADifferentState(t, ctx, fixture)
+	})
+	t.Run("ADestructiveOperationEnumeratesAffectedAddressesFirst", func(t *testing.T) {
+		conformance.RunADestructiveOperationEnumeratesAffectedAddressesFirst(t, ctx, fixture)
+	})
+	t.Run("AHoldPreventsRemovalAndReportsInRetainedBounds", func(t *testing.T) {
+		conformance.RunAHoldPreventsRemovalAndReportsInRetainedBounds(t, ctx, fixture)
+	})
+	t.Run("ForcingAHeldRemovalRecordsWhoWhenWhy", func(t *testing.T) {
+		conformance.RunForcingAHeldRemovalRecordsWhoWhenWhy(t, ctx, fixture)
+	})
+	t.Run("EveryRetentionAnswerNamesItsProducingStore", func(t *testing.T) {
+		conformance.RunEveryRetentionAnswerNamesItsProducingStore(t, ctx, fixture)
+	})
+	t.Run("AStoreWithNoLineageKnowledgeAnswersUnknownNotGone", func(t *testing.T) {
+		conformance.RunAStoreWithNoLineageKnowledgeAnswersUnknownNotGone(t, ctx, fixture)
+	})
+	t.Run("AStoreThatRemovesStateStillAnswersGoneDurably", func(t *testing.T) {
+		conformance.RunAStoreThatRemovesStateStillAnswersGoneDurably(t, ctx, fixture)
+	})
+	t.Run("ErasureMintsACorrectedVersionRatherThanEditingInPlace", func(t *testing.T) {
+		conformance.RunErasureMintsACorrectedVersionRatherThanEditingInPlace(t, ctx, fixture)
+	})
+}
+
+// TestEpochContract wires this leg into the R20 epoch contract. Same Phase 0
+// all-nil state as TestRetentionContract above.
+func TestEpochContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := conformance.EpochFixture{IssuePrefix: "epch"}
+
+	t.Run("AnEpochBumpIsTriggeredOnlyByRestoreReinitOrSchemeChange", func(t *testing.T) {
+		conformance.RunAnEpochBumpIsTriggeredOnlyByRestoreReinitOrSchemeChange(t, ctx, fixture)
+	})
+	t.Run("EpochBumpVoidsOnlyAddressesOfVersionsNoLongerServed", func(t *testing.T) {
+		conformance.RunEpochBumpVoidsOnlyAddressesOfVersionsNoLongerServed(t, ctx, fixture)
+	})
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -306,6 +306,7 @@ var _ storage.Compactor = (*DoltStore)(nil)
 var _ storage.SchemaMigrator = (*DoltStore)(nil)
 var _ storage.ExternalRefHistoryQuerier = (*DoltStore)(nil)
 var _ storage.EventsJournalConfigurer = (*DoltStore)(nil)
+var _ storage.VersionedHistoryConfigurer = (*DoltStore)(nil)
 
 // DoltStore implements the Storage interface using Dolt
 type DoltStore struct {
@@ -317,12 +318,16 @@ type DoltStore struct {
 	// eventsJournalEnabled activates the durable events journal for THIS store
 	// instance only (storage.EventsJournalConfigurer); never process-global.
 	eventsJournalEnabled atomic.Bool
-	connStr              string       // Connection string for reconnection
-	cfg                  *Config      // Config this store was opened with (rebuildPoolAfterMigration)
-	serverEndpoint       string       // Exact endpoint bound to bootstrap reset authority
-	mu                   sync.RWMutex // Protects concurrent access
-	readOnly             bool         // True if opened in read-only mode
-	credentialKey        []byte       // Random encryption key for federation credentials
+	// versionedHistoryEnabled activates dual-write issue-version history for
+	// THIS store instance only (storage.VersionedHistoryConfigurer); never
+	// process-global.
+	versionedHistoryEnabled atomic.Bool
+	connStr                 string       // Connection string for reconnection
+	cfg                     *Config      // Config this store was opened with (rebuildPoolAfterMigration)
+	serverEndpoint          string       // Exact endpoint bound to bootstrap reset authority
+	mu                      sync.RWMutex // Protects concurrent access
+	readOnly                bool         // True if opened in read-only mode
+	credentialKey           []byte       // Random encryption key for federation credentials
 
 	// localActiveDatabaseDir is the exact active database directory when this
 	// store instance has authoritative local filesystem access. It is resolved
@@ -1201,6 +1206,8 @@ func (s *DoltStore) withWriteTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 	}
 	clearJournalScope := s.scopeEventsJournalTransaction(tx)
 	defer clearJournalScope()
+	clearVersionScope := s.scopeVersionedHistoryTransaction(tx)
+	defer clearVersionScope()
 	if err := fn(tx); err != nil {
 		return errors.Join(err, tx.Rollback())
 	}
@@ -1217,6 +1224,16 @@ func (s *DoltStore) SetEventsJournalEnabled(enabled bool) {
 
 func (s *DoltStore) scopeEventsJournalTransaction(tx *sql.Tx) func() {
 	return issueops.ScopeEventsJournalTransaction(tx, s.eventsJournalEnabled.Load())
+}
+
+// SetVersionedHistoryEnabled activates dual-write issue-version history for
+// this store instance only.
+func (s *DoltStore) SetVersionedHistoryEnabled(enabled bool) {
+	s.versionedHistoryEnabled.Store(enabled)
+}
+
+func (s *DoltStore) scopeVersionedHistoryTransaction(tx *sql.Tx) func() {
+	return issueops.ScopeVersionedHistoryTransaction(tx, s.versionedHistoryEnabled.Load())
 }
 
 func (s *DoltStore) commitSQLTx(ctx context.Context, op string, tx *sql.Tx) error {

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -81,7 +81,10 @@ func (r *issueSQLRepositoryImpl) Insert(ctx context.Context, issue *types.Issue,
 		}, domain.RecordEventOpts{UseWispsTable: opts.UseWispsTable}); err != nil {
 			return err
 		}
-		return issueops.RecordEventInTx(ctx, r.runner, issueops.EventCreate, issue.ID, actor)
+		if err := issueops.RecordEventInTx(ctx, r.runner, issueops.EventCreate, issue.ID, actor); err != nil {
+			return err
+		}
+		return issueops.RecordVersionInTx(ctx, r.runner, issue.ID, actor)
 	}
 	if err := insertIssueRow(ctx, r.runner, table, issue); err != nil {
 		return err
@@ -93,7 +96,10 @@ func (r *issueSQLRepositoryImpl) Insert(ctx context.Context, issue *types.Issue,
 	}, domain.RecordEventOpts{UseWispsTable: opts.UseWispsTable}); err != nil {
 		return err
 	}
-	return issueops.RecordEventInTx(ctx, r.runner, issueops.EventCreate, issue.ID, actor)
+	if err := issueops.RecordEventInTx(ctx, r.runner, issueops.EventCreate, issue.ID, actor); err != nil {
+		return err
+	}
+	return issueops.RecordVersionInTx(ctx, r.runner, issue.ID, actor)
 }
 
 func (r *issueSQLRepositoryImpl) InsertBatch(ctx context.Context, issues []*types.Issue, actor string, opts domain.InsertIssueOpts) error {
@@ -327,7 +333,10 @@ func (r *issueSQLRepositoryImpl) Update(ctx context.Context, id string, updates 
 	}
 	// Snapshot only after all derived blocked-state maintenance has completed.
 	// The no-op early returns above wrote nothing and journal nothing.
-	return issueops.RecordEventInTx(ctx, r.runner, issueops.EventUpdate, id, actor)
+	if err := issueops.RecordEventInTx(ctx, r.runner, issueops.EventUpdate, id, actor); err != nil {
+		return err
+	}
+	return issueops.RecordVersionInTx(ctx, r.runner, id, actor)
 }
 
 // CompareAndSetMetadataKey runs the SHARED compare-and-set body, unwrapped.

--- a/internal/storage/embeddeddolt/cross_record_invariant_contract_test.go
+++ b/internal/storage/embeddeddolt/cross_record_invariant_contract_test.go
@@ -1,0 +1,43 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+)
+
+// TestCrossRecordInvariantContract wires this leg into the R16.1
+// cross-record invariant contract. Phase 0 leaves every hook nil in every
+// backend's fixture kit (architecture §12), so each case below skips by
+// name; this file exists so TestEveryLegWiresEveryRoleContract counts this
+// leg, and so the cases start running for real the moment this leg's fixture
+// kit grows a non-nil hook.
+func TestCrossRecordInvariantContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := conformance.CrossRecordInvariantFixture{IssuePrefix: "xrec"}
+
+	t.Run("SurvivesTwoPassingPerRecordGuards", func(t *testing.T) {
+		conformance.RunCrossRecordInvariantSurvivesTwoPassingPerRecordGuards(t, ctx, fixture)
+	})
+	t.Run("StoreInvariantTransactionScopesExactlyTheSpanningRecords", func(t *testing.T) {
+		conformance.RunStoreInvariantTransactionScopesExactlyTheSpanningRecords(t, ctx, fixture)
+	})
+	t.Run("InvariantRefusalNamesTheViolatedInvariant", func(t *testing.T) {
+		conformance.RunInvariantRefusalNamesTheViolatedInvariant(t, ctx, fixture)
+	})
+	t.Run("MemoryKeyAliasUniquenessIsAStoreInvariantNotACAS", func(t *testing.T) {
+		conformance.RunMemoryKeyAliasUniquenessIsAStoreInvariantNotACAS(t, ctx, fixture)
+	})
+	t.Run("MaximumEndpointMultiplicityIsAStoreInvariantNotACAS", func(t *testing.T) {
+		conformance.RunMaximumEndpointMultiplicityIsAStoreInvariantNotACAS(t, ctx, fixture)
+	})
+	t.Run("AdvisoryLeaseAloneDoesNotPreventTheInvariantViolation", func(t *testing.T) {
+		conformance.RunAdvisoryLeaseAloneDoesNotPreventTheInvariantViolation(t, ctx, fixture)
+	})
+	t.Run("LeaseAcquisitionRecordsNoHistoryEntry", func(t *testing.T) {
+		conformance.RunLeaseAcquisitionRecordsNoHistoryEntry(t, ctx, fixture)
+	})
+}

--- a/internal/storage/embeddeddolt/dependency_editor_version_history_test.go
+++ b/internal/storage/embeddeddolt/dependency_editor_version_history_test.go
@@ -1,0 +1,113 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// TestEmbeddedDependencyEditorVersionsOnlyARealAddOrRemove is the FOURTH
+// ADDENDUM's own no-op-detection clause (design bead be-0uifx): the
+// dependency editor is the one RecordVersionInTx caller not already
+// short-circuited by DiscardNoopIssueUpdates, so it must draw its own R3
+// exemption from the eventWritten signal AddDependencyInTx/
+// RemoveDependencyInTx already return. This is an ENGINE CHECK on the shared
+// internal/storage/issueops call sites (addDependencyEdgeInTx,
+// ExecuteRemoveDependency) rather than a per-backend vote — see
+// TestDualWriteContract's own doc comment for why one leg is proof for all
+// three here, since dolt and uow route through the identical issueops
+// functions.
+//
+// It asserts by DELTA against the source issue's own version-row count
+// rather than an absolute value, so it stays correct regardless of how many
+// rows the two CreateIssue seeds above it already minted.
+func TestEmbeddedDependencyEditorVersionsOnlyARealAddOrRemove(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "depver")
+	ctx := t.Context()
+
+	configurer, ok := any(te.store).(storage.VersionedHistoryConfigurer)
+	if !ok {
+		t.Fatalf("%T does not implement storage.VersionedHistoryConfigurer", te.store)
+	}
+	configurer.SetVersionedHistoryEnabled(true)
+
+	kit := newEmbeddedRoleFixtureKit(te, "depver")
+	source := kit.IssuePrefix + "-src"
+	target := kit.IssuePrefix + "-tgt"
+	for _, id := range []string{source, target} {
+		if err := kit.CreateIssue(ctx, &types.Issue{
+			ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask,
+		}, "seed"); err != nil {
+			t.Fatalf("CreateIssue(%s): %v", id, err)
+		}
+	}
+
+	editor, err := te.store.DependencyEditor()
+	if err != nil {
+		t.Fatalf("DependencyEditor(): %v", err)
+	}
+
+	versionRowCount := func(id string) int {
+		t.Helper()
+		var count int
+		if err := kit.QueryScalar(ctx, "SELECT COUNT(*) FROM issue_versions WHERE issue_id = ?", []any{id}, &count); err != nil {
+			t.Fatalf("QueryScalar(issue_versions count for %s): %v", id, err)
+		}
+		return count
+	}
+
+	sourceBefore := versionRowCount(source)
+	targetBefore := versionRowCount(target)
+
+	if _, err := editor.AddDependencies(ctx, issueops.AddDependenciesRequest{
+		Actor: "actor",
+		Edges: []issueops.DependencyEdge{{IssueID: source, DependsOnID: target, Type: issueops.DepBlocks}},
+	}); err != nil {
+		t.Fatalf("AddDependencies (real add): %v", err)
+	}
+	afterAdd := versionRowCount(source)
+	if afterAdd != sourceBefore+1 {
+		t.Fatalf("real add: source version rows = %d, want %d (before %d)", afterAdd, sourceBefore+1, sourceBefore)
+	}
+	if got := versionRowCount(target); got != targetBefore {
+		t.Fatalf("real add: target (non-referencing side) version rows = %d, want unchanged %d", got, targetBefore)
+	}
+
+	// Idempotent same-type re-add: AddDependencyInTx reports eventWritten
+	// false, so this must not mint a second row (R3).
+	if _, err := editor.AddDependencies(ctx, issueops.AddDependenciesRequest{
+		Actor: "actor",
+		Edges: []issueops.DependencyEdge{{IssueID: source, DependsOnID: target, Type: issueops.DepBlocks}},
+	}); err != nil {
+		t.Fatalf("AddDependencies (idempotent re-add): %v", err)
+	}
+	if got := versionRowCount(source); got != afterAdd {
+		t.Fatalf("idempotent re-add: source version rows = %d, want unchanged %d", got, afterAdd)
+	}
+
+	if _, err := editor.RemoveDependency(ctx, issueops.RemoveDependencyRequest{
+		Actor: "actor", IssueID: source, DependsOnID: target,
+	}); err != nil {
+		t.Fatalf("RemoveDependency (real remove): %v", err)
+	}
+	afterRemove := versionRowCount(source)
+	if afterRemove != afterAdd+1 {
+		t.Fatalf("real remove: source version rows = %d, want %d", afterRemove, afterAdd+1)
+	}
+
+	// Absent edge: RemoveDependencyInTx reports eventWritten false and
+	// Removed false, so this must not mint a third row (R3).
+	if _, err := editor.RemoveDependency(ctx, issueops.RemoveDependencyRequest{
+		Actor: "actor", IssueID: source, DependsOnID: target,
+	}); err != nil {
+		t.Fatalf("RemoveDependency (already-absent): %v", err)
+	}
+	if got := versionRowCount(source); got != afterRemove {
+		t.Fatalf("absent remove: source version rows = %d, want unchanged %d", got, afterRemove)
+	}
+}

--- a/internal/storage/embeddeddolt/dualwrite_history_contract_test.go
+++ b/internal/storage/embeddeddolt/dualwrite_history_contract_test.go
@@ -1,0 +1,133 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestDualWriteContract runs the dual-write history contract against the
+// embedded store, which reaches issueops mutation entrypoints through its own
+// per-operation connection. All three legs share RecordVersionInTx's one
+// body, so this is an ENGINE CHECK rather than an independent vote — what it
+// can actually catch here is a wrapper that loses the transaction the
+// version row must land in, or a backend that stops implementing the seam
+// at all.
+func TestDualWriteContract(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "dwc")
+	ctx := t.Context()
+	fixture := newEmbeddedDualWriteFixture(t, te, "dwc", true)
+
+	t.Run("MintsOneVersionRowPerAcceptedMutation", func(t *testing.T) {
+		conformance.RunDualWriteMintsOneVersionRowPerAcceptedMutation(t, ctx, fixture)
+	})
+	t.Run("NoOpMutationMintsNoRow", func(t *testing.T) {
+		conformance.RunDualWriteNoOpMutationMintsNoRow(t, ctx, fixture)
+	})
+	t.Run("AttributionIsRecordedWithTheMutation", func(t *testing.T) {
+		conformance.RunDualWriteAttributionIsRecordedWithTheMutation(t, ctx, fixture)
+	})
+	t.Run("CurrentRevisionMatchesTheNewVersionRow", func(t *testing.T) {
+		conformance.RunDualWriteCurrentRevisionMatchesTheNewVersionRow(t, ctx, fixture)
+	})
+	t.Run("NoOpMutationLeavesThePriorVersionRowUnperturbed", func(t *testing.T) {
+		conformance.RunDualWriteNoOpMutationLeavesThePriorVersionRowUnperturbed(t, ctx, fixture)
+	})
+}
+
+// TestDualWriteContractFlagOff runs FR-7 against an environment constructed
+// with the flag OFF from the start — its own environment, not a shared one,
+// so "flag off" means what FR-7 promises rather than "not yet turned on this
+// session".
+func TestDualWriteContractFlagOff(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "dwcoff")
+	ctx := t.Context()
+	fixture := newEmbeddedDualWriteFixture(t, te, "dwcoff", false)
+
+	t.Run("FlagOffProducesNoVersionRows", func(t *testing.T) {
+		conformance.RunDualWriteFlagOffProducesNoVersionRows(t, ctx, fixture)
+	})
+}
+
+// TestDualWriteFixtureKitIsWired is this leg's half of the explicit per-leg
+// guardrail design §8.5 calls for in place of AST auto-discovery — see the
+// dolt leg's TestDualWriteFixtureKitIsWired for why the guardrail is needed
+// even though TestEveryLegWiresEveryRoleContract's scan already enumerates
+// and confirms wiring for all six RunDualWriteXxx entrypoints.
+func TestDualWriteFixtureKitIsWired(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "dwk")
+	fixture := newEmbeddedDualWriteFixture(t, te, "dwk", true)
+
+	if fixture.Mutate == nil {
+		t.Error("DualWriteFixture.Mutate is nil")
+	}
+	if fixture.MutateAsNoOp == nil {
+		t.Error("DualWriteFixture.MutateAsNoOp is nil")
+	}
+	if fixture.CurrentRevision == nil {
+		t.Error("DualWriteFixture.CurrentRevision is nil")
+	}
+	if fixture.VersionRowCount == nil {
+		t.Error("DualWriteFixture.VersionRowCount is nil")
+	}
+	if fixture.LatestVersionAttribution == nil {
+		t.Error("DualWriteFixture.LatestVersionAttribution is nil")
+	}
+}
+
+func newEmbeddedDualWriteFixture(t *testing.T, te *testEnv, prefix string, enabled bool) conformance.DualWriteFixture {
+	t.Helper()
+	store := te.store
+	// Through the type assertion `bd serve` makes, never the concrete method
+	// set: dual-write history is not on storage.DoltStorage, so publishing it
+	// IS implementing this interface, matching newEmbeddedJournalFixture's own
+	// discipline for storage.EventsJournalCursor above.
+	configurer, ok := any(store).(storage.VersionedHistoryConfigurer)
+	if !ok {
+		t.Fatalf("%T does not implement storage.VersionedHistoryConfigurer", store)
+	}
+	configurer.SetVersionedHistoryEnabled(enabled)
+
+	kit := newEmbeddedRoleFixtureKit(te, prefix)
+	return conformance.DualWriteFixture{
+		IssuePrefix: prefix,
+		Mutate: func(ctx context.Context, id string) error {
+			return store.CreateIssue(ctx, &types.Issue{
+				ID: id, Title: "t-" + id, IssueType: types.TypeTask, Status: types.StatusOpen,
+			}, "actor")
+		},
+		MutateAsNoOp: func(ctx context.Context, id string) error {
+			// Re-sets title to the exact value Mutate already gave it, so
+			// issueops.DiscardNoopIssueUpdates discards it before it ever
+			// reaches RecordVersionInTx.
+			return store.UpdateIssue(ctx, id, map[string]any{"title": "t-" + id}, "actor")
+		},
+		CurrentRevision: func(ctx context.Context, id string) (int64, error) {
+			var revision int64
+			err := kit.QueryScalar(ctx, "SELECT current_revision FROM issues WHERE id = ?", []any{id}, &revision)
+			return revision, err
+		},
+		VersionRowCount: func(ctx context.Context, id string) (int, error) {
+			var count int
+			err := kit.QueryScalar(ctx, "SELECT COUNT(*) FROM issue_versions WHERE issue_id = ?", []any{id}, &count)
+			return count, err
+		},
+		LatestVersionAttribution: func(ctx context.Context, id string) (actor, agent, message string, err error) {
+			err = kit.QueryScalar(ctx, `
+				SELECT COALESCE(change_actor, ''), COALESCE(change_agent, ''), COALESCE(change_message, '')
+				FROM issue_versions
+				WHERE issue_id = ?
+				ORDER BY revision DESC
+				LIMIT 1`, []any{id}, &actor, &agent, &message)
+			return actor, agent, message, err
+		},
+	}
+}

--- a/internal/storage/embeddeddolt/expected_revision_contract_test.go
+++ b/internal/storage/embeddeddolt/expected_revision_contract_test.go
@@ -1,0 +1,52 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+)
+
+// TestExpectedRevisionContract wires this leg into the R16/R17
+// expected-revision contract. Phase 0 leaves every hook nil in every
+// backend's fixture kit (architecture §12), so each case below skips by
+// name; this file exists so TestEveryLegWiresEveryRoleContract counts this
+// leg, and so the cases start running for real the moment this leg's fixture
+// kit grows a non-nil hook.
+func TestExpectedRevisionContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := conformance.ExpectedRevisionFixture{IssuePrefix: "erev"}
+
+	t.Run("AcceptsAWriteNamingTheCurrentVersion", func(t *testing.T) {
+		conformance.RunExpectedRevisionAcceptsAWriteNamingTheCurrentVersion(t, ctx, fixture)
+	})
+	t.Run("AcceptsAWriteNamingNoVersion", func(t *testing.T) {
+		conformance.RunExpectedRevisionAcceptsAWriteNamingNoVersion(t, ctx, fixture)
+	})
+	t.Run("CoversFieldsOutsideAnyWatchedSubset", func(t *testing.T) {
+		conformance.RunExpectedRevisionCoversFieldsOutsideAnyWatchedSubset(t, ctx, fixture)
+	})
+	t.Run("RefusalReportsTheRefusingVersionAddress", func(t *testing.T) {
+		conformance.RunRefusalReportsTheRefusingVersionAddress(t, ctx, fixture)
+	})
+	t.Run("RefusalReportsTheRefusingVersionsChangeAttribution", func(t *testing.T) {
+		conformance.RunRefusalReportsTheRefusingVersionsChangeAttribution(t, ctx, fixture)
+	})
+	t.Run("RefusalIsATypedOutcomeNotAGenericError", func(t *testing.T) {
+		conformance.RunRefusalIsATypedOutcomeNotAGenericError(t, ctx, fixture)
+	})
+	t.Run("RefusalIsDistinguishableFromAnAcceptedWrite", func(t *testing.T) {
+		conformance.RunRefusalIsDistinguishableFromAnAcceptedWrite(t, ctx, fixture)
+	})
+	t.Run("RefusalIsDistinguishableFromNotFound", func(t *testing.T) {
+		conformance.RunRefusalIsDistinguishableFromNotFound(t, ctx, fixture)
+	})
+	t.Run("RefusalIsDistinguishableFromValidationFailure", func(t *testing.T) {
+		conformance.RunRefusalIsDistinguishableFromValidationFailure(t, ctx, fixture)
+	})
+	t.Run("RefusalNeverSilentlyPicksAWinner", func(t *testing.T) {
+		conformance.RunRefusalNeverSilentlyPicksAWinner(t, ctx, fixture)
+	})
+}

--- a/internal/storage/embeddeddolt/retention_epoch_contract_test.go
+++ b/internal/storage/embeddeddolt/retention_epoch_contract_test.go
@@ -1,0 +1,74 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+)
+
+// TestRetentionContract wires this leg into the R20 retention contract.
+// Phase 0 leaves every hook nil in every backend's fixture kit (architecture
+// §12), so each case below skips by name; this file exists so
+// TestEveryLegWiresEveryRoleContract counts this leg, and so the cases start
+// running for real the moment this leg's fixture kit grows a non-nil hook.
+func TestRetentionContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := conformance.RetentionFixture{IssuePrefix: "rete"}
+
+	t.Run("RemovalLeavesTheAddressAbleToAnswer", func(t *testing.T) {
+		conformance.RunRemovalLeavesTheAddressAbleToAnswer(t, ctx, fixture)
+	})
+	t.Run("RemovalReasonIsRetentionErasureOrReorganizationDistinctly", func(t *testing.T) {
+		conformance.RunRemovalReasonIsRetentionErasureOrReorganizationDistinctly(t, ctx, fixture)
+	})
+	t.Run("RemovalReportsTheSurvivingRetainedWindow", func(t *testing.T) {
+		conformance.RunRemovalReportsTheSurvivingRetainedWindow(t, ctx, fixture)
+	})
+	t.Run("RemovalNeverReassignsASurvivingAddress", func(t *testing.T) {
+		conformance.RunRemovalNeverReassignsASurvivingAddress(t, ctx, fixture)
+	})
+	t.Run("GoneIsDistinguishableFromUnknown", func(t *testing.T) {
+		conformance.RunGoneIsDistinguishableFromUnknown(t, ctx, fixture)
+	})
+	t.Run("AnAddressNeverResolvesToADifferentState", func(t *testing.T) {
+		conformance.RunAnAddressNeverResolvesToADifferentState(t, ctx, fixture)
+	})
+	t.Run("ADestructiveOperationEnumeratesAffectedAddressesFirst", func(t *testing.T) {
+		conformance.RunADestructiveOperationEnumeratesAffectedAddressesFirst(t, ctx, fixture)
+	})
+	t.Run("AHoldPreventsRemovalAndReportsInRetainedBounds", func(t *testing.T) {
+		conformance.RunAHoldPreventsRemovalAndReportsInRetainedBounds(t, ctx, fixture)
+	})
+	t.Run("ForcingAHeldRemovalRecordsWhoWhenWhy", func(t *testing.T) {
+		conformance.RunForcingAHeldRemovalRecordsWhoWhenWhy(t, ctx, fixture)
+	})
+	t.Run("EveryRetentionAnswerNamesItsProducingStore", func(t *testing.T) {
+		conformance.RunEveryRetentionAnswerNamesItsProducingStore(t, ctx, fixture)
+	})
+	t.Run("AStoreWithNoLineageKnowledgeAnswersUnknownNotGone", func(t *testing.T) {
+		conformance.RunAStoreWithNoLineageKnowledgeAnswersUnknownNotGone(t, ctx, fixture)
+	})
+	t.Run("AStoreThatRemovesStateStillAnswersGoneDurably", func(t *testing.T) {
+		conformance.RunAStoreThatRemovesStateStillAnswersGoneDurably(t, ctx, fixture)
+	})
+	t.Run("ErasureMintsACorrectedVersionRatherThanEditingInPlace", func(t *testing.T) {
+		conformance.RunErasureMintsACorrectedVersionRatherThanEditingInPlace(t, ctx, fixture)
+	})
+}
+
+// TestEpochContract wires this leg into the R20 epoch contract. Same Phase 0
+// all-nil state as TestRetentionContract above.
+func TestEpochContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := conformance.EpochFixture{IssuePrefix: "epch"}
+
+	t.Run("AnEpochBumpIsTriggeredOnlyByRestoreReinitOrSchemeChange", func(t *testing.T) {
+		conformance.RunAnEpochBumpIsTriggeredOnlyByRestoreReinitOrSchemeChange(t, ctx, fixture)
+	})
+	t.Run("EpochBumpVoidsOnlyAddressesOfVersionsNoLongerServed", func(t *testing.T) {
+		conformance.RunEpochBumpVoidsOnlyAddressesOfVersionsNoLongerServed(t, ctx, fixture)
+	})
+}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -31,6 +31,7 @@ var _ storage.Flattener = (*EmbeddedDoltStore)(nil)
 var _ storage.Compactor = (*EmbeddedDoltStore)(nil)
 var _ storage.SchemaMigrator = (*EmbeddedDoltStore)(nil)
 var _ storage.EventsJournalConfigurer = (*EmbeddedDoltStore)(nil)
+var _ storage.VersionedHistoryConfigurer = (*EmbeddedDoltStore)(nil)
 var _ storage.ExternalRefHistoryQuerier = (*EmbeddedDoltStore)(nil)
 
 // EmbeddedDoltStore implements storage.DoltStorage backed by the embedded Dolt engine.
@@ -51,6 +52,10 @@ type EmbeddedDoltStore struct {
 	// eventsJournalEnabled activates the durable events journal for THIS store
 	// instance only (storage.EventsJournalConfigurer); never process-global.
 	eventsJournalEnabled atomic.Bool
+	// versionedHistoryEnabled activates dual-write issue-version history for
+	// THIS store instance only (storage.VersionedHistoryConfigurer); never
+	// process-global.
+	versionedHistoryEnabled atomic.Bool
 	// readOnly marks a store opened via OpenReadOnly or
 	// OpenForPreviewCommand: open-time mutations (CREATE DATABASE, schema
 	// migrations) were skipped and write transactions are refused
@@ -244,6 +249,8 @@ func (s *EmbeddedDoltStore) withConn(ctx context.Context, commit bool, fn func(t
 	}
 	clearJournalScope := issueops.ScopeEventsJournalTransaction(tx, s.eventsJournalEnabled.Load())
 	defer clearJournalScope()
+	clearVersionScope := issueops.ScopeVersionedHistoryTransaction(tx, s.versionedHistoryEnabled.Load())
+	defer clearVersionScope()
 
 	if fnErr := fn(tx); fnErr != nil {
 		err = errors.Join(fnErr, tx.Rollback())
@@ -266,6 +273,12 @@ func (s *EmbeddedDoltStore) withConn(ctx context.Context, commit bool, fn func(t
 // SetEventsJournalEnabled activates the journal for this store instance only.
 func (s *EmbeddedDoltStore) SetEventsJournalEnabled(enabled bool) {
 	s.eventsJournalEnabled.Store(enabled)
+}
+
+// SetVersionedHistoryEnabled activates dual-write issue-version history for
+// this store instance only.
+func (s *EmbeddedDoltStore) SetVersionedHistoryEnabled(enabled bool) {
+	s.versionedHistoryEnabled.Store(enabled)
 }
 
 // commitEmbeddedTx classifies an unconfirmed SQL commit response as

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -193,6 +193,9 @@ func CreateIssueInTxWithResult(ctx context.Context, tx DBTX, bc *BatchContext, i
 	if err := RecordEventInTx(ctx, tx, EventCreate, issue.ID, actor); err != nil {
 		return result, err
 	}
+	if err := RecordVersionInTx(ctx, tx, issue.ID, actor); err != nil {
+		return result, err
+	}
 	// Creation-time comments (import/interchange carries them inline) are
 	// replayable content the create snapshot does NOT contain — issue hydration
 	// joins labels but not comments — so each inserted comment gets its own op,

--- a/internal/storage/issueops/dependency_editor.go
+++ b/internal/storage/issueops/dependency_editor.go
@@ -173,6 +173,15 @@ func addDependencyEdgeInTx(ctx context.Context, tx *sql.Tx, request publicops.Ad
 	if err != nil {
 		return nil, err
 	}
+	// Version the edge's referencing (source) issue — but only when a row was
+	// actually recorded, the same idempotent-re-add exemption eventWritten
+	// already draws for the events table just below: a duplicate add must not
+	// mint a version row any more than it mints an event.
+	if eventWritten {
+		if err := RecordVersionInTx(ctx, tx, edge.IssueID, request.Actor); err != nil {
+			return nil, err
+		}
+	}
 	// Stage the source's dependency table always and its events table only
 	// when a row was recorded — the same selective staging the stores' own
 	// AddDependencyWithOptions does, so an idempotent re-add cannot sweep
@@ -257,6 +266,11 @@ func ExecuteRemoveDependency(ctx context.Context, tx *sql.Tx, request publicops.
 	}
 	if !eventWritten {
 		return publicops.RemoveDependencyResult{Removed: false}, nil, nil
+	}
+	// An absent edge already returned above without reaching this line: only
+	// a removal that actually happened versions the referencing issue.
+	if err := RecordVersionInTx(ctx, tx, request.IssueID, request.Actor); err != nil {
+		return publicops.RemoveDependencyResult{}, nil, err
 	}
 	tables := ChangedTables{}
 	tables.Add(depTable, eventTable)

--- a/internal/storage/issueops/journal_completeness_test.go
+++ b/internal/storage/issueops/journal_completeness_test.go
@@ -136,13 +136,15 @@ var mutationEntryPoints = []string{
 
 // beadDMLExemptions are exported functions the DML detector flags as writing a
 // work-bead table but which legitimately do NOT journal, each with a reason.
-// They fall into four buckets: (1) derived child-counter maintenance; (2)
+// They fall into five buckets: (1) derived child-counter maintenance; (2)
 // aux-table writers the templated-%s heuristic can't distinguish from a bead
 // table (events, child counters); (3) constituent sub-helpers of a
 // create/rename/promote/delete whose top-level entry point journals the whole
 // mutation once; (4) compaction maintenance outside the
-// create/update/close/delete/dep/label op vocabulary. The staleness check fails
-// if any stops being flagged, so an exemption cannot rot.
+// create/update/close/delete/dep/label op vocabulary; (5) dual-write
+// version-history bookkeeping that runs after the mutation is already
+// journaled. The staleness check fails if any stops being flagged, so an
+// exemption cannot rot.
 var beadDMLExemptions = map[string]string{
 	// (1) Child counters are derived CLI acceleration state. In contrast,
 	// is_blocked is part of the exported bead snapshot and its recompute helpers
@@ -181,6 +183,18 @@ var beadDMLExemptions = map[string]string{
 	// omission is invisible to consumers.
 	"ApplyCompactionInTx":     "compaction content rewrite outside the op vocabulary; consumer mirrors of this bead go stale until its next journaled mutation (known contract gap, carried from the reference lineage)",
 	"RestoreFromSnapshotInTx": "restores a compacted issue outside the op vocabulary; consumer mirrors of this bead go stale until its next journaled mutation (known contract gap, carried from the reference lineage)",
+
+	// (5) dual-write version-history bookkeeping. RecordVersionInTx is called
+	// from inside the same mutationEntryPoints functions (CreateIssueInTx,
+	// UpdateIssueInTx, and their domain/db equivalents used by the uow leg)
+	// immediately after those callers already invoke RecordEventInTx, so the
+	// mutation itself is already journaled by the time RecordVersionInTx runs.
+	// Its own UPDATE issues SET current_revision = ? only advances a
+	// denormalized pointer to match the snapshot row it just inserted into
+	// issue_versions (not a bead table, so it can't anchor the exemption on
+	// its own) — bookkeeping for an already-journaled mutation, not a second
+	// mutation that needs its own emit.
+	"RecordVersionInTx": "advances the denormalized current_revision pointer to match a snapshot just inserted into issue_versions (not a bead table); called from the same entry points that already journal the mutation via RecordEventInTx, so this is bookkeeping for an already-journaled mutation, not a second one",
 }
 
 // journalExemptMutations are mutation paths that deliberately do NOT journal

--- a/internal/storage/issueops/row_lock_guard_test.go
+++ b/internal/storage/issueops/row_lock_guard_test.go
@@ -139,6 +139,20 @@ var funcNameExemptions = map[string]string{
 	// Reminting here would be pointless content-wise and would let a stale
 	// ExpectedVersion CAS reject a row it should still recognize.
 	"resolveOneConflictRow": "whole-row `theirs` adoption: the adopted row_lock already vouches for the (identical) adopted content",
+
+	// RecordVersionInTx (version_history.go) runs immediately after the
+	// mutation it is snapshotting — create.go/update.go's own writes, or
+	// domain/db's Insert/Update — and those callers have already minted a
+	// fresh row_lock in that same INSERT/UPDATE, in the same transaction.
+	// RecordVersionInTx's own `UPDATE issues SET current_revision = ?` only
+	// advances a denormalized pointer to the issue_versions row it just
+	// inserted; it deliberately does not touch row_lock at all (not even to
+	// carry the existing value forward) because reminting here would bump the
+	// token a second time within one transaction, invalidating the
+	// RowVersion/CAS value the primary mutation's own caller already
+	// captured and could cause a legitimate subsequent CAS check to fail as a
+	// spurious lost update.
+	"RecordVersionInTx": "runs after the primary mutation already minted a fresh row_lock in the same transaction; reminting here would double-bump the token and invalidate the RowVersion/CAS value already returned to that mutation's caller",
 }
 
 // TestAllIssueRowWritesStampRowLock is the load-bearing completeness guard for

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -544,6 +544,9 @@ func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 	if err := RecordEventInTx(ctx, tx, EventUpdate, id, actor); err != nil {
 		return nil, err
 	}
+	if err := RecordVersionInTx(ctx, tx, id, actor); err != nil {
+		return nil, err
+	}
 	return updateResult, nil
 }
 

--- a/internal/storage/issueops/version_history.go
+++ b/internal/storage/issueops/version_history.go
@@ -1,0 +1,120 @@
+package issueops
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Dual-write issue-version history records every accepted issue mutation as a
+// row in issue_versions, written in the SAME transaction as the mutation
+// itself (see internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql).
+// Activation mirrors the durable events journal (journal.go): a per-instance
+// flag (storage.VersionedHistoryConfigurer) is bound to a concrete
+// transaction via ScopeVersionedHistoryTransaction immediately after
+// BeginTx, so enabling history on one store instance cannot turn it on for
+// any other sharing the process.
+//
+// RecordVersionInTx is the single seam both direct-SQL legs (dolt,
+// embeddeddolt) and the domain/db package (used by uow) call through, from
+// inside the same already-short-circuited functions that call
+// RecordEventInTx: a mutation DiscardNoopIssueUpdates has already discarded
+// never reaches either seam. dependency_editor.go's edge add/remove is the
+// one caller that is NOT already short-circuited by that helper — it gates
+// on its own eventWritten signal instead (a duplicate add / absent remove
+// never reaches this seam either).
+
+var versionedHistoryTransactions sync.Map // map[DBTX]bool; entries live for one transaction
+
+// ScopeVersionedHistoryTransaction associates versioned-history activation
+// with one concrete transaction and returns a cleanup function. Store
+// implementations call it immediately after BeginTx, alongside (not instead
+// of) ScopeEventsJournalTransaction. This is instance/project scoped even
+// when many stores share a process; there is no process-wide activation
+// switch.
+func ScopeVersionedHistoryTransaction(tx DBTX, enabled bool) func() {
+	if tx == nil {
+		return func() {}
+	}
+	versionedHistoryTransactions.Store(tx, enabled)
+	return func() { versionedHistoryTransactions.Delete(tx) }
+}
+
+func versionedHistoryEnabled(tx DBTX) bool {
+	enabled, _ := versionedHistoryTransactions.Load(tx)
+	on, _ := enabled.(bool)
+	return on
+}
+
+// RecordVersionInTx mints one issue_versions row for issueID and advances
+// issues.current_revision to match, as of tx (read-your-writes within the
+// same transaction). A no-op when versioned history is disabled for tx, or
+// when issueID resolves to a wisp: wisps carry current_revision for shape
+// parity only and are never versioned this phase (design FR-8).
+//
+// actor is the acting identity that performed the mutation, recorded as the
+// version row's attribution — "" when the mutation path genuinely has none,
+// matching RecordEventInTx's own convention.
+func RecordVersionInTx(ctx context.Context, tx DBTX, issueID, actor string) error {
+	if !versionedHistoryEnabled(tx) {
+		return nil
+	}
+
+	issue, err := GetIssueInTx(ctx, tx, issueID)
+	if err != nil {
+		return fmt.Errorf("versioned history: snapshot %s: %w", issueID, err)
+	}
+	if IsWisp(issue) {
+		return nil
+	}
+
+	// durable_state is a verbatim marshal of the mutated issue (design §15.3,
+	// corrected by §17.1): the write-path loader GetIssueInTx never hydrates
+	// Dependencies (types.Issue.Dependencies is omitempty and unrelated to
+	// this snapshot's own read), so it is populated here, once, for every
+	// caller of this seam — in GetDependencyRecordsForIssuesInTx's own
+	// ordering (issue_id, depends_on_id, type, id).
+	deps, err := GetDependencyRecordsForIssuesInTx(ctx, tx, []string{issueID})
+	if err != nil {
+		return fmt.Errorf("versioned history: load dependencies for %s: %w", issueID, err)
+	}
+	issue.Dependencies = deps[issueID]
+
+	if _, err := tx.ExecContext(ctx, "INSERT IGNORE INTO store_epoch (id, epoch) VALUES (1, 1)"); err != nil {
+		return fmt.Errorf("versioned history: seed store epoch: %w", err)
+	}
+	var epoch int
+	if err := tx.QueryRowContext(ctx, "SELECT epoch FROM store_epoch WHERE id = 1").Scan(&epoch); err != nil {
+		return fmt.Errorf("versioned history: read store epoch: %w", err)
+	}
+
+	var newRevision int64
+	if err := tx.QueryRowContext(ctx,
+		"SELECT COALESCE(MAX(revision), 0) + 1 FROM issue_versions WHERE issue_id = ?", issueID,
+	).Scan(&newRevision); err != nil {
+		return fmt.Errorf("versioned history: compute next revision for %s: %w", issueID, err)
+	}
+
+	durableState, err := json.Marshal(issue)
+	if err != nil {
+		return fmt.Errorf("versioned history: marshal durable state for %s: %w", issueID, err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO issue_versions
+			(issue_id, revision, epoch, durable_state, change_actor, change_agent, change_message, change_at)
+		VALUES (?, ?, ?, ?, ?, NULL, NULL, ?)`,
+		issueID, newRevision, epoch, string(durableState), actor, time.Now().UTC(),
+	); err != nil {
+		return fmt.Errorf("versioned history: insert version row for %s: %w", issueID, err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		"UPDATE issues SET current_revision = ? WHERE id = ?", newRevision, issueID,
+	); err != nil {
+		return fmt.Errorf("versioned history: advance current_revision for %s: %w", issueID, err)
+	}
+	return nil
+}

--- a/internal/storage/issueops/version_history.go
+++ b/internal/storage/issueops/version_history.go
@@ -48,6 +48,32 @@ func versionedHistoryEnabled(tx DBTX) bool {
 	return on
 }
 
+// Design §16.4 (R14, be-hs42e.3): issue_versions.attribution_status is a
+// NOT NULL column (migration 0068 step 6) with four legal values. Phase 2 is
+// the sole writer of this table during its era and never writes "imported"
+// — that value is reserved for whichever later phase first writes history
+// that did not originate as a Phase-2-accepted mutation (import/backfill
+// tooling has no owner yet).
+const (
+	attributionStatusSupplied     = "supplied"
+	attributionStatusNotSupplied  = "not_supplied"
+	attributionStatusUndetermined = "undetermined"
+	attributionStatusImported     = "imported"
+)
+
+// attributionStatusForActor derives issue_versions.attribution_status from
+// the same actor string every RecordVersionInTx call site already passes.
+// "not_supplied" would assert a deliberate, confirmed absence of attribution
+// that no current call site actually claims — every call site just passes
+// through whatever actor string it has, with no additional signal — so an
+// empty actor gets the conservative "undetermined" instead.
+func attributionStatusForActor(actor string) string {
+	if actor == "" {
+		return attributionStatusUndetermined
+	}
+	return attributionStatusSupplied
+}
+
 // RecordVersionInTx mints one issue_versions row for issueID and advances
 // issues.current_revision to match, as of tx (read-your-writes within the
 // same transaction). A no-op when versioned history is disabled for tx, or
@@ -56,7 +82,8 @@ func versionedHistoryEnabled(tx DBTX) bool {
 //
 // actor is the acting identity that performed the mutation, recorded as the
 // version row's attribution — "" when the mutation path genuinely has none,
-// matching RecordEventInTx's own convention.
+// matching RecordEventInTx's own convention. It also drives
+// attribution_status via attributionStatusForActor.
 func RecordVersionInTx(ctx context.Context, tx DBTX, issueID, actor string) error {
 	if !versionedHistoryEnabled(tx) {
 		return nil
@@ -104,9 +131,9 @@ func RecordVersionInTx(ctx context.Context, tx DBTX, issueID, actor string) erro
 
 	if _, err := tx.ExecContext(ctx,
 		`INSERT INTO issue_versions
-			(issue_id, revision, epoch, durable_state, change_actor, change_agent, change_message, change_at)
-		VALUES (?, ?, ?, ?, ?, NULL, NULL, ?)`,
-		issueID, newRevision, epoch, string(durableState), actor, time.Now().UTC(),
+			(issue_id, revision, epoch, durable_state, change_actor, change_agent, change_message, change_at, attribution_status)
+		VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, ?)`,
+		issueID, newRevision, epoch, string(durableState), actor, time.Now().UTC(), attributionStatusForActor(actor),
 	); err != nil {
 		return fmt.Errorf("versioned history: insert version row for %s: %w", issueID, err)
 	}

--- a/internal/storage/issueops/version_history_test.go
+++ b/internal/storage/issueops/version_history_test.go
@@ -1,0 +1,60 @@
+package issueops
+
+import "testing"
+
+// These tests pin the derivation rule for issue_versions.attribution_status
+// (design §16.4 on be-hs42e.3, R14): a NOT NULL column added by migration
+// 0068 step 6. Phase 2 is the sole writer of this column and, per §16.4,
+// writes only three of its four legal values — "imported" is reserved for a
+// later phase's import/backfill tooling and is never minted here.
+//
+// RecordVersionInTx currently receives only a plain actor string from every
+// call site (7 production call sites, none passing any additional
+// attribution context), so the only signal available to derive
+// attribution_status from, without widening this bead's diff into a
+// call-site-by-call-site attribution audit, is whether actor is empty.
+// "not_supplied" would assert a confident, deliberate absence of attribution
+// that no current call site actually claims; "undetermined" is the honest,
+// conservative reading for a call site that simply has no actor threaded to
+// it. attributionStatusForActor and its constants do not exist yet: this
+// file is RED until version_history.go defines them.
+func TestAttributionStatusForActor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		actor string
+		want  string
+	}{
+		{name: "non-empty actor is supplied", actor: "alice", want: attributionStatusSupplied},
+		{name: "empty actor is undetermined", actor: "", want: attributionStatusUndetermined},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := attributionStatusForActor(tc.actor); got != tc.want {
+				t.Errorf("attributionStatusForActor(%q) = %q, want %q", tc.actor, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAttributionStatusValuesMatchR14 pins the four legal values verbatim
+// against design §16.4's own text, so a future edit cannot silently rename
+// or drop one without failing here.
+func TestAttributionStatusValuesMatchR14(t *testing.T) {
+	t.Parallel()
+
+	values := map[string]string{
+		"supplied":     attributionStatusSupplied,
+		"not_supplied": attributionStatusNotSupplied,
+		"undetermined": attributionStatusUndetermined,
+		"imported":     attributionStatusImported,
+	}
+	for want, got := range values {
+		if got != want {
+			t.Errorf("attribution status constant = %q, want %q", got, want)
+		}
+	}
+}

--- a/internal/storage/schema/cli_migrations.go
+++ b/internal/storage/schema/cli_migrations.go
@@ -126,6 +126,18 @@ func cliCompatibleMigrationSQL(name, sqlText string) string {
 		// itself is always present here: 0064's prepared RENAME executes on
 		// 2.2.0 (same measurement), so a fresh bundle always needs the column.
 		return cliMigration0066AddEventsJournalActor
+	case "0067_add_versioned_beads_schema.up.sql":
+		// Direct DDL for the same reason as 0060: the source migration's
+		// PREPARE guards (INFORMATION_SCHEMA probes) are what make the raw
+		// .up.sql idempotent when replayed onto an already-migrated store,
+		// and the 2.2.x CLI no-ops a prepared ADD COLUMN. Both planes always
+		// need the column here -- a fresh bundle runs the whole main series
+		// in order, so `issues` and `wisps` both exist and neither carries
+		// current_revision yet. The CREATE TABLEs are carried over verbatim:
+		// IF NOT EXISTS is ordinary unwrapped DDL that the CLI executes.
+		// Replays over a database that never synced the wisp tables must use
+		// the frozen source text instead -- see cliSubstituteAssumesWispTables.
+		return cliMigration0067AddVersionedBeadsSchema
 	default:
 		return sqlText
 	}
@@ -157,6 +169,10 @@ func cliSubstituteAssumesWispTables(name string) bool {
 	case "0065_widen_wisp_comments_text.up.sql":
 		// cliMigration0065WidenWispCommentsText is a bare MODIFY on
 		// wisp_comments.
+		return true
+	case "0067_add_versioned_beads_schema.up.sql":
+		// cliMigration0067AddVersionedBeadsSchema drops the source's
+		// @wisps_cr_needs_add table-exists guard and ALTERs wisps directly.
 		return true
 	default:
 		return false
@@ -204,6 +220,34 @@ ALTER TABLE wisps ADD COLUMN storage_class VARCHAR(16);`
 
 const cliMigration0065WidenWispCommentsText = `ALTER TABLE wisp_comments MODIFY COLUMN text LONGTEXT NOT NULL;`
 const cliMigration0066AddEventsJournalActor = `ALTER TABLE bd_events_journal ADD COLUMN actor VARCHAR(255) NOT NULL DEFAULT '';`
+
+// cliMigration0067AddVersionedBeadsSchema is 0067 with its two guarded
+// PREPARE blocks replaced by the direct ALTERs they would run on a fresh
+// database. The CREATE TABLEs are the source file's own text: CREATE TABLE
+// IF NOT EXISTS executes on the CLI batch path unchanged.
+const cliMigration0067AddVersionedBeadsSchema = `CREATE TABLE IF NOT EXISTS issue_versions (
+    issue_id VARCHAR(255) NOT NULL,
+    revision BIGINT NOT NULL,
+    epoch INT NOT NULL,
+    durable_state JSON,
+    change_actor VARCHAR(255),
+    change_agent VARCHAR(255),
+    change_message TEXT,
+    change_at DATETIME NOT NULL,
+    removed_at DATETIME,
+    removed_reason VARCHAR(255),
+    PRIMARY KEY (issue_id, revision)
+);
+CREATE TABLE IF NOT EXISTS store_epoch (
+    id TINYINT(1) NOT NULL DEFAULT 1,
+    epoch INT NOT NULL DEFAULT 1,
+    bumped_at DATETIME,
+    bumped_reason VARCHAR(255),
+    PRIMARY KEY (id),
+    CONSTRAINT ck_store_epoch_singleton CHECK (id = 1)
+);
+ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;
+ALTER TABLE wisps ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;`
 
 const cliMigration0041SplitDependenciesTarget = `DELETE FROM dolt_nonlocal_tables;
 CALL DOLT_COMMIT('-Am', 'disable nonlocal tables for fk migrations');

--- a/internal/storage/schema/cli_migrations.go
+++ b/internal/storage/schema/cli_migrations.go
@@ -138,6 +138,14 @@ func cliCompatibleMigrationSQL(name, sqlText string) string {
 		// Replays over a database that never synced the wisp tables must use
 		// the frozen source text instead -- see cliSubstituteAssumesWispTables.
 		return cliMigration0067AddVersionedBeadsSchema
+	case "0068_add_attribution_status.up.sql":
+		// Direct DDL for the same reason as 0067: the source migration's
+		// PREPARE guard (an INFORMATION_SCHEMA probe) is what makes the raw
+		// .up.sql idempotent when replayed onto an already-migrated store,
+		// and the 2.2.x CLI no-ops a prepared ADD COLUMN. issue_versions is
+		// always present here -- 0067 runs earlier in the same fresh-bundle
+		// series -- and never carries attribution_status yet.
+		return cliMigration0068AddAttributionStatus
 	default:
 		return sqlText
 	}
@@ -248,6 +256,12 @@ CREATE TABLE IF NOT EXISTS store_epoch (
 );
 ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;
 ALTER TABLE wisps ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;`
+
+// cliMigration0068AddAttributionStatus is 0068 with its guarded PREPARE
+// block replaced by the direct ALTER it would run on a fresh database.
+// issue_versions is created earlier in the same series by 0067, so the
+// column always needs adding here; no wisps twin exists for this table.
+const cliMigration0068AddAttributionStatus = `ALTER TABLE issue_versions ADD COLUMN attribution_status VARCHAR(20) NOT NULL;`
 
 const cliMigration0041SplitDependenciesTarget = `DELETE FROM dolt_nonlocal_tables;
 CALL DOLT_COMMIT('-Am', 'disable nonlocal tables for fk migrations');

--- a/internal/storage/schema/migration_0067_versioned_beads_test.go
+++ b/internal/storage/schema/migration_0067_versioned_beads_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -63,10 +64,15 @@ func TestMigration0067AddsVersionedBeadsSchema(t *testing.T) {
 		t.Error("0067 up migration must not seed store_epoch — every new table starts empty in Phase 1 (no reads/writes of the new surfaces until Phase 2)")
 	}
 
-	downSQL, err := MigrationSQL(migration0067Down)
+	// down.sql files are not part of the embedded FS (only migrations/*.up.sql
+	// is //go:embed'd — see mainSource.files), so unlike the up side above,
+	// this reads straight from disk by package-relative path, matching
+	// TestMigration0035HandlesLegacyWispDependenciesShape's precedent.
+	downBytes, err := os.ReadFile("migrations/" + migration0067Down)
 	if err != nil {
-		t.Fatalf("MigrationSQL(%s) error = %v, want the migration file to exist", migration0067Down, err)
+		t.Fatalf("read %s: %v, want the migration file to exist", migration0067Down, err)
 	}
+	downSQL := string(downBytes)
 	for _, want := range []string{
 		"DROP TABLE",
 		"issue_versions",
@@ -105,7 +111,7 @@ func TestMigration0067AddsVersionedBeadsSchemaThroughDoltCLI(t *testing.T) {
 	requireDoltDataType(t, dir, "issue_versions", "durable_state", "json", "YES")
 	requireDoltColumnShape(t, dir, "issue_versions", "change_actor", "varchar(255)", "YES")
 	requireDoltColumnShape(t, dir, "issue_versions", "change_agent", "varchar(255)", "YES")
-	requireDoltColumnShape(t, dir, "issue_versions", "change_message", "longtext", "YES")
+	requireDoltColumnShape(t, dir, "issue_versions", "change_message", "text", "YES")
 	requireDoltColumnShape(t, dir, "issue_versions", "change_at", "datetime", "NO")
 	requireDoltColumnShape(t, dir, "issue_versions", "removed_at", "datetime", "YES")
 	requireDoltColumnShape(t, dir, "issue_versions", "removed_reason", "varchar(255)", "YES")

--- a/internal/storage/schema/migration_0067_versioned_beads_test.go
+++ b/internal/storage/schema/migration_0067_versioned_beads_test.go
@@ -48,8 +48,8 @@ func TestMigration0067AddsVersionedBeadsSchema(t *testing.T) {
 		t.Fatalf("MigrationSQL(%s) error = %v, want the migration file to exist", migration0067Up, err)
 	}
 	for _, want := range []string{
-		"CREATE TABLE issue_versions",
-		"CREATE TABLE store_epoch",
+		"CREATE TABLE IF NOT EXISTS issue_versions",
+		"CREATE TABLE IF NOT EXISTS store_epoch",
 		"PRIMARY KEY (issue_id, revision)",
 		"ALTER TABLE issues ADD COLUMN current_revision",
 	} {

--- a/internal/storage/schema/migration_0067_versioned_beads_test.go
+++ b/internal/storage/schema/migration_0067_versioned_beads_test.go
@@ -35,13 +35,26 @@ func TestLatestVersionIncludesMigration0067(t *testing.T) {
 
 // TestMigration0067AddsVersionedBeadsSchema is a pure-Go, DB-independent
 // check of the frozen migration bytes themselves — it runs even where no
-// `dolt` binary is available. It also freezes the one hazard this phase's
-// research surfaced: a PREPARE'd ADD COLUMN/DROP COLUMN silently vanishes
-// under the CLI-bundle path on a pre-2.3 Dolt CLI (see cli_prepared_ddl.go),
-// and unlike migration 0066's guarded actor-column PREPARE, an analogous
-// guard here would still fire on a fresh bundle (issues always exists),
-// so no preparedALTERSafeOnFreshBundle justification would be honest. The
-// column/table churn this phase adds must stay plain, unwrapped DDL.
+// `dolt` binary is available.
+//
+// It pins the shape both ADD COLUMNs must keep: an INFORMATION_SCHEMA-guarded
+// PREPARE, on both planes. That guard is not decoration — it is what makes a
+// raw replay of this file onto an already-migrated store a no-op, which
+// internal/storage/dolt's pr4107 replay harness requires of every migration
+// >= 0046 (it re-executes the .up.sql bytes directly, so no Go-side guard is
+// in the path). Dolt accepts no unprepared conditional DDL that would do the
+// same job: ADD COLUMN IF NOT EXISTS, DROP COLUMN IF EXISTS and a top-level
+// IF are all parse errors, and a stored procedure's body needs a client-side
+// DELIMITER the CLI batch path requires and the Go driver rejects.
+//
+// The cost is the pre-2.3 CLI hazard a PREPARE'd ADD COLUMN carries (it
+// silently vanishes on the CLI-bundle path — see cli_prepared_ddl.go), and
+// the fix for that is the same one 0060/0065/0066 use: a direct-DDL override
+// in cliCompatibleMigrationSQL, which
+// TestBundleMigrationsWithPreparedALTERAreOverriddenOrJustified and
+// TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities both police.
+// The assertion below is the local anchor for that pairing: if someone ever
+// unwraps these PREPAREs, the override silently becomes a lie.
 func TestMigration0067AddsVersionedBeadsSchema(t *testing.T) {
 	upSQL, err := MigrationSQL(migration0067Up)
 	if err != nil {
@@ -51,14 +64,36 @@ func TestMigration0067AddsVersionedBeadsSchema(t *testing.T) {
 		"CREATE TABLE IF NOT EXISTS issue_versions",
 		"CREATE TABLE IF NOT EXISTS store_epoch",
 		"PRIMARY KEY (issue_id, revision)",
-		"ALTER TABLE issues ADD COLUMN current_revision",
+		"ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1",
+		// Shape parity with issues, identical type. Nothing reads or writes
+		// this column in any phase — see the migration header's asymmetry
+		// note and ignored/0026.
+		"ALTER TABLE wisps ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1",
+		// Both ALTERs are INFORMATION_SCHEMA-guarded so a raw replay no-ops.
+		"COLUMN_NAME = 'current_revision'",
+		"@issues_cr_needs_add",
+		"@wisps_cr_needs_add",
 	} {
 		if !strings.Contains(upSQL, want) {
 			t.Errorf("0067 up migration missing %q\nfull SQL:\n%s", want, upSQL)
 		}
 	}
-	if strings.Contains(strings.ToUpper(upSQL), "PREPARE ") {
-		t.Error("0067 up migration must not PREPARE/EXECUTE its ALTER TABLE ADD COLUMN — ADD COLUMN vanishes under the CLI-bundle PREPARE path on a fresh database (cli_prepared_ddl.go); use plain unwrapped DDL")
+	if !strings.Contains(strings.ToUpper(upSQL), "PREPARE STMT FROM @SQL") {
+		t.Error("0067 up migration must keep its guarded PREPARE blocks — they are what make a raw .up.sql replay onto an already-migrated store a no-op (pr4107_corruption_test.go's harness bypasses every Go-side guard), and Dolt accepts no unprepared conditional ADD COLUMN. Unwrapping them also invalidates cliMigration0067AddVersionedBeadsSchema.")
+	}
+	// The bundle override is what keeps the PREPARE above off the pre-2.3
+	// CLI path. Assert it directly rather than trusting the two schema_test
+	// assertions to stay pointed at this migration.
+	for _, want := range []string{
+		"ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;",
+		"ALTER TABLE wisps ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;",
+	} {
+		if !strings.Contains(cliCompatibleMigrationSQL(migration0067Up, upSQL), want) {
+			t.Errorf("0067's CLI bundle substitute missing direct DDL %q", want)
+		}
+	}
+	if !cliSubstituteAssumesWispTables(migration0067Up) {
+		t.Error("0067's CLI substitute ALTERs wisps unguarded, so it must be listed in cliSubstituteAssumesWispTables — a replay over a clone that never synced the wisp tables has to fall back to the frozen source text")
 	}
 	if strings.Contains(upSQL, "INSERT INTO store_epoch") || strings.Contains(upSQL, "INSERT IGNORE INTO store_epoch") {
 		t.Error("0067 up migration must not seed store_epoch — every new table starts empty in Phase 1 (no reads/writes of the new surfaces until Phase 2)")
@@ -78,13 +113,19 @@ func TestMigration0067AddsVersionedBeadsSchema(t *testing.T) {
 		"issue_versions",
 		"store_epoch",
 		"ALTER TABLE issues DROP COLUMN current_revision",
+		// The down side reverses both planes, or a rolled-back workspace
+		// keeps a wisps column its binary no longer knows about.
+		"ALTER TABLE wisps DROP COLUMN current_revision",
 	} {
 		if !strings.Contains(downSQL, want) {
 			t.Errorf("0067 down migration missing %q\nfull SQL:\n%s", want, downSQL)
 		}
 	}
-	if strings.Contains(strings.ToUpper(downSQL), "PREPARE ") {
-		t.Error("0067 down migration must not PREPARE/EXECUTE its ALTER TABLE DROP COLUMN — DROP COLUMN is in the same CLI-bundle vanishing bucket as ADD COLUMN (cli_prepared_ddl.go)")
+	// Only migrations/*.up.sql is embedded into the CLI fresh bundle
+	// (mainSource.files), so the pre-2.3 prepared-DDL hazard never reaches a
+	// down migration and the guard is free — 0060's down is the precedent.
+	if !strings.Contains(strings.ToUpper(downSQL), "PREPARE STMT FROM @SQL") {
+		t.Error("0067 down migration must guard its DROP COLUMNs the way the up migration guards its ADD COLUMNs, so an issues-only or partially-applied workspace rolls back as safely as it migrated up")
 	}
 }
 
@@ -125,8 +166,17 @@ func TestMigration0067AddsVersionedBeadsSchemaThroughDoltCLI(t *testing.T) {
 	requireDoltColumnShape(t, dir, "store_epoch", "bumped_reason", "varchar(255)", "YES")
 	requireDoltNoRows(t, dir, "SELECT id FROM store_epoch", "store_epoch")
 
-	// issues.current_revision — the fast-path CAS column.
+	// current_revision on BOTH planes. issues.current_revision is the
+	// fast-path CAS column later phases read and write; wisps.current_revision
+	// is shape parity only (nothing ever reads or writes it — see the
+	// migration header and ignored/0026), and it is asserted here for exactly
+	// the reason the parity oracle exists: the two planes share
+	// column-list-shaped code paths, so the shape obligation is real even
+	// where the semantics are not. Same type on both, or
+	// TestSchemaParityIssuesVsWisps' type check fails instead of its
+	// name check.
 	requireDoltDataType(t, dir, "issues", "current_revision", "bigint", "NO")
+	requireDoltDataType(t, dir, "wisps", "current_revision", "bigint", "NO")
 
 	// Composite PK (issue_id, revision) is enforced: same pair twice fails.
 	runDoltSQL(t, dir, `INSERT INTO issue_versions (issue_id, revision, epoch, change_at) VALUES ('iv-1', 1, 1, '2026-09-01 00:00:00')`)

--- a/internal/storage/schema/migration_0067_versioned_beads_test.go
+++ b/internal/storage/schema/migration_0067_versioned_beads_test.go
@@ -1,0 +1,172 @@
+package schema
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/testutil"
+)
+
+// Phase 1 of the versioned-beads epic (be-hs42e / gastownhall/beads#6132,
+// this slice: be-hs42e.2 / #6134) adds purely additive schema: a per-issue
+// version log, a store-global epoch singleton, and a fast-path revision
+// column on issues. Nothing reads or writes these surfaces yet — that is
+// Phase 2 (#6135) and Phase 3 (#6136). These tests only assert the DDL
+// itself: shape, emptiness, and that old, unmodified callers of `issues`
+// are unaffected.
+
+const migration0067Up = "0067_add_versioned_beads_schema.up.sql"
+const migration0067Down = "0067_add_versioned_beads_schema.down.sql"
+
+// TestLatestVersionIncludesMigration0067 pins the real next free slot this
+// phase claims. It is deliberately a hardcoded literal, not a comparison
+// against another derived value: schema.LatestVersion() drifting to 67 for
+// the wrong reason (an unrelated migration landing first) should still be
+// caught by this test failing to explain why 67 is versioned-beads-shaped,
+// which the CLI test below checks.
+func TestLatestVersionIncludesMigration0067(t *testing.T) {
+	const want = 67
+	if got := LatestVersion(); got != want {
+		t.Fatalf("LatestVersion() = %d, want %d (issue_versions/store_epoch/issues.current_revision migration slot claimed by be-hs42e.2)", got, want)
+	}
+}
+
+// TestMigration0067AddsVersionedBeadsSchema is a pure-Go, DB-independent
+// check of the frozen migration bytes themselves — it runs even where no
+// `dolt` binary is available. It also freezes the one hazard this phase's
+// research surfaced: a PREPARE'd ADD COLUMN/DROP COLUMN silently vanishes
+// under the CLI-bundle path on a pre-2.3 Dolt CLI (see cli_prepared_ddl.go),
+// and unlike migration 0066's guarded actor-column PREPARE, an analogous
+// guard here would still fire on a fresh bundle (issues always exists),
+// so no preparedALTERSafeOnFreshBundle justification would be honest. The
+// column/table churn this phase adds must stay plain, unwrapped DDL.
+func TestMigration0067AddsVersionedBeadsSchema(t *testing.T) {
+	upSQL, err := MigrationSQL(migration0067Up)
+	if err != nil {
+		t.Fatalf("MigrationSQL(%s) error = %v, want the migration file to exist", migration0067Up, err)
+	}
+	for _, want := range []string{
+		"CREATE TABLE issue_versions",
+		"CREATE TABLE store_epoch",
+		"PRIMARY KEY (issue_id, revision)",
+		"ALTER TABLE issues ADD COLUMN current_revision",
+	} {
+		if !strings.Contains(upSQL, want) {
+			t.Errorf("0067 up migration missing %q\nfull SQL:\n%s", want, upSQL)
+		}
+	}
+	if strings.Contains(strings.ToUpper(upSQL), "PREPARE ") {
+		t.Error("0067 up migration must not PREPARE/EXECUTE its ALTER TABLE ADD COLUMN — ADD COLUMN vanishes under the CLI-bundle PREPARE path on a fresh database (cli_prepared_ddl.go); use plain unwrapped DDL")
+	}
+	if strings.Contains(upSQL, "INSERT INTO store_epoch") || strings.Contains(upSQL, "INSERT IGNORE INTO store_epoch") {
+		t.Error("0067 up migration must not seed store_epoch — every new table starts empty in Phase 1 (no reads/writes of the new surfaces until Phase 2)")
+	}
+
+	downSQL, err := MigrationSQL(migration0067Down)
+	if err != nil {
+		t.Fatalf("MigrationSQL(%s) error = %v, want the migration file to exist", migration0067Down, err)
+	}
+	for _, want := range []string{
+		"DROP TABLE",
+		"issue_versions",
+		"store_epoch",
+		"ALTER TABLE issues DROP COLUMN current_revision",
+	} {
+		if !strings.Contains(downSQL, want) {
+			t.Errorf("0067 down migration missing %q\nfull SQL:\n%s", want, downSQL)
+		}
+	}
+	if strings.Contains(strings.ToUpper(downSQL), "PREPARE ") {
+		t.Error("0067 down migration must not PREPARE/EXECUTE its ALTER TABLE DROP COLUMN — DROP COLUMN is in the same CLI-bundle vanishing bucket as ADD COLUMN (cli_prepared_ddl.go)")
+	}
+}
+
+// TestMigration0067AddsVersionedBeadsSchemaThroughDoltCLI applies the full
+// migration bundle through a real `dolt` binary (skipped without one — see
+// testutil.RequireDoltBinary) and checks the shape acceptance criteria a
+// pure-Go SQL-text check cannot: actual column types/nullability as Dolt
+// reports them, that both new tables start empty, that the composite and
+// singleton primary keys are enforced, and compat direction 1 — an
+// old-shaped INSERT/SELECT against `issues` that has never heard of
+// current_revision still behaves unchanged, because the column is
+// NOT NULL DEFAULT 1 rather than a value old callers must supply.
+func TestMigration0067AddsVersionedBeadsSchemaThroughDoltCLI(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+
+	dir := t.TempDir()
+	runDoltCommand(t, dir, "init", "--name", "test", "--email", "test@example.com")
+	runDoltSQL(t, dir, AllMigrationsSQL())
+
+	// issue_versions shape.
+	requireDoltColumnShape(t, dir, "issue_versions", "issue_id", "varchar(255)", "NO")
+	requireDoltDataType(t, dir, "issue_versions", "revision", "bigint", "NO")
+	requireDoltDataType(t, dir, "issue_versions", "epoch", "int", "NO")
+	requireDoltDataType(t, dir, "issue_versions", "durable_state", "json", "YES")
+	requireDoltColumnShape(t, dir, "issue_versions", "change_actor", "varchar(255)", "YES")
+	requireDoltColumnShape(t, dir, "issue_versions", "change_agent", "varchar(255)", "YES")
+	requireDoltColumnShape(t, dir, "issue_versions", "change_message", "longtext", "YES")
+	requireDoltColumnShape(t, dir, "issue_versions", "change_at", "datetime", "NO")
+	requireDoltColumnShape(t, dir, "issue_versions", "removed_at", "datetime", "YES")
+	requireDoltColumnShape(t, dir, "issue_versions", "removed_reason", "varchar(255)", "YES")
+	requireDoltNoRows(t, dir, "SELECT issue_id FROM issue_versions", "issue_versions")
+
+	// store_epoch shape — singleton table, starts empty (Phase 1 does not
+	// seed it; a later phase's lazy-init owns creating the id=1 row).
+	requireDoltColumnShape(t, dir, "store_epoch", "id", "tinyint(1)", "NO")
+	requireDoltDataType(t, dir, "store_epoch", "epoch", "int", "NO")
+	requireDoltColumnShape(t, dir, "store_epoch", "bumped_at", "datetime", "YES")
+	requireDoltColumnShape(t, dir, "store_epoch", "bumped_reason", "varchar(255)", "YES")
+	requireDoltNoRows(t, dir, "SELECT id FROM store_epoch", "store_epoch")
+
+	// issues.current_revision — the fast-path CAS column.
+	requireDoltDataType(t, dir, "issues", "current_revision", "bigint", "NO")
+
+	// Composite PK (issue_id, revision) is enforced: same pair twice fails.
+	runDoltSQL(t, dir, `INSERT INTO issue_versions (issue_id, revision, epoch, change_at) VALUES ('iv-1', 1, 1, '2026-09-01 00:00:00')`)
+	if err := runDoltSQLExpectingError(t, dir, `INSERT INTO issue_versions (issue_id, revision, epoch, change_at) VALUES ('iv-1', 1, 1, '2026-09-01 00:00:01')`); err == nil {
+		t.Error("duplicate (issue_id, revision) insert into issue_versions succeeded, want primary key violation")
+	}
+
+	// Singleton PK (id) is enforced the same way.
+	runDoltSQL(t, dir, `INSERT INTO store_epoch (id) VALUES (1)`)
+	if err := runDoltSQLExpectingError(t, dir, `INSERT INTO store_epoch (id) VALUES (1)`); err == nil {
+		t.Error("duplicate id=1 insert into store_epoch succeeded, want primary key violation")
+	}
+	if err := runDoltSQLExpectingError(t, dir, `INSERT INTO store_epoch (id) VALUES (2)`); err == nil {
+		t.Error("id=2 insert into store_epoch succeeded, want the singleton CHECK constraint to reject any id other than 1")
+	}
+
+	// Compat direction 1: an old (pre-Phase-1) binary only ever issues
+	// explicit-column statements against `issues` that don't mention
+	// current_revision. Those must still work unchanged post-migration.
+	runDoltSQL(t, dir, `INSERT INTO issues (id, title, description, design, acceptance_criteria, notes) VALUES ('old-style-1', 'Old-style insert', 'd', 'des', 'ac', 'n')`)
+	rows := queryDoltCSV(t, dir, `SELECT title FROM issues WHERE id = 'old-style-1'`)
+	if len(rows) != 1 || rows[0]["title"] != "Old-style insert" {
+		t.Fatalf("old-shaped explicit-column insert/select round-trip failed post-migration: %v", rows)
+	}
+}
+
+// requireDoltDataType is requireDoltColumnShape's data_type-based sibling:
+// it asserts the coarse, display-width-independent information_schema
+// column (always "bigint"/"int"/"json", never e.g. "bigint(20)"), for
+// column types this package has no existing column_type-string precedent
+// to match against.
+func requireDoltDataType(t *testing.T, dir, tableName, columnName, wantDataType, wantNullable string) {
+	t.Helper()
+	rows := queryDoltCSV(t, dir, fmt.Sprintf(`
+SELECT data_type AS data_type, is_nullable AS is_nullable
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = %s
+  AND column_name = %s`, doltSQLString(tableName), doltSQLString(columnName)))
+	if len(rows) != 1 {
+		t.Fatalf("%s.%s column query returned %d rows, want 1: %v", tableName, columnName, len(rows), rows)
+	}
+	if got := rows[0]["data_type"]; got != wantDataType {
+		t.Fatalf("%s.%s DATA_TYPE = %s, want %s", tableName, columnName, got, wantDataType)
+	}
+	if got := rows[0]["is_nullable"]; got != wantNullable {
+		t.Fatalf("%s.%s IS_NULLABLE = %s, want %s", tableName, columnName, got, wantNullable)
+	}
+}

--- a/internal/storage/schema/migration_0067_versioned_beads_test.go
+++ b/internal/storage/schema/migration_0067_versioned_beads_test.go
@@ -20,19 +20,6 @@ import (
 const migration0067Up = "0067_add_versioned_beads_schema.up.sql"
 const migration0067Down = "0067_add_versioned_beads_schema.down.sql"
 
-// TestLatestVersionIncludesMigration0067 pins the real next free slot this
-// phase claims. It is deliberately a hardcoded literal, not a comparison
-// against another derived value: schema.LatestVersion() drifting to 67 for
-// the wrong reason (an unrelated migration landing first) should still be
-// caught by this test failing to explain why 67 is versioned-beads-shaped,
-// which the CLI test below checks.
-func TestLatestVersionIncludesMigration0067(t *testing.T) {
-	const want = 67
-	if got := LatestVersion(); got != want {
-		t.Fatalf("LatestVersion() = %d, want %d (issue_versions/store_epoch/issues.current_revision migration slot claimed by be-hs42e.2)", got, want)
-	}
-}
-
 // TestMigration0067AddsVersionedBeadsSchema is a pure-Go, DB-independent
 // check of the frozen migration bytes themselves — it runs even where no
 // `dolt` binary is available.
@@ -179,8 +166,12 @@ func TestMigration0067AddsVersionedBeadsSchemaThroughDoltCLI(t *testing.T) {
 	requireDoltDataType(t, dir, "wisps", "current_revision", "bigint", "NO")
 
 	// Composite PK (issue_id, revision) is enforced: same pair twice fails.
-	runDoltSQL(t, dir, `INSERT INTO issue_versions (issue_id, revision, epoch, change_at) VALUES ('iv-1', 1, 1, '2026-09-01 00:00:00')`)
-	if err := runDoltSQLExpectingError(t, dir, `INSERT INTO issue_versions (issue_id, revision, epoch, change_at) VALUES ('iv-1', 1, 1, '2026-09-01 00:00:01')`); err == nil {
+	// attribution_status is 0068's NOT NULL column (not yet Phase 1's
+	// concern, but present on any schema this test's fresh bundle produces),
+	// so both inserts must supply it or Dolt rejects them before the PK
+	// check below ever runs.
+	runDoltSQL(t, dir, `INSERT INTO issue_versions (issue_id, revision, epoch, change_at, attribution_status) VALUES ('iv-1', 1, 1, '2026-09-01 00:00:00', 'undetermined')`)
+	if err := runDoltSQLExpectingError(t, dir, `INSERT INTO issue_versions (issue_id, revision, epoch, change_at, attribution_status) VALUES ('iv-1', 1, 1, '2026-09-01 00:00:01', 'undetermined')`); err == nil {
 		t.Error("duplicate (issue_id, revision) insert into issue_versions succeeded, want primary key violation")
 	}
 

--- a/internal/storage/schema/migration_0068_add_attribution_status_test.go
+++ b/internal/storage/schema/migration_0068_add_attribution_status_test.go
@@ -1,0 +1,130 @@
+package schema
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/testutil"
+)
+
+// Phase 2 of the versioned-beads epic (be-hs42e / gastownhall/beads#6132,
+// this slice: be-hs42e.3 / #6135) adds one column: issue_versions gains a
+// NOT NULL attribution_status (design §16.4, R14), written by
+// RecordVersionInTx / attributionStatusForActor
+// (internal/storage/issueops/version_history.go) from the same build that
+// ships this migration, so the NOT NULL constraint never rejects a
+// pre-existing row. Steps 1-5 of design §16.3 (the version_id PK swap and
+// participation_generation) are a different bead's scope and are not in this
+// migration file.
+
+const migration0068Up = "0068_add_attribution_status.up.sql"
+const migration0068Down = "0068_add_attribution_status.down.sql"
+
+// TestLatestVersionIncludesMigration0068 pins the real next free slot this
+// phase claims, superseding 0067's own version of this test (LatestVersion()
+// moved from 67 to 68 the moment this migration file was added). Deliberately
+// a hardcoded literal for the same reason 0067's was: LatestVersion()
+// drifting to 68 for the wrong reason (an unrelated migration landing first)
+// should still be caught by this test failing to explain why 68 is
+// attribution-status-shaped, which the CLI test below checks.
+func TestLatestVersionIncludesMigration0068(t *testing.T) {
+	const want = 68
+	if got := LatestVersion(); got != want {
+		t.Fatalf("LatestVersion() = %d, want %d (issue_versions.attribution_status migration slot claimed by be-hs42e.3)", got, want)
+	}
+}
+
+// TestMigration0068AddsAttributionStatus is a pure-Go, DB-independent check
+// of the frozen migration bytes themselves — it runs even where no `dolt`
+// binary is available.
+//
+// It pins the same guarded-PREPARE shape 0067 uses and for the same reason:
+// the guard is what makes a raw replay of this file onto an already-migrated
+// store a no-op (internal/storage/dolt's pr4107 replay harness requires this
+// of every migration >= 0046), and Dolt accepts no unprepared conditional
+// ADD COLUMN. The cost is the same pre-2.3 CLI hazard 0060/0065/0066/0067
+// carry, so this migration needs the same direct-DDL override in
+// cliCompatibleMigrationSQL, policed by the same two guard tests
+// (TestBundleMigrationsWithPreparedALTERAreOverriddenOrJustified and
+// TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities).
+func TestMigration0068AddsAttributionStatus(t *testing.T) {
+	upSQL, err := MigrationSQL(migration0068Up)
+	if err != nil {
+		t.Fatalf("MigrationSQL(%s) error = %v, want the migration file to exist", migration0068Up, err)
+	}
+	for _, want := range []string{
+		"ALTER TABLE issue_versions ADD COLUMN attribution_status VARCHAR(20) NOT NULL",
+		"COLUMN_NAME = 'attribution_status'",
+		"@issue_versions_as_needs_add",
+	} {
+		if !strings.Contains(upSQL, want) {
+			t.Errorf("0068 up migration missing %q\nfull SQL:\n%s", want, upSQL)
+		}
+	}
+	if !strings.Contains(strings.ToUpper(upSQL), "PREPARE STMT FROM @SQL") {
+		t.Error("0068 up migration must keep its guarded PREPARE block — it is what makes a raw .up.sql replay onto an already-migrated store a no-op, and Dolt accepts no unprepared conditional ADD COLUMN. Unwrapping it also invalidates cliMigration0068AddAttributionStatus.")
+	}
+	// The bundle override is what keeps the PREPARE above off the pre-2.3
+	// CLI path. Assert it directly rather than trusting the two schema_test
+	// assertions to stay pointed at this migration.
+	want := "ALTER TABLE issue_versions ADD COLUMN attribution_status VARCHAR(20) NOT NULL;"
+	if !strings.Contains(cliCompatibleMigrationSQL(migration0068Up, upSQL), want) {
+		t.Errorf("0068's CLI bundle substitute missing direct DDL %q", want)
+	}
+	if cliSubstituteAssumesWispTables(migration0068Up) {
+		t.Error("0068's CLI substitute touches only issue_versions, which has no wisps-side counterpart table — it must not be listed in cliSubstituteAssumesWispTables")
+	}
+
+	// down.sql files are not part of the embedded FS (only migrations/*.up.sql
+	// is //go:embed'd — see mainSource.files), so unlike the up side above,
+	// this reads straight from disk by package-relative path, matching
+	// TestMigration0067AddsVersionedBeadsSchema's precedent.
+	downBytes, err := os.ReadFile("migrations/" + migration0068Down)
+	if err != nil {
+		t.Fatalf("read %s: %v, want the migration file to exist", migration0068Down, err)
+	}
+	downSQL := string(downBytes)
+	for _, want := range []string{
+		"ALTER TABLE issue_versions DROP COLUMN attribution_status",
+		"COLUMN_NAME = 'attribution_status'",
+	} {
+		if !strings.Contains(downSQL, want) {
+			t.Errorf("0068 down migration missing %q\nfull SQL:\n%s", want, downSQL)
+		}
+	}
+	// Only migrations/*.up.sql is embedded into the CLI fresh bundle
+	// (mainSource.files), so the pre-2.3 prepared-DDL hazard never reaches a
+	// down migration and the guard is free — 0060's/0067's downs are the
+	// precedent.
+	if !strings.Contains(strings.ToUpper(downSQL), "PREPARE STMT FROM @SQL") {
+		t.Error("0068 down migration must guard its DROP COLUMN the way the up migration guards its ADD COLUMN, so a partially-applied or already-rolled-back workspace rolls back safely")
+	}
+}
+
+// TestMigration0068AddsAttributionStatusThroughDoltCLI applies the full
+// migration bundle through a real `dolt` binary (skipped without one — see
+// testutil.RequireDoltBinary) and checks the shape acceptance criteria a
+// pure-Go SQL-text check cannot: actual column type/nullability as Dolt
+// reports it, and that the NOT NULL constraint is real (an insert that omits
+// attribution_status must fail, matching the fixture fix this migration
+// forced onto TestMigration0067AddsVersionedBeadsSchemaThroughDoltCLI).
+func TestMigration0068AddsAttributionStatusThroughDoltCLI(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+
+	dir := t.TempDir()
+	runDoltCommand(t, dir, "init", "--name", "test", "--email", "test@example.com")
+	runDoltSQL(t, dir, AllMigrationsSQL())
+
+	requireDoltColumnShape(t, dir, "issue_versions", "attribution_status", "varchar(20)", "NO")
+	requireDoltNoRows(t, dir, "SELECT issue_id FROM issue_versions", "issue_versions")
+
+	if err := runDoltSQLExpectingError(t, dir, `INSERT INTO issue_versions (issue_id, revision, epoch, change_at) VALUES ('iv-1', 1, 1, '2026-09-01 00:00:00')`); err == nil {
+		t.Error("insert into issue_versions omitting attribution_status succeeded, want a NOT NULL violation")
+	}
+	runDoltSQL(t, dir, `INSERT INTO issue_versions (issue_id, revision, epoch, change_at, attribution_status) VALUES ('iv-1', 1, 1, '2026-09-01 00:00:00', 'supplied')`)
+	rows := queryDoltCSV(t, dir, `SELECT attribution_status FROM issue_versions WHERE issue_id = 'iv-1'`)
+	if len(rows) != 1 || rows[0]["attribution_status"] != "supplied" {
+		t.Fatalf("attribution_status round-trip failed post-migration: %v", rows)
+	}
+}

--- a/internal/storage/schema/migrations/0067_add_versioned_beads_schema.down.sql
+++ b/internal/storage/schema/migrations/0067_add_versioned_beads_schema.down.sql
@@ -1,0 +1,10 @@
+-- Reverse of 0067. Plain, unwrapped DDL -- see the up migration for why no
+-- PREPARE/EXECUTE wrapper applies here (DROP COLUMN is in the same
+-- CLI-bundle vanishing bucket as ADD COLUMN; see cli_prepared_ddl.go).
+-- Every surface this reverses is still unread and unwritten in Phase 1, so
+-- this is a plain schema rollback, not a data-loss concern.
+ALTER TABLE issues DROP COLUMN current_revision;
+
+DROP TABLE IF EXISTS store_epoch;
+
+DROP TABLE IF EXISTS issue_versions;

--- a/internal/storage/schema/migrations/0067_add_versioned_beads_schema.down.sql
+++ b/internal/storage/schema/migrations/0067_add_versioned_beads_schema.down.sql
@@ -1,9 +1,32 @@
--- Reverse of 0067. Plain, unwrapped DDL -- see the up migration for why no
--- PREPARE/EXECUTE wrapper applies here (DROP COLUMN is in the same
--- CLI-bundle vanishing bucket as ADD COLUMN; see cli_prepared_ddl.go).
--- Every surface this reverses is still unread and unwritten in Phase 1, so
--- this is a plain schema rollback, not a data-loss concern.
-ALTER TABLE issues DROP COLUMN current_revision;
+-- Reverse of 0067. Every surface this reverses is still unread and unwritten
+-- in Phase 1, so this is a plain schema rollback, not a data-loss concern.
+--
+-- Guarded on INFORMATION_SCHEMA the same way the up migration is, so an
+-- issues-only or partially-applied workspace rolls back as safely as it
+-- migrated up (0060's down is the precedent). Only migrations/*.up.sql is
+-- embedded into the CLI fresh bundle, so the PREPARE hazard
+-- (cli_prepared_ddl.go) never reaches this file.
+SET @issues_cr_has = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'current_revision'
+);
+SET @sql = IF(@issues_cr_has > 0,
+    'ALTER TABLE issues DROP COLUMN current_revision',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @wisps_cr_has = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisps'
+      AND COLUMN_NAME = 'current_revision'
+);
+SET @sql = IF(@wisps_cr_has > 0,
+    'ALTER TABLE wisps DROP COLUMN current_revision',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 DROP TABLE IF EXISTS store_epoch;
 

--- a/internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql
+++ b/internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql
@@ -2,31 +2,55 @@
 -- this slice: be-hs42e.2 / #6134).
 --
 -- Purely additive: a per-issue version log (issue_versions), a store-global
--- epoch singleton (store_epoch), and a fast-path revision column on issues
--- (current_revision). Nothing reads or writes these surfaces yet -- CAS
--- enforcement, dual-write and epoch-bump logic land in Phase 2 (#6135) and
--- Phase 3 (#6136). No DML/backfill here: current_revision has a safe default
--- for every existing row, and both new tables start completely empty.
+-- epoch singleton (store_epoch), and a fast-path revision column on BOTH
+-- record planes (issues.current_revision, wisps.current_revision). Nothing
+-- reads or writes these surfaces yet -- CAS enforcement, dual-write and
+-- epoch-bump logic land in Phase 2 (#6135) and Phase 3 (#6136). No
+-- DML/backfill here: current_revision has a safe default for every existing
+-- row, and both new tables start completely empty.
 --
--- Plain, unwrapped DDL throughout -- no PREPARE/EXECUTE. `issues` always
--- exists by the time any migration runs, so unlike 0066's guarded ADD COLUMN
--- (needed because bd_events_journal is a dolt-ignored table that a fresh
--- clone may materialize from the ignored series instead of via this file),
--- no PREPARE-based idempotent-replay justification applies here, and a
--- PREPARE'd ADD COLUMN/DROP COLUMN silently vanishes under the CLI-bundle
--- path on a pre-2.3 Dolt CLI (see cli_prepared_ddl.go).
+-- SEMANTIC ASYMMETRY, DELIBERATE: only the issues column is ever read or
+-- written. Versioning is an issues-plane contract -- wisps are the ephemeral
+-- plane and no phase of this epic (2 or 3) will CAS on, bump, or log a wisp
+-- revision. The wisps column is a SHAPE obligation, not a semantic one:
+-- issues and wisps share the row shape and the shared scans build one column
+-- list for both tables (TestSchemaParityIssuesVsWisps in
+-- internal/storage/dolt enforces strict column-name parity with no exemption
+-- list), so a column on one plane only is a live drift hazard for
+-- column-list-shaped code paths regardless of whether anything reads it.
+-- wisps.row_lock (0054 + ignored/0013) is the precedent: carried on both
+-- planes, meaningful on one.
 --
--- The CREATE TABLEs below are guarded with IF NOT EXISTS -- ordinary,
--- unwrapped MySQL-flavored DDL, so this doesn't reintroduce the PREPARE
--- hazard -- so a designated-migrator replay (schema_migrations bookkeeping
--- row missing, e.g. BD_ALLOW_REMOTE_MIGRATE=1 against a clone that already
--- has these tables) doesn't die on Error 1105. The ADD COLUMN below has no
--- equivalent IF NOT EXISTS: MySQL, which Dolt follows, has never had that
--- construct for ADD COLUMN (it's a MariaDB-only extension), and PREPARE-ing
--- it to fake one is exactly the vanishing hazard above. Its replay guard
--- instead lives in Go, keyed to this migration's filename, right where the
--- runtime executes migration bodies (see execMigration0067Body in
--- schema.go).
+-- The CREATE TABLEs are guarded with IF NOT EXISTS -- ordinary, unwrapped
+-- MySQL-flavored DDL -- so a designated-migrator replay (schema_migrations
+-- bookkeeping row missing, e.g. BD_ALLOW_REMOTE_MIGRATE=1 against a clone
+-- that already has these tables) doesn't die on Error 1105.
+--
+-- The ADD COLUMNs have no equivalent IF NOT EXISTS: MySQL, which Dolt
+-- follows, has never had that construct for ADD COLUMN (it's a MariaDB-only
+-- extension; measured on dolt 2.2.3 -- `syntax error at position 33 near
+-- 'IF'`). Neither does Dolt accept `DROP COLUMN IF EXISTS` or a top-level
+-- IF. The only conditional DDL forms Dolt does accept are the PREPARE guard
+-- below and a stored procedure, and a procedure body's inner semicolons
+-- need a client-side DELIMITER that the CLI batch path requires and the Go
+-- driver rejects -- the frozen file cannot satisfy both. So these are the
+-- guarded PREPARE shape 0060 and 0066 already use for exactly this: their
+-- INFORMATION_SCHEMA probe makes a raw-SQL replay of this whole file a clean
+-- no-op on an already-migrated store, which is what
+-- pr4107_corruption_test.go's replay harness (raw .up.sql from 0046 onward
+-- onto a live store) requires of every migration >= 0046.
+--
+-- A PREPARE'd ADD COLUMN silently vanishes under the CLI-bundle path on a
+-- pre-2.3 Dolt CLI (dolthub/dolt#11345; see cli_prepared_ddl.go), so the
+-- fresh bundle gets a direct-DDL override -- cliMigration0067AddVersionedBeadsSchema
+-- in cli_migrations.go, the same escape hatch 0060/0065/0066 use, guarded by
+-- TestBundleMigrationsWithPreparedALTERAreOverriddenOrJustified.
+--
+-- wisps is dolt-ignored (clone-local), so this file's wisps ALTER never runs
+-- on a fresh clone: it ships with the ignored-series twin ignored/0026, the
+-- mechanism check D of scripts/check-migration-hygiene.sh enforces and
+-- ignored/0013 (0054's row_lock) and ignored/0020 (0060's storage_class)
+-- record.
 CREATE TABLE IF NOT EXISTS issue_versions (
     issue_id VARCHAR(255) NOT NULL,
     revision BIGINT NOT NULL,
@@ -53,4 +77,36 @@ CREATE TABLE IF NOT EXISTS store_epoch (
     CONSTRAINT ck_store_epoch_singleton CHECK (id = 1)
 );
 
-ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;
+-- issues.current_revision -- the fast-path CAS column, the only one any
+-- later phase reads or writes.
+SET @issues_cr_needs_add = (
+    SELECT IF(COUNT(*) = 0, 1, 0)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'current_revision'
+);
+SET @sql = IF(@issues_cr_needs_add = 1,
+    'ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- wisps.current_revision -- shape parity only (see the asymmetry note above).
+-- Guarded on the wisps table existing as well as the column: older
+-- workspaces created issues-only, and a clone that never synced the
+-- clone-local wisp tables must no-op rather than abort the pass (0060
+-- precedent).
+SET @wisps_cr_needs_add = IF(
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps') > 0
+    AND
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisps'
+          AND COLUMN_NAME = 'current_revision') = 0,
+    1, 0
+);
+SET @sql = IF(@wisps_cr_needs_add = 1,
+    'ALTER TABLE wisps ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql
+++ b/internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql
@@ -1,0 +1,44 @@
+-- Migration 0067: Phase 1 schema for versioned beads (be-hs42e / gastownhall/beads#6132,
+-- this slice: be-hs42e.2 / #6134).
+--
+-- Purely additive: a per-issue version log (issue_versions), a store-global
+-- epoch singleton (store_epoch), and a fast-path revision column on issues
+-- (current_revision). Nothing reads or writes these surfaces yet -- CAS
+-- enforcement, dual-write and epoch-bump logic land in Phase 2 (#6135) and
+-- Phase 3 (#6136). No DML/backfill here: current_revision has a safe default
+-- for every existing row, and both new tables start completely empty.
+--
+-- Plain, unwrapped DDL throughout -- no PREPARE/EXECUTE. `issues` always
+-- exists by the time any migration runs, so unlike 0066's guarded ADD COLUMN
+-- (needed because bd_events_journal is a dolt-ignored table that a fresh
+-- clone may materialize from the ignored series instead of via this file),
+-- no idempotent-replay justification applies here, and a PREPARE'd ADD
+-- COLUMN/DROP COLUMN silently vanishes under the CLI-bundle path on a
+-- pre-2.3 Dolt CLI (see cli_prepared_ddl.go).
+CREATE TABLE issue_versions (
+    issue_id VARCHAR(255) NOT NULL,
+    revision BIGINT NOT NULL,
+    epoch INT NOT NULL,
+    durable_state JSON,
+    change_actor VARCHAR(255),
+    change_agent VARCHAR(255),
+    change_message TEXT,
+    change_at DATETIME NOT NULL,
+    removed_at DATETIME,
+    removed_reason VARCHAR(255),
+    PRIMARY KEY (issue_id, revision)
+);
+
+-- Singleton: exactly one row, id=1, once a later phase creates it. Phase 1
+-- leaves the table empty -- the CHECK just pins the shape the lazy-init that
+-- eventually seeds it (Phase 2/3) must follow.
+CREATE TABLE store_epoch (
+    id TINYINT(1) NOT NULL DEFAULT 1,
+    epoch INT NOT NULL DEFAULT 1,
+    bumped_at DATETIME,
+    bumped_reason VARCHAR(255),
+    PRIMARY KEY (id),
+    CONSTRAINT ck_store_epoch_singleton CHECK (id = 1)
+);
+
+ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;

--- a/internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql
+++ b/internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql
@@ -12,10 +12,22 @@
 -- exists by the time any migration runs, so unlike 0066's guarded ADD COLUMN
 -- (needed because bd_events_journal is a dolt-ignored table that a fresh
 -- clone may materialize from the ignored series instead of via this file),
--- no idempotent-replay justification applies here, and a PREPARE'd ADD
--- COLUMN/DROP COLUMN silently vanishes under the CLI-bundle path on a
--- pre-2.3 Dolt CLI (see cli_prepared_ddl.go).
-CREATE TABLE issue_versions (
+-- no PREPARE-based idempotent-replay justification applies here, and a
+-- PREPARE'd ADD COLUMN/DROP COLUMN silently vanishes under the CLI-bundle
+-- path on a pre-2.3 Dolt CLI (see cli_prepared_ddl.go).
+--
+-- The CREATE TABLEs below are guarded with IF NOT EXISTS -- ordinary,
+-- unwrapped MySQL-flavored DDL, so this doesn't reintroduce the PREPARE
+-- hazard -- so a designated-migrator replay (schema_migrations bookkeeping
+-- row missing, e.g. BD_ALLOW_REMOTE_MIGRATE=1 against a clone that already
+-- has these tables) doesn't die on Error 1105. The ADD COLUMN below has no
+-- equivalent IF NOT EXISTS: MySQL, which Dolt follows, has never had that
+-- construct for ADD COLUMN (it's a MariaDB-only extension), and PREPARE-ing
+-- it to fake one is exactly the vanishing hazard above. Its replay guard
+-- instead lives in Go, keyed to this migration's filename, right where the
+-- runtime executes migration bodies (see execMigration0067Body in
+-- schema.go).
+CREATE TABLE IF NOT EXISTS issue_versions (
     issue_id VARCHAR(255) NOT NULL,
     revision BIGINT NOT NULL,
     epoch INT NOT NULL,
@@ -32,7 +44,7 @@ CREATE TABLE issue_versions (
 -- Singleton: exactly one row, id=1, once a later phase creates it. Phase 1
 -- leaves the table empty -- the CHECK just pins the shape the lazy-init that
 -- eventually seeds it (Phase 2/3) must follow.
-CREATE TABLE store_epoch (
+CREATE TABLE IF NOT EXISTS store_epoch (
     id TINYINT(1) NOT NULL DEFAULT 1,
     epoch INT NOT NULL DEFAULT 1,
     bumped_at DATETIME,

--- a/internal/storage/schema/migrations/0068_add_attribution_status.down.sql
+++ b/internal/storage/schema/migrations/0068_add_attribution_status.down.sql
@@ -1,0 +1,24 @@
+-- Reverse of 0068 step 6 only (attribution_status). Steps 1-5 of section
+-- 16.3 do not exist in this migration (see 0068's up file), so there is
+-- nothing else to reverse here.
+--
+-- issue_versions is guaranteed empty in any real rollback scenario for the
+-- same reason the up migration's NOT NULL-no-default is safe (Phase 2 is
+-- this table's first writer, shipping in the same build as this column), so
+-- dropping the column loses no data that could exist independent of this
+-- migration.
+--
+-- Guarded on INFORMATION_SCHEMA the same way 0067's down is, so a
+-- partially-applied or already-rolled-back workspace rolls back safely.
+-- Only migrations/*.up.sql is embedded into the CLI fresh bundle, so the
+-- PREPARE hazard (cli_prepared_ddl.go) never reaches this file.
+SET @issue_versions_as_has = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issue_versions'
+      AND COLUMN_NAME = 'attribution_status'
+);
+SET @sql = IF(@issue_versions_as_has > 0,
+    'ALTER TABLE issue_versions DROP COLUMN attribution_status',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/0068_add_attribution_status.up.sql
+++ b/internal/storage/schema/migrations/0068_add_attribution_status.up.sql
@@ -1,0 +1,44 @@
+-- Migration 0068: Phase 2 dual-write schema for versioned beads (be-hs42e.3
+-- / gastownhall/beads#6135), step 6 of design section 16.3 (be-dt74u
+-- amendment, be-hs42e.3's design field) only.
+--
+-- Steps 1-5 of section 16.3 (version_id CHAR(36) UUID PK swap;
+-- participation_generation BIGINT NULL on issues and its wisps shape-parity
+-- mirror) are deliberately NOT in this file: be-v33pa's own scope is BASE
+-- re-seating + attribution_status (section 16.4) only, per its exit
+-- contract. A later bead may append the remaining steps to this same file --
+-- scripts/check-migration-hygiene.sh Check C only protects a migration
+-- already shipped on the base branch, and this one is still unmerged.
+--
+-- attribution_status (R14, section 16.4): a NOT NULL column with no default
+-- is safe here because issue_versions (created by 0067, a prior migration in
+-- this same set) is guaranteed empty at this point in any replay -- Phase 2
+-- is this table's first and only writer, and its dual-write code lands in
+-- the same build as this column, so there is no pre-existing row for the
+-- NOT NULL constraint to reject. See RecordVersionInTx /
+-- attributionStatusForActor in internal/storage/issueops/version_history.go
+-- for what populates it.
+--
+-- Guarded the same way 0067's ADD COLUMNs are (see that file's header for
+-- the full explanation of why: no MariaDB-only IF NOT EXISTS on Dolt 2.2.3's
+-- ADD COLUMN, so an INFORMATION_SCHEMA probe + PREPARE is the only
+-- replay-safe shape) -- makes a raw-SQL replay of this file a clean no-op on
+-- an already-migrated store. Needs a CLI-bundle direct-DDL override
+-- (cliMigration0068AddAttributionStatus in cli_migrations.go), the same
+-- dolthub/dolt#11345 escape hatch 0067 uses, guarded by
+-- TestBundleMigrationsWithPreparedALTERAreOverriddenOrJustified.
+--
+-- No wisps twin needed: issue_versions has no wisps-side counterpart table
+-- at all (design section 16.3), so cliSubstituteAssumesWispTables does not
+-- apply to this migration either.
+SET @issue_versions_as_needs_add = (
+    SELECT IF(COUNT(*) = 0, 1, 0)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issue_versions'
+      AND COLUMN_NAME = 'attribution_status'
+);
+SET @sql = IF(@issue_versions_as_needs_add = 1,
+    'ALTER TABLE issue_versions ADD COLUMN attribution_status VARCHAR(20) NOT NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/ignored/0026_add_wisps_current_revision.up.sql
+++ b/internal/storage/schema/migrations/ignored/0026_add_wisps_current_revision.up.sql
@@ -1,0 +1,38 @@
+-- Ignored migration 0026: ensure wisps.current_revision exists on every clone
+-- (be-hs42e.2 / gastownhall/beads#6134).
+--
+-- Synced migration 0067 adds current_revision to issues and wisps — but wisps
+-- is dolt-ignored (migration 0019), so its schema is clone-local, and a
+-- workspace that bootstraps or re-clones from a remote whose
+-- schema_migrations cursor is already >= 0067 adopts the cursor without ever
+-- executing 0067. Its wisps table (materialized by ignored/0001, which
+-- predates current_revision) would then permanently lack the column, and the
+-- shared issues/wisps column lists would drift by one column between the
+-- fresh-clone door and the fresh-init door. Same mechanism, same shape, same
+-- fix as ignored/0013 (wisps.row_lock, wy-pt82l) and ignored/0020
+-- (wisps.storage_class, bd-hs7fa).
+--
+-- Carried here for SHAPE only. Nothing in Phase 2 (#6135) or Phase 3 (#6136)
+-- reads or writes the wisps column: versioning is an issues-plane contract
+-- and wisps are the ephemeral plane. wisps.row_lock is the precedent for a
+-- column that exists on both planes and means something on one — see 0067's
+-- header for the full asymmetry note.
+--
+-- The guard makes this a no-op on in-place-upgraded workspaces where synced
+-- 0067 already added the column, and on workspaces with no local wisps table
+-- yet. Definition mirrors 0067 exactly: BIGINT NOT NULL DEFAULT 1, so every
+-- pre-existing row reads as revision 1 with no backfill.
+SET @needs_add = IF(
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps') > 0
+    AND
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisps'
+          AND COLUMN_NAME = 'current_revision') = 0,
+    1, 0
+);
+SET @sql = IF(@needs_add = 1,
+    'ALTER TABLE wisps ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -1551,6 +1551,79 @@ func execMigrationBody(ctx context.Context, db DBConn, sqlText string) error {
 	return DrainCall(ctx, db, sqlText)
 }
 
+// migration0067Filename keys the designated-migrator replay guard below to
+// exactly one frozen migration file — see execMigrationBodyForFile.
+const migration0067Filename = "0067_add_versioned_beads_schema.up.sql"
+
+// alterIssuesAddCurrentRevision is the exact leading text of migration 0067's
+// one ALTER TABLE statement, frozen alongside the migration file itself. Used
+// only to recognize that one statement out of the handful splitSQLStatements
+// hands back; not a general SQL parser.
+const alterIssuesAddCurrentRevision = "ALTER TABLE issues ADD COLUMN current_revision"
+
+// execMigrationBodyForFile is runMigrations' single dispatch point: most
+// migrations run through the shared execMigrationBody, but a migration whose
+// frozen SQL cannot fully guard its own idempotent replay gets a
+// filename-keyed override here instead.
+func execMigrationBodyForFile(ctx context.Context, db DBConn, name, sqlText string) error {
+	if name == migration0067Filename {
+		return execMigration0067Body(ctx, db, sqlText)
+	}
+	return execMigrationBody(ctx, db, sqlText)
+}
+
+// execMigration0067Body applies migration 0067's frozen SQL exactly like
+// execMigrationBody — one ExecContext call, the file's bytes unchanged — so
+// an ordinary forward migration (the only shape any pre-existing test in this
+// package simulates, e.g. lock_test.go's expectOnePendingMigration) is
+// byte-for-byte identical in call shape and behavior to before this guard
+// existed. It only does something different when that single call fails: a
+// designated-migrator replay (be-xrl84) hits this file again after
+// issue_versions, store_epoch and issues.current_revision all already exist.
+// The two CREATE TABLEs guard themselves (CREATE TABLE IF NOT EXISTS is
+// ordinary, unwrapped MySQL DDL), so on replay the batch fails on the ALTER's
+// duplicate-column condition specifically — MySQL, which Dolt follows, has
+// never had ADD COLUMN IF NOT EXISTS (it's a MariaDB-only extension), and
+// PREPARE-ing one to fake it silently vanishes under the CLI-bundle path on a
+// pre-2.3 Dolt CLI (see cli_prepared_ddl.go).
+//
+// Rather than pattern-match Dolt's DDL-conflict error text or number to
+// confirm that guess, failure is confirmed the same way success is: reread
+// INFORMATION_SCHEMA. CREATE TABLE's own conflict surfaces as a generic
+// Error 1105 ("table ... already exists") rather than MySQL's usual
+// table-exists code, so there is no reason to trust the ALTER's conflict is
+// any more standardized. If issues.current_revision exists after the
+// failure, that failure is this exact replay collision — retry once with the
+// ALTER statement stripped from the batch (statements re-derived from sqlText
+// itself via splitSQLStatements, not a hand-maintained copy, so the retry
+// cannot silently drift from the frozen file it is guarding). Any other
+// failure (column still absent) is a real error and is returned unchanged.
+func execMigration0067Body(ctx context.Context, db DBConn, sqlText string) error {
+	_, err := db.ExecContext(ctx, sqlText)
+	if err == nil {
+		return nil
+	}
+
+	exists, existsErr := schemaColumnExists(ctx, db, "issues", "current_revision")
+	if existsErr != nil || !exists {
+		return err
+	}
+
+	var kept []string
+	for _, stmt := range splitSQLStatements(sqlText) {
+		text := strings.TrimSpace(stmt.text)
+		if text == "" || strings.HasPrefix(text, alterIssuesAddCurrentRevision) {
+			continue
+		}
+		kept = append(kept, text)
+	}
+	if len(kept) == 0 {
+		return nil
+	}
+	_, err = db.ExecContext(ctx, strings.Join(kept, ";\n")+";")
+	return err
+}
+
 // migrate brings the source up to its latest version and returns the number of
 // numbered migrations applied plus whether it added the content_hash column to a
 // pre-existing cursor table. The column signal lets MigrateUp stage and commit
@@ -1668,7 +1741,7 @@ func runMigrations(ctx context.Context, db DBConn, src migrationSource, minVersi
 
 		fmt.Fprintf(stderr, "Applying migration %04d: %s…\n", mf.version, humanMigrationName(mf.name))
 		start := time.Now()
-		if err := execMigrationBody(ctx, db, string(data)); err != nil {
+		if err := execMigrationBodyForFile(ctx, db, mf.name, string(data)); err != nil {
 			return count, fmt.Errorf("migration %s: %w", mf.name, err)
 		}
 		sum := sha256.Sum256(data)

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -1551,79 +1551,6 @@ func execMigrationBody(ctx context.Context, db DBConn, sqlText string) error {
 	return DrainCall(ctx, db, sqlText)
 }
 
-// migration0067Filename keys the designated-migrator replay guard below to
-// exactly one frozen migration file — see execMigrationBodyForFile.
-const migration0067Filename = "0067_add_versioned_beads_schema.up.sql"
-
-// alterIssuesAddCurrentRevision is the exact leading text of migration 0067's
-// one ALTER TABLE statement, frozen alongside the migration file itself. Used
-// only to recognize that one statement out of the handful splitSQLStatements
-// hands back; not a general SQL parser.
-const alterIssuesAddCurrentRevision = "ALTER TABLE issues ADD COLUMN current_revision"
-
-// execMigrationBodyForFile is runMigrations' single dispatch point: most
-// migrations run through the shared execMigrationBody, but a migration whose
-// frozen SQL cannot fully guard its own idempotent replay gets a
-// filename-keyed override here instead.
-func execMigrationBodyForFile(ctx context.Context, db DBConn, name, sqlText string) error {
-	if name == migration0067Filename {
-		return execMigration0067Body(ctx, db, sqlText)
-	}
-	return execMigrationBody(ctx, db, sqlText)
-}
-
-// execMigration0067Body applies migration 0067's frozen SQL exactly like
-// execMigrationBody — one ExecContext call, the file's bytes unchanged — so
-// an ordinary forward migration (the only shape any pre-existing test in this
-// package simulates, e.g. lock_test.go's expectOnePendingMigration) is
-// byte-for-byte identical in call shape and behavior to before this guard
-// existed. It only does something different when that single call fails: a
-// designated-migrator replay (be-xrl84) hits this file again after
-// issue_versions, store_epoch and issues.current_revision all already exist.
-// The two CREATE TABLEs guard themselves (CREATE TABLE IF NOT EXISTS is
-// ordinary, unwrapped MySQL DDL), so on replay the batch fails on the ALTER's
-// duplicate-column condition specifically — MySQL, which Dolt follows, has
-// never had ADD COLUMN IF NOT EXISTS (it's a MariaDB-only extension), and
-// PREPARE-ing one to fake it silently vanishes under the CLI-bundle path on a
-// pre-2.3 Dolt CLI (see cli_prepared_ddl.go).
-//
-// Rather than pattern-match Dolt's DDL-conflict error text or number to
-// confirm that guess, failure is confirmed the same way success is: reread
-// INFORMATION_SCHEMA. CREATE TABLE's own conflict surfaces as a generic
-// Error 1105 ("table ... already exists") rather than MySQL's usual
-// table-exists code, so there is no reason to trust the ALTER's conflict is
-// any more standardized. If issues.current_revision exists after the
-// failure, that failure is this exact replay collision — retry once with the
-// ALTER statement stripped from the batch (statements re-derived from sqlText
-// itself via splitSQLStatements, not a hand-maintained copy, so the retry
-// cannot silently drift from the frozen file it is guarding). Any other
-// failure (column still absent) is a real error and is returned unchanged.
-func execMigration0067Body(ctx context.Context, db DBConn, sqlText string) error {
-	_, err := db.ExecContext(ctx, sqlText)
-	if err == nil {
-		return nil
-	}
-
-	exists, existsErr := schemaColumnExists(ctx, db, "issues", "current_revision")
-	if existsErr != nil || !exists {
-		return err
-	}
-
-	var kept []string
-	for _, stmt := range splitSQLStatements(sqlText) {
-		text := strings.TrimSpace(stmt.text)
-		if text == "" || strings.HasPrefix(text, alterIssuesAddCurrentRevision) {
-			continue
-		}
-		kept = append(kept, text)
-	}
-	if len(kept) == 0 {
-		return nil
-	}
-	_, err = db.ExecContext(ctx, strings.Join(kept, ";\n")+";")
-	return err
-}
-
 // migrate brings the source up to its latest version and returns the number of
 // numbered migrations applied plus whether it added the content_hash column to a
 // pre-existing cursor table. The column signal lets MigrateUp stage and commit
@@ -1741,7 +1668,7 @@ func runMigrations(ctx context.Context, db DBConn, src migrationSource, minVersi
 
 		fmt.Fprintf(stderr, "Applying migration %04d: %s…\n", mf.version, humanMigrationName(mf.name))
 		start := time.Now()
-		if err := execMigrationBodyForFile(ctx, db, mf.name, string(data)); err != nil {
+		if err := execMigrationBody(ctx, db, string(data)); err != nil {
 			return count, fmt.Errorf("migration %s: %w", mf.name, err)
 		}
 		sum := sha256.Sum256(data)

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -1927,6 +1927,9 @@ func TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities(t *testing.T)
 		"ALTER TABLE wisp_comments MODIFY COLUMN text LONGTEXT NOT NULL;",
 		// 0066: same prepared-ALTER shape as 0060, same CLI no-op on 2.2.x.
 		"ALTER TABLE bd_events_journal ADD COLUMN actor VARCHAR(255) NOT NULL DEFAULT '';",
+		// 0067: two-plane prepared ADD COLUMN, same shape as 0060.
+		"ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;",
+		"ALTER TABLE wisps ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("AllMigrationsSQL missing direct CLI DDL %q", want)
@@ -1948,6 +1951,11 @@ func TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities(t *testing.T)
 		// 0066 guards its ALTER the same way; only its source text carries
 		// this probe (the events table's actor column is a bare CREATE).
 		"COLUMN_NAME = 'actor'",
+		// 0067 guards both planes' ALTERs the same way. Its two guard
+		// variables are the per-migration anchors; the probe token would
+		// also appear in the ignored twin, which is not bundled.
+		"@issues_cr_needs_add",
+		"@wisps_cr_needs_add",
 	} {
 		if strings.Contains(got, forbidden) {
 			t.Fatalf("AllMigrationsSQL contains source prepared-DDL guard %q", forbidden)

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -1930,6 +1930,9 @@ func TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities(t *testing.T)
 		// 0067: two-plane prepared ADD COLUMN, same shape as 0060.
 		"ALTER TABLE issues ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;",
 		"ALTER TABLE wisps ADD COLUMN current_revision BIGINT NOT NULL DEFAULT 1;",
+		// 0068: single-plane prepared ADD COLUMN, same shape as 0066 (no
+		// wisps twin — issue_versions has none).
+		"ALTER TABLE issue_versions ADD COLUMN attribution_status VARCHAR(20) NOT NULL;",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("AllMigrationsSQL missing direct CLI DDL %q", want)
@@ -1956,6 +1959,9 @@ func TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities(t *testing.T)
 		// also appear in the ignored twin, which is not bundled.
 		"@issues_cr_needs_add",
 		"@wisps_cr_needs_add",
+		// 0068 guards its single ALTER the same way; only its source text
+		// carries this probe.
+		"@issue_versions_as_needs_add",
 	} {
 		if strings.Contains(got, forbidden) {
 			t.Fatalf("AllMigrationsSQL contains source prepared-DDL guard %q", forbidden)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -820,6 +820,16 @@ type EventsJournalConfigurer interface {
 	SetEventsJournalEnabled(enabled bool)
 }
 
+// VersionedHistoryConfigurer controls dual-write issue-version history
+// activation on ONE storage instance. Implementations must never use
+// process-global state, for the same reason as EventsJournalConfigurer:
+// a process can hold several stores at once, and enabling history on one must
+// not turn it on for any other. Callers type-assert; a store that does not
+// implement it simply cannot record version history.
+type VersionedHistoryConfigurer interface {
+	SetVersionedHistoryEnabled(enabled bool)
+}
+
 // LifecycleManager provides lifecycle inspection beyond Close().
 type LifecycleManager interface {
 	IsClosed() bool

--- a/internal/storage/uow/cross_record_invariant_contract_test.go
+++ b/internal/storage/uow/cross_record_invariant_contract_test.go
@@ -1,0 +1,41 @@
+package uow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+)
+
+// TestCrossRecordInvariantContract wires this leg into the R16.1
+// cross-record invariant contract. Phase 0 leaves every hook nil in every
+// backend's fixture kit (architecture §12), so each case below skips by
+// name; this file exists so TestEveryLegWiresEveryRoleContract counts this
+// leg, and so the cases start running for real the moment this leg's fixture
+// kit grows a non-nil hook.
+func TestCrossRecordInvariantContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := conformance.CrossRecordInvariantFixture{IssuePrefix: "xrec"}
+
+	t.Run("SurvivesTwoPassingPerRecordGuards", func(t *testing.T) {
+		conformance.RunCrossRecordInvariantSurvivesTwoPassingPerRecordGuards(t, ctx, fixture)
+	})
+	t.Run("StoreInvariantTransactionScopesExactlyTheSpanningRecords", func(t *testing.T) {
+		conformance.RunStoreInvariantTransactionScopesExactlyTheSpanningRecords(t, ctx, fixture)
+	})
+	t.Run("InvariantRefusalNamesTheViolatedInvariant", func(t *testing.T) {
+		conformance.RunInvariantRefusalNamesTheViolatedInvariant(t, ctx, fixture)
+	})
+	t.Run("MemoryKeyAliasUniquenessIsAStoreInvariantNotACAS", func(t *testing.T) {
+		conformance.RunMemoryKeyAliasUniquenessIsAStoreInvariantNotACAS(t, ctx, fixture)
+	})
+	t.Run("MaximumEndpointMultiplicityIsAStoreInvariantNotACAS", func(t *testing.T) {
+		conformance.RunMaximumEndpointMultiplicityIsAStoreInvariantNotACAS(t, ctx, fixture)
+	})
+	t.Run("AdvisoryLeaseAloneDoesNotPreventTheInvariantViolation", func(t *testing.T) {
+		conformance.RunAdvisoryLeaseAloneDoesNotPreventTheInvariantViolation(t, ctx, fixture)
+	})
+	t.Run("LeaseAcquisitionRecordsNoHistoryEntry", func(t *testing.T) {
+		conformance.RunLeaseAcquisitionRecordsNoHistoryEntry(t, ctx, fixture)
+	})
+}

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -49,6 +49,9 @@ type doltSQLProvider struct {
 	// eventsJournalEnabled activates the durable events journal for THIS
 	// provider instance only. See SetEventsJournalEnabled.
 	eventsJournalEnabled atomic.Bool
+	// versionedHistoryEnabled activates dual-write issue-version history for
+	// THIS provider instance only. See SetVersionedHistoryEnabled.
+	versionedHistoryEnabled atomic.Bool
 }
 
 // SetEventsJournalEnabled activates the durable events journal for every unit
@@ -63,6 +66,13 @@ type doltSQLProvider struct {
 // write lands and the journal is simply empty.
 func (p *doltSQLProvider) SetEventsJournalEnabled(enabled bool) {
 	p.eventsJournalEnabled.Store(enabled)
+}
+
+// SetVersionedHistoryEnabled activates dual-write issue-version history for
+// every unit of work this provider begins from now on. Per instance, never
+// process-global — see SetEventsJournalEnabled.
+func (p *doltSQLProvider) SetVersionedHistoryEnabled(enabled bool) {
+	p.versionedHistoryEnabled.Store(enabled)
 }
 
 type bootstrapPreparationError struct {
@@ -125,9 +135,10 @@ func applyProviderOptions(opts []ProviderOption) providerOptions {
 }
 
 var (
-	_ UnitOfWorkProvider              = (*doltSQLProvider)(nil)
-	_ TxProvider                      = (*doltSQLProvider)(nil)
-	_ storage.EventsJournalConfigurer = (*doltSQLProvider)(nil)
+	_ UnitOfWorkProvider                 = (*doltSQLProvider)(nil)
+	_ TxProvider                         = (*doltSQLProvider)(nil)
+	_ storage.EventsJournalConfigurer    = (*doltSQLProvider)(nil)
+	_ storage.VersionedHistoryConfigurer = (*doltSQLProvider)(nil)
 )
 
 func (p *doltSQLProvider) NewUOW(ctx context.Context) (UnitOfWork, error) {
@@ -155,14 +166,16 @@ func (p *doltSQLProvider) BeginTx(ctx context.Context) (Tx, error) {
 		return nil, fmt.Errorf("uow: failed to start transaction: %w", err)
 	}
 
-	// Bind journal activation to the connection this unit of work is pinned to,
-	// AFTER START TRANSACTION so the seq allocation's UPDATE and the SELECT that
-	// must observe it are inside one transaction on one session. The scope is
-	// released when the connection is (doltServerTx.releaseConn / poisonConn),
-	// so an entry cannot outlive its transaction.
+	// Bind journal and versioned-history activation to the connection this unit
+	// of work is pinned to, AFTER START TRANSACTION so the seq allocation's
+	// UPDATE and the SELECT that must observe it are inside one transaction on
+	// one session. Both scopes are released when the connection is
+	// (doltServerTx.releaseConn / poisonConn), so an entry cannot outlive its
+	// transaction.
 	return &doltServerTx{
 		conn:              conn,
 		clearJournalScope: issueops.ScopeEventsJournalTransaction(conn, p.eventsJournalEnabled.Load()),
+		clearVersionScope: issueops.ScopeVersionedHistoryTransaction(conn, p.versionedHistoryEnabled.Load()),
 	}, nil
 }
 

--- a/internal/storage/uow/doltserver_tx.go
+++ b/internal/storage/uow/doltserver_tx.go
@@ -18,6 +18,10 @@ type doltServerTx struct {
 	// releaseConn and poisonConn — so the activation entry cannot outlive the
 	// transaction it describes, whichever way the transaction ends.
 	clearJournalScope func()
+	// clearVersionScope is clearJournalScope's counterpart for dual-write
+	// issue-version history: same binding at BeginTx, same release at
+	// releaseConn/poisonConn.
+	clearVersionScope func()
 }
 
 var _ Tx = (*doltServerTx)(nil)
@@ -155,6 +159,7 @@ func (t *doltServerTx) rollbackConn(ctx context.Context) error {
 
 func (t *doltServerTx) releaseConn() {
 	t.releaseJournalScope()
+	t.releaseVersionScope()
 	if t.conn != nil {
 		_ = t.conn.Close()
 		t.conn = nil
@@ -171,6 +176,15 @@ func (t *doltServerTx) releaseJournalScope() {
 	}
 }
 
+// releaseVersionScope is releaseJournalScope's counterpart for dual-write
+// issue-version history. Idempotent for the same reason.
+func (t *doltServerTx) releaseVersionScope() {
+	if t.clearVersionScope != nil {
+		t.clearVersionScope()
+		t.clearVersionScope = nil
+	}
+}
+
 // poisonConn discards the pinned session instead of returning it to the pool.
 // A session whose transaction may still be open must never be reused: because
 // go-sql-driver's ResetSession only performs a liveness check (no
@@ -179,6 +193,7 @@ func (t *doltServerTx) releaseJournalScope() {
 // database/sql close the connection and drop it from the pool.
 func (t *doltServerTx) poisonConn() {
 	t.releaseJournalScope()
+	t.releaseVersionScope()
 	if t.conn == nil {
 		return
 	}

--- a/internal/storage/uow/dualwrite_history_contract_test.go
+++ b/internal/storage/uow/dualwrite_history_contract_test.go
@@ -1,0 +1,136 @@
+package uow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestDualWriteContract runs the dual-write history contract against the
+// unit-of-work provider. All three legs share RecordVersionInTx's one body,
+// so this is an engine check rather than a second vote — and here it checks
+// the composition, the part that genuinely differs on this leg: dual-write
+// history has to land inside the SAME unit of work as the mutation it
+// accompanies, and this is the only leg where that mutation's own commit is
+// assembled by composition rather than opened directly against a *sql.DB.
+func TestDualWriteContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := newUOWDualWriteFixture(t, ctx, "dwc", true)
+
+	t.Run("MintsOneVersionRowPerAcceptedMutation", func(t *testing.T) {
+		conformance.RunDualWriteMintsOneVersionRowPerAcceptedMutation(t, ctx, fixture)
+	})
+	t.Run("NoOpMutationMintsNoRow", func(t *testing.T) {
+		conformance.RunDualWriteNoOpMutationMintsNoRow(t, ctx, fixture)
+	})
+	t.Run("AttributionIsRecordedWithTheMutation", func(t *testing.T) {
+		conformance.RunDualWriteAttributionIsRecordedWithTheMutation(t, ctx, fixture)
+	})
+	t.Run("CurrentRevisionMatchesTheNewVersionRow", func(t *testing.T) {
+		conformance.RunDualWriteCurrentRevisionMatchesTheNewVersionRow(t, ctx, fixture)
+	})
+	t.Run("NoOpMutationLeavesThePriorVersionRowUnperturbed", func(t *testing.T) {
+		conformance.RunDualWriteNoOpMutationLeavesThePriorVersionRowUnperturbed(t, ctx, fixture)
+	})
+}
+
+// TestDualWriteContractFlagOff runs FR-7 against a provider constructed with
+// the flag OFF from the start — its own provider, not a shared one, so "flag
+// off" means what FR-7 promises rather than "not yet turned on this session".
+func TestDualWriteContractFlagOff(t *testing.T) {
+	ctx := context.Background()
+	fixture := newUOWDualWriteFixture(t, ctx, "dwcoff", false)
+
+	t.Run("FlagOffProducesNoVersionRows", func(t *testing.T) {
+		conformance.RunDualWriteFlagOffProducesNoVersionRows(t, ctx, fixture)
+	})
+}
+
+// TestDualWriteFixtureKitIsWired is this leg's half of the explicit
+// per-leg guardrail design §8.5 calls for in place of AST auto-discovery —
+// see the dolt leg's TestDualWriteFixtureKitIsWired for why the guardrail is
+// needed even though TestEveryLegWiresEveryRoleContract's scan already
+// enumerates and confirms wiring for all six RunDualWriteXxx entrypoints.
+func TestDualWriteFixtureKitIsWired(t *testing.T) {
+	ctx := context.Background()
+	fixture := newUOWDualWriteFixture(t, ctx, "dwk", true)
+
+	if fixture.Mutate == nil {
+		t.Error("DualWriteFixture.Mutate is nil")
+	}
+	if fixture.MutateAsNoOp == nil {
+		t.Error("DualWriteFixture.MutateAsNoOp is nil")
+	}
+	if fixture.CurrentRevision == nil {
+		t.Error("DualWriteFixture.CurrentRevision is nil")
+	}
+	if fixture.VersionRowCount == nil {
+		t.Error("DualWriteFixture.VersionRowCount is nil")
+	}
+	if fixture.LatestVersionAttribution == nil {
+		t.Error("DualWriteFixture.LatestVersionAttribution is nil")
+	}
+}
+
+func newUOWDualWriteFixture(t *testing.T, ctx context.Context, prefix string, enabled bool) conformance.DualWriteFixture {
+	t.Helper()
+	provider := newUOWRoleFixtureProvider(t, ctx, prefix)
+	// Through the capability accessor's operator half, the same way
+	// newUOWJournalFixture reaches storage.EventsJournalConfigurer: a
+	// provider that stopped offering the role is the regression this
+	// assertion exists to catch.
+	configurer, ok := provider.(storage.VersionedHistoryConfigurer)
+	if !ok {
+		t.Fatalf("provider %T does not implement storage.VersionedHistoryConfigurer", provider)
+	}
+	configurer.SetVersionedHistoryEnabled(enabled)
+
+	kit := newUOWRoleFixtureKit(provider, prefix)
+	return conformance.DualWriteFixture{
+		IssuePrefix: prefix,
+		Mutate: func(ctx context.Context, id string) error {
+			return RunTx(ctx, provider, func(ctx context.Context, uw UnitOfWork) (string, error) {
+				_, err := uw.IssueUseCase().CreateIssue(ctx, domain.CreateIssueParams{
+					Issue: &types.Issue{
+						ID: id, Title: "t-" + id, IssueType: types.TypeTask, Status: types.StatusOpen,
+					},
+					ExplicitID: id,
+					CreateOnly: true,
+				}, "actor")
+				return "create " + id, err
+			})
+		},
+		MutateAsNoOp: func(ctx context.Context, id string) error {
+			// Re-sets title to the exact value Mutate already gave it, so
+			// issueops.DiscardNoopIssueUpdates discards it before it ever
+			// reaches RecordVersionInTx.
+			return RunTx(ctx, provider, func(ctx context.Context, uw UnitOfWork) (string, error) {
+				return "update " + id, uw.IssueUseCase().UpdateIssue(ctx, id,
+					map[string]any{"title": "t-" + id}, "actor")
+			})
+		},
+		CurrentRevision: func(ctx context.Context, id string) (int64, error) {
+			var revision int64
+			err := kit.QueryScalar(ctx, "SELECT current_revision FROM issues WHERE id = ?", []any{id}, &revision)
+			return revision, err
+		},
+		VersionRowCount: func(ctx context.Context, id string) (int, error) {
+			var count int
+			err := kit.QueryScalar(ctx, "SELECT COUNT(*) FROM issue_versions WHERE issue_id = ?", []any{id}, &count)
+			return count, err
+		},
+		LatestVersionAttribution: func(ctx context.Context, id string) (actor, agent, message string, err error) {
+			err = kit.QueryScalar(ctx, `
+				SELECT COALESCE(change_actor, ''), COALESCE(change_agent, ''), COALESCE(change_message, '')
+				FROM issue_versions
+				WHERE issue_id = ?
+				ORDER BY revision DESC
+				LIMIT 1`, []any{id}, &actor, &agent, &message)
+			return actor, agent, message, err
+		},
+	}
+}

--- a/internal/storage/uow/expected_revision_contract_test.go
+++ b/internal/storage/uow/expected_revision_contract_test.go
@@ -1,0 +1,50 @@
+package uow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+)
+
+// TestExpectedRevisionContract wires this leg into the R16/R17
+// expected-revision contract. Phase 0 leaves every hook nil in every
+// backend's fixture kit (architecture §12), so each case below skips by
+// name; this file exists so TestEveryLegWiresEveryRoleContract counts this
+// leg, and so the cases start running for real the moment this leg's fixture
+// kit grows a non-nil hook.
+func TestExpectedRevisionContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := conformance.ExpectedRevisionFixture{IssuePrefix: "erev"}
+
+	t.Run("AcceptsAWriteNamingTheCurrentVersion", func(t *testing.T) {
+		conformance.RunExpectedRevisionAcceptsAWriteNamingTheCurrentVersion(t, ctx, fixture)
+	})
+	t.Run("AcceptsAWriteNamingNoVersion", func(t *testing.T) {
+		conformance.RunExpectedRevisionAcceptsAWriteNamingNoVersion(t, ctx, fixture)
+	})
+	t.Run("CoversFieldsOutsideAnyWatchedSubset", func(t *testing.T) {
+		conformance.RunExpectedRevisionCoversFieldsOutsideAnyWatchedSubset(t, ctx, fixture)
+	})
+	t.Run("RefusalReportsTheRefusingVersionAddress", func(t *testing.T) {
+		conformance.RunRefusalReportsTheRefusingVersionAddress(t, ctx, fixture)
+	})
+	t.Run("RefusalReportsTheRefusingVersionsChangeAttribution", func(t *testing.T) {
+		conformance.RunRefusalReportsTheRefusingVersionsChangeAttribution(t, ctx, fixture)
+	})
+	t.Run("RefusalIsATypedOutcomeNotAGenericError", func(t *testing.T) {
+		conformance.RunRefusalIsATypedOutcomeNotAGenericError(t, ctx, fixture)
+	})
+	t.Run("RefusalIsDistinguishableFromAnAcceptedWrite", func(t *testing.T) {
+		conformance.RunRefusalIsDistinguishableFromAnAcceptedWrite(t, ctx, fixture)
+	})
+	t.Run("RefusalIsDistinguishableFromNotFound", func(t *testing.T) {
+		conformance.RunRefusalIsDistinguishableFromNotFound(t, ctx, fixture)
+	})
+	t.Run("RefusalIsDistinguishableFromValidationFailure", func(t *testing.T) {
+		conformance.RunRefusalIsDistinguishableFromValidationFailure(t, ctx, fixture)
+	})
+	t.Run("RefusalNeverSilentlyPicksAWinner", func(t *testing.T) {
+		conformance.RunRefusalNeverSilentlyPicksAWinner(t, ctx, fixture)
+	})
+}

--- a/internal/storage/uow/notifying.go
+++ b/internal/storage/uow/notifying.go
@@ -352,6 +352,16 @@ func (p *notifyingProvider) SetEventsJournalEnabled(enabled bool) {
 	}
 }
 
+// SetVersionedHistoryEnabled forwards dual-write issue-version history
+// activation to the provider that actually binds it to a transaction
+// (doltSQLProvider.BeginTx), for the same reason and in the same shape as
+// SetEventsJournalEnabled above.
+func (p *notifyingProvider) SetVersionedHistoryEnabled(enabled bool) {
+	if configurer, ok := p.inner.(storage.VersionedHistoryConfigurer); ok {
+		configurer.SetVersionedHistoryEnabled(enabled)
+	}
+}
+
 // eventsMaintenanceRunner is issueops.EventsMaintenanceRunner under this file's
 // import alias, named once so the forwarder below reads as an ordinary
 // capability check.

--- a/internal/storage/uow/notifying_parity_test.go
+++ b/internal/storage/uow/notifying_parity_test.go
@@ -294,11 +294,13 @@ func TestNotifyingProviderBuildsRolesOnItself(t *testing.T) {
 		"RunNonTx":      true,
 		"SetPoolLimits": true,
 		"Unwrap":        true,
-		// Events-journal capability plumbing: activation binds on the inner
-		// provider's transactions, and a retention pass writes no bead. Neither
-		// builds a role, so neither can build one "on itself".
-		"SetEventsJournalEnabled": true,
-		"RunEventsMaintenanceTx":  true,
+		// Events-journal and versioned-history capability plumbing: activation
+		// for both binds on the inner provider's transactions, and a retention
+		// pass writes no bead. None of these build a role, so none of them can
+		// build one "on itself".
+		"SetEventsJournalEnabled":    true,
+		"RunEventsMaintenanceTx":     true,
+		"SetVersionedHistoryEnabled": true,
 	}
 
 	var checked int

--- a/internal/storage/uow/retention_epoch_contract_test.go
+++ b/internal/storage/uow/retention_epoch_contract_test.go
@@ -1,0 +1,72 @@
+package uow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+)
+
+// TestRetentionContract wires this leg into the R20 retention contract.
+// Phase 0 leaves every hook nil in every backend's fixture kit (architecture
+// §12), so each case below skips by name; this file exists so
+// TestEveryLegWiresEveryRoleContract counts this leg, and so the cases start
+// running for real the moment this leg's fixture kit grows a non-nil hook.
+func TestRetentionContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := conformance.RetentionFixture{IssuePrefix: "rete"}
+
+	t.Run("RemovalLeavesTheAddressAbleToAnswer", func(t *testing.T) {
+		conformance.RunRemovalLeavesTheAddressAbleToAnswer(t, ctx, fixture)
+	})
+	t.Run("RemovalReasonIsRetentionErasureOrReorganizationDistinctly", func(t *testing.T) {
+		conformance.RunRemovalReasonIsRetentionErasureOrReorganizationDistinctly(t, ctx, fixture)
+	})
+	t.Run("RemovalReportsTheSurvivingRetainedWindow", func(t *testing.T) {
+		conformance.RunRemovalReportsTheSurvivingRetainedWindow(t, ctx, fixture)
+	})
+	t.Run("RemovalNeverReassignsASurvivingAddress", func(t *testing.T) {
+		conformance.RunRemovalNeverReassignsASurvivingAddress(t, ctx, fixture)
+	})
+	t.Run("GoneIsDistinguishableFromUnknown", func(t *testing.T) {
+		conformance.RunGoneIsDistinguishableFromUnknown(t, ctx, fixture)
+	})
+	t.Run("AnAddressNeverResolvesToADifferentState", func(t *testing.T) {
+		conformance.RunAnAddressNeverResolvesToADifferentState(t, ctx, fixture)
+	})
+	t.Run("ADestructiveOperationEnumeratesAffectedAddressesFirst", func(t *testing.T) {
+		conformance.RunADestructiveOperationEnumeratesAffectedAddressesFirst(t, ctx, fixture)
+	})
+	t.Run("AHoldPreventsRemovalAndReportsInRetainedBounds", func(t *testing.T) {
+		conformance.RunAHoldPreventsRemovalAndReportsInRetainedBounds(t, ctx, fixture)
+	})
+	t.Run("ForcingAHeldRemovalRecordsWhoWhenWhy", func(t *testing.T) {
+		conformance.RunForcingAHeldRemovalRecordsWhoWhenWhy(t, ctx, fixture)
+	})
+	t.Run("EveryRetentionAnswerNamesItsProducingStore", func(t *testing.T) {
+		conformance.RunEveryRetentionAnswerNamesItsProducingStore(t, ctx, fixture)
+	})
+	t.Run("AStoreWithNoLineageKnowledgeAnswersUnknownNotGone", func(t *testing.T) {
+		conformance.RunAStoreWithNoLineageKnowledgeAnswersUnknownNotGone(t, ctx, fixture)
+	})
+	t.Run("AStoreThatRemovesStateStillAnswersGoneDurably", func(t *testing.T) {
+		conformance.RunAStoreThatRemovesStateStillAnswersGoneDurably(t, ctx, fixture)
+	})
+	t.Run("ErasureMintsACorrectedVersionRatherThanEditingInPlace", func(t *testing.T) {
+		conformance.RunErasureMintsACorrectedVersionRatherThanEditingInPlace(t, ctx, fixture)
+	})
+}
+
+// TestEpochContract wires this leg into the R20 epoch contract. Same Phase 0
+// all-nil state as TestRetentionContract above.
+func TestEpochContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := conformance.EpochFixture{IssuePrefix: "epch"}
+
+	t.Run("AnEpochBumpIsTriggeredOnlyByRestoreReinitOrSchemeChange", func(t *testing.T) {
+		conformance.RunAnEpochBumpIsTriggeredOnlyByRestoreReinitOrSchemeChange(t, ctx, fixture)
+	})
+	t.Run("EpochBumpVoidsOnlyAddressesOfVersionsNoLongerServed", func(t *testing.T) {
+		conformance.RunEpochBumpVoidsOnlyAddressesOfVersionsNoLongerServed(t, ctx, fixture)
+	})
+}

--- a/release-gates/be-dy66n-gate.md
+++ b/release-gates/be-dy66n-gate.md
@@ -78,3 +78,15 @@ This follows established precedent: be-gd3v, be-79jh, be-39ss, be-pp7e, be-r3ysh
 ## Disposition
 
 **PASS, 7/7, no waivers.** PR [gastownhall/beads#6304](https://github.com/gastownhall/beads/pull/6304) opened, verified OPEN and MERGEABLE, authored by our own account (no external-contributor human-hold triggered). Four pre-existing, non-diff-owned failure/finding classes encountered during gate evaluation, all attributed to their exact pre-existing tracker beads (be-9ogs6, be-irise, be-w4qbu, be-a0dxu) with clause-3 proof and citation comments posted this round. Reporting to mayor for visibility only; no merge-request routed, per contributor-only merge-authority carve-out.
+
+## Fix-round amendment — 2026-09-05, maintainer review of PR #6304
+
+This gate's verdict stands as recorded for source commit `26033d8e4`. It is **not** re-run here; this section exists so the record does not read as current for a head it never evaluated.
+
+Maintainer review on PR #6304 returned two decisions that change facts asserted above:
+
+1. **`current_revision` is now on both planes.** `wisps.current_revision BIGINT NOT NULL DEFAULT 1` is carried for shape parity (nothing reads or writes it in any phase) — `TestSchemaParityIssuesVsWisps` enforces strict issues↔wisps column-name parity with no exemption list. This amends the section-8 issues-only decision the gated commit encoded. Because `wisps` is dolt-ignored, the change ships with an ignored-series twin, `migrations/ignored/0026_add_wisps_current_revision.up.sql` (check D of `scripts/check-migration-hygiene.sh`; precedent ignored/0013 for 0054, ignored/0020 for 0060).
+
+2. **The ADD COLUMN idempotency guard moved from Go into the SQL.** Criterion 1's evidence line above records a verified "non-PREPARE ADD COLUMN idempotency guard" (`execMigration0067Body` in `schema.go`). That guard is gone and `schema.go` is back at `origin/main`: `internal/storage/dolt/pr4107_corruption_test.go`'s replay harness re-executes the frozen `.up.sql` bytes directly, so no Go-side guard is in that path and every migration ≥ 0046 must be idempotent as raw SQL on its own. Both ADD COLUMNs are now INFORMATION_SCHEMA-guarded PREPAREs (0060/0066 pattern), with a direct-DDL fresh-bundle override in `cliCompatibleMigrationSQL` for the pre-2.3 CLI hazard (0060/0065/0066 precedent).
+
+The diffstat recorded above is likewise the gated commit's, not the fix round's.

--- a/release-gates/be-dy66n-gate.md
+++ b/release-gates/be-dy66n-gate.md
@@ -1,0 +1,80 @@
+# Release gate — be-dy66n (Review: Phase 1: additive schema + migration slot claim - gastownhall/beads#6134)
+
+**Date:** 2026-09-05
+**Deployer:** beads/deployer
+**Bead (deploy):** be-4ka6t
+**Source bead:** be-dy66n — status closed, verdict `pass`. Reviewer notes confirm: gofmt/vet/build clean, full OWASP-Top-10-style security walk (9 categories, all N/A/checked, one non-blocking minor: insufficient logging, not required for this PR's exit contract), and all 5 exit-contract items verified first-hand (IF NOT EXISTS on both CREATE TABLEs; non-PREPARE ADD COLUMN idempotency guard; `TestProtocol_V2_DesignatedMigratorOverride` passes; no regression in 3 pre-existing diff-owned tests; redundant CLAIMED.md commit dropped). `uncovered_criteria: none`.
+**Source commit:** `26033d8e476a88c6220ea9febd42e51272b0455c`
+  - Parent: `41fd9c9b12737f5933c7ab9baf2c9efccf0f58af` (test(feat): red, refs be-xrl84)
+  - Branch history: `460a2e660` (red, refs be-hs42e.2) → `74a9b8906` (green, refs be-hs42e.2) → `41fd9c9b1` (red, refs be-xrl84) → `26033d8e4` (green, refs be-xrl84)
+  - All 5 SHAs (4 commits + base) independently re-verified via `git rev-parse --verify --quiet "<sha>^{commit}"` — all resolve.
+  - Base: `origin/main` @ `c0d8da42de5fd15c95adac85e342ba4a121da0fb`. Re-confirmed via fresh `git fetch origin main` immediately before writing this gate: `origin/main` tip and `merge-base(HEAD, origin/main)` are identical — origin/main has not moved since the branch was cut.
+**Branch:** `deploy/be-dy66n-gate`
+**Push target:** `headfork` (`quad341/beads-sec003-contrib`) — pushed and independently re-verified: `git ls-remote headfork refs/heads/deploy/be-dy66n-gate` returns `26033d8e476a88c6220ea9febd42e51272b0455c`, matching local `HEAD` exactly.
+**PR:** [gastownhall/beads#6304](https://github.com/gastownhall/beads/pull/6304) — `quad341:deploy/be-dy66n-gate` → `gastownhall:main`. Verified via `gh pr view 6304`: `state=OPEN`, `mergeable=MERGEABLE`, `author=quad341` (our own account — not an external contributor, no human-hold triggered).
+
+## Verdict: 7/7 — PASS, no waivers
+
+## Criteria walk
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review pass | PASS | be-dy66n closed, verdict `pass`, full first-hand reviewer verification of all 5 exit-contract items |
+| 2 | Acceptance criteria met | PASS | All 4 diff-owned tests confirmed passing (see Criterion 3); reviewer's exit-contract walk independently corroborates |
+| 3 | Full-suite tests | PASS (attributed) | See Criterion 3 detail below — 4 pre-existing, non-diff-owned failure classes attributed to trackers; zero diff-owned failures |
+| 3a | Pre-existing-failure attribution | PASS | 4 failure classes, all attributed with clause-3 proof (see below) |
+| 3b | Policy/lint lane (`ci-pr-policy` + `ci-pr-lint`) | PASS (attributed) | 2 further pre-existing findings attributed to trackers; see Criterion 3 detail |
+| 3c | CI-config-diff live-run | N/A | Diff touches no `.github/` or `scripts/ci/` files (`git diff --name-only origin/main...HEAD` confirms) |
+| 4 | Zero open HIGH | PASS | Reviewer's OWASP walk: 9 categories, all N/A/checked, one non-blocking minor (logging), no HIGH findings |
+| 5 | Clean git status | PASS | `git status --short` clean on `deploy/be-dy66n-gate` at SHA `26033d8e4` |
+| 6 | No merge conflicts with BASE_REF | PASS | `origin/main` unchanged since branch cut; merge-base == origin/main tip; no conflict possible |
+| 7 | Single feature theme/ancestry scope | PASS | 5 files, +424/-1, all on-theme for migration-0067 versioned-beads schema (see diffstat below) |
+
+**Diffstat** (`git diff --stat origin/main...HEAD`):
+```
+internal/storage/dolt/initschema_0067_versioned_beads_replay_test.go | 106 ++++++++++++
+internal/storage/schema/migration_0067_versioned_beads_test.go      | 178 +++++++++++++++++++++
+internal/storage/schema/migrations/0067_add_versioned_beads_schema.down.sql |  10 ++
+internal/storage/schema/migrations/0067_add_versioned_beads_schema.up.sql   |  56 +++++++
+internal/storage/schema/schema.go                                   |  75 ++++++++-
+5 files changed, 424 insertions(+), 1 deletion(-)
+```
+
+## Criterion 3 — full-suite test evidence + policy/lint lane + CI-config-diff (3c)
+
+**test_cmd:** `TEST_COVER=1 ./scripts/test.sh` (via `make test`)
+**test_cmd_scope:** whole-repo, `BEADS_TEST_SKIP=dolt` default (skips all Dolt-backed tests repo-wide, including all `internal/storage/dolt` package tests)
+**test_counts:** 90+ packages clean; `cmd/bd` package FAILed overall (282.560s) due to 4 named tests (below); all other packages `ok`
+
+**diff_tests_executed** (all PASS):
+- `TestLatestVersionIncludesMigration0067`
+- `TestMigration0067AddsVersionedBeadsSchema`
+- `TestMigration0067AddsVersionedBeadsSchemaThroughDoltCLI`
+- `TestSchemaInitReplaysMigration0067WhenBookkeepingRowMissing` — independently re-verified by name under `BEADS_TEST_ENV_RUN_DOLT=1` + `-tags=integration,gms_pure_go` (this test lives in `internal/storage/dolt`, package-skipped by plain `make test`'s `BEADS_TEST_SKIP=dolt`)
+
+**failure_attribution:**
+
+1. `TestFindBeadsRepoRoot_WorktreeFallback, TestCountExistingIssues_WorktreeNoBeadsAnywhere, TestReset_WorktreeNoBeadsReturnsEmpty, TestReset_WorktreeSubdirFindsBeadsDir` (`cmd/bd`) -> `be-9ogs6` | clause 3: same root-condition class as be-9ogs6's tracked "ambient `.beads` directory defeats clean-workspace walk-up assumption" — this environment has a real ambient `/tmp/.beads` (birth ~13h before this run, unrelated to this diff) that satisfies these tests' "no `.beads` found anywhere under `/tmp`" assumption during walk-up. SHA `26033d8e476a88c6220ea9febd42e51272b0455c`, log in deployer scratchpad `be-dy66n-full-suite.log`.
+2. `internal/storage/dolt` package, 9 pre-existing failures -> `be-irise` | clause 3: pre-existing, independently tracked failure class, not caused by this diff. clause 4 note: this diff adds a new test file to the *same package* (`initschema_0067_versioned_beads_replay_test.go`); flagged as a non-blocking observation on `be-irise` for whoever next runs the whole-package suite. Not gate-blocking: `make test`'s required full-suite command skips Dolt tests entirely, so none of the 9 appear in this gate's own criterion-3 evidence — confirmed via this run's own full-suite output, `internal/storage/dolt` reports clean `ok`.
+3. `ci-pr-lint` (`golangci-lint`): 3x `G602: slice index out of range (gosec)` in `backend/conformance/importer_contract.go:390,392` and `relations_contract.go:672` -> `be-w4qbu` | clause 3: matches `be-w4qbu`'s known false-positive class (via its own comment history citing `be-ckoic`); confirmed not diff-owned (`git diff --name-only origin/main...HEAD -- backend/` empty). A first `ci-pr-lint` attempt also surfaced 29 issues under a phantom, nonexistent path (`../builder/worktrees/be-kh65q/...`) — diagnosed as a stale, content-hash-keyed `golangci-lint` shared result cache (`~/quad341-claude/.cache/golangci-lint`) leaking path metadata from a since-deleted worktree; `golangci-lint cache clean` + rerun reproduced only the 3 genuine, correctly-pathed findings above. This cache phenomenon itself also matches `be-w4qbu`'s own tracked history (`be-vf95`). Log `be-dy66n-ci-lint-2.log`.
+4. `ci-pr-policy`: "check version consistency" step fails on `.githooks/commit-msg: no 'BEGIN BEADS INTEGRATION' marker found` -> `be-a0dxu` | clause 3: identical symptom reproduced verbatim, matches `be-a0dxu`'s tracked condition exactly — `.githooks/commit-msg` on disk is a local, untracked dev shim (excluded via `.git/info/exclude:40`), not part of the repo's committed `.githooks/` fileset; confirmed not diff-owned (`git diff --name-only origin/main...HEAD -- .githooks/` empty). **Cross-confirmed by the real upstream CI**: PR #6304's own "Check version consistency" GitHub Actions check passed cleanly on first report — this local-only shim does not exist on a clean checkout. Log `be-dy66n-ci-policy.log`.
+
+**attribution_evidence:** all 4 citations posted as `bd comment` to their respective tracker beads this gate round (be-9ogs6, be-irise, be-w4qbu, be-a0dxu), each including SHA, log reference, and clause-3 proof.
+
+**ci_lane_run (3c):** N/A — diff touches no `.github/` or `scripts/ci/` paths, so no CI-config live-run is required. `make ci-pr-policy` and `make ci-pr-lint` were still run in full as the standard 3b policy/lint lane (see failure_attribution items 3–4 above); both are attributed-PASS with zero diff-owned findings.
+
+**waiver_ref:** none — no waiver needed, all failures cleanly attributed to pre-existing, non-diff-owned conditions with clause-3 proof and zero clause-4 path overlap (except the single non-blocking dolt-package observation on be-irise, which does not block this gate per the reasoning above).
+
+**uncovered_criteria:** none
+
+Beyond the above, `gc beads-contributor pre-pr-check` (10-point pre-PR sanity check) ran clean: 0 blockers, 0 warnings — branch 0 commits behind origin/main, 5 changed files, 4 commits, 1 top-level dir touched, no `.claude/**` paths, no postgres tokens, no undefined build tags. On the live PR, `gh pr checks 6304` at open time shows two already-resolved checks passing (`Resolve versions to test`, `Check version consistency` — the latter corroborating the local-shim diagnosis above) and the remainder queued/pending with zero immediate failures.
+
+## Merge authority
+
+This rig is a **contributor-only** participant in `gastownhall/beads` (upstream `origin` is fetch-only by design; all push/PR traffic goes through `headfork`/`prhead`, both `quad341/beads-sec003-contrib`). No rig agent — builder, reviewer, or deployer — holds merge rights on `gastownhall/beads`, and no rig agent ever runs `gh pr merge`. Per standing policy, the deployer's job for a contributor-only rig ends at a verified open, mergeable PR; this gate stops there and reports to mayor for **visibility only**, with no merge-request routed.
+
+This follows established precedent: be-gd3v, be-79jh, be-39ss, be-pp7e, be-r3ysh, be-krza3, be-vc1m (PR #5792), be-7q688 (PR #6003), be-6iglh/be-0l89e (PR #6082), be-c8kgv (PR #6221), be-1wwre (PR #6247), be-3vzut (PR #6262), be-kqg23 (PR #6271).
+
+## Disposition
+
+**PASS, 7/7, no waivers.** PR [gastownhall/beads#6304](https://github.com/gastownhall/beads/pull/6304) opened, verified OPEN and MERGEABLE, authored by our own account (no external-contributor human-hold triggered). Four pre-existing, non-diff-owned failure/finding classes encountered during gate evaluation, all attributed to their exact pre-existing tracker beads (be-9ogs6, be-irise, be-w4qbu, be-a0dxu) with clause-3 proof and citation comments posted this round. Reporting to mayor for visibility only; no merge-request routed, per contributor-only merge-authority carve-out.

--- a/release-gates/be-e0w8y-phase0-conformance-suite-gate.md
+++ b/release-gates/be-e0w8y-phase0-conformance-suite-gate.md
@@ -1,0 +1,81 @@
+# Release gate — Phase 0: conformance suite (history, expectedRevision R16.1, epochs R20)
+
+- **Deploy bead:** be-e0w8y
+- **Review bead (CLOSED, verdict PASS):** be-g8mp3
+- **Builder bead / source branch (provenance only):** be-zv3ob / `builder/be-hs42e.1`
+- **Reviewed commit:** `d52dfba0a798903ac956323080c15fca855e1e1f`
+- **Deployed commit:** `d52dfba0a798903ac956323080c15fca855e1e1f` (identical — zero divergence from `origin/main`, no self-rebase needed)
+- **Deploy branch:** `deploy/be-e0w8y-gate`, cut from the reviewed commit
+- **Upstream issue:** gastownhall/beads#6133
+- **Evaluated:** 2026-09-02 by beads/deployer
+
+## Pre-flight: has the target already merged?
+
+Checked before any gate criteria: `gh api repos/gastownhall/beads/commits/d52dfba0a798903ac956323080c15fca855e1e1f/pulls` returned empty, and `gh pr list --repo gastownhall/beads --search 6133 --state all` returned no matches. The target was never PR-borne — proceeded with the normal single-bead flow.
+
+## Scope
+
+14 files, +2442/-14, 3 commits (`85165e964` red, `8631c38cf` green round 1, `d52dfba0a` green round 2 — fixes round 1's wiring gap). All files under `backend/conformance/` and `internal/storage/{dolt,embeddeddolt,uow}/`. Single feature theme: the Phase 0 conformance suite for expectedRevision (R16/R16.1), cross-record invariants, and retention epochs (R20), landing identical contract tests across all three storage backends. Re-verified independently via `git diff --shortstat`/`--name-only` against `$(git merge-base origin/main HEAD)` — matches the review bead's own recorded file list and diffstat exactly.
+
+## Gate criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|:-:|----------|
+| 1 | Review PASS present | PASS | be-g8mp3 closed, verdict PASS, verified from its own NOTES record (not just be-e0w8y's secondhand description) |
+| 2 | Acceptance criteria met | PASS | be-g8mp3's `uncovered_criteria: none` — full 1:1 walk of architecture §4 R16/R16.1/R17/R20 clauses against `diff_tests_executed`; two FR-08 E2E XFail clauses out-of-scope per architecture §9 ("no in-process fixture hook models compaction") |
+| 3 | Tests pass (full-scope) | PASS | See "Tests run on release branch" below |
+| 3a | Pre-existing-failure attribution | PASS | See "Pre-existing failure attribution" below — all four required conditions independently satisfied |
+| 3b | Policy/lint lane | PASS | be-g8mp3 `style_findings: none` — gofmt clean, `make ci-pr-lint` scoped to true merge-base clean, `go vet ./...` clean |
+| 3c | CI-config diff needs own lane's first run | N/A | No CI configuration files in diff (confirmed via file list above) |
+| 4 | No high-severity findings | PASS | be-g8mp3 `security_findings: none` — full 9-point OWASP walk, imports confirmed via direct grep, zero new dependencies |
+| 5 | Clean tree | PASS | `git status --short` on the deploy branch shows no modifications outside this gate file |
+| 6 | Clean divergence from `origin/main` | PASS | `git rev-list --left-right --count origin/main...HEAD` = `0␉3` (0 behind, 3 ahead) — fresh recheck immediately before writing this gate, matches the pre-existing check; no self-rebase needed |
+| 7 | Single feature theme | PASS | 14 files, one theme (Phase 0 conformance suite), see Scope above |
+
+## Tests run on release branch
+
+**Command:** `make test` (full-scope, `./...`)
+**Scope:** `full-suite`
+**Branch/SHA:** `deploy/be-e0w8y-gate` @ `d52dfba0a798903ac956323080c15fca855e1e1f`
+**Result:** `EXIT_CODE:2` — 93 packages `ok`, 3 packages `FAIL`
+
+| Package | Result | Duration |
+|---|---|---|
+| `cmd/bd` | FAIL | 1507.907s (timed out, `panic: test timed out after 25m0s`) |
+| `cmd/bd/doctor` | FAIL | 37.747s |
+| `internal/storage/dolt` | FAIL | 1508.227s (timed out, `panic: test timed out after 25m0s`) |
+| `backend/conformance` | ok | 0.327s |
+| `internal/storage/embeddeddolt` | ok | 83.713s |
+| `internal/storage/uow` | ok | 363.892s |
+| (90 other packages) | ok | — |
+
+47 distinct `--- FAIL:` test names total across the 3 failing packages (independently re-counted fresh from the saved run log via `grep -oE '^\s*--- FAIL: [A-Za-z0-9_/]+' | sort -u | wc -l`), consistent with — though not identically scoped to — be-g8mp3's own narrower count of 34 distinct top-level names / 45 `--- FAIL:` lines for `cmd/bd`+`cmd/bd/doctor` alone (the reviewer's count excluded `internal/storage/dolt`; the two are reconciled once that package's lines are added back in). Zero diff-owned tests appear in any failing package.
+
+**Diff-owned tests, resolved by name** (all 20 top-level tests, all PASS at top level; nested subtests within them carry 32 explained SKIPs — see below):
+
+All test files under `backend/conformance/` and the three `internal/storage/{dolt,embeddeddolt,uow}/*_test.go` files listed in Scope were located by name in the full-suite output and confirmed PASS. Full per-test list matches be-g8mp3's `diff_tests_executed` record; independently reconfirmed present and PASS-ing in this session's own fresh full-suite run (not copied from the review).
+
+**SKIP pattern (32 nested subtests, within otherwise-PASSing diff-owned top-level tests):** Justified by issue gastownhall/beads#6133's own acceptance criterion ("green in CI in skipped mode") together with architecture §12 / NFR-01. Resolved at the granularity the protocol's own worked example uses — top-level test name, not per-nested-subtest — via two independent routes converging on the same conclusion: (1) my own reading of #6133 and architecture §12/NFR-01 before consulting the review at all, and (2) be-g8mp3's `skip_justification`, reached independently by the reviewer citing the same primary sources (be-hs42e.1 §0/§12, NFR-01). Convergent, not inherited, verification. Representative tests: `TestVersionedHistoryPhase0RunsInFullSkipMode`, `TestEveryLegWiresEveryRoleContract`.
+
+**Pre-existing failure attribution (criterion 3a — all four conditions required):**
+
+| Condition | Cluster: `cmd/bd` hang (`dolt`-backed pool timeout) | Cluster: `cmd/bd`+`cmd/bd/doctor` (34 tests) |
+|---|---|---|
+| Not diff-owned | ✅ zero diff files touch `cmd/bd` or `internal/storage/dolt`'s pool code | ✅ zero diff files touch `cmd/bd` |
+| Tracked bead predating this run | ✅ be-ek5o4, `Created: 2026-09-01`, predates this 2026-09-02 gate run | ✅ same tracker, be-ek5o4 |
+| Not caused by diff (MECHANISM) | ✅ root cause is `cenkalti/backoff.Retry` looping against `defaultPoolReadTimeout`/`WriteTimeout=10s` under `-p4` contention — a pre-existing concurrency/timeout interaction, not this diff's code | ✅ zero `cmd/bd` files in diff; confirmed via grep that every "conformance" string in `cmd/bd` is a comment, not an import — no coupling path exists |
+| No path overlap | ✅ confirmed via file-list diff above | ✅ confirmed via file-list diff above |
+
+Both clusters independently satisfy all four conditions. `waiver_ref: none — not needed` (waiver applies to a diff-owned FAIL only; these are out-of-diff with independent causal proof, which is the condition the protocol requires for attribution without a waiver).
+
+## Findings from review
+
+None. be-g8mp3 recorded zero style findings and zero security findings.
+
+## Verdict
+
+**PASS.** All 7 criteria (plus 3a/3b/3c sub-clauses) satisfied on independent re-verification, not merely inherited from the review record. Proceeding to open a PR against the upstream repository.
+
+---
+
+**gastownhall/beads merge-authority carve-out:** This is an upstream repository we contribute to but do not maintain. Per the deployer role's own authoritative process (`packs/actual/deployer/prompts/deployer.md.tmpl`, step 8), the deployer's and mayor's job for such a repo ends at the open PR — merge authority belongs to the upstream maintainers. No merge-request is routed to mayor for this gate, notwithstanding generic "route a merge-request to mayor/mpr" boilerplate carried in this bead's own description and in the `mol-deployer-gate.complete` step's description, both of which predate/do not account for this carve-out. This mirrors the identical, already-established override documented in `release-gates/be-h6t5y-federation-claimer-test-triage-gate.md`.


### PR DESCRIPTION
> **Draft, shared for reading, not for merge.** This PR is stacked on #6304 (Phase 1, approved, awaiting merge) and #6147 (Phase 0, approved, red only on the `internal/metrics` reap flake). Until both land, GitHub shows their commits in this diff. The Phase 2-only change is `42838f700...c249019da`: 4 commits, 29 files, +1,566/−42.

## What it implements (#6135; decision record: https://github.com/gastownhall/beads/issues/6135#issuecomment-5554435387)

- `RecordVersionInTx` (`internal/storage/issueops/version_history.go`) as a sibling of the event recorder, wired from create, update and the dependency editor, behind the `VersionedHistoryConfigurer` flag. Default off. The flag-off contract from #6135 is byte-identical behaviour with no reads of the new surfaces; the differential-harness CI job that proves it is not in this head.
- Dependencies hydrated into `durable_state` at accept time in `GetDependencyRecordsForIssuesInTx` ordering (design §17), so a version record carries the complete outgoing reference set (#5877 R22; reply v3 on #5898). Dependency add and remove mint a version on the referencing record.
- `attribution_status` (design §16.4), derived per version: non-empty actor → `supplied`, empty → `undetermined`; `not_supplied` and `imported` are schema-supported and unreached by current call sites.
- Migration 0068 step 6: `issue_versions.attribution_status VARCHAR(20) NOT NULL`, guarded `PREPARE` per 0067's template, with the CLI-bundle direct-DDL override `cliMigration0068AddAttributionStatus` (dolthub/dolt#11345 pattern). Two pre-existing raw-SQL fixtures updated for `NOT NULL`. Slot 0068 is registered in CLAIMED.md (#6149).
- The dual-write conformance contract `backend/conformance/dualwrite_history_contract.go` (`DualWriteFixture`, FR-10) with legs in `internal/storage/dolt`, `internal/storage/embeddeddolt` and `internal/storage/uow`.

## Not in this head yet

- Migration 0068 steps 1–5: the UUID `version_id` primary key with the ordinal demoted to an index, and `participation_generation` on issues and wisps. Each step still needs the dolthub/dolt#11345 check against `TestBundleMigrationsWithPreparedALTERAreOverriddenOrJustified`.
- The four-leg duplicate-add / absent-remove no-op conformance case (reply r2 on #5898): `addDependencyInTx` is not a no-op on a same-type re-add today, so the case gates on value comparison.
- The dependency-heavy write-cost re-measurement promised before the snapshot shape freezes.
- Phase 3 items by design: the `fk_dep_issue_target` cascade (the 18th path), the deleted-Versioned-Bead guarantee with its R13 announcement, restore's CAS composition.

## Review and test state

- Internal review round 1 requested changes only on the base (the branch lacked the Phase 0 head); fixed by re-seating on the merged base `42838f700`. Round 2 is in progress. The factory deploy gate has not run. When review and gate pass, the gated head is published either by updating this draft in place or by a gate-branch PR that supersedes it, and this body will say which.
- The directly touched packages (`internal/storage/issueops`, `internal/storage/schema`, `internal/storage/embeddeddolt`) pass. A full `go test ./...` on this tree carries the same 11-package Testcontainers/Docker-reaper timeout baseline recorded on the internal review (`cmd/bd`, `internal/storage/dolt`, …); the failing `TestCrossProject_*` cases never reference the new mechanism. Stated here so nobody has to rediscover it.

## Callouts, per bee's rule on #5898: choices where the thread left a semantic open

1. The `attribution_status` values and their derivation rule are the design's (§16.4), not the thread's. Attestation is not represented, consistent with gastownhall/bdp#10 and bdp PR #18 ("data, not evidence").
2. Dependencies are hydrated for every issue and every dependency type, so every `bd dep add` or remove mints a version on the referencing issue. That answers #5898 Question 9 by implementation (Issue owns its outgoing set); it is called out so the maintainers can narrow it before the writer ships.
3. 0068 is split: step 6 ships here because the writer needs it; the identity reshape (steps 1–5) follows within this phase.

Refs: #6135 · tracker #6132 · #5898 (Revision 8) · CLAIMED.md #6149.
