### PR TITLE
perf(storage/uow): open the proxied provider with one pool and fewer statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **The proxied-server open path uses one pool instead of two, and fewer
-  statements on it.** Every bd invocation on a proxied server opened a
+  statements on it** ([#6364](https://github.com/gastownhall/beads/pull/6364)).
+  Every bd invocation on a proxied server opened a
   database-less pool for the schema probe, closed it, then opened a second
   pool bound to the database: two full TCP, TLS and auth handshakes plus a
   COM_PING on each, before any command ran. The open now binds the pool to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,18 +60,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **The proxied-server open path uses one pool instead of two, and fewer
   statements on it** ([#6364](https://github.com/gastownhall/beads/pull/6364)).
-  Every bd invocation on a proxied server opened a
-  database-less pool for the schema probe, closed it, then opened a second
-  pool bound to the database: two full TCP, TLS and auth handshakes plus a
-  COM_PING on each, before any command ran. The open now binds the pool to
-  the database up front, uses the handshake itself as the liveness probe
-  (the retry policy from #6003 is unchanged, it now retries the connect),
-  skips the USE the bound session no longer needs, and in team-server mode
-  reads the schema cursor and the project identity in one SELECT. The
-  database-less pool survives only as the fallback when the bound connect
-  is refused with 1049, so a fresh database still bootstraps exactly as
-  before. Part of the open-path preamble counted in #6114, and the proxied
-  twin of #5273 items 1 and 3.
+  Every bd invocation on a proxied server opened a database-less pool for the
+  schema probe, closed it, then opened a second pool bound to the database:
+  two full TCP, TLS and auth handshakes plus a COM_PING on each, before any
+  command ran. The open now binds the pool to the database up front, uses the
+  handshake itself as the liveness probe (the retry policy from
+  [#6003](https://github.com/gastownhall/beads/pull/6003) is unchanged, it now
+  retries the connect), skips the USE the bound session no longer needs, and
+  in team-server mode reads the schema cursor and the project identity in one
+  SELECT. The database-less pool survives only as the fallback when the bound
+  connect is refused with 1049, so a fresh database still bootstraps exactly
+  as before. Part of the open-path preamble counted in
+  [#6114](https://github.com/gastownhall/beads/issues/6114), and the proxied
+  twin of [#5273](https://github.com/gastownhall/beads/issues/5273) items 1
+  and 3.
 
 - **`bd gate check` resolves bead gates whose target lives in a prefix-routed
   rig** ([#5859](https://github.com/gastownhall/beads/pull/5859)). After a local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The proxied-server open path uses one pool instead of two, and fewer
+  statements on it.** Every bd invocation on a proxied server opened a
+  database-less pool for the schema probe, closed it, then opened a second
+  pool bound to the database: two full TCP, TLS and auth handshakes plus a
+  COM_PING on each, before any command ran. The open now binds the pool to
+  the database up front, uses the handshake itself as the liveness probe
+  (the retry policy from #6003 is unchanged, it now retries the connect),
+  skips the USE the bound session no longer needs, and in team-server mode
+  reads the schema cursor and the project identity in one SELECT. The
+  database-less pool survives only as the fallback when the bound connect
+  is refused with 1049, so a fresh database still bootstraps exactly as
+  before. Part of the open-path preamble counted in #6114, and the proxied
+  twin of #5273 items 1 and 3.
+
 - **`bd gate check` resolves bead gates whose target lives in a prefix-routed
   rig** ([#5859](https://github.com/gastownhall/beads/pull/5859)). After a local
   miss, the evaluator follows the target bead ID through `routes.jsonl` and

--- a/internal/storage/schema/converged.go
+++ b/internal/storage/schema/converged.go
@@ -36,12 +36,12 @@ func alreadyConverged(ctx context.Context, db DBConn, databaseName string, selec
 		return false, nil
 	}
 
-	// Put the session on the target database first. The hot path — the proxied
-	// CLI open in uow.openAndInitSchema — pins its schema-init pool with an
-	// EMPTY DSN database and only USEs the database after GET_LOCK, so a probe
-	// that merely ASKED whether the session was already on databaseName read
-	// NULL from DATABASE() and declined on every single invocation: the fast
-	// path never fired where it was needed.
+	// Put the session on the target database first. The proxied CLI open in
+	// uow.openAndInitSchema binds its pool to the database, so DATABASE()
+	// already answers databaseName and the selector is never called; on its
+	// fallback for a database that does not exist yet the pool has an EMPTY DSN
+	// database and the USE happens only after GET_LOCK, so a probe that merely
+	// ASKED whether the session was on databaseName read NULL and declined.
 	onTarget, qualifier, err := selectTargetDatabase(ctx, db, databaseName, selector)
 	if err != nil {
 		return false, err

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -49,6 +49,7 @@ type doltSQLProvider struct {
 	// eventsJournalEnabled activates the durable events journal for THIS
 	// provider instance only. See SetEventsJournalEnabled.
 	eventsJournalEnabled atomic.Bool
+	dbSelected           bool
 }
 
 // SetEventsJournalEnabled activates the durable events journal for every unit
@@ -245,24 +246,19 @@ func (p *doltSQLProvider) initSchemaAttempt(ctx context.Context, database string
 // project identity — identity is checked only after the schema check proves the
 // metadata table exists at this binary's version.
 func (p *doltSQLProvider) verifyTeamServerSchema(ctx context.Context, conn *sql.Conn, database string) error {
-	ddl := db.NewDDLSQLRepository(conn)
-	if err := ddl.UseDatabase(ctx, database); err != nil {
-		if isSerializationError(err) {
-			return fmt.Errorf("uow: switching to database: %w", err)
+	if !p.dbSelected {
+		if err := db.NewDDLSQLRepository(conn).UseDatabase(ctx, database); err != nil {
+			if isSerializationError(err) {
+				return fmt.Errorf("uow: switching to database: %w", err)
+			}
+			return backoff.Permanent(fmt.Errorf(
+				"uow: database %q not found — the schema is managed by beads-team-server; ask your operator to run 'bts init' first: %w",
+				database, err))
 		}
-		return backoff.Permanent(fmt.Errorf(
-			"uow: database %q not found — the schema is managed by beads-team-server; ask your operator to run 'bts init' first: %w",
-			database, err))
 	}
-	if err := checkTeamServerSchema(ctx, conn, database); err != nil {
+	if err := checkTeamServerSchemaAndIdentity(ctx, conn, database, p.expectedProjectID); err != nil {
 		if isSerializationError(err) {
-			return fmt.Errorf("uow: team-server schema check: %w", err)
-		}
-		return backoff.Permanent(err)
-	}
-	if err := checkTeamServerIdentity(ctx, conn, database, p.expectedProjectID); err != nil {
-		if isSerializationError(err) {
-			return fmt.Errorf("uow: team-server identity check: %w", err)
+			return fmt.Errorf("uow: team-server check: %w", err)
 		}
 		return backoff.Permanent(err)
 	}
@@ -274,6 +270,9 @@ func (p *doltSQLProvider) verifyTeamServerSchema(ctx context.Context, conn *sql.
 // or --inspect that migrated the workspace before rendering its plan would be the
 // exact side effect the flag exists to prevent.
 func (p *doltSQLProvider) attachPreviewDatabase(ctx context.Context, conn *sql.Conn, database string) error {
+	if p.dbSelected {
+		return nil
+	}
 	ddl := db.NewDDLSQLRepository(conn)
 	if err := ddl.UseDatabase(ctx, database); err != nil {
 		if isSerializationError(err) {
@@ -466,6 +465,16 @@ func pingWithRetry(ctx context.Context, p pinger, bo *backoff.ExponentialBackOff
 	}, backoff.WithContext(bo, ctx))
 }
 
+type poolConnector struct{ db *sql.DB }
+
+func (c poolConnector) PingContext(ctx context.Context) error {
+	conn, err := c.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
+
 func openDB(ctx context.Context, dsn string) (*sql.DB, error) {
 	conn, err := sql.Open("mysql", dsn)
 	if err != nil {
@@ -473,32 +482,46 @@ func openDB(ctx context.Context, dsn string) (*sql.DB, error) {
 	}
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxElapsedTime = 30 * time.Second
-	if err := pingWithRetry(ctx, conn, bo, pingAttemptTimeout); err != nil {
-		return nil, errors.Join(fmt.Errorf("uow: ping db: %w", err), conn.Close())
+	if err := pingWithRetry(ctx, poolConnector{conn}, bo, pingAttemptTimeout); err != nil {
+		return nil, errors.Join(fmt.Errorf("uow: connect db: %w", err), conn.Close())
 	}
 	return conn, nil
 }
 
 func openAndInitSchema(ctx context.Context, ep proxy.Endpoint, database, rootUser, rootPassword, tlsConfigName string, teamServer bool, expectedProjectID string, opts providerOptions) (UnitOfWorkProvider, error) {
+	newProvider := func(pool *sql.DB, dbSelected bool) *doltSQLProvider {
+		return &doltSQLProvider{
+			defaultBranch:     defaultBranch,
+			db:                pool,
+			serverEndpoint:    "tcp:" + ep.Address(),
+			teamServer:        teamServer,
+			expectedProjectID: expectedProjectID,
+			preview:           opts.preview,
+			dbSelected:        dbSelected,
+		}
+	}
+
+	pool, err := openDB(ctx, buildDSN(ep, database, rootUser, rootPassword, tlsConfigName))
+	switch {
+	case err == nil:
+		provider := newProvider(pool, true)
+		if err := provider.initSchema(ctx, database); err != nil {
+			_ = pool.Close()
+			return nil, fmt.Errorf("uow: init schema: %w", err)
+		}
+		return provider, nil
+	case !isUnknownDatabaseError(err):
+		return nil, err
+	}
+
 	initDB, err := openDB(ctx, buildDSN(ep, "", rootUser, rootPassword, tlsConfigName))
 	if err != nil {
 		return nil, err
 	}
-
-	initProvider := &doltSQLProvider{
-		defaultBranch:     defaultBranch,
-		db:                initDB,
-		serverEndpoint:    "tcp:" + ep.Address(),
-		teamServer:        teamServer,
-		expectedProjectID: expectedProjectID,
-		preview:           opts.preview,
-	}
-
-	if err := initProvider.initSchema(ctx, database); err != nil {
+	if err := newProvider(initDB, false).initSchema(ctx, database); err != nil {
 		_ = initDB.Close()
 		return nil, fmt.Errorf("uow: init schema: %w", err)
 	}
-
 	if err := initDB.Close(); err != nil {
 		return nil, fmt.Errorf("uow: close init db: %w", err)
 	}
@@ -507,13 +530,5 @@ func openAndInitSchema(ctx context.Context, ep proxy.Endpoint, database, rootUse
 	if err != nil {
 		return nil, err
 	}
-
-	return &doltSQLProvider{
-		defaultBranch:     defaultBranch,
-		db:                dbConn,
-		serverEndpoint:    "tcp:" + ep.Address(),
-		teamServer:        teamServer,
-		expectedProjectID: expectedProjectID,
-		preview:           opts.preview,
-	}, nil
+	return newProvider(dbConn, true), nil
 }

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -168,18 +168,23 @@ func (p *doltSQLProvider) BeginTx(ctx context.Context) (Tx, error) {
 }
 
 // selectProbeDatabase lets schema's pre-lock convergence probe reach the
-// database on a session that is not yet on one. openAndInitSchema pins its
-// schema-init pool with an EMPTY DSN database, so without this the probe reads
-// NULL from DATABASE(), declines, and every invocation queues on the
-// server-wide migration lock it exists to skip.
+// database on a session that is not yet on one. openAndInitSchema binds its
+// pool to the database up front, so on the ordinary open the probe finds
+// DATABASE() already answering the target name and never calls this. It is
+// reached on the fallback only: a database that does not exist yet refuses the
+// bound connect, the probe then runs on a database-less pool, and without this
+// it would read NULL from DATABASE(), decline, and queue on the server-wide
+// migration lock it exists to skip.
 //
 // The USE MUST remain the DDL repository's own UseDatabase — the exact
 // statement prepareBootstrap issues below. That identity is the reason the
 // probe may skip locked preparation when it reports converged: preparation's
 // contribution on an existing database is precisely this USE (its bare CREATE
 // DATABASE can only have failed with "database exists" and captured no heal
-// authority). Reimplementing the statement here, or letting the two quote
-// identifiers differently, would silently break that argument.
+// authority). On the bound pool the session is on the database by handshake,
+// which is the same state the USE would leave it in, so the argument holds
+// there without any statement. Reimplementing the statement here, or letting
+// the two quote identifiers differently, would silently break it.
 //
 // It is injected rather than reached for from schema/: domain/db's own test
 // suite migrates a scratch database with schema, so a schema -> domain/db
@@ -465,6 +470,8 @@ func pingWithRetry(ctx context.Context, p pinger, bo *backoff.ExponentialBackOff
 	}, backoff.WithContext(bo, ctx))
 }
 
+// poolConnector answers pingWithRetry with a connect instead of a COM_PING:
+// the handshake is the liveness proof, and the connection stays in the pool.
 type poolConnector struct{ db *sql.DB }
 
 func (c poolConnector) PingContext(ctx context.Context) error {

--- a/internal/storage/uow/dolt_sql_provider_lock_test.go
+++ b/internal/storage/uow/dolt_sql_provider_lock_test.go
@@ -61,12 +61,18 @@ func TestClassifyInitSchemaErrorKeepsBootstrapPreparationErrorsDistinct(t *testi
 }
 
 // expectNoSessionDatabase mocks the opening question of the pre-lock
-// convergence probe on the shape every production seat presents: initSchema
-// pins its connection from a pool opened with an EMPTY DSN database (see
-// openAndInitSchema), so DATABASE() is NULL until something issues USE.
+// convergence probe on the fallback shape: openAndInitSchema could not bind
+// its pool to the database (it does not exist yet) and pins the connection
+// from a pool opened with an EMPTY DSN database, so DATABASE() is NULL until
+// something issues USE. expectSessionDatabase is the ordinary shape.
 func expectNoSessionDatabase(mock sqlmock.Sqlmock) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT DATABASE()")).
 		WillReturnRows(sqlmock.NewRows([]string{"DATABASE()"}).AddRow(nil))
+}
+
+func expectSessionDatabase(mock sqlmock.Sqlmock, database string) {
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT DATABASE()")).
+		WillReturnRows(sqlmock.NewRows([]string{"DATABASE()"}).AddRow(database))
 }
 
 // expectDatabaseExistsProbe mocks the always-succeeding existence probe the
@@ -138,13 +144,13 @@ func TestInitSchemaAcquiresMigrationLockBeforeBootstrapDDL(t *testing.T) {
 }
 
 // TestInitSchemaConvergenceProbeRunsWithNoSessionDatabase is the caller-side
-// regression for the fast path that could not fire. openAndInitSchema opens
-// its schema-init pool with an EMPTY DSN database and the USE happens only
-// inside the locked bootstrap preparation, so when the pre-lock convergence
-// probe asked DATABASE() it read NULL on every production seat's open, gave
-// up on its first statement, and took the server-wide GET_LOCK exactly as
-// before — the change measured on the shared rig was a no-op on the only path
-// that mattered.
+// regression for the fast path that could not fire. When openAndInitSchema
+// falls back to a schema-init pool with an EMPTY DSN database (the database
+// does not exist yet), the USE happens only inside the locked bootstrap
+// preparation, so when the pre-lock convergence probe asked DATABASE() it read
+// NULL, gave up on its first statement, and took the server-wide GET_LOCK
+// exactly as before — the change measured on the shared rig was a no-op on
+// the path every seat took at the time.
 //
 // From this caller, with the database already present, the probe must reach
 // the schema predicates: prove the database exists with a query that cannot
@@ -199,6 +205,55 @@ func TestInitSchemaConvergenceProbeRunsWithNoSessionDatabase(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("the convergence probe must reach the schema predicates on a session with no database selected: %v", err)
+	}
+}
+
+// TestInitSchemaConvergenceProbeRunsOnBoundSession is the ordinary open:
+// openAndInitSchema bound its pool to the database, so the probe finds
+// DATABASE() already answering and goes straight to the schema predicates,
+// with no existence probe and no USE of its own. The cursor is far behind, so
+// the probe declines and the locked pass follows as before.
+func TestInitSchemaConvergenceProbeRunsOnBoundSession(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	lockName := schema.MigrationLockName("beads")
+	expectSessionDatabase(mock, "beads")
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM information_schema\.tables`).
+		WithArgs("schema_migrations").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COALESCE(MAX(version), 0) FROM schema_migrations")).
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(1))
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT GET_LOCK(?, ?)")).
+		WithArgs(lockName, 5).
+		WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(1))
+	mock.ExpectExec(regexp.QuoteMeta("CREATE DATABASE `beads`")).
+		WillReturnError(&mysql.MySQLError{Number: 1007, Message: "database exists"})
+	mock.ExpectExec(regexp.QuoteMeta("USE `beads`")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO dolt_ignore VALUES (?, true)")).
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnError(errors.New("first migration statement failed"))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT RELEASE_LOCK(?)")).
+		WithArgs(lockName).
+		WillReturnRows(sqlmock.NewRows([]string{"released"}).AddRow(1))
+
+	p := &doltSQLProvider{
+		defaultBranch:  defaultBranch,
+		db:             db,
+		serverEndpoint: "tcp:127.0.0.1:3306",
+		dbSelected:     true,
+	}
+	err = p.initSchema(context.Background(), "beads")
+	if err == nil || !strings.Contains(err.Error(), "first migration statement failed") {
+		t.Fatalf("initSchema() error = %v, want first migration sentinel", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("the convergence probe must reach the schema predicates on a bound session without an existence probe or USE: %v", err)
 	}
 }
 

--- a/internal/storage/uow/errors.go
+++ b/internal/storage/uow/errors.go
@@ -50,3 +50,15 @@ func isDatabaseExistsError(err error) bool {
 	errLower := strings.ToLower(err.Error())
 	return strings.Contains(errLower, "database exists") || strings.Contains(errLower, "1007")
 }
+
+func isUnknownDatabaseError(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) && mysqlErr.Number == 1049 {
+		return true
+	}
+	if err == nil {
+		return false
+	}
+	errLower := strings.ToLower(err.Error())
+	return strings.Contains(errLower, "database not found") || strings.Contains(errLower, "unknown database") || strings.Contains(errLower, "1049")
+}

--- a/internal/storage/uow/errors.go
+++ b/internal/storage/uow/errors.go
@@ -60,5 +60,5 @@ func isUnknownDatabaseError(err error) bool {
 		return false
 	}
 	errLower := strings.ToLower(err.Error())
-	return strings.Contains(errLower, "database not found") || strings.Contains(errLower, "unknown database") || strings.Contains(errLower, "1049")
+	return strings.Contains(errLower, "database not found") || strings.Contains(errLower, "unknown database")
 }

--- a/internal/storage/uow/open_roundtrips_test.go
+++ b/internal/storage/uow/open_roundtrips_test.go
@@ -1,0 +1,184 @@
+package uow
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
+	"github.com/steveyegge/beads/internal/testutil"
+)
+
+type countingProxy struct {
+	addr     string
+	conns    atomic.Int32
+	awaited  atomic.Int32
+	mu       sync.Mutex
+	sessions map[int32]int
+	trace    []string
+}
+
+func startCountingProxy(t *testing.T, backend string) *countingProxy {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	p := &countingProxy{addr: ln.Addr().String(), sessions: map[int32]int{}}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			p.conns.Add(1)
+			go p.serve(c, backend)
+		}
+	}()
+	return p
+}
+
+func (p *countingProxy) serve(client net.Conn, backend string) {
+	id := p.conns.Load()
+	defer client.Close()
+	server, err := net.Dial("tcp", backend)
+	if err != nil {
+		return
+	}
+	defer server.Close()
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(client, server)
+		_ = client.(*net.TCPConn).CloseWrite()
+	}()
+	go func() {
+		defer wg.Done()
+		defer func() { _ = server.(*net.TCPConn).CloseWrite() }()
+		var hdr [4]byte
+		for {
+			if _, err := io.ReadFull(client, hdr[:]); err != nil {
+				return
+			}
+			n := int(binary.LittleEndian.Uint32([]byte{hdr[0], hdr[1], hdr[2], 0}))
+			payload := make([]byte, n)
+			if _, err := io.ReadFull(client, payload); err != nil {
+				return
+			}
+			if hdr[3] == 0 && n > 0 {
+				switch payload[0] {
+				case 0x01, 0x19: // COM_QUIT, COM_STMT_CLOSE
+				default:
+					p.awaited.Add(1)
+					text := string(payload[1:])
+					if len(text) > 70 {
+						text = text[:70]
+					}
+					p.mu.Lock()
+					p.sessions[id]++
+					p.trace = append(p.trace, fmt.Sprintf("conn#%d cmd=0x%02x %q", id, payload[0], text))
+					p.mu.Unlock()
+				}
+			}
+			if _, err := server.Write(append(hdr[:], payload...)); err != nil {
+				return
+			}
+		}
+	}()
+	wg.Wait()
+}
+
+func (p *countingProxy) reset() (conns, sessions, awaited int32) {
+	p.mu.Lock()
+	sessions = int32(len(p.sessions))
+	p.sessions = map[int32]int{}
+	p.trace = nil
+	p.mu.Unlock()
+	return p.conns.Swap(0), sessions, p.awaited.Swap(0)
+}
+
+func (p *countingProxy) dump(t *testing.T) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, line := range p.trace {
+		t.Log(line)
+	}
+}
+
+func TestOpenAndInitSchema_ExistingDatabaseUsesOneConnection(t *testing.T) {
+	port := testutil.StartIsolatedDoltContainer(t)
+	cp := startCountingProxy(t, net.JoinHostPort("127.0.0.1", port))
+	proxyHost, proxyPortStr, err := net.SplitHostPort(cp.addr)
+	require.NoError(t, err)
+	proxyPort, err := strconv.Atoi(proxyPortStr)
+	require.NoError(t, err)
+
+	bdBin := buildBDBinary(t)
+	prev := proxy.ResolveExecutable
+	proxy.ResolveExecutable = func() (string, error) { return bdBin, nil }
+	t.Cleanup(func() { proxy.ResolveExecutable = prev })
+	t.Setenv("HOME", t.TempDir())
+
+	storeRootDir := t.TempDir()
+	shutdownOnInterrupt(t, storeRootDir)
+	t.Cleanup(func() { _ = proxy.Shutdown(storeRootDir) })
+	logPath := filepath.Join(t.TempDir(), "server.log")
+	external := configfile.ExternalDoltConfig{Host: proxyHost, Port: proxyPort}
+
+	open := func(teamServer bool, projectID string) *doltSQLProvider {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		provider, err := NewExternalDoltServerUOWProvider(ctx, storeRootDir, "beads_fresh", logPath,
+			external, "root", "", 0, 0, teamServer, projectID)
+		require.NoError(t, err)
+		sqlProv, ok := provider.(*doltSQLProvider)
+		require.True(t, ok, "expected *doltSQLProvider, got %T", provider)
+		return sqlProv
+	}
+
+	cp.reset()
+	first := open(false, "")
+	conns, sessions, awaited := cp.reset()
+	t.Logf("fresh database: %d connections, %d sessions, %d awaited commands", conns, sessions, awaited)
+	_, err = first.db.ExecContext(context.Background(),
+		"INSERT INTO metadata (`key`, value) VALUES ('_project_id', 'proj-1')")
+	require.NoError(t, err)
+	require.NoError(t, first.Close(context.Background()))
+
+	cp.reset()
+	second := open(false, "")
+	if cp.sessionCount() != 1 {
+		cp.dump(t)
+	}
+	conns, sessions, awaited = cp.reset()
+	t.Logf("existing database: %d connections, %d sessions, %d awaited commands", conns, sessions, awaited)
+	require.Equal(t, int32(1), sessions)
+	require.NoError(t, second.Close(context.Background()))
+
+	third := open(true, "proj-1")
+	if cp.sessionCount() != 1 {
+		cp.dump(t)
+	}
+	conns, sessions, awaited = cp.reset()
+	t.Logf("team-server: %d connections, %d sessions, %d awaited commands", conns, sessions, awaited)
+	require.Equal(t, int32(1), sessions)
+	require.LessOrEqual(t, awaited, int32(2), "team-server open should be the driver's connect probe plus one SELECT")
+	require.NoError(t, third.Close(context.Background()))
+}
+
+func (p *countingProxy) sessionCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.sessions)
+}

--- a/internal/storage/uow/open_roundtrips_test.go
+++ b/internal/storage/uow/open_roundtrips_test.go
@@ -137,7 +137,7 @@ func TestOpenAndInitSchema_ExistingDatabaseUsesOneConnection(t *testing.T) {
 	external := configfile.ExternalDoltConfig{Host: proxyHost, Port: proxyPort}
 
 	open := func(teamServer bool, projectID string) *doltSQLProvider {
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 		provider, err := NewExternalDoltServerUOWProvider(ctx, storeRootDir, "beads_fresh", logPath,
 			external, "root", "", 0, 0, teamServer, projectID)
@@ -151,6 +151,7 @@ func TestOpenAndInitSchema_ExistingDatabaseUsesOneConnection(t *testing.T) {
 	first := open(false, "")
 	conns, sessions, awaited := cp.reset()
 	t.Logf("fresh database: %d connections, %d sessions, %d awaited commands", conns, sessions, awaited)
+	require.Equal(t, int32(2), sessions, "fresh database bootstraps on a database-less session, then opens the bound one")
 	_, err = first.db.ExecContext(context.Background(),
 		"INSERT INTO metadata (`key`, value) VALUES ('_project_id', 'proj-1')")
 	require.NoError(t, err)

--- a/internal/storage/uow/team_server_schema.go
+++ b/internal/storage/uow/team_server_schema.go
@@ -10,6 +10,12 @@ import (
 )
 
 func checkTeamServerSchemaAndIdentity(ctx context.Context, conn schema.DBConn, database, expectedProjectID string) error {
+	// This SELECT can fail against a database without the beads schema, which
+	// schema.currentVersion avoids by probing information_schema first (be-bv7x:
+	// a failed statement can pin a pooled Dolt session to a stale catalog). It
+	// does not bind here: a failure falls through to the two-step checks, every
+	// path out of those on such a database is a refusal, and a refused open
+	// closes the pool, so the session never serves another statement.
 	if expectedProjectID != "" {
 		var current int
 		var projectID sql.NullString

--- a/internal/storage/uow/team_server_schema.go
+++ b/internal/storage/uow/team_server_schema.go
@@ -15,7 +15,10 @@ func checkTeamServerSchemaAndIdentity(ctx context.Context, conn schema.DBConn, d
 	// a failed statement can pin a pooled Dolt session to a stale catalog). It
 	// does not bind here: a failure falls through to the two-step checks, every
 	// path out of those on such a database is a refusal, and a refused open
-	// closes the pool, so the session never serves another statement.
+	// closes the pool, so the session never serves another statement. The one
+	// exception is a serialization-class failure, which backoff retries on the
+	// same pool; that session keeps the pin, on a bts-managed schema that any
+	// skew already refuses.
 	if expectedProjectID != "" {
 		var current int
 		var projectID sql.NullString

--- a/internal/storage/uow/team_server_schema.go
+++ b/internal/storage/uow/team_server_schema.go
@@ -2,11 +2,29 @@ package uow
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/storage/schema"
 )
+
+func checkTeamServerSchemaAndIdentity(ctx context.Context, conn schema.DBConn, database, expectedProjectID string) error {
+	if expectedProjectID != "" {
+		var current int
+		var projectID sql.NullString
+		err := conn.QueryRowContext(ctx,
+			"SELECT (SELECT COALESCE(MAX(version), 0) FROM schema_migrations), "+
+				"(SELECT value FROM metadata WHERE `key` = '_project_id' LIMIT 1)").Scan(&current, &projectID)
+		if err == nil && current == schema.LatestVersion() && projectID.Valid && projectID.String == expectedProjectID {
+			return nil
+		}
+	}
+	if err := checkTeamServerSchema(ctx, conn, database); err != nil {
+		return err
+	}
+	return checkTeamServerIdentity(ctx, conn, database, expectedProjectID)
+}
 
 // checkTeamServerSchema verifies that a bts-managed database's schema version
 // matches this binary's. The connection must already have the database selected.

--- a/internal/storage/uow/team_server_schema_test.go
+++ b/internal/storage/uow/team_server_schema_test.go
@@ -342,3 +342,18 @@ func TestCheckTeamServerSchemaAndIdentity_NoExpectedID_SkipsProbe(t *testing.T) 
 		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }
+
+func TestCheckTeamServerSchemaAndIdentity_Behind_RefusesWithBtsMigrate(t *testing.T) {
+	mock, db, closeDB := newVersionMockDB(t)
+	defer closeDB()
+	expectConvergedProbe(mock, schema.LatestVersion()-1, "project-AAAA")
+	expectVersionQuery(mock, schema.LatestVersion()-1)
+
+	err := checkTeamServerSchemaAndIdentity(context.Background(), db, "beads_team", "project-AAAA")
+	if err == nil || !strings.Contains(err.Error(), "bts migrate") {
+		t.Fatalf("checkTeamServerSchemaAndIdentity = %v, want the bts-migrate refusal for a behind schema even with a matching identity", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}

--- a/internal/storage/uow/team_server_schema_test.go
+++ b/internal/storage/uow/team_server_schema_test.go
@@ -279,3 +279,66 @@ func TestCheckTeamServerIdentity_ReadError_Surfaces(t *testing.T) {
 		t.Errorf("error %q should name the database", err)
 	}
 }
+
+func expectConvergedProbe(mock sqlmock.Sqlmock, version int, projectID any) {
+	mock.ExpectQuery(`SELECT \(SELECT COALESCE\(MAX\(version\), 0\) FROM schema_migrations\), \(SELECT value FROM metadata`).
+		WillReturnRows(sqlmock.NewRows([]string{"version", "project_id"}).AddRow(version, projectID))
+}
+
+func TestCheckTeamServerSchemaAndIdentity_Converged_OneQuery(t *testing.T) {
+	mock, db, closeDB := newVersionMockDB(t)
+	defer closeDB()
+	expectConvergedProbe(mock, schema.LatestVersion(), "project-AAAA")
+
+	if err := checkTeamServerSchemaAndIdentity(context.Background(), db, "beads_team", "project-AAAA"); err != nil {
+		t.Fatalf("checkTeamServerSchemaAndIdentity = %v, want nil", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("converged state must be answered by the single probe: %v", err)
+	}
+}
+
+func TestCheckTeamServerSchemaAndIdentity_Mismatch_FallsThroughToDiagnostics(t *testing.T) {
+	mock, db, closeDB := newVersionMockDB(t)
+	defer closeDB()
+	expectConvergedProbe(mock, schema.LatestVersion(), "project-BBBB")
+	expectVersionQuery(mock, schema.LatestVersion())
+	expectProjectIDQuery(mock, "project-BBBB")
+
+	err := checkTeamServerSchemaAndIdentity(context.Background(), db, "beads_team", "project-AAAA")
+	if err == nil || !strings.Contains(err.Error(), "PROJECT IDENTITY MISMATCH") {
+		t.Fatalf("checkTeamServerSchemaAndIdentity = %v, want identity mismatch from the two-step check", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestCheckTeamServerSchemaAndIdentity_ProbeError_FallsThroughToDiagnostics(t *testing.T) {
+	mock, db, closeDB := newVersionMockDB(t)
+	defer closeDB()
+	mock.ExpectQuery(`SELECT \(SELECT COALESCE\(MAX\(version\), 0\) FROM schema_migrations\)`).
+		WillReturnError(errors.New("table not found: schema_migrations"))
+	expectVersionQuery(mock, 0)
+
+	err := checkTeamServerSchemaAndIdentity(context.Background(), db, "beads_team", "project-AAAA")
+	if err == nil || !strings.Contains(err.Error(), "bts init") {
+		t.Fatalf("checkTeamServerSchemaAndIdentity = %v, want the fresh-database diagnostic", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestCheckTeamServerSchemaAndIdentity_NoExpectedID_SkipsProbe(t *testing.T) {
+	mock, db, closeDB := newVersionMockDB(t)
+	defer closeDB()
+	expectVersionQuery(mock, schema.LatestVersion())
+
+	if err := checkTeamServerSchemaAndIdentity(context.Background(), db, "beads_team", ""); err != nil {
+		t.Fatalf("checkTeamServerSchemaAndIdentity = %v, want nil", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## What

The proxied-server provider opens one pool bound to the target database and runs the schema probe on it, instead of a database-less pool for the probe plus a second pool for the command. Along the same path it drops the COM_PING after the handshake, skips the USE the bound session no longer needs, and in team-server mode reads the schema cursor and project identity in one SELECT.

## Why

Every bd invocation paid two full handshakes before any command ran. Our shared server is about 254 ms away from part of the team, so that alone was around 3 s per command. This is the proxied route's version of #5273 items 1 and 3 (skip the second no-database pool, translate 1049, drop the redundant ping), and part of the open-path preamble counted in #6114.

Bootstrap is unchanged. A database that does not exist yet refuses the bound connect with 1049, and only then does the probe run on a database-less pool so CREATE DATABASE and the migration pass happen exactly as before. The retry policy from #6003 is kept, pingWithRetry now retries the connect instead of a ping on top of it.

The team-server fast path is one SELECT with two subselects. If the answer is not "schema at this binary's version and identity matches", it falls through to checkTeamServerSchema and checkTeamServerIdentity, so every existing diagnostic (bts init, bts migrate, forward drift, identity mismatch) is still produced by the code that owned it.

## Verification

New test internal/storage/uow/open_roundtrips_test.go puts a packet counting TCP proxy between the db-proxy child and a Dolt container, the method from #6114, and opens the provider three times. Fresh database (bootstrap path, logged only), existing database, and team-server on that database. Numbers from the run:

existing database, before: 3 connections, 2 sessions, 29 awaited commands. After: 2 connections, 1 session, 23 awaited commands. The connection with no session is the db-proxy child's readiness probe, not touched here.
team-server, after: 1 session, 2 awaited commands (the driver's max_allowed_packet probe and the one SELECT).

Run against the code before this change (current main) the same test fails, reporting 2 sessions for the existing database. With the change it passes with 1. sqlmock tests cover the merged team-server check, converged in one query, mismatch and probe error falling through, and no probe when there is no expected identity. Existing provider tests against the Dolt container pass (end to end bootstrap, concurrent instantiation, self heal after mid pass failure, dirty database not healed, team server mode). make ci-pr-lint clean.

Wall clock on our server at 254 ms RTT, measured with the same change on the build our team runs (commit 8c7db45c8, this PR is the port to main). bd sql 'select 1' 4.9 s to 2.4 s and bd ready 9.9 s to 5.1 s in team-server mode, bd sql 12.2 s to 7.6 s without it. I did not rerun the wall clock numbers on main, our shared database is on the older schema.


