### PR TITLE
fix(smoke): reject invalid candidate binaries before side effects

### DIFF
--- a/scripts/cross-version-smoke-test.sh
+++ b/scripts/cross-version-smoke-test.sh
@@ -28,6 +28,7 @@ set -uo pipefail
 # Exit codes:
 #   0  All tested versions passed (skips don't count as failures)
 #   1  One or more versions failed verification after upgrade
+#   2  Invalid nonempty CANDIDATE_BIN (compiler failures retain their exit status)
 # =============================================================================
 
 RED='\033[0;31m'

--- a/scripts/cross-version-smoke-test.sh
+++ b/scripts/cross-version-smoke-test.sh
@@ -22,7 +22,7 @@ set -uo pipefail
 #   CANDIDATE_BIN=./bd ./scripts/cross-version-smoke-test.sh    # prebuilt candidate
 #
 # Environment:
-#   CANDIDATE_BIN    Path to prebuilt candidate binary (skip build)
+#   CANDIDATE_BIN    Executable prebuilt path; empty builds, invalid refuses
 #   BEADS_TEST_MODE  Set to 1 to suppress telemetry/prompts
 #
 # Exit codes:
@@ -42,6 +42,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Canonical build flags (GOFLAGS=-tags=gms_pure_go, CGO_ENABLED=1).
 # shellcheck source=../.buildflags
 source "$PROJECT_ROOT/.buildflags"
+# shellcheck source=lib/smoke-candidate.sh
+source "$PROJECT_ROOT/scripts/lib/smoke-candidate.sh" || exit $?
 
 CACHE_DIR="${HOME}/.cache/beads-regression"
 mkdir -p "$CACHE_DIR"
@@ -112,18 +114,6 @@ download_all_binaries() {
     done
     echo -e "${GREEN}Downloaded ${downloaded}${NC}, skipped ${skipped}"
     echo ""
-}
-
-build_candidate() {
-    if [ -n "${CANDIDATE_BIN:-}" ] && [ -x "${CANDIDATE_BIN}" ]; then
-        echo "$(cd "$(dirname "$CANDIDATE_BIN")" && pwd)/$(basename "$CANDIDATE_BIN")"
-        return
-    fi
-
-    local candidate="$CACHE_DIR/bd-candidate-$$"
-    echo -e "${YELLOW}Building candidate binary...${NC}" >&2
-    (cd "$PROJECT_ROOT" && go build -o "$candidate" ./cmd/bd) >&2
-    echo "$candidate"
 }
 
 # ---------------------------------------------------------------------------
@@ -483,7 +473,7 @@ fi
 # Main
 # ---------------------------------------------------------------------------
 
-CAND_BIN=$(build_candidate)
+CAND_BIN=$(build_candidate) || exit $?
 echo "Candidate: $CAND_BIN"
 DOLT_STATUS="not installed"
 if command -v dolt >/dev/null 2>&1; then

--- a/scripts/cross-version-smoke-test.sh
+++ b/scripts/cross-version-smoke-test.sh
@@ -27,9 +27,8 @@ set -uo pipefail
 #
 # Exit codes:
 #   0  All tested versions passed (skips don't count as failures)
-#   1  One or more versions failed
-#   2  Invalid nonempty CANDIDATE_BIN in a direct run (compiler failures retain their status)
-# Multi-version dispatch returns 1 if any child fails, including child status 2.
+#   1  One or more versions failed verification after upgrade
+#   2  Invalid nonempty CANDIDATE_BIN (compiler failures retain their exit status)
 # =============================================================================
 
 RED='\033[0;31m'

--- a/scripts/cross-version-smoke-test.sh
+++ b/scripts/cross-version-smoke-test.sh
@@ -27,8 +27,9 @@ set -uo pipefail
 #
 # Exit codes:
 #   0  All tested versions passed (skips don't count as failures)
-#   1  One or more versions failed verification after upgrade
-#   2  Invalid nonempty CANDIDATE_BIN (compiler failures retain their exit status)
+#   1  One or more versions failed
+#   2  Invalid nonempty CANDIDATE_BIN in a direct run (compiler failures retain their status)
+# Multi-version dispatch returns 1 if any child fails, including child status 2.
 # =============================================================================
 
 RED='\033[0;31m'

