### PR TITLE
fix(gitignore): preserve CRLF when appending project rules

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -770,13 +770,12 @@ func CheckProjectGitignore(repoPath string) DoctorCheck {
 func EnsureProjectGitignore(repoPath string) error {
 	gitignorePath := filepath.Join(repoPath, ".gitignore")
 
-	var existingContent string
 	// #nosec G304 -- path is hardcoded
-	if content, err := os.ReadFile(gitignorePath); err == nil {
-		existingContent = string(content)
-	} else if !os.IsNotExist(err) {
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to read .gitignore: %w", err)
 	}
+	existingContent := string(content)
 
 	var toAdd []string
 	for _, pattern := range ProjectGitignorePatterns {
@@ -789,7 +788,7 @@ func EnsureProjectGitignore(repoPath string) error {
 		return nil // All patterns already present
 	}
 
-	lineEnding := gitignore.AppendLineEnding([]byte(existingContent))
+	lineEnding := gitignore.AppendLineEnding(content)
 	newContent := existingContent
 	if len(newContent) > 0 && !strings.HasSuffix(newContent, "\n") {
 		if strings.HasSuffix(newContent, "\r") {

--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/steveyegge/beads/internal/gitignore"
 )
 
 // GitignoreTemplate is the canonical .beads/.gitignore content
@@ -787,14 +789,19 @@ func EnsureProjectGitignore(repoPath string) error {
 		return nil // All patterns already present
 	}
 
+	lineEnding := gitignore.AppendLineEnding([]byte(existingContent))
 	newContent := existingContent
 	if len(newContent) > 0 && !strings.HasSuffix(newContent, "\n") {
-		newContent += "\n"
+		if strings.HasSuffix(newContent, "\r") {
+			newContent += "\n" // Complete the existing CR without doubling it.
+		} else {
+			newContent += lineEnding
+		}
 	}
 
-	newContent += "\n" + ProjectGitignoreHeader + "\n"
+	newContent += lineEnding + ProjectGitignoreHeader + lineEnding
 	for _, pattern := range toAdd {
-		newContent += pattern + "\n"
+		newContent += pattern + lineEnding
 	}
 
 	// #nosec G306 -- gitignore needs to be readable by git and collaborators

--- a/cmd/bd/doctor/gitignore_test.go
+++ b/cmd/bd/doctor/gitignore_test.go
@@ -1967,6 +1967,50 @@ func TestEnsureProjectGitignore_AppendsToExisting(t *testing.T) {
 	}
 }
 
+func TestEnsureProjectGitignore_PreservesAppendLineEndings(t *testing.T) {
+	lfBlock := "\n" + ProjectGitignoreHeader + "\n" + strings.Join(ProjectGitignorePatterns, "\n") + "\n"
+	crlfBlock := "\r\n" + ProjectGitignoreHeader + "\r\n" + strings.Join(ProjectGitignorePatterns, "\r\n") + "\r\n"
+	partial := ProjectGitignoreHeader + "\r\n" + ProjectGitignorePatterns[0] + "\r\n"
+	remaining := "\r\n" + ProjectGitignoreHeader + "\r\n" + strings.Join(ProjectGitignorePatterns[1:], "\r\n") + "\r\n"
+	complete := ProjectGitignoreHeader + "\r\n" + strings.Join(ProjectGitignorePatterns, "\r\n")
+	for _, tc := range []struct {
+		name, existing, want string
+	}{
+		{"empty", "", lfBlock},
+		{"delimiter-free", "local", "local\n" + lfBlock},
+		{"LF", "local\n", "local\n" + lfBlock},
+		{"CRLF", "local\r\n", "local\r\n" + crlfBlock},
+		{"CRLF unterminated", "local\r\nlast", "local\r\nlast\r\n" + crlfBlock},
+		{"CRLF trailing CR", "local\r\nlast\r", "local\r\nlast\r\n" + crlfBlock},
+		{"LF trailing CR", "local\nlast\r", "local\nlast\r\n" + lfBlock},
+		{"only trailing CR", "local\r", "local\r\n" + lfBlock},
+		{"mixed majority CRLF", "a\r\nb\r\nc\n", "a\r\nb\r\nc\n" + lfBlock},
+		{"partial with header", partial, partial + remaining},
+		{"complete unterminated", complete, complete},
+		{"complete CRLF", complete + "\r\n", complete + "\r\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, ".gitignore")
+			if err := os.WriteFile(path, []byte(tc.existing), 0600); err != nil {
+				t.Fatal(err)
+			}
+			for call := 1; call <= 2; call++ {
+				if err := EnsureProjectGitignore(dir); err != nil {
+					t.Fatalf("call %d: %v", call, err)
+				}
+				got, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if string(got) != tc.want {
+					t.Fatalf("call %d: got bytes %q, want %q", call, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
 func TestEnsureProjectGitignore_Idempotent(t *testing.T) {
 	tmpDir := t.TempDir()
 	oldDir, err := os.Getwd()

--- a/cmd/bd/doctor/gitignore_test.go
+++ b/cmd/bd/doctor/gitignore_test.go
@@ -1985,6 +1985,7 @@ func TestEnsureProjectGitignore_PreservesAppendLineEndings(t *testing.T) {
 		{"LF trailing CR", "local\nlast\r", "local\nlast\r\n" + lfBlock},
 		{"only trailing CR", "local\r", "local\r\n" + lfBlock},
 		{"mixed majority CRLF", "a\r\nb\r\nc\n", "a\r\nb\r\nc\n" + lfBlock},
+		// Re-emitting an existing header is pre-existing behavior, preserved here.
 		{"partial with header", partial, partial + remaining},
 		{"complete unterminated", complete, complete},
 		{"complete CRLF", complete + "\r\n", complete + "\r\n"},

--- a/internal/gitignore/append.go
+++ b/internal/gitignore/append.go
@@ -4,7 +4,7 @@ package gitignore
 import "bytes"
 
 // AppendLineEnding preserves an unambiguous CRLF convention, following the
-// worktree append policy in #5677. Empty, delimiter-free, LF and mixed files
+// append policy in #6343. Empty, delimiter-free, LF and mixed files
 // default to LF; callers must leave existing bytes unchanged.
 func AppendLineEnding(content []byte) string {
 	lineFeeds := bytes.Count(content, []byte{'\n'})

--- a/internal/gitignore/append.go
+++ b/internal/gitignore/append.go
@@ -1,0 +1,15 @@
+// Package gitignore provides formatting helpers for user-owned gitignore files.
+package gitignore
+
+import "bytes"
+
+// AppendLineEnding preserves an unambiguous CRLF convention, following the
+// worktree append policy in #5677. Empty, delimiter-free, LF and mixed files
+// default to LF; callers must leave existing bytes unchanged.
+func AppendLineEnding(content []byte) string {
+	lineFeeds := bytes.Count(content, []byte{'\n'})
+	if lineFeeds > 0 && lineFeeds == bytes.Count(content, []byte("\r\n")) {
+		return "\r\n"
+	}
+	return "\n"
+}

--- a/internal/gitignore/append_test.go
+++ b/internal/gitignore/append_test.go
@@ -1,0 +1,26 @@
+package gitignore
+
+import "testing"
+
+func TestAppendLineEnding(t *testing.T) {
+	for _, tc := range []struct{ name, content, want string }{
+		{"empty", "", "\n"},
+		{"delimiter-free", "local", "\n"},
+		{"LF", "a\n", "\n"},
+		{"CRLF", "a\r\n", "\r\n"},
+		{"mixed", "a\r\nb\r\nc\n", "\n"},
+		{"BOM LF", "\xef\xbb\xbfa\n", "\n"},
+		{"BOM CRLF", "\xef\xbb\xbfa\r\n", "\r\n"},
+		{"lone CR", "\r", "\n"},
+		{"CR-only", "a\rb\rc\r", "\n"},
+		{"interior CR", "a\rb\r\n", "\r\n"},
+		{"CRCRLF", "a\r\r\n", "\r\n"},
+		{"UTF16-like", "a\x00\r\x00\n\x00", "\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := AppendLineEnding([]byte(tc.content)); got != tc.want {
+				t.Errorf("AppendLineEnding(%q) = %q, want %q", tc.content, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/storage/domain/fs/beads.go
+++ b/internal/storage/domain/fs/beads.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/gitignore"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/utils"
 )
@@ -164,19 +165,24 @@ func (r *beadsDirFSRepositoryImpl) WriteProjectGitignore(ctx context.Context) er
 		return nil
 	}
 
+	lineEnding := gitignore.AppendLineEnding(existing)
 	var buf bytes.Buffer
 	buf.Write(existing)
 	if len(existing) > 0 && !bytes.HasSuffix(existing, []byte("\n")) {
-		buf.WriteByte('\n')
+		if existing[len(existing)-1] == '\r' {
+			buf.WriteByte('\n') // Complete the existing CR without doubling it.
+		} else {
+			buf.WriteString(lineEnding)
+		}
 	}
 	if header := r.templates.ProjectGitignoreHeader; header != "" && !containsLine(existing, header) {
 		if len(existing) > 0 {
-			buf.WriteByte('\n')
+			buf.WriteString(lineEnding)
 		}
-		buf.WriteString(header + "\n")
+		buf.WriteString(header + lineEnding)
 	}
 	for _, pattern := range toAdd {
-		buf.WriteString(pattern + "\n")
+		buf.WriteString(pattern + lineEnding)
 	}
 
 	// #nosec G306 -- .gitignore must be world-readable so users can read/edit it

--- a/internal/storage/domain/fs/beads_test.go
+++ b/internal/storage/domain/fs/beads_test.go
@@ -38,6 +38,7 @@ func (s *testSuite) TestBeadsDirFSRepository() {
 		s.Run("SkipsAlreadyPresentPatterns", s.writeProjectGitignoreNoDuplicates)
 		s.Run("NoChangeWhenAllPresent", s.writeProjectGitignoreNoOpWhenComplete)
 		s.Run("AddsLeadingNewlineWhenMissing", s.writeProjectGitignoreFixesTrailingNewline)
+		s.Run("PreservesAppendLineEndings", s.writeProjectGitignorePreservesAppendLineEndings)
 	})
 	s.Run("ProjectGitignoreExists", func() {
 		s.Run("MissingReturnsFalse", s.projectGitignoreExistsMissing)
@@ -276,6 +277,50 @@ func (s *testSuite) writeProjectGitignoreFixesTrailingNewline() {
 
 	s.True(strings.HasPrefix(body, "no-trailing-newline\n"), "trailing newline must be inserted before appended content")
 	s.Contains(body, testTemplates().ProjectGitignoreHeader)
+}
+
+func (s *testSuite) writeProjectGitignorePreservesAppendLineEndings() {
+	tpl := testTemplates()
+	lfSection := tpl.ProjectGitignoreHeader + "\n" + strings.Join(tpl.ProjectGitignorePatterns, "\n") + "\n"
+	crlfSection := tpl.ProjectGitignoreHeader + "\r\n" + strings.Join(tpl.ProjectGitignorePatterns, "\r\n") + "\r\n"
+	partial := tpl.ProjectGitignoreHeader + "\r\n.dolt/\r\n"
+	complete := strings.TrimSuffix(crlfSection, "\r\n")
+	for _, tc := range []struct {
+		name, existing, want string
+		omitHeader           bool
+	}{
+		{"empty", "", lfSection, false},
+		{"delimiter-free", "local", "local\n\n" + lfSection, false},
+		{"LF", "local\n", "local\n\n" + lfSection, false},
+		{"CRLF", "local\r\n", "local\r\n\r\n" + crlfSection, false},
+		{"CRLF unterminated", "local\r\nlast", "local\r\nlast\r\n\r\n" + crlfSection, false},
+		{"CRLF trailing CR", "local\r\nlast\r", "local\r\nlast\r\n\r\n" + crlfSection, false},
+		{"LF trailing CR", "local\nlast\r", "local\nlast\r\n\n" + lfSection, false},
+		{"only trailing CR", "local\r", "local\r\n\n" + lfSection, false},
+		{"mixed majority CRLF", "a\r\nb\r\nc\n", "a\r\nb\r\nc\n\n" + lfSection, false},
+		{"partial with header", partial, partial + "*.db\r\n", false},
+		{"complete unterminated", complete, complete, false},
+		{"complete CRLF", crlfSection, crlfSection, false},
+		{"no header", "local\r\n", "local\r\n.dolt/\r\n*.db\r\n", true},
+	} {
+		s.Run(tc.name, func() {
+			s.T().Setenv("BEADS_DIR", "")
+			dir := s.T().TempDir()
+			templates := testTemplates()
+			if tc.omitHeader {
+				templates.ProjectGitignoreHeader = ""
+			}
+			repo := NewBeadsDirFSRepository(dir, templates)
+			path := filepath.Join(dir, ".gitignore")
+			s.Require().NoError(os.WriteFile(path, []byte(tc.existing), 0600))
+			for call := 1; call <= 2; call++ {
+				s.Require().NoError(repo.WriteProjectGitignore(s.Ctx()), "call %d", call)
+				got, err := os.ReadFile(path)
+				s.Require().NoError(err)
+				s.Equal(tc.want, string(got), "call %d: exact file bytes", call)
+			}
+		})
+	}
 }
 
 func (s *testSuite) projectGitignoreExistsMissing() {


### PR DESCRIPTION
Both project-root `.gitignore` writers append LF to existing CRLF files, so `bd init` or `bd doctor --fix` can introduce mixed endings. They now share `internal/gitignore.AppendLineEnding`: preserve CRLF when every existing LF is preceded by CR, and retain LF for empty, delimiter-free or mixed files.

Existing bytes, each writer's header and blank-line behavior, pattern matching and no-op behavior are preserved. A trailing CR receives only LF before the new section. Files already damaged by an LF managed section in CRLF content count as mixed; this change preserves them and does not repair their existing endings. The doctor test explicitly documents its pre-existing duplicate-header behavior.

The detector has a direct twelve-case byte table covering BOM prefixes, lone/interior CR, CRCRLF, CR-only, mixed and UTF16-like input alongside ordinary cases. Doctor reuses the bytes returned by `os.ReadFile` for detection. This PR remains scoped to the two project writers in Bee's #6343 report; #5677 owns the worktree writer.

At `3f1c05adff5208410348d949b9143795652dc950`, native Windows normal and race/shuffle6362 runs pass the twelve detector cases and all 25 actual-writer exact-byte/idempotence cases, plus adjacent creation, append and partial-pattern coverage. Scoped vet and native/Windows lint pass. The original main-writer counterexamples remain recorded at `5bd4784`, where each old writer failed its CRLF cases. The two existing Unix permission tests remain outside this selected run; no permission or native Linux/macOS claim is made. Required PR Core and exact-head hosted verification remain part of publication.

Fixes #6343

_unknown-model/unknown-reasoning on behalf of Ewen Cuthiell_
