### PR TITLE
perf(ready): load parent epics in one batched read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`bd ready` loads the parent epics it prints in one read** instead of one
+  `GetIssue` per parent, on both the direct and the proxied route. Only the
+  number of statements changes, the epic filter and the printed suffix are
+  the same. Against a proxied Dolt server at 254 ms RTT a ready list with
+  four distinct parents spent about 2 s on those lookups alone.
+
 - **`bd gate check` resolves bead gates whose target lives in a prefix-routed
   rig** ([#5859](https://github.com/gastownhall/beads/pull/5859)). After a local
   miss, the evaluator follows the target bead ID through `routes.jsonl` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,11 +58,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`bd ready` loads the parent epics it prints in one read** instead of one
-  `GetIssue` per parent, on both the direct and the proxied route. Only the
-  number of statements changes, the epic filter and the printed suffix are
-  the same. Against a proxied Dolt server at 254 ms RTT a ready list with
-  four distinct parents spent about 2 s on those lookups alone.
+- **`bd ready` loads the parent epics it prints in one batch** instead of one
+  `GetIssue` per parent ([#6361](https://github.com/gastownhall/beads/pull/6361)),
+  on both the direct and the proxied route. On the proxied route that is one
+  statement; on the direct route it is one read transaction with the wisp
+  probe, the issues and the labels, instead of one such transaction per
+  parent. Only the number of statements changes, the epic filter and the
+  printed suffix are the same. Against a proxied Dolt server at 254 ms RTT a
+  ready list with four distinct parents spent about 2 s on those lookups
+  alone.
 
 - **`bd gate check` resolves bead gates whose target lives in a prefix-routed
   rig** ([#5859](https://github.com/gastownhall/beads/pull/5859)). After a local

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -412,15 +412,18 @@ func buildParentEpicMap(ctx context.Context, s storage.DoltStorage, issues []*ty
 		return nil
 	}
 
-	// Fetch parent issues and filter to epics
-	epicTitles := make(map[string]string) // parentID -> title
+	parentList := make([]string, 0, len(parentIDs))
 	for parentID := range parentIDs {
-		parent, err := s.GetIssue(ctx, parentID)
-		if err != nil || parent == nil {
-			continue
-		}
-		if parent.IssueType == "epic" {
-			epicTitles[parentID] = parent.Title
+		parentList = append(parentList, parentID)
+	}
+	parents, err := s.GetIssuesByIDs(ctx, parentList)
+	if err != nil {
+		return nil
+	}
+	epicTitles := make(map[string]string)
+	for _, parent := range parents {
+		if parent != nil && parent.IssueType == "epic" {
+			epicTitles[parent.ID] = parent.Title
 		}
 	}
 

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -418,11 +418,12 @@ func buildParentEpicMap(ctx context.Context, s storage.DoltStorage, issues []*ty
 	}
 	parents, err := s.GetIssuesByIDs(ctx, parentList)
 	if err != nil {
+		debug.Logf("warning: failed to get parent issues: %v", err)
 		return nil
 	}
 	epicTitles := make(map[string]string)
 	for _, parent := range parents {
-		if parent != nil && parent.IssueType == "epic" {
+		if parent != nil && parent.IssueType == types.TypeEpic {
 			epicTitles[parent.ID] = parent.Title
 		}
 	}

--- a/cmd/bd/ready_parent_epics_test.go
+++ b/cmd/bd/ready_parent_epics_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+type parentEpicFixture struct {
+	getIssueCalls   int
+	getByIDsCalls   int
+	getByIDsRequest []string
+}
+
+func (f *parentEpicFixture) issues() []*types.Issue {
+	return []*types.Issue{
+		{ID: "child-of-epic", Title: "Implement login", IssueType: types.TypeTask},
+		{ID: "child-of-task", Title: "Subtask of non-epic", IssueType: types.TypeTask},
+	}
+}
+
+func (f *parentEpicFixture) deps(ids []string) map[string][]*types.Dependency {
+	return map[string][]*types.Dependency{
+		"child-of-epic": {{IssueID: "child-of-epic", DependsOnID: "epic-1", Type: types.DepParentChild}},
+		"child-of-task": {{IssueID: "child-of-task", DependsOnID: "task-1", Type: types.DepParentChild}},
+	}
+}
+
+func (f *parentEpicFixture) getIssue(string) (*types.Issue, error) {
+	f.getIssueCalls++
+	return nil, nil
+}
+
+func (f *parentEpicFixture) getIssuesByIDs(ids []string) ([]*types.Issue, error) {
+	f.getByIDsCalls++
+	f.getByIDsRequest = append([]string(nil), ids...)
+	sort.Strings(f.getByIDsRequest)
+	return []*types.Issue{
+		{ID: "epic-1", Title: "Auth Overhaul", IssueType: types.TypeEpic},
+		{ID: "task-1", Title: "Not an epic", IssueType: types.TypeTask},
+	}, nil
+}
+
+func (f *parentEpicFixture) check(t *testing.T, result map[string]string) {
+	t.Helper()
+	if result["child-of-epic"] != "Auth Overhaul" {
+		t.Errorf("child-of-epic should map to the epic title, got %q", result["child-of-epic"])
+	}
+	if _, ok := result["child-of-task"]; ok {
+		t.Errorf("child-of-task should not be in the map, its parent is not an epic")
+	}
+	if f.getIssueCalls != 0 {
+		t.Errorf("parents were fetched one by one: %d GetIssue calls", f.getIssueCalls)
+	}
+	if f.getByIDsCalls != 1 {
+		t.Errorf("parents should be fetched in one batch, got %d GetIssuesByIDs calls", f.getByIDsCalls)
+	}
+	if want := []string{"epic-1", "task-1"}; len(f.getByIDsRequest) != 2 || f.getByIDsRequest[0] != want[0] || f.getByIDsRequest[1] != want[1] {
+		t.Errorf("batch should name every parent once, got %v", f.getByIDsRequest)
+	}
+}
+
+type parentEpicStore struct {
+	storage.DoltStorage
+	f *parentEpicFixture
+}
+
+func (s parentEpicStore) GetDependencyRecordsForIssues(_ context.Context, ids []string) (map[string][]*types.Dependency, error) {
+	return s.f.deps(ids), nil
+}
+
+func (s parentEpicStore) GetIssue(_ context.Context, id string) (*types.Issue, error) {
+	return s.f.getIssue(id)
+}
+
+func (s parentEpicStore) GetIssuesByIDs(_ context.Context, ids []string) ([]*types.Issue, error) {
+	return s.f.getIssuesByIDs(ids)
+}
+
+type parentEpicIssues struct {
+	domain.IssueUseCase
+	f *parentEpicFixture
+}
+
+func (u parentEpicIssues) GetIssue(_ context.Context, id string) (*types.Issue, error) {
+	return u.f.getIssue(id)
+}
+
+func (u parentEpicIssues) GetIssuesByIDs(_ context.Context, ids []string) ([]*types.Issue, error) {
+	return u.f.getIssuesByIDs(ids)
+}
+
+type parentEpicDeps struct {
+	domain.DependencyUseCase
+	f *parentEpicFixture
+}
+
+func (d parentEpicDeps) GetForIssueIDs(_ context.Context, ids []string) (map[string][]*types.Dependency, error) {
+	return d.f.deps(ids), nil
+}
+
+type parentEpicUOW struct {
+	uow.UnitOfWork
+	f *parentEpicFixture
+}
+
+func (u parentEpicUOW) IssueUseCase() domain.IssueUseCase           { return parentEpicIssues{f: u.f} }
+func (u parentEpicUOW) DependencyUseCase() domain.DependencyUseCase { return parentEpicDeps{f: u.f} }
+
+func TestBuildParentEpicMap_FetchesParentsInOneBatch(t *testing.T) {
+	f := &parentEpicFixture{}
+	f.check(t, buildParentEpicMap(context.Background(), parentEpicStore{f: f}, f.issues()))
+}
+
+func TestBuildParentEpicMapProxied_FetchesParentsInOneBatch(t *testing.T) {
+	f := &parentEpicFixture{}
+	f.check(t, buildParentEpicMapProxied(context.Background(), parentEpicUOW{f: f}, f.issues()))
+}

--- a/cmd/bd/ready_proxied_server.go
+++ b/cmd/bd/ready_proxied_server.go
@@ -525,11 +525,12 @@ func buildParentEpicMapProxied(ctx context.Context, uw uow.UnitOfWork, issues []
 	}
 	parents, err := uw.IssueUseCase().GetIssuesByIDs(ctx, parentList)
 	if err != nil {
+		debug.Logf("warning: failed to get parent issues: %v", err)
 		return nil
 	}
 	epicTitles := make(map[string]string)
 	for _, parent := range parents {
-		if parent != nil && parent.IssueType == "epic" {
+		if parent != nil && parent.IssueType == types.TypeEpic {
 			epicTitles[parent.ID] = parent.Title
 		}
 	}

--- a/cmd/bd/ready_proxied_server.go
+++ b/cmd/bd/ready_proxied_server.go
@@ -519,14 +519,18 @@ func buildParentEpicMapProxied(ctx context.Context, uw uow.UnitOfWork, issues []
 	if len(parentIDs) == 0 {
 		return nil
 	}
-	epicTitles := make(map[string]string)
+	parentList := make([]string, 0, len(parentIDs))
 	for parentID := range parentIDs {
-		parent, err := uw.IssueUseCase().GetIssue(ctx, parentID)
-		if err != nil || parent == nil {
-			continue
-		}
-		if parent.IssueType == "epic" {
-			epicTitles[parentID] = parent.Title
+		parentList = append(parentList, parentID)
+	}
+	parents, err := uw.IssueUseCase().GetIssuesByIDs(ctx, parentList)
+	if err != nil {
+		return nil
+	}
+	epicTitles := make(map[string]string)
+	for _, parent := range parents {
+		if parent != nil && parent.IssueType == "epic" {
+			epicTitles[parent.ID] = parent.Title
 		}
 	}
 	result := make(map[string]string)


### PR DESCRIPTION
## What

bd ready fetches the parent epics it prints with one GetIssuesByIDs instead of one GetIssue per parent. Both routes, cmd/bd/ready.go and cmd/bd/ready_proxied_server.go.

## Why

Every GetIssue is a round trip, and on a remote server that is the whole cost. Our shared server sits at about 254 ms from some of the team, and a ready list with four distinct parents spent about 2 s on those lookups alone (read off a query log of the proxied route, one full row SELECT per parent, two round trips each with the prepare). GetIssuesByIDs reads the same issues table GetIssue did, so the epic filter and the printed suffix do not change.

This is one of the per command items behind #6114, the bd ready row there counts 92 round trips.

## Verification

New test cmd/bd/ready_parent_epics_test.go drives both routes through counting fakes. Run against the code before this change (current main) it fails, reporting two GetIssue calls and no batch. With the change it passes, exactly one GetIssuesByIDs naming every parent once, and the resulting map is the same. TestReadySuite still passes on the embedded store (it covers the epic and non epic parent cases on real data). Full ./scripts/test.sh ./cmd/bd/ passes (184 s) and make ci-pr-lint is clean.
