### PR TITLE
kv: add 'bd kv list --prefix' — SQL-side key-prefix filter for scoped reads (wy-1rrwt8)

### DIFF
--- a/cmd/bd/kv.go
+++ b/cmd/bd/kv.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sort"
@@ -108,6 +109,32 @@ func kvPairsFromConfig(allConfig map[string]string) map[string]string {
 		}
 	}
 	return kvPairs
+}
+
+// configPrefixReader mirrors domain.ConfigPrefixReader structurally: the
+// optional store fast path that reads only the keys under a prefix. Both
+// list paths discover it by assertion and fall back to the full read plus
+// kvPairsWithPrefix when the store predates it.
+type configPrefixReader interface {
+	GetConfigByPrefix(ctx context.Context, prefix string) (map[string]string, error)
+}
+
+// kvPairsWithPrefix is kvPairsFromConfig narrowed to user keys starting with
+// userPrefix. It runs on every listing: after a SQL-side prefix read it is a
+// no-op re-check, and on the GetAllConfig fallback it IS the filter — so the
+// output is identical whichever path served the read.
+func kvPairsWithPrefix(allConfig map[string]string, userPrefix string) map[string]string {
+	kvPairs := kvPairsFromConfig(allConfig)
+	if userPrefix == "" {
+		return kvPairs
+	}
+	out := make(map[string]string)
+	for k, v := range kvPairs {
+		if strings.HasPrefix(k, userPrefix) {
+			out[k] = v
+		}
+	}
+	return out
 }
 
 // printKVListResult renders the `bd kv list` output. Shared by the classic
@@ -292,15 +319,23 @@ Examples:
 	},
 }
 
