### PR TITLE
perf(dbproxy): interpolate params in the proxied-server DSN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The proxied-server DSN now interpolates query parameters client-side**, the
+  same setting #4617 gave the plain server-mode DSN. Every parameterized
+  statement bd sends through the proxy was a server-side PREPARE followed by
+  an EXECUTE, two awaited round trips for one row. With `interpolateParams`
+  it is one. The driver still falls back to a server-side prepare for any
+  argument it cannot render safely, so results are unchanged. Measured on a
+  proxied Dolt 2.2.3 server at 254 ms RTT, `bd ready` went from 17.7 s to
+  12.7 s and `bd sql 'select 1'` from 12.3 s to 9.4 s with no other change.
+
 - **`bd gate check` resolves bead gates whose target lives in a prefix-routed
   rig** ([#5859](https://github.com/gastownhall/beads/pull/5859)). After a local
   miss, the evaluator follows the target bead ID through `routes.jsonl` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,14 +58,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **The proxied-server DSN now interpolates query parameters client-side**, the
-  same setting #4617 gave the plain server-mode DSN. Every parameterized
-  statement bd sends through the proxy was a server-side PREPARE followed by
-  an EXECUTE, two awaited round trips for one row. With `interpolateParams`
-  it is one. The driver still falls back to a server-side prepare for any
-  argument it cannot render safely, so results are unchanged. Measured on a
-  proxied Dolt 2.2.3 server at 254 ms RTT, `bd ready` went from 17.7 s to
-  12.7 s and `bd sql 'select 1'` from 12.3 s to 9.4 s with no other change.
+- **The proxied-server DSN now interpolates query parameters client-side**
+  ([#6360](https://github.com/gastownhall/beads/pull/6360)), the same setting
+  [#4617](https://github.com/gastownhall/beads/pull/4617) gave the plain
+  server-mode DSN. Every parameterized statement bd sends through the proxy
+  was a server-side PREPARE followed by an EXECUTE, two awaited round trips
+  for one row. With `interpolateParams` it is one. The driver still falls back
+  to a server-side prepare for any argument it cannot render safely, so
+  results are unchanged. Measured on a proxied Dolt 2.2.3 server at 254 ms
+  RTT with no other change, `bd ready` went from 17.7 s to 12.7 s. The
+  parameterized statements of the open path get the same cut, which is why
+  even `bd sql 'select 1'`, itself unparameterized, went from 12.3 s to 9.4 s.
 
 - **`bd gate check` resolves bead gates whose target lives in a prefix-routed
   rig** ([#5859](https://github.com/gastownhall/beads/pull/5859)). After a local

--- a/internal/storage/dbproxy/util/dsn.go
+++ b/internal/storage/dbproxy/util/dsn.go
@@ -46,6 +46,7 @@ func (d DoltServerDSN) String() string {
 		Timeout:              timeout,
 		AllowNativePasswords: true,
 		ClientFoundRows:      d.ClientFoundRows,
+		InterpolateParams:    true,
 	}
 	switch {
 	case d.TLSConfigName != "":

--- a/internal/storage/dbproxy/util/dsn.go
+++ b/internal/storage/dbproxy/util/dsn.go
@@ -46,7 +46,8 @@ func (d DoltServerDSN) String() string {
 		Timeout:              timeout,
 		AllowNativePasswords: true,
 		ClientFoundRows:      d.ClientFoundRows,
-		InterpolateParams:    true,
+		// Same setting, same reasons as doltutil.ServerDSN; see the comment there.
+		InterpolateParams: true,
 	}
 	switch {
 	case d.TLSConfigName != "":

--- a/internal/storage/dbproxy/util/dsn_test.go
+++ b/internal/storage/dbproxy/util/dsn_test.go
@@ -3,6 +3,8 @@ package util
 import (
 	"strings"
 	"testing"
+
+	mysql "github.com/go-sql-driver/mysql"
 )
 
 func TestDoltServerDSN_TLS(t *testing.T) {
@@ -33,4 +35,15 @@ func TestDoltServerDSN_TLS(t *testing.T) {
 			t.Fatalf("dsn %q missing unix socket", dsn)
 		}
 	})
+}
+
+func TestDoltServerDSN_InterpolatesParams(t *testing.T) {
+	dsn := DoltServerDSN{Host: "127.0.0.1", Port: 3306, User: "root", Database: "beads"}.String()
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		t.Fatalf("parse dsn %q: %v", dsn, err)
+	}
+	if !cfg.InterpolateParams {
+		t.Fatalf("dsn %q does not enable interpolateParams", dsn)
+	}
 }


### PR DESCRIPTION
## What

Sets interpolateParams on the proxied-server DSN (internal/storage/dbproxy/util/dsn.go), same as #4617 did for the plain server-mode DSN in doltutil.

## Why

Every parameterized statement bd sends through the proxy goes out as a server-side PREPARE followed by an EXECUTE, two awaited round trips for one row. With interpolation it is one. The driver still falls back to a server-side prepare for any argument it cannot render safely, so results do not change. Same shape and same reasoning as #4617, this is the half of it the proxied route never got.

Measured on a proxied Dolt 2.2.3 server at 254 ms RTT, nothing else changed. bd ready 17.7 s before, 12.7 s after, that is the number that measures the claim directly, ready_work.go binds args on every query. bd sql 'select 1' also went 12.3 s to 9.4 s, but not because of the statement itself, bd sql binds nothing. The gain there is the parameterized statements of the open path (dolt_ignore inserts, GET_LOCK, the metadata read). Numbers come from timing the bd binary built with and without this one line against the same server. The RTT is not artificial, our team is spread across several countries with one shared server somewhere in the middle, so 200+ ms per round trip is the everyday case for some of us.

Refs #6116 (prepared statements still dominate the write path after #4617) and #5273. This does not overlap #5316, which pins MaxAllowedPacket in the same file, the two settings are independent.

## Verification

go test ./internal/storage/dbproxy/util/... with the new test that parses the DSN and checks InterpolateParams. make ci-pr-lint clean. Existing proxied integration tests in cmd/bd (TestProxiedServerReady, TestProxiedServerReady2) and internal/storage/uow (external provider end to end, team server) pass against a Dolt container with this change in place.

