### PR TITLE
fix(dolt): make the server-side transfer read deadline configurable

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -550,6 +550,54 @@ func withCLIExecTimeout(ctx context.Context) (context.Context, context.CancelFun
 	return context.WithTimeout(ctx, cliExecTimeoutDuration())
 }
 
+// transferExecTimeout is the default read deadline on the one-shot connections
+// that carry server-side transfer work — CALL DOLT_PUSH / DOLT_FETCH /
+// DOLT_PULL and the merge that follows a pull. It is the server-mode sibling of
+// cliExecTimeout: the pool's much shorter deadline would kill any procedure
+// that performs sustained network I/O to a git remote, so these callers open
+// their own connection with this deadline instead.
+//
+// Five minutes is ample for an ordinary store and far too short for a large
+// one. A 2.3GB / ~28k-commit store took well over half an hour to push, and
+// before this was configurable every attempt died at exactly 5m with a bare
+// "read tcp ...: i/o timeout / invalid connection" that named neither the
+// deadline nor a way to raise it. Set BEADS_DOLT_TRANSFER_TIMEOUT to override.
+const transferExecTimeout = 5 * time.Minute
+
+// transferExecTimeoutEnv is the environment variable that overrides
+// transferExecTimeout.
+const transferExecTimeoutEnv = "BEADS_DOLT_TRANSFER_TIMEOUT"
+
+// annotateTransferTimeout turns the driver's opaque read-deadline failure into
+// an actionable one. When the one-shot connection's ReadTimeout fires mid
+// transfer, the go-sql-driver logs "read tcp ...: i/o timeout" and returns
+// driver.ErrBadConn, which surfaces to the user as a bare "invalid connection"
+// — naming neither the deadline that fired nor the knob that raises it. This
+// mirrors what cliTransferError does for the dolt-CLI path.
+func annotateTransferTimeout(err error, deadline time.Duration) error {
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, mysql.ErrInvalidConn) && !errors.Is(err, driver.ErrBadConn) &&
+		!errors.Is(err, os.ErrDeadlineExceeded) {
+		return err
+	}
+	return fmt.Errorf("%w (the server-side transfer exceeded the %v read deadline; raise it with %s, e.g. %s=90m)",
+		err, deadline, transferExecTimeoutEnv, transferExecTimeoutEnv)
+}
+
+// transferExecTimeoutDuration returns the configured server-side transfer read
+// deadline. BEADS_DOLT_TRANSFER_TIMEOUT overrides the compiled-in
+// transferExecTimeout const; valid time.ParseDuration strings (e.g. "90m",
+// "300s") or bare numbers treated as seconds (e.g. "5400") are accepted. Unset,
+// invalid, or non-positive values fall back to transferExecTimeout — to remove
+// the deadline entirely, pass a duration longer than any transfer you expect
+// (the no-deadline callers below pass 0 to oneShotConn directly and are
+// deliberately not routed through this).
+func transferExecTimeoutDuration() time.Duration {
+	return timeoutFromEnv(transferExecTimeoutEnv, transferExecTimeout)
+}
+
 // timeoutFromEnv returns the duration configured in the named env var, falling
 // back to fallback when the var is unset, unparsable, or non-positive. Valid
 // time.ParseDuration strings (e.g. "2m", "90s") or bare numbers treated as
@@ -2229,9 +2277,11 @@ func buildServerDSN(cfg *Config, database string) string {
 	return parsed.FormatDSN()
 }
 
-// execWithLongTimeout opens a one-shot database connection with readTimeout=5m
-// and executes the given query. Push/pull operations can exceed the default
-// readTimeout when the server performs network I/O to git remotes.
+// execWithLongTimeout opens a one-shot database connection with the configured
+// transfer read deadline (transferExecTimeoutDuration, default 5m, overridable
+// with BEADS_DOLT_TRANSFER_TIMEOUT) and executes the given query. Push/pull
+// operations can exceed the default readTimeout when the server performs
+// network I/O to git remotes.
 //
 // The query is wrapped in an explicit transaction (BEGIN/COMMIT) so that
 // DOLT_PULL merge operations succeed even when the server runs with