+// kvListPrefix is the --prefix flag: list only keys starting with it.
+var kvListPrefix string
+
 // kvListCmd lists all key-value pairs
 var kvListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all key-value pairs",
 	Long: `List all key-value pairs in the beads key-value store.
 
+With --prefix, list only the keys starting with that prefix. The filter is
+pushed into SQL on stores that support it, so a scoped read of a large kv
+store does not serialize the whole table.
+
 Examples:
   bd kv list
-  bd kv list --json`,
+  bd kv list --json
+  bd kv list --prefix mail.dog. --json`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -312,7 +347,7 @@ Examples:
 		}()
 
 		if usesProxiedServer() {
-			return runKVListProxiedServer(rootCtx)
+			return runKVListProxiedServer(rootCtx, kvListPrefix)
 		}
 
 		if err := ensureDirectMode("kv list requires direct database access"); err != nil {
@@ -320,16 +355,24 @@ Examples:
 		}
 
 		ctx := rootCtx
-		allConfig, err := store.GetAllConfig(ctx)
+		var allConfig map[string]string
+		var err error
+		if pr, ok := store.(configPrefixReader); ok && kvListPrefix != "" {
+			allConfig, err = pr.GetConfigByPrefix(ctx, kvPrefix+kvListPrefix)
+		} else {
+			allConfig, err = store.GetAllConfig(ctx)
+		}
 		if err != nil {
 			return HandleErrorRespectJSON("listing keys: %v", err)
 		}
 
-		return printKVListResult(kvPairsFromConfig(allConfig))
+		return printKVListResult(kvPairsWithPrefix(allConfig, kvListPrefix))
 	},
 }
 
 func init() {
+	kvListCmd.Flags().StringVar(&kvListPrefix, "prefix", "", "list only keys starting with this prefix (filtered in SQL where supported)")
+
 	// Register all kv subcommands under kvCmd
 	kvCmd.AddCommand(kvSetCmd)
 	kvCmd.AddCommand(kvGetCmd)

--- a/cmd/bd/kv_prefix_test.go
+++ b/cmd/bd/kv_prefix_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// kvPairsWithPrefix is the shared post-filter on both `bd kv list` paths: a
+// no-op re-check after a SQL-side prefix read, and the whole filter on the
+// GetAllConfig fallback — so its semantics define the flag's output either way.
+func TestKVPairsWithPrefix(t *testing.T) {
+	allConfig := map[string]string{
+		"kv.mail.dog.m1":      "a",
+		"kv.mail.dog.m2":      "b",
+		"kv.mail.doggerel.m3": "c",
+		"kv.mail.hare.m1":     "d",
+		"jira.url":            "not-kv",
+	}
+
+	t.Run("empty prefix lists every kv pair", func(t *testing.T) {
+		got := kvPairsWithPrefix(allConfig, "")
+		want := map[string]string{
+			"mail.dog.m1":      "a",
+			"mail.dog.m2":      "b",
+			"mail.doggerel.m3": "c",
+			"mail.hare.m1":     "d",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("prefix narrows to one box and strips kv.", func(t *testing.T) {
+		got := kvPairsWithPrefix(allConfig, "mail.dog.")
+		want := map[string]string{
+			"mail.dog.m1": "a",
+			"mail.dog.m2": "b",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("prefix without trailing dot matches sibling boxes literally", func(t *testing.T) {
+		got := kvPairsWithPrefix(allConfig, "mail.dog")
+		if len(got) != 3 {
+			t.Fatalf("got %v, want mail.dog.* plus mail.doggerel.*", got)
+		}
+	})
+
+	t.Run("no matches returns empty map", func(t *testing.T) {
+		got := kvPairsWithPrefix(allConfig, "mail.owl.")
+		if len(got) != 0 {
+			t.Fatalf("got %v, want empty", got)
+		}
+	})
+}

--- a/cmd/bd/kv_proxied_server.go
+++ b/cmd/bd/kv_proxied_server.go
@@ -75,17 +75,21 @@ func runKVClearProxiedServer(ctx context.Context, key string) error {
 	return printKVClearResult(key)
 }
 
-func runKVListProxiedServer(ctx context.Context) error {
+func runKVListProxiedServer(ctx context.Context, prefix string) error {
 	if uowProvider == nil {
 		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
 	}
 
 	allConfig, err := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (map[string]string, error) {
-		return uw.ConfigUseCase().GetAllConfig(ctx)
+		cfg := uw.ConfigUseCase()
+		if pr, ok := cfg.(configPrefixReader); ok && prefix != "" {
+			return pr.GetConfigByPrefix(ctx, kvPrefix+prefix)
+		}
+		return cfg.GetAllConfig(ctx)
 	})
 	if err != nil {
 		return HandleErrorRespectJSON("listing keys: %v", err)
 	}
 
-	return printKVListResult(kvPairsFromConfig(allConfig))
+	return printKVListResult(kvPairsWithPrefix(allConfig, prefix))
 }

--- a/internal/storage/dolt/config.go
+++ b/internal/storage/dolt/config.go
@@ -76,6 +76,18 @@ func (s *DoltStore) GetAllConfig(ctx context.Context) (map[string]string, error)
 	return result, err
 }
 
+// GetConfigByPrefix retrieves the configuration values whose key starts with
+// prefix, filtered in SQL (the domain.ConfigPrefixReader optional fast path).
+func (s *DoltStore) GetConfigByPrefix(ctx context.Context, prefix string) (map[string]string, error) {
+	var result map[string]string
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.GetConfigByPrefixInTx(ctx, tx, prefix)
+		return err
+	})
+	return result, err
+}
+
 // DeleteConfig removes a configuration value
 func (s *DoltStore) DeleteConfig(ctx context.Context, key string) error {
 	return s.withRetryTx(ctx, func(tx *sql.Tx) error {

--- a/internal/storage/domain/config.go
+++ b/internal/storage/domain/config.go
@@ -3,10 +3,21 @@ package domain
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/types"
 )
+
+// ConfigPrefixReader is the optional fast path for prefix-scoped config
+// reads (`bd kv list --prefix`): only the rows whose key starts with prefix
+// leave the database. It is deliberately NOT part of ConfigSQLRepository or
+// ConfigUseCase — existing implementations and test doubles keep compiling —
+// and callers discover it by type assertion, falling back to GetAllConfig
+// plus in-process filtering when the assertion misses.
+type ConfigPrefixReader interface {
+	GetConfigByPrefix(ctx context.Context, prefix string) (map[string]string, error)
+}
 
 type ConfigSQLRepository interface {
 	GetMetadata(ctx context.Context, key string) (string, error)
@@ -225,6 +236,30 @@ func (u *configUseCaseImpl) GetAllConfig(ctx context.Context) (map[string]string
 	out, err := u.cfgRepo.GetAllConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("GetAllConfig: %w", err)
+	}
+	return out, nil
+}
+
+// GetConfigByPrefix implements ConfigPrefixReader on the use case, pushing
+// the prefix into SQL when the repository supports it and filtering the
+// GetAllConfig result in-process when it does not (same rows either way).
+func (u *configUseCaseImpl) GetConfigByPrefix(ctx context.Context, prefix string) (map[string]string, error) {
+	if pr, ok := u.cfgRepo.(ConfigPrefixReader); ok {
+		out, err := pr.GetConfigByPrefix(ctx, prefix)
+		if err != nil {
+			return nil, fmt.Errorf("GetConfigByPrefix: %w", err)
+		}
+		return out, nil
+	}
+	all, err := u.cfgRepo.GetAllConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("GetConfigByPrefix: %w", err)
+	}
+	out := make(map[string]string)
+	for k, v := range all {
+		if strings.HasPrefix(k, prefix) {
+			out[k] = v
+		}
 	}
 	return out, nil
 }

--- a/internal/storage/domain/db/config.go
+++ b/internal/storage/domain/db/config.go
@@ -126,6 +126,29 @@ func (r *configSQLRepositoryImpl) GetAllConfig(ctx context.Context) (map[string]
 	return out, nil
 }
 
+// GetConfigByPrefix retrieves only the config rows whose key starts with
+// prefix, pushing the filter into SQL (domain.ConfigPrefixReader — the
+// optional fast path `bd kv list --prefix` discovers by assertion).
+func (r *configSQLRepositoryImpl) GetConfigByPrefix(ctx context.Context, prefix string) (map[string]string, error) {
+	rows, err := r.runner.QueryContext(ctx, issueops.ConfigPrefixLikeQuery, issueops.ConfigPrefixPattern(prefix))
+	if err != nil {
+		return nil, fmt.Errorf("db: GetConfigByPrefix %s: %w", prefix, err)
+	}
+	defer rows.Close()
+	out := make(map[string]string)
+	for rows.Next() {
+		var k, v string
+		if err := rows.Scan(&k, &v); err != nil {
+			return nil, fmt.Errorf("db: GetConfigByPrefix %s: scan: %w", prefix, err)
+		}
+		out[k] = v
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: GetConfigByPrefix %s: read: %w", prefix, err)
+	}
+	return out, nil
+}
+
 func (r *configSQLRepositoryImpl) GetCustomTypes(ctx context.Context) ([]string, error) {
 	fromTable, err := r.readCustomTypesTable(ctx)
 	if err != nil {

--- a/internal/storage/domain/db/config_test.go
+++ b/internal/storage/domain/db/config_test.go
@@ -41,6 +41,10 @@ func (s *testSuite) TestConfigSQLRepository() {
 		s.Run("EmptyReturnsEmptyMap", s.configGetAllConfigEmpty)
 		s.Run("ReturnsAllRows", s.configGetAllConfigAllRows)
 	})
+	s.Run("GetConfigByPrefix", func() {
+		s.Run("ReturnsOnlyPrefixedRows", s.configGetConfigByPrefixOnlyPrefixed)
+		s.Run("EscapesLikeMetacharacters", s.configGetConfigByPrefixEscapesLike)
+	})
 	s.Run("LocalMetadata", func() {
 		s.Run("SetThenGetRoundTrips", s.configLocalMetadataRoundTrip)
 		s.Run("SetOverwrites", s.configLocalMetadataOverwrite)
@@ -54,6 +58,7 @@ func (s *testSuite) TestConfigSQLRepository() {
 		s.Run("DeleteConfigMissingKeyIsNoop", s.configUseCaseDeleteConfigMissing)
 		s.Run("GetAllConfigEmpty", s.configUseCaseGetAllConfigEmpty)
 		s.Run("GetAllConfigReturnsAllRows", s.configUseCaseGetAllConfigAllRows)
+		s.Run("GetConfigByPrefixReturnsOnlyPrefixedRows", s.configUseCaseGetConfigByPrefixOnlyPrefixed)
 	})
 	s.Run("GetCustomTypes", func() {
 		s.Run("MissingKeyReturnsNil", s.configGetCustomTypesMissing)
@@ -589,6 +594,47 @@ func (s *testSuite) configUseCaseDeleteConfigMissing() {
 	s.Require().NoError(s.configUC().DeleteConfig(s.Ctx(), "no_such_key"))
 }
 
+func (s *testSuite) configGetConfigByPrefixOnlyPrefixed() {
+	_, err := s.Runner().ExecContext(s.Ctx(), "DELETE FROM config")
+	s.Require().NoError(err)
+	r := s.configRepo()
+	s.Require().NoError(r.SetConfig(s.Ctx(), "kv.mail.dog.m1", "a"))
+	s.Require().NoError(r.SetConfig(s.Ctx(), "kv.mail.dog.m2", "b"))
+	s.Require().NoError(r.SetConfig(s.Ctx(), "kv.mail.doggerel.m3", "c"))
+	s.Require().NoError(r.SetConfig(s.Ctx(), "kv.mail.hare.m1", "d"))
+	s.Require().NoError(r.SetConfig(s.Ctx(), "jira.url", "https://example.atlassian.net"))
+
+	pr, ok := interface{}(r).(domain.ConfigPrefixReader)
+	s.Require().True(ok, "configSQLRepositoryImpl must implement domain.ConfigPrefixReader")
+	got, err := pr.GetConfigByPrefix(s.Ctx(), "kv.mail.dog.")
+	s.Require().NoError(err)
+	s.Equal(map[string]string{
+		"kv.mail.dog.m1": "a",
+		"kv.mail.dog.m2": "b",
+	}, got)
+}
+
+func (s *testSuite) configGetConfigByPrefixEscapesLike() {
+	_, err := s.Runner().ExecContext(s.Ctx(), "DELETE FROM config")
+	s.Require().NoError(err)
+	r := s.configRepo()
+	// `_` and `%` are LIKE metacharacters: an unescaped prefix "kv.a_." would
+	// also match "kv.axb"-shaped keys. The literal-prefix contract must hold.
+	s.Require().NoError(r.SetConfig(s.Ctx(), "kv.a_.one", "underscore"))
+	s.Require().NoError(r.SetConfig(s.Ctx(), "kv.ax.one", "letter"))
+	s.Require().NoError(r.SetConfig(s.Ctx(), "kv.a%.one", "percent"))
+
+	pr, ok := interface{}(r).(domain.ConfigPrefixReader)
+	s.Require().True(ok)
+	got, err := pr.GetConfigByPrefix(s.Ctx(), "kv.a_.")
+	s.Require().NoError(err)
+	s.Equal(map[string]string{"kv.a_.one": "underscore"}, got)
+
+	got, err = pr.GetConfigByPrefix(s.Ctx(), "kv.a%.")
+	s.Require().NoError(err)
+	s.Equal(map[string]string{"kv.a%.one": "percent"}, got)
+}
+
 func (s *testSuite) configUseCaseGetAllConfigEmpty() {
 	_, err := s.Runner().ExecContext(s.Ctx(), "DELETE FROM config")
 	s.Require().NoError(err)
@@ -610,6 +656,20 @@ func (s *testSuite) configUseCaseGetAllConfigAllRows() {
 		"jira.url":     "https://example.atlassian.net",
 		"jira.project": "PROJ",
 	}, got)
+}
+
+func (s *testSuite) configUseCaseGetConfigByPrefixOnlyPrefixed() {
+	_, err := s.Runner().ExecContext(s.Ctx(), "DELETE FROM config")
+	s.Require().NoError(err)
+	uc := s.configUC()
+	s.Require().NoError(uc.SetConfig(s.Ctx(), "kv.mail.dog.m1", "a"))
+	s.Require().NoError(uc.SetConfig(s.Ctx(), "kv.mail.hare.m1", "b"))
+
+	pr, ok := interface{}(uc).(domain.ConfigPrefixReader)
+	s.Require().True(ok, "configUseCaseImpl must implement domain.ConfigPrefixReader")
+	got, err := pr.GetConfigByPrefix(s.Ctx(), "kv.mail.dog.")
+	s.Require().NoError(err)
+	s.Equal(map[string]string{"kv.mail.dog.m1": "a"}, got)
 }
 
 func (s *testSuite) configGetCustomTypesTablePrecedence() {

--- a/internal/storage/embeddeddolt/config_metadata.go
+++ b/internal/storage/embeddeddolt/config_metadata.go
@@ -43,6 +43,18 @@ func (s *EmbeddedDoltStore) GetAllConfig(ctx context.Context) (map[string]string
 	return result, err
 }
 
+// GetConfigByPrefix retrieves the configuration values whose key starts with
+// prefix, filtered in SQL (the domain.ConfigPrefixReader optional fast path).
+func (s *EmbeddedDoltStore) GetConfigByPrefix(ctx context.Context, prefix string) (map[string]string, error) {
+	var result map[string]string
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.GetConfigByPrefixInTx(ctx, tx, prefix)
+		return err
+	})
+	return result, err
+}
+
 func (s *EmbeddedDoltStore) GetMetadata(ctx context.Context, key string) (string, error) {
 	var value string
 	err := s.withConn(ctx, false, func(tx *sql.Tx) error {

--- a/internal/storage/issueops/config_metadata.go
+++ b/internal/storage/issueops/config_metadata.go
@@ -53,6 +53,43 @@ func GetAllConfigInTx(ctx context.Context, tx DBTX) (map[string]string, error) {
 	return result, rows.Err()
 }
 
+// ConfigPrefixLikeQuery is the one SELECT for prefix-scoped config reads.
+// Its explicit ESCAPE character pairs with ConfigPrefixPattern's escaping
+// ('!' rather than backslash: the engine does not treat backslash as the
+// default LIKE escape, and '!' avoids literal-vs-placeholder ambiguity);
+// keeping query and pattern builder side by side is what stops them drifting.
+const ConfigPrefixLikeQuery = "SELECT `key`, value FROM config WHERE `key` LIKE ? ESCAPE '!'"
+
+// ConfigPrefixPattern builds the LIKE pattern that matches config keys
+// starting with the given literal prefix, escaping LIKE metacharacters
+// (%, _) and the escape character itself so the prefix always matches
+// literally. Use only with ConfigPrefixLikeQuery.
+func ConfigPrefixPattern(prefix string) string {
+	return strings.NewReplacer(`!`, `!!`, `%`, `!%`, `_`, `!_`).Replace(prefix) + "%"
+}
+
+// GetConfigByPrefixInTx retrieves the configuration pairs whose key starts
+// with prefix, within an existing transaction. The filter runs in SQL so a
+// scoped read of a large config/kv store (e.g. one mailbox out of thousands
+// of kv mail envelopes) does not serialize the whole table.
+func GetConfigByPrefixInTx(ctx context.Context, tx DBTX, prefix string) (map[string]string, error) {
+	rows, err := tx.QueryContext(ctx, ConfigPrefixLikeQuery, ConfigPrefixPattern(prefix))
+	if err != nil {
+		return nil, fmt.Errorf("get config by prefix %s: %w", prefix, err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]string)
+	for rows.Next() {
+		var k, v string
+		if err := rows.Scan(&k, &v); err != nil {
+			return nil, fmt.Errorf("get config by prefix %s: scan: %w", prefix, err)
+		}
+		result[k] = v
+	}
+	return result, rows.Err()
+}
+
 // SetMetadataInTx sets a metadata value within an existing transaction.
 func SetMetadataInTx(ctx context.Context, tx DBTX, key, value string) error {
 	_, err := tx.ExecContext(ctx, "REPLACE INTO metadata (`key`, value) VALUES (?, ?)", key, value)

--- a/internal/storage/issueops/config_prefix_test.go
+++ b/internal/storage/issueops/config_prefix_test.go
@@ -1,0 +1,20 @@
+package issueops
+
+import "testing"
+
+// ConfigPrefixPattern must escape every LIKE metacharacter so a prefix always
+// matches literally: an unescaped `_` in "kv.a_." would also match "kv.axb".
+func TestConfigPrefixPattern(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"kv.mail.dog.", "kv.mail.dog.%"},
+		{"kv.a_.", "kv.a!_.%"},
+		{"kv.a%.", "kv.a!%.%"},
+		{"kv.a!.", "kv.a!!.%"},
+		{"", "%"},
+	}
+	for _, c := range cases {
+		if got := ConfigPrefixPattern(c.in); got != c.want {
+			t.Errorf("ConfigPrefixPattern(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/telemetry/storage.go
+++ b/internal/telemetry/storage.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -556,6 +557,33 @@ func (s *InstrumentedStorage) GetAllConfig(ctx context.Context) (map[string]stri
 	v, err := s.inner.GetAllConfig(ctx)
 	s.done(ctx, span, t, err)
 	return v, err
+}
+
+// GetConfigByPrefix forwards the domain.ConfigPrefixReader optional fast
+// path when the wrapped store provides it. When the inner store does not,
+// it falls back to instrumented GetAllConfig filtered in-process, so the
+// wrapper never hides the capability decision from callers asserting on it.
+func (s *InstrumentedStorage) GetConfigByPrefix(ctx context.Context, prefix string) (map[string]string, error) {
+	attrs := []attribute.KeyValue{attribute.String("bd.config.prefix", prefix)}
+	if pr, ok := s.inner.(interface {
+		GetConfigByPrefix(ctx context.Context, prefix string) (map[string]string, error)
+	}); ok {
+		ctx, span, t := s.op(ctx, "GetConfigByPrefix", attrs...)
+		v, err := pr.GetConfigByPrefix(ctx, prefix)
+		s.done(ctx, span, t, err, attrs...)
+		return v, err
+	}
+	all, err := s.GetAllConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]string)
+	for k, v := range all {
+		if strings.HasPrefix(k, prefix) {
+			out[k] = v
+		}
+	}
+	return out, nil
 }
 
 func (s *InstrumentedStorage) SetLocalMetadata(ctx context.Context, key, value string) error {


### PR DESCRIPTION
Downstream mail transports (wyvern wh-mail) read the whole kv store — 3.4MB / ~1988 mail.* envelopes — on every inbox render, fleet-wide. This adds `bd kv list --prefix <p>` pushing the filter into SQL.

Design: an **optional** `domain.ConfigPrefixReader` interface discovered by type assertion — no existing storage interface or test double changes shape; every caller falls back to `GetAllConfig` + in-process filter when the assertion misses, and `kvPairsWithPrefix` re-checks on every path so the output is identical whichever path served the read.

LIKE escaping uses an explicit `ESCAPE '!'` clause: the engine does not honor backslash as a default LIKE escape (verified by test — the backslash variant matched nothing), and '!' avoids literal-vs-placeholder ambiguity. `ConfigPrefixLikeQuery` and `ConfigPrefixPattern` sit side by side in issueops so query and escaping cannot drift.

Verified locally (darwin/arm64, -tags gms_pure_go): `go build ./...`, `go vet` on touched packages, `go test ./internal/storage/issueops -run TestConfigPrefixPattern`, `go test ./cmd/bd -run TestKVPairsWithPrefix`, `go test ./internal/storage/domain/db -run TestDomainDB/TestConfigSQLRepository` (incl. new ReturnsOnlyPrefixedRows / EscapesLikeMetacharacters / use-case prefix tests). PR CI is the full gate.

Wyvern tracking bead: wy-1rrwt8 (sibling upstream work: wy-s8ytnw PR #6122).

🤖 Generated with [Claude Code](https://claude.com/claude-code)