### PR TITLE
fix(make): clean binaries from the configured build directory

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1248,6 +1248,54 @@ jobs:
             throw 'Native Make split the spaced install path or otherwise mutated the fixture repository'
           }
 
+          # Clean only the selected build outputs, including both host suffixes.
+          foreach ($cleanDir in @('.', 'clean output')) {
+            $targetDir = Join-Path $fixtureRepo $cleanDir
+            New-Item -ItemType Directory -Force -Path (Join-Path $targetDir 'keep dir') | Out-Null
+            Set-Content -LiteralPath (Join-Path $targetDir 'keep.txt') -NoNewline -Value 'keep'
+            foreach ($name in @('bd', 'bd.exe')) {
+              Set-Content -LiteralPath (Join-Path $targetDir $name) -NoNewline -Value 'clean-output'
+              if ($cleanDir -ne '.') {
+                Set-Content -LiteralPath (Join-Path $fixtureRepo $name) -NoNewline -Value 'keep-root'
+              }
+            }
+            $cleanArgs = @('--no-print-directory', 'clean')
+            if ($cleanDir -ne '.') { $cleanArgs += "BUILD_DIR=$cleanDir" }
+            Push-Location $fixtureRepo
+            try {
+              foreach ($attempt in 1..2) {
+                & $make @cleanArgs
+                if ($LASTEXITCODE -ne 0) { throw "Native Make clean failed for $cleanDir (attempt $attempt)" }
+              }
+            } finally {
+              Pop-Location
+            }
+            foreach ($name in @('bd', 'bd.exe')) {
+              if (Test-Path -LiteralPath (Join-Path $targetDir $name)) { throw "Clean left $cleanDir/$name" }
+              if ($cleanDir -ne '.' -and [IO.File]::ReadAllText((Join-Path $fixtureRepo $name)) -cne 'keep-root') {
+                throw "Custom clean changed root $name"
+              }
+            }
+            if ([IO.File]::ReadAllText((Join-Path $targetDir 'keep.txt')) -cne 'keep' -or
+                -not (Test-Path -LiteralPath (Join-Path $targetDir 'keep dir') -PathType Container)) {
+              throw 'Clean changed an unrelated neighbor or directory'
+            }
+          }
+          Push-Location $fixtureRepo
+          try {
+            & $make --no-print-directory 'BUILD_DIR=absent clean output' clean
+            if ($LASTEXITCODE -ne 0) { throw 'Clean failed for a missing build directory' }
+          } finally {
+            Pop-Location
+          }
+          foreach ($name in @('bd', 'bd.exe')) {
+            if ([IO.File]::ReadAllText((Join-Path $fixtureRepo $name)) -cne 'keep-root') {
+              throw "Missing-directory clean changed root $name"
+            }
+          }
+          Write-Output 'Native Make clean default, spaced, repeated and missing-directory checks passed'
+
+
       - name: Exercise MSYS2-hosted Make
         if: matrix.host == 'msys2'
         shell: msys2 {0}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1281,14 +1281,15 @@ jobs:
               throw 'Clean changed an unrelated neighbor or directory'
             }
           }
+          $absentDir = 'absent clean output'
           Push-Location $fixtureRepo
           try {
-            & $make --no-print-directory 'BUILD_DIR=absent clean output' clean
+            & $make --no-print-directory "BUILD_DIR=$absentDir" clean
             if ($LASTEXITCODE -ne 0) { throw 'Clean failed for a missing build directory' }
           } finally {
             Pop-Location
           }
-          if (Test-Path -LiteralPath (Join-Path $fixtureRepo 'absent clean output')) {
+          if (Test-Path -LiteralPath (Join-Path $fixtureRepo $absentDir)) {
             throw 'Clean created a missing build directory'
           }
           foreach ($name in @('bd', 'bd.exe')) {

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1288,14 +1288,15 @@ jobs:
           } finally {
             Pop-Location
           }
+          if (Test-Path -LiteralPath (Join-Path $fixtureRepo 'absent clean output')) {
+            throw 'Clean created a missing build directory'
+          }
           foreach ($name in @('bd', 'bd.exe')) {
             if ([IO.File]::ReadAllText((Join-Path $fixtureRepo $name)) -cne 'keep-root') {
               throw "Missing-directory clean changed root $name"
             }
           }
           Write-Output 'Native Make clean default, spaced, repeated and missing-directory checks passed'
-
-
       - name: Exercise MSYS2-hosted Make
         if: matrix.host == 'msys2'
         shell: msys2 {0}

--- a/Makefile
+++ b/Makefile
@@ -398,8 +398,8 @@ check-testing-short:
 # Clean build artifacts and benchmark profiles
 clean:
 	@echo "Cleaning..."
-	rm -f bd
-	rm -f bd.exe
+	rm -f "$(BUILD_DIR)/bd"
+	rm -f "$(BUILD_DIR)/bd.exe"
 	rm -f internal/storage/dolt/bench-cpu-*.prof
 	rm -f beads-perf-*.prof
 


### PR DESCRIPTION
With a custom BUILD_DIR, make build writes into that directory while make clean still removes repository-root binaries. Clean now removes the quoted $(BUILD_DIR)/bd and $(BUILD_DIR)/bd.exe paths, preserving the directory, neighboring files and existing profile cleanup.

The existing native Windows workflow checks default, spaced custom, repeated and missing directories, both binary names and preserved neighbors/root decoys. The missing-directory invocation and no-creation assertion now share one absentDir variable.

Validation: the actual final workflow run scalar parses and passes with native Windows GNU Make, including its existing install checks. Only the existing Make/Git executable resolver lines are substituted for installed tools. Actionlint and PR lint pass. Earlier original-Makefile causal failure and six workflow tests remain bound to their original head. Owned sentinels exercise clean; they do not compile or execute bd. Native POSIX execution is not claimed.

This nit changes five lines; the full main-relative diff is 54 changed lines across two files. Standalone on main, with Makefile overlaps in #6363/#5667/#5638/#6318 to reconcile during composition. No CI job is added. Hosted native verification and local adoption remain pending.

Fixes #6372

_unknown-model/unknown-reasoning on behalf of Ewen Cuthiell_