--- a/scripts/lib/smoke-candidate.sh
+++ b/scripts/lib/smoke-candidate.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Shared candidate policy; callers own PROJECT_ROOT, CACHE_DIR and cleanup.
+build_candidate() {
+    if [ -n "${CANDIDATE_BIN:-}" ]; then
+        if [ ! -f "$CANDIDATE_BIN" ] || [ ! -x "$CANDIDATE_BIN" ]; then
+            printf 'ERROR: CANDIDATE_BIN must name an executable file: %s\n' "$CANDIDATE_BIN" >&2
+            return 1
+        fi
+        local directory
+        directory=$(cd "$(dirname "$CANDIDATE_BIN")" && pwd) || return $?
+        printf '%s/%s\n' "$directory" "$(basename "$CANDIDATE_BIN")"
+        return
+    fi
+
+    # Empty is automatic too: the upgrade version loop forwards an empty value.
+    local candidate="$CACHE_DIR/bd-candidate-$$"
+    printf '%bBuilding candidate binary...%b\n' "${YELLOW:-}" "${NC:-}" >&2
+    (
+        cd "$PROJECT_ROOT" || exit $?
+        # Keep canonical candidate flags out of historical release builds.
+        # shellcheck source=../../.buildflags
+        source "$PROJECT_ROOT/.buildflags" || exit $?
+        go build -o "$candidate" ./cmd/bd
+    ) >&2 || return $?
+    # Command substitution may disable errexit; emit a path only after success.
+    printf '%s\n' "$candidate"
+}

--- a/scripts/lib/smoke-candidate.sh
+++ b/scripts/lib/smoke-candidate.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Shared candidate policy; callers own PROJECT_ROOT, CACHE_DIR and cleanup.
+# Shared candidate policy; callers own PROJECT_ROOT, CACHE_DIR and successful-output cleanup.
 build_candidate() {
     if [ -n "${CANDIDATE_BIN:-}" ]; then
         if [ ! -f "$CANDIDATE_BIN" ] || [ ! -x "$CANDIDATE_BIN" ]; then
             printf 'ERROR: CANDIDATE_BIN must name an executable file: %s\n' "$CANDIDATE_BIN" >&2
-            return 1
+            return 2
         fi
         local directory
         directory=$(cd "$(dirname "$CANDIDATE_BIN")" && pwd) || return $?
@@ -21,7 +21,12 @@ build_candidate() {
         # shellcheck source=../../.buildflags
         source "$PROJECT_ROOT/.buildflags" || exit $?
         go build -o "$candidate" ./cmd/bd
-    ) >&2 || return $?
+    ) >&2 || {
+        local status=$?
+        # Remove only this attempted build's output; cleanup must not mask failure.
+        rm -f -- "$candidate" || :
+        return "$status"
+    }
     # Command substitution may disable errexit; emit a path only after success.
     printf '%s\n' "$candidate"
 }

--- a/scripts/migration-test/historical-dolt-upgrade-test.sh
+++ b/scripts/migration-test/historical-dolt-upgrade-test.sh
@@ -27,6 +27,7 @@ Usage: historical-dolt-upgrade-test.sh [--version VERSION]
 Runs the authentic historical SQLite bridges (v0.9.1, v0.17.0, v0.49.6, v0.50.3), historical server-Dolt corpus
 (v0.55.4, v0.56.1, v0.57.0, v0.62.0), and direct embedded-Dolt corpus
 (v0.63.3, v1.0.0, v1.0.1, v1.1.0, v1.1.2) against CANDIDATE_BIN. Every release archive is pinned and verified.
+An invalid nonempty CANDIDATE_BIN exits 2; compiler failures retain their exit status.
 EOF
 }
 

--- a/scripts/migration-test/historical-dolt-upgrade-test.sh
+++ b/scripts/migration-test/historical-dolt-upgrade-test.sh
@@ -98,8 +98,7 @@ for version in "${SELECTED_VERSIONS[@]}"; do
     esac
 done
 
-candidate="${CANDIDATE_BIN:-}"
-if [ -z "$candidate" ]; then candidate=$(build_candidate); fi
+candidate=$(build_candidate) || exit $?
 candidate=$(resolve_existing_path "$candidate") || die 'candidate binary cannot be resolved'
 [ -x "$candidate" ] || die "candidate binary is not executable: $candidate"
 

--- a/scripts/migration-test/lib/binary.sh
+++ b/scripts/migration-test/lib/binary.sh
@@ -2,6 +2,9 @@
 # Binary management — download old releases, build candidate.
 # Extracted from cross-version-smoke-test.sh for reuse.
 
+# shellcheck source=../../lib/smoke-candidate.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/smoke-candidate.sh" || return $?
+
 CACHE_DIR="${HOME}/.cache/beads-regression"
 mkdir -p "$CACHE_DIR"
 
@@ -243,15 +246,3 @@ build_verified_v091_source_binary() (
     temporary=""
     printf '%s\n' "$binary"
 )