@@ -2251,7 +2301,7 @@ func (s *DoltStore) execWithLongTimeout(ctx context.Context, query string, args 
 	if err != nil {
 		return fmt.Errorf("failed to parse DSN for long-timeout connection: %w", err)
 	}
-	cfg.ReadTimeout = 5 * time.Minute
+	cfg.ReadTimeout = transferExecTimeoutDuration()
 	db, err := sql.Open("mysql", cfg.FormatDSN())
 	if err != nil {
 		return fmt.Errorf("failed to open long-timeout connection: %w", err)
@@ -2278,19 +2328,21 @@ func (s *DoltStore) execWithLongTimeout(ctx context.Context, query string, args 
 // passes s.branch explicitly as a CALL DOLT_PUSH(...) arg, so this fresh
 // connection's default checkout never matters.
 func (s *DoltStore) execWithLongTimeoutNoTx(ctx context.Context, query string, args ...any) error {
-	db, err := s.oneShotConn(5 * time.Minute)
+	deadline := transferExecTimeoutDuration()
+	db, err := s.oneShotConn(deadline)
 	if err != nil {
 		return err
 	}
 	defer db.Close()
 	_, err = db.ExecContext(ctx, query, args...)
-	return err
+	return annotateTransferTimeout(err, deadline)
 }
 
 // oneShotConn opens a one-shot connection with the given read deadline
 // (0 = no deadline), for callers that pass a DBConn into versioncontrolops.
 // The pool's 10s ReadTimeout kills any server-side procedure that performs
-// sustained network I/O; push/pull use 5m, while backup sync/restore use no
+// sustained network I/O; push/pull use transferExecTimeoutDuration (5m by
+// default, BEADS_DOLT_TRANSFER_TIMEOUT), while backup sync/restore use no
 // deadline at all — a first sync to a remote destination (gs://) can exceed
 // any fixed budget, and the server aborts the transfer when the client
 // connection drops, so a too-short deadline can never converge by retrying.
@@ -4320,7 +4372,7 @@ func (s *DoltStore) openLongTimeoutConn() (*sql.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse DSN for long-timeout connection: %w", err)
 	}
-	cfg.ReadTimeout = 5 * time.Minute
+	cfg.ReadTimeout = transferExecTimeoutDuration()
 	db, err := sql.Open("mysql", cfg.FormatDSN())
 	if err != nil {
 		return nil, fmt.Errorf("failed to open long-timeout connection: %w", err)

--- a/internal/storage/dolt/transfer_exec_timeout_test.go
+++ b/internal/storage/dolt/transfer_exec_timeout_test.go
@@ -1,0 +1,97 @@
+package dolt
+
+import (
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	mysql "github.com/go-sql-driver/mysql"
+)
+
+// TestTransferExecTimeoutDuration verifies BEADS_DOLT_TRANSFER_TIMEOUT parsing:
+// valid durations and bare seconds are honored, unset/invalid/non-positive
+// values fall back to the compiled-in default. This is the server-mode sibling
+// of TestCLIExecTimeoutDuration; before it existed the deadline on the one-shot
+// CALL DOLT_PUSH / DOLT_PULL connection was a hardcoded 5m with no override, so
+// a store large enough to need longer could not be pushed at all.
+func TestTransferExecTimeoutDuration(t *testing.T) {
+	t.Run("duration string", func(t *testing.T) {
+		t.Setenv(transferExecTimeoutEnv, "90m")
+		if got := transferExecTimeoutDuration(); got != 90*time.Minute {
+			t.Fatalf("transferExecTimeoutDuration() = %v, want 90m", got)
+		}
+	})
+	t.Run("bare seconds", func(t *testing.T) {
+		t.Setenv(transferExecTimeoutEnv, "5400")
+		if got := transferExecTimeoutDuration(); got != 5400*time.Second {
+			t.Fatalf("transferExecTimeoutDuration() = %v, want 5400s", got)
+		}
+	})
+	t.Run("unset falls back", func(t *testing.T) {
+		t.Setenv(transferExecTimeoutEnv, "")
+		if got := transferExecTimeoutDuration(); got != transferExecTimeout {
+			t.Fatalf("transferExecTimeoutDuration() = %v, want default %v", got, transferExecTimeout)
+		}
+	})
+	t.Run("invalid falls back", func(t *testing.T) {
+		t.Setenv(transferExecTimeoutEnv, "eventually")
+		if got := transferExecTimeoutDuration(); got != transferExecTimeout {
+			t.Fatalf("transferExecTimeoutDuration() = %v, want default %v", got, transferExecTimeout)
+		}
+	})
+	t.Run("non-positive falls back", func(t *testing.T) {
+		t.Setenv(transferExecTimeoutEnv, "-1m")
+		if got := transferExecTimeoutDuration(); got != transferExecTimeout {
+			t.Fatalf("transferExecTimeoutDuration() = %v, want default %v", got, transferExecTimeout)
+		}
+	})
+}
+
+// TestAnnotateTransferTimeout pins that a read-deadline failure on the one-shot
+// transfer connection names the deadline and the env var that raises it. The
+// driver's own message is just "invalid connection", which sent an operator
+// looking at the network and at GitHub rather than at the 5m deadline that had
+// actually fired.
+func TestAnnotateTransferTimeout(t *testing.T) {
+	t.Run("nil stays nil", func(t *testing.T) {
+		if err := annotateTransferTimeout(nil, time.Minute); err != nil {
+			t.Fatalf("annotateTransferTimeout(nil) = %v, want nil", err)
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"mysql invalid conn", mysql.ErrInvalidConn},
+		{"driver bad conn", driver.ErrBadConn},
+		{"os deadline exceeded", os.ErrDeadlineExceeded},
+		{"wrapped", fmt.Errorf("failed to push to origin/main: %w", mysql.ErrInvalidConn)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := annotateTransferTimeout(tc.err, 5*time.Minute)
+			msg := got.Error()
+			if !strings.Contains(msg, "5m0s") {
+				t.Errorf("message does not name the deadline that fired: %q", msg)
+			}
+			if !strings.Contains(msg, transferExecTimeoutEnv) {
+				t.Errorf("message does not name %s: %q", transferExecTimeoutEnv, msg)
+			}
+			if !errors.Is(got, tc.err) {
+				t.Errorf("annotation broke the error chain: %v does not wrap %v", got, tc.err)
+			}
+		})
+	}
+
+	t.Run("unrelated error passes through unchanged", func(t *testing.T) {
+		orig := errors.New("remote origin not found")
+		got := annotateTransferTimeout(orig, 5*time.Minute)
+		if got != orig { //nolint:errorlint // identity is the assertion
+			t.Fatalf("annotateTransferTimeout rewrote a non-timeout error: %v", got)
+		}
+	})
+}


### PR DESCRIPTION
## What

Make the server-side transfer read deadline configurable via
`BEADS_DOLT_TRANSFER_TIMEOUT`, and name the deadline in the error when it
fires. The default is unchanged at 5 minutes, so behavior only changes when an
operator opts in.

## Why

Fixes #6375.

`CALL DOLT_PUSH` / `DOLT_FETCH` / `DOLT_PULL` run on one-shot connections whose
`ReadTimeout` was hardcoded to 5 minutes in three places. A store large enough
to need longer than that cannot be pushed at all — and the failure gives the
operator nothing to act on:

```
[mysql] read tcp 127.0.0.1:...->127.0.0.1:58506: i/o timeout
Error: failed to push to origin/main: invalid connection
```

That names neither the deadline that fired nor any way to raise it. The symptom
reads as a network or remote-side fault, so the obvious next moves (retry, check
GitHub, check ssh) all lead away from the actual cause.

Observed on a large store: every push attempt died at exactly 5m.

The change replaces the three literals with `transferExecTimeoutDuration()`,
mirroring the existing `cliExecTimeout` / `BEADS_CLI_TRANSFER_TIMEOUT` pattern
already used for the dolt-CLI transfer path, and adds `annotateTransferTimeout`
so a deadline hit says what fired and how to raise it instead of
`invalid connection`. Non-timeout errors pass through untouched.

The no-deadline callers (backup sync/restore, which pass `0` to `oneShotConn`)
are deliberately left alone: a first sync to a cloud destination can exceed any
fixed budget, and the server aborts when the client drops, so a too-short
deadline there can never converge by retrying.

## Verification

```
go test ./internal/storage/dolt/ -run TransferExecTimeout -count=1
ok      github.com/steveyegge/beads/internal/storage/dolt       3.136s
```

The new `transfer_exec_timeout_test.go` covers env-var override parsing
(duration strings and bare seconds), fallback to the 5m default when the value
is unset / unparsable / non-positive, and the annotated error text.

`make ci-pr-lint`: currently fails with 5 gosec findings
(`internal/config/permissions_open_nonlinux.go`, `internal/utils/path_case_darwin.go`,
and a profiling path). These are **pre-existing** — the same 5 failures reproduce
on a clean checkout of `origin/main` without this change, and **none** of them
are in the two files this PR touches.