-
-build_candidate() {
-    if [ -n "${CANDIDATE_BIN:-}" ] && [ -x "${CANDIDATE_BIN}" ]; then
-        echo "$(cd "$(dirname "$CANDIDATE_BIN")" && pwd)/$(basename "$CANDIDATE_BIN")"
-        return
-    fi
-
-    local candidate="$CACHE_DIR/bd-candidate-$$"
-    echo -e "${YELLOW:-}Building candidate binary...${NC:-}" >&2
-    (cd "$PROJECT_ROOT" && go build -tags gms_pure_go -o "$candidate" ./cmd/bd) >&2
-    echo "$candidate"
-}

--- a/scripts/smoke_candidate_test.go
+++ b/scripts/smoke_candidate_test.go
@@ -26,28 +26,26 @@ func TestSmokeCandidateContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cases := []struct {
-		name, override, cgo string
-		buildExit, wantExit int
-		partial             bool
-	}{
-		{"relative prebuilt", "relative", "", 93, 0, false},
-		{"absolute prebuilt", "absolute", "", 93, 0, false},
-		{"missing prebuilt", "missing", "", 93, 1, false},
-		{"directory prebuilt", "directory", "", 93, 1, false},
-		{"unset builds", "unset", "", 0, 0, false},
-		{"empty builds", "", "", 0, 0, false},
-		{"explicit nocgo", "", "0", 0, 0, false},
-		{"compiler failure", "", "", 23, 23, false},
-		{"compiler partial output", "", "", 23, 23, true},
+	type candidateCase struct {
+		name, override, cgo   string
+		buildExit, wantExit   int
+		partial, cleanupFails bool
+	}
+	cases := []candidateCase{
+		{"relative prebuilt", "relative", "", 93, 0, false, false},
+		{"absolute prebuilt", "absolute", "", 93, 0, false, false},
+		{"missing prebuilt", "missing", "", 93, 2, false, false},
+		{"directory prebuilt", "directory", "", 93, 2, false, false},
+		{"unset builds", "unset", "", 0, 0, false, false},
+		{"empty builds", "", "", 0, 0, false, false},
+		{"explicit nocgo", "", "0", 0, 0, false, false},
+		{"compiler failure", "", "", 23, 23, false, false},
+		{"compiler partial output", "", "", 23, 23, true, false},
+		{"compiler cleanup failure", "", "", 23, 23, true, true},
 	}
 	// Windows does not provide the POSIX executable-bit refusal boundary.
 	if runtime.GOOS != "windows" {
-		cases = append(cases, struct {
-			name, override, cgo string
-			buildExit, wantExit int
-			partial             bool
-		}{"nonexecutable prebuilt", "nonexecutable", "", 93, 1, false})
+		cases = append(cases, candidateCase{"nonexecutable prebuilt", "nonexecutable", "", 93, 2, false, false})
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -57,6 +55,9 @@ func TestSmokeCandidateContract(t *testing.T) {
 				if err := os.MkdirAll(path, 0755); err != nil {
 					t.Fatal(err)
 				}
+			}
+			if err := os.WriteFile(filepath.Join(cache, "keep"), []byte("unrelated cache entry"), 0600); err != nil {
+				t.Fatal(err)
 			}
 			const fakeGo = `#!/usr/bin/env bash
 set -eu
@@ -69,6 +70,12 @@ exit "$BEADS_CANDIDATE_EXIT"
 `
 			if err := os.WriteFile(filepath.Join(bin, "go"), []byte(fakeGo), 0755); err != nil {
 				t.Fatal(err)
+			}
+			if tc.cleanupFails {
+				const fakeRM = "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\" > \"$BEADS_CANDIDATE_RM_LOG\"\nexit 47\n"
+				if err := os.WriteFile(filepath.Join(bin, "rm"), []byte(fakeRM), 0755); err != nil {
+					t.Fatal(err)
+				}
 			}
 			prebuilt := filepath.Join(dir, "candidate with spaces")
 			if err := os.WriteFile(prebuilt, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
@@ -91,7 +98,7 @@ exit "$BEADS_CANDIDATE_EXIT"
 				}
 			}
 			env = append(env, "BEADS_TEST_COMMAND_PATH="+commandPath, "PROJECT_ROOT="+root,
-				"CACHE_DIR="+cachePath, "BEADS_CANDIDATE_LOG="+dirPath+"/calls")
+				"CACHE_DIR="+cachePath, "BEADS_CANDIDATE_LOG="+dirPath+"/calls", "BEADS_CANDIDATE_RM_LOG="+dirPath+"/rm-calls")
 			env = append(env, "BEADS_CANDIDATE_EXIT="+strconv.Itoa(tc.buildExit), "BEADS_CANDIDATE_PARTIAL="+strconv.FormatBool(tc.partial))
 			if tc.cgo != "" {
 				env = append(env, "CGO_ENABLED="+tc.cgo)
@@ -111,6 +118,9 @@ exit "$BEADS_CANDIDATE_EXIT"
 				env = append(env, "CANDIDATE_BIN="+value)
 			}
 			requireShellCommandPath(t, bash, dir, env, "go", binPath+"/go")
+			if tc.cleanupFails {
+				requireShellCommandPath(t, bash, dir, env, "rm", binPath+"/rm")
+			}
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 			cmd := exec.CommandContext(ctx, bash, "--noprofile", "--norc", "-c", `
@@ -131,6 +141,9 @@ exit "$status"
 			if tc.wantExit != 0 && len(out) != 0 {
 				t.Fatalf("failed selection emitted a path: %q", out)
 			}
+			if got, err := os.ReadFile(filepath.Join(cache, "keep")); err != nil || string(got) != "unrelated cache entry" {
+				t.Fatalf("unrelated cache entry changed: %q, %v", got, err)
+			}
 			calls, callErr := os.ReadFile(filepath.Join(dir, "calls"))
 			if value != "" {
 				if !os.IsNotExist(callErr) {
@@ -139,7 +152,7 @@ exit "$status"
 				if tc.wantExit == 0 && string(out) != prebuiltPath {
 					t.Fatalf("selected %q, want %q", out, prebuiltPath)
 				}
-				if tc.wantExit == 1 && !strings.Contains(stderr.String(), "CANDIDATE_BIN must name an executable file") {
+				if tc.wantExit == 2 && !strings.Contains(stderr.String(), "CANDIDATE_BIN must name an executable file") {
 					t.Fatalf("missing explicit override diagnostic: %s", &stderr)
 				}
 				return
@@ -156,13 +169,129 @@ exit "$status"
 			if tc.wantExit == 0 && string(out) != fields[5] {
 				t.Fatalf("returned %q, built %q", out, fields[5])
 			}
+			if tc.cleanupFails {
+				got, err := os.ReadFile(filepath.Join(dir, "rm-calls"))
+				if err != nil || string(got) != "-f\n--\n"+fields[5]+"\n" {
+					t.Fatalf("cleanup did not target only the attempted output: %q, %v", got, err)
+				}
+			}
 			entries, err := os.ReadDir(cache)
-			wantFiles := 0
-			if tc.buildExit == 0 || tc.partial {
-				wantFiles = 1
+			wantFiles := 1 // The unrelated cache entry always survives.
+			if tc.buildExit == 0 || tc.cleanupFails {
+				wantFiles++
 			}
 			if err != nil || len(entries) != wantFiles {
 				t.Fatalf("compiler fixture outputs = %v, want %d: %v", entries, wantFiles, err)
+			}
+		})
+	}
+}
+
+func TestSmokeCandidateEntrypointOrdering(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseEnv := shellPathEnv()
+	root := shellPathUnderEnv(t, bash, sourceRepoRoot(t), baseEnv)
+	for _, tc := range []struct {
+		name, script, override string
+		wantExit               int
+	}{
+		{"upgrade invalid", "upgrade-smoke-test.sh", "missing", 2},
+		{"cross invalid", "cross-version-smoke-test.sh", "missing", 2},
+		{"upgrade download failure automatic", "upgrade-smoke-test.sh", "", 1},
+		{"upgrade download failure prebuilt", "upgrade-smoke-test.sh", "prebuilt", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			bin, home := filepath.Join(dir, "tools"), filepath.Join(dir, "home")
+			for _, path := range []string{bin, home} {
+				if err := os.MkdirAll(path, 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			const forbidden = "#!/usr/bin/env bash\nprintf '%s\\n' \"$0 $*\" >> \"$BEADS_CANDIDATE_FORBIDDEN\"\nexit 97\n"
+			tools := []string{"curl", "wget", "go", "git", "dolt"}
+			for _, tool := range tools {
+				if err := os.WriteFile(filepath.Join(bin, tool), []byte(forbidden), 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			const fakeGo = `#!/usr/bin/env bash
+printf '%s\n' "$0 $*" >> "$BEADS_CANDIDATE_FORBIDDEN"
+[ "$#" = 4 ] && [ "$1" = build ] && [ "$2" = -o ] && [ "$4" = ./cmd/bd ] || exit 92
+case "$3" in "$HOME/.cache/beads-regression/bd-candidate-"*) ;; *) exit 92;; esac
+printf 'owned successful compiler output' > "$3"
+`
+			if err := os.WriteFile(filepath.Join(bin, "go"), []byte(fakeGo), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if tc.wantExit == 1 {
+				const failedDownload = "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$BEADS_CANDIDATE_DOWNLOAD\"\nexit 63\n"
+				if err := os.WriteFile(filepath.Join(bin, "curl"), []byte(failedDownload), 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			const prebuiltBytes = "#!/bin/sh\nexit 0\n"
+			prebuilt := filepath.Join(dir, "provided candidate")
+			if err := os.WriteFile(prebuilt, []byte(prebuiltBytes), 0755); err != nil {
+				t.Fatal(err)
+			}
+			dirPath := shellPathUnderEnv(t, bash, dir, baseEnv)
+			binPath := shellPathUnderEnv(t, bash, bin, baseEnv)
+			homePath := shellPathUnderEnv(t, bash, home, baseEnv)
+			candidate := ""
+			if tc.override == "missing" {
+				candidate = dirPath + "/missing candidate"
+			} else if tc.override == "prebuilt" {
+				candidate = dirPath + "/provided candidate"
+			}
+			commandPath := binPath
+			for _, entry := range baseEnv {
+				if strings.HasPrefix(entry, "PATH=") {
+					commandPath += ":" + strings.TrimPrefix(entry, "PATH=")
+				}
+			}
+			// The isolated HOME has no cached release; no inherited version loop is present.
+			env := append(append([]string{}, baseEnv...), "HOME="+homePath, "TMPDIR="+dirPath,
+				"BEADS_TEST_COMMAND_PATH="+commandPath, "CANDIDATE_BIN="+candidate,
+				"BEADS_CANDIDATE_FORBIDDEN="+dirPath+"/forbidden", "BEADS_CANDIDATE_DOWNLOAD="+dirPath+"/download")
+			for _, tool := range tools {
+				requireShellCommandPath(t, bash, dir, env, tool, binPath+"/"+tool)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			// An explicit version reaches download if the caller loses its refusal guard.
+			cmd := exec.CommandContext(ctx, bash, "--noprofile", "--norc", "-c", `
+PATH="$BEADS_TEST_COMMAND_PATH"; export PATH
+exec "$BASH" --noprofile --norc "$1" v0.62.0
+`, "candidate-entrypoint", root+"/scripts/"+tc.script)
+			cmd.Dir, cmd.Env = dir, env
+			out, err := cmd.CombinedOutput()
+			if ctx.Err() != nil || cmd.ProcessState == nil || cmd.ProcessState.ExitCode() != tc.wantExit {
+				t.Fatalf("entrypoint exit = %v, want %d: %s", err, tc.wantExit, out)
+			}
+			if tc.wantExit == 2 && !bytes.Contains(out, []byte("CANDIDATE_BIN must name an executable file:")) {
+				t.Fatalf("missing invalid-override diagnostic: %s", out)
+			}
+			if calls, err := os.ReadFile(filepath.Join(dir, "forbidden")); !os.IsNotExist(err) {
+				t.Fatalf("entrypoint reached a forbidden compiler/downloader/database tool: %s, %v", calls, err)
+			}
+			calls, err := os.ReadFile(filepath.Join(dir, "download"))
+			if tc.wantExit == 1 {
+				if err != nil || bytes.Count(calls, []byte{'\n'}) != 1 || !bytes.Contains(out, []byte("Failed to download")) {
+					t.Fatalf("previous-release failure was not exercised: %q, %v: %s", calls, err, out)
+				}
+			} else if !os.IsNotExist(err) {
+				t.Fatalf("invalid override attempted a download: %q, %v", calls, err)
+			}
+			if got, err := os.ReadFile(prebuilt); err != nil || string(got) != prebuiltBytes {
+				t.Fatalf("prebuilt input changed: %q, %v", got, err)
+			}
+			entries, err := os.ReadDir(filepath.Join(home, ".cache", "beads-regression"))
+			if (err != nil && !os.IsNotExist(err)) || len(entries) != 0 {
+				t.Fatalf("failed entrypoint left cached output: %v, %v", entries, err)
 			}
 		})
 	}

--- a/scripts/smoke_candidate_test.go
+++ b/scripts/smoke_candidate_test.go
@@ -218,15 +218,6 @@ func TestSmokeCandidateEntrypointOrdering(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			const fakeGo = `#!/usr/bin/env bash
-printf '%s\n' "$0 $*" >> "$BEADS_CANDIDATE_FORBIDDEN"
-[ "$#" = 4 ] && [ "$1" = build ] && [ "$2" = -o ] && [ "$4" = ./cmd/bd ] || exit 92
-case "$3" in "$HOME/.cache/beads-regression/bd-candidate-"*) ;; *) exit 92;; esac
-printf 'owned successful compiler output' > "$3"
-`
-			if err := os.WriteFile(filepath.Join(bin, "go"), []byte(fakeGo), 0755); err != nil {
-				t.Fatal(err)
-			}
 			if tc.wantExit == 1 {
 				const failedDownload = "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$BEADS_CANDIDATE_DOWNLOAD\"\nexit 63\n"
 				if err := os.WriteFile(filepath.Join(bin, "curl"), []byte(failedDownload), 0755); err != nil {

--- a/scripts/smoke_candidate_test.go
+++ b/scripts/smoke_candidate_test.go
@@ -1,0 +1,191 @@
+package scripts_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSmokeCandidateContract(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseEnv := append(shellPathEnv(), "GOFLAGS=-trimpath")
+	root := shellPathUnderEnv(t, bash, sourceRepoRoot(t), baseEnv)
+	flags := exec.Command(bash, "--noprofile", "--norc", "-c", `source "$1/.buildflags" || exit $?; printf '%s' "$GOFLAGS"`, "flags", root)
+	flags.Env = baseEnv
+	wantFlags, err := flags.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name, override, cgo string
+		buildExit, wantExit int
+		partial             bool
+	}{
+		{"relative prebuilt", "relative", "", 93, 0, false},
+		{"absolute prebuilt", "absolute", "", 93, 0, false},
+		{"missing prebuilt", "missing", "", 93, 1, false},
+		{"directory prebuilt", "directory", "", 93, 1, false},
+		{"unset builds", "unset", "", 0, 0, false},
+		{"empty builds", "", "", 0, 0, false},
+		{"explicit nocgo", "", "0", 0, 0, false},
+		{"compiler failure", "", "", 23, 23, false},
+		{"compiler partial output", "", "", 23, 23, true},
+	}
+	// Windows does not provide the POSIX executable-bit refusal boundary.
+	if runtime.GOOS != "windows" {
+		cases = append(cases, struct {
+			name, override, cgo string
+			buildExit, wantExit int
+			partial             bool
+		}{"nonexecutable prebuilt", "nonexecutable", "", 93, 1, false})
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			bin, cache := filepath.Join(dir, "tools"), filepath.Join(dir, "cache with spaces")
+			for _, path := range []string{bin, cache} {
+				if err := os.MkdirAll(path, 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			const fakeGo = `#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$GOFLAGS" "$CGO_ENABLED" "$PWD" "$@" > "$BEADS_CANDIDATE_LOG"
+if [ "$BEADS_CANDIDATE_EXIT" = 0 ] || [ "$BEADS_CANDIDATE_PARTIAL" = true ]; then
+    [ "$1" = build ] && [ "$2" = -o ] || exit 92
+    printf 'owned candidate' > "$3"
+fi
+exit "$BEADS_CANDIDATE_EXIT"
+`
+			if err := os.WriteFile(filepath.Join(bin, "go"), []byte(fakeGo), 0755); err != nil {
+				t.Fatal(err)
+			}
+			prebuilt := filepath.Join(dir, "candidate with spaces")
+			if err := os.WriteFile(prebuilt, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if tc.override == "nonexecutable" {
+				if err := os.Chmod(prebuilt, 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			dirPath := shellPathUnderEnv(t, bash, dir, baseEnv)
+			binPath := shellPathUnderEnv(t, bash, bin, baseEnv)
+			cachePath := shellPathUnderEnv(t, bash, cache, baseEnv)
+			prebuiltPath := dirPath + "/candidate with spaces"
+			env := append([]string{}, baseEnv...)
+			commandPath := binPath
+			for _, entry := range baseEnv {
+				if strings.HasPrefix(entry, "PATH=") {
+					commandPath += ":" + strings.TrimPrefix(entry, "PATH=")
+				}
+			}
+			env = append(env, "BEADS_TEST_COMMAND_PATH="+commandPath, "PROJECT_ROOT="+root,
+				"CACHE_DIR="+cachePath, "BEADS_CANDIDATE_LOG="+dirPath+"/calls")
+			env = append(env, "BEADS_CANDIDATE_EXIT="+strconv.Itoa(tc.buildExit), "BEADS_CANDIDATE_PARTIAL="+strconv.FormatBool(tc.partial))
+			if tc.cgo != "" {
+				env = append(env, "CGO_ENABLED="+tc.cgo)
+			}
+			value := ""
+			switch tc.override {
+			case "relative":
+				value = "candidate with spaces"
+			case "absolute", "nonexecutable":
+				value = prebuiltPath
+			case "missing":
+				value = dirPath + "/missing"
+			case "directory":
+				value = cachePath
+			}
+			if tc.override != "unset" {
+				env = append(env, "CANDIDATE_BIN="+value)
+			}
+			requireShellCommandPath(t, bash, dir, env, "go", binPath+"/go")
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, bash, "--noprofile", "--norc", "-c", `
+PATH="$BEADS_TEST_COMMAND_PATH"; export PATH
+source "$PROJECT_ROOT/scripts/lib/smoke-candidate.sh" || exit $?
+[ "$GOFLAGS" = -trimpath ] || exit 91
+candidate=$(build_candidate); status=$?
+printf '%s' "$candidate"
+exit "$status"
+`)
+			cmd.Dir, cmd.Env = dir, env
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+			out, err := cmd.Output()
+			if ctx.Err() != nil || cmd.ProcessState == nil || cmd.ProcessState.ExitCode() != tc.wantExit {
+				t.Fatalf("exit = %v, want %d: %s", err, tc.wantExit, &stderr)
+			}
+			if tc.wantExit != 0 && len(out) != 0 {
+				t.Fatalf("failed selection emitted a path: %q", out)
+			}
+			calls, callErr := os.ReadFile(filepath.Join(dir, "calls"))
+			if value != "" {
+				if !os.IsNotExist(callErr) {
+					t.Fatalf("prebuilt selection invoked go: %s, %v", calls, callErr)
+				}
+				if tc.wantExit == 0 && string(out) != prebuiltPath {
+					t.Fatalf("selected %q, want %q", out, prebuiltPath)
+				}
+				if tc.wantExit == 1 && !strings.Contains(stderr.String(), "CANDIDATE_BIN must name an executable file") {
+					t.Fatalf("missing explicit override diagnostic: %s", &stderr)
+				}
+				return
+			}
+			fields := strings.Split(strings.TrimSpace(string(calls)), "\n")
+			cgo := tc.cgo
+			if cgo == "" {
+				cgo = "1"
+			}
+			if callErr != nil || len(fields) != 7 || fields[0] != string(wantFlags) || fields[1] != cgo || fields[2] != root ||
+				fields[3] != "build" || fields[4] != "-o" || !strings.HasPrefix(fields[5], cachePath+"/bd-candidate-") || fields[6] != "./cmd/bd" {
+				t.Fatalf("unexpected compiler call: %q, %v", calls, callErr)
+			}
+			if tc.wantExit == 0 && string(out) != fields[5] {
+				t.Fatalf("returned %q, built %q", out, fields[5])
+			}
+			entries, err := os.ReadDir(cache)
+			wantFiles := 0
+			if tc.buildExit == 0 || tc.partial {
+				wantFiles = 1
+			}
+			if err != nil || len(entries) != wantFiles {
+				t.Fatalf("compiler fixture outputs = %v, want %d: %v", entries, wantFiles, err)
+			}
+		})
+	}
+}
+
+func TestSmokeCandidateLibraryImport(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := shellPathEnv()
+	root := shellPathUnderEnv(t, bash, sourceRepoRoot(t), env)
+	env = append(env, "HOME="+shellPathUnderEnv(t, bash, t.TempDir(), env), "GOFLAGS=-trimpath")
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	// legacy-bridge-test.sh imports verification functions without PROJECT_ROOT.
+	cmd := exec.CommandContext(ctx, bash, "--noprofile", "--norc", "-uc", `
+source "$1/scripts/migration-test/lib/binary.sh" || exit $?
+[ "$GOFLAGS" = -trimpath ] && [ -z "${CGO_ENABLED+x}" ] || exit 91
+declare -f verify_release_binary_version >/dev/null && declare -f build_candidate >/dev/null
+`, "library-import", root)
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("historical library import: %v\n%s", err, out)
+	}
+}

--- a/scripts/upgrade-smoke-test.sh
+++ b/scripts/upgrade-smoke-test.sh
@@ -22,7 +22,8 @@ set -euo pipefail
 #
 
 # The candidate binary is built from the current worktree if CANDIDATE_BIN
-# is not set. The previous release binary is downloaded and cached in
+# is unset or empty. Nonempty values must name an executable file.
+# The previous release binary is downloaded and cached in
 # ~/.cache/beads-regression/.
 #
 # Exit codes:
@@ -41,6 +42,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Canonical build flags (GOFLAGS=-tags=gms_pure_go, CGO_ENABLED=1).
 # shellcheck source=../.buildflags
 source "$PROJECT_ROOT/.buildflags"
+# shellcheck source=lib/smoke-candidate.sh
+source "$PROJECT_ROOT/scripts/lib/smoke-candidate.sh" || exit $?
 
 # ---------------------------------------------------------------------------
 # Multi-version mode: SMOKE_VERSIONS overrides single-version argument
@@ -136,20 +139,8 @@ get_previous_binary() {
     echo "$cached"
 }
 
-build_candidate() {
-    if [ -n "${CANDIDATE_BIN:-}" ] && [ -x "${CANDIDATE_BIN}" ]; then
-        echo "$(cd "$(dirname "$CANDIDATE_BIN")" && pwd)/$(basename "$CANDIDATE_BIN")"
-        return
-    fi
-
-    local candidate="$CACHE_DIR/bd-candidate-$$"
-    echo -e "${YELLOW}Building candidate binary...${NC}" >&2
-    (cd "$PROJECT_ROOT" && go build -o "$candidate" ./cmd/bd) >&2
-    echo "$candidate"
-}
-
 PREV_BIN=$(get_previous_binary)
-CAND_BIN=$(build_candidate)
+CAND_BIN=$(build_candidate) || exit $?
 
 echo "Previous: $PREV_BIN (${PREV_VERSION})"
 echo "Candidate: $CAND_BIN"

--- a/scripts/upgrade-smoke-test.sh
+++ b/scripts/upgrade-smoke-test.sh
@@ -30,6 +30,7 @@ set -euo pipefail
 #   0  All scenarios passed
 #   1  One or more scenarios failed
 #   2  Invalid nonempty CANDIDATE_BIN (compiler failures retain their exit status)
+# SMOKE_VERSIONS dispatch returns 1 if any child fails, including child status 2.
 # =============================================================================
 
 RED='\033[0;31m'

--- a/scripts/upgrade-smoke-test.sh
+++ b/scripts/upgrade-smoke-test.sh
@@ -29,6 +29,7 @@ set -euo pipefail
 # Exit codes:
 #   0  All scenarios passed
 #   1  One or more scenarios failed
+#   2  Invalid nonempty CANDIDATE_BIN (compiler failures retain their exit status)
 # =============================================================================
 
 RED='\033[0;31m'
@@ -139,8 +140,14 @@ get_previous_binary() {
     echo "$cached"
 }
 
+# Refuse invalid prebuilt input early; build only after the previous release is available.
+if [ -n "${CANDIDATE_BIN:-}" ]; then
+    CAND_BIN=$(build_candidate) || exit $?
+fi
 PREV_BIN=$(get_previous_binary)
-CAND_BIN=$(build_candidate) || exit $?
+if [ -z "${CANDIDATE_BIN:-}" ]; then
+    CAND_BIN=$(build_candidate) || exit $?
+fi
 
 echo "Previous: $PREV_BIN (${PREV_VERSION})"
 echo "Candidate: $CAND_BIN"


### PR DESCRIPTION
A nonempty invalid CANDIDATE_BIN is rejected with status 2 by the shared selector. Upgrade validates explicit prebuilt input before fetching a release, while automatic compilation stays after that release is available. Compiler failures preserve their status and attempt to remove only the partial output; cleanup failure does not replace the compiler error. Empty overrides still build through .buildflags, and executable paths containing spaces remain supported.

The upgrade-smoke header now documents that SMOKE_VERSIONS dispatch aggregates any child failure, including status 2, into status 1. The cross-version header remains unchanged. The entrypoint fixture removes only its dead second fake-Go overwrite and retains the original forbidden-compiler guard. The separate #6383/#6398 dispatch implementation keeps its own ownership.

Validation at this head: three actual selector/entrypoint/library parents with fourteen children pass on native Windows normally and with race/shuffle; five shell syntax checks, vet and PR lint pass. Earlier Linux fifteen-case coverage, historical early-refusal entrypoint proof, seven causal controls and positive source fixture remain bound to their original heads. The historical candidate build keeps its canonical CGO default and explicit override. No successful database upgrade or historical corpus run is claimed.

The combined review cleanup changes ten added/deleted lines across two files above the last published head; the full main-relative diff is 408 changed lines across six files. This remains standalone on main. #6385/#6388 retain separate docs-date/metrics CI ownership; hosted checks and local adoption remain pending.

Fixes #6367

_unknown-model/unknown-reasoning on behalf of Ewen Cuthiell_
