### PR TITLE
test(cli): prove JSON fixture restoration after subtest cleanup

### DIFF
--- a/cmd/bd/ado_test.go
+++ b/cmd/bd/ado_test.go
@@ -382,12 +382,10 @@ func TestADOSyncMissingProject(t *testing.T) {
 // TestADOStatusTextOutput verifies the ado status command text output.
 func TestADOStatusTextOutput(t *testing.T) {
 	oldDBPath, oldStore := dbPath, store
-	oldJSON := jsonOutput
 	dbPath, store = "", nil
-	jsonOutput = false
+	pinJSONOutput(t, false)
 	t.Cleanup(func() {
 		dbPath, store = oldDBPath, oldStore
-		jsonOutput = oldJSON
 	})
 
 	t.Setenv("AZURE_DEVOPS_PAT", "abcdefghij")
@@ -423,12 +421,10 @@ func TestADOStatusTextOutput(t *testing.T) {
 // TestADOStatusUnconfigured verifies the status command output when not configured.
 func TestADOStatusUnconfigured(t *testing.T) {
 	oldDBPath, oldStore := dbPath, store
-	oldJSON := jsonOutput
 	dbPath, store = "", nil
-	jsonOutput = false
+	pinJSONOutput(t, false)
 	t.Cleanup(func() {
 		dbPath, store = oldDBPath, oldStore
-		jsonOutput = oldJSON
 	})
 
 	t.Setenv("AZURE_DEVOPS_PAT", "")
@@ -458,12 +454,10 @@ func TestADOStatusUnconfigured(t *testing.T) {
 // TestADOStatusJSONConfigured verifies JSON output for a configured status.
 func TestADOStatusJSONConfigured(t *testing.T) {
 	oldDBPath, oldStore := dbPath, store
-	oldJSON := jsonOutput
 	dbPath, store = "", nil
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	t.Cleanup(func() {
 		dbPath, store = oldDBPath, oldStore
-		jsonOutput = oldJSON
 	})
 
 	t.Setenv("AZURE_DEVOPS_PAT", "test-pat-1234")
@@ -504,12 +498,10 @@ func TestADOStatusJSONConfigured(t *testing.T) {
 // TestADOStatusJSONUnconfigured verifies JSON output when not configured.
 func TestADOStatusJSONUnconfigured(t *testing.T) {
 	oldDBPath, oldStore := dbPath, store
-	oldJSON := jsonOutput
 	dbPath, store = "", nil
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	t.Cleanup(func() {
 		dbPath, store = oldDBPath, oldStore
-		jsonOutput = oldJSON
 	})
 
 	t.Setenv("AZURE_DEVOPS_PAT", "")
@@ -543,12 +535,10 @@ func TestADOStatusJSONUnconfigured(t *testing.T) {
 // TestADOStatusWithCustomURL verifies status output includes custom URL.
 func TestADOStatusWithCustomURL(t *testing.T) {
 	oldDBPath, oldStore := dbPath, store
-	oldJSON := jsonOutput
 	dbPath, store = "", nil
-	jsonOutput = false
+	pinJSONOutput(t, false)
 	t.Cleanup(func() {
 		dbPath, store = oldDBPath, oldStore
-		jsonOutput = oldJSON
 	})
 
 	t.Setenv("AZURE_DEVOPS_PAT", "test-pat-1234")
@@ -574,12 +564,10 @@ func TestADOStatusWithCustomURL(t *testing.T) {
 // TestADOProjectsWithMockServer tests ado projects using a mock HTTP server.
 func TestADOProjectsWithMockServer(t *testing.T) {
 	oldDBPath, oldStore := dbPath, store
-	oldJSON := jsonOutput
 	dbPath, store = "", nil
-	jsonOutput = false
+	pinJSONOutput(t, false)
 	t.Cleanup(func() {
 		dbPath, store = oldDBPath, oldStore
-		jsonOutput = oldJSON
 	})
 
 	// Mock ADO projects endpoint
@@ -631,12 +619,10 @@ func TestADOProjectsWithMockServer(t *testing.T) {
 // TestADOProjectsJSONOutput tests ado projects JSON output with mock server.
 func TestADOProjectsJSONOutput(t *testing.T) {
 	oldDBPath, oldStore := dbPath, store
-	oldJSON := jsonOutput
 	dbPath, store = "", nil
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	t.Cleanup(func() {
 		dbPath, store = oldDBPath, oldStore
-		jsonOutput = oldJSON
 	})
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -692,12 +678,10 @@ func TestADOProjectsJSONOutput(t *testing.T) {
 // TestADOProjectsEmptyList tests ado projects with no projects found.
 func TestADOProjectsEmptyList(t *testing.T) {
 	oldDBPath, oldStore := dbPath, store
-	oldJSON := jsonOutput
 	dbPath, store = "", nil
-	jsonOutput = false
+	pinJSONOutput(t, false)
 	t.Cleanup(func() {
 		dbPath, store = oldDBPath, oldStore
-		jsonOutput = oldJSON
 	})
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/bd/compact_test.go
+++ b/cmd/bd/compact_test.go
@@ -134,15 +134,13 @@ func TestCompactSuite(t *testing.T) {
 		}
 
 		// Test stats - should work without API key
-		savedJSONOutput := jsonOutput
-		jsonOutput = false
-		defer func() { jsonOutput = savedJSONOutput }()
+		pinJSONOutput(t, false)
 
 		// Actually call runCompactStats to increase coverage
 		runCompactStats(ctx, s)
 
 		// Also test with JSON output
-		jsonOutput = true
+		pinJSONOutput(t, true)
 		runCompactStats(ctx, s)
 	})
 
@@ -163,9 +161,7 @@ func TestCompactSuite(t *testing.T) {
 		}
 
 		// Test with JSON output
-		savedJSONOutput := jsonOutput
-		jsonOutput = true
-		defer func() { jsonOutput = savedJSONOutput }()
+		pinJSONOutput(t, true)
 
 		// Should not panic and should execute JSON path
 		runCompactStats(ctx, s)

--- a/cmd/bd/doctor_test.go
+++ b/cmd/bd/doctor_test.go
@@ -148,9 +148,7 @@ func TestRunDiagnostics_JSONSkipsNetworkUpdateChecks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	prevJSON := jsonOutput
-	jsonOutput = true
-	t.Cleanup(func() { jsonOutput = prevJSON })
+	pinJSONOutput(t, true)
 
 	result := runDiagnostics(tmpDir)
 

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -71,9 +71,7 @@ func TestDoltShowConfigDefaultMode(t *testing.T) {
 	defer func() { _ = os.Chdir(oldCwd) }()
 
 	t.Run("text output", func(t *testing.T) {
-		origJsonOutput := jsonOutput
-		defer func() { jsonOutput = origJsonOutput }()
-		jsonOutput = false
+		pinJSONOutput(t, false)
 
 		output := captureDoltShowOutput(t)
 
@@ -92,9 +90,7 @@ func TestDoltShowConfigDefaultMode(t *testing.T) {
 	})
 
 	t.Run("json output", func(t *testing.T) {
-		origJsonOutput := jsonOutput
-		defer func() { jsonOutput = origJsonOutput }()
-		jsonOutput = true
+		pinJSONOutput(t, true)
 
 		output := captureDoltShowOutput(t)
 
@@ -155,9 +151,7 @@ func TestDoltShowConfigServerMode(t *testing.T) {
 	defer func() { _ = os.Chdir(oldCwd) }()
 
 	t.Run("text output", func(t *testing.T) {
-		origJsonOutput := jsonOutput
-		defer func() { jsonOutput = origJsonOutput }()
-		jsonOutput = false
+		pinJSONOutput(t, false)
 
 		output := captureDoltShowOutput(t)
 
@@ -177,9 +171,7 @@ func TestDoltShowConfigServerMode(t *testing.T) {
 	})
 
 	t.Run("json output", func(t *testing.T) {
-		origJsonOutput := jsonOutput
-		defer func() { jsonOutput = origJsonOutput }()
-		jsonOutput = true
+		pinJSONOutput(t, true)
 
 		output := captureDoltShowOutput(t)
 
@@ -303,9 +295,7 @@ func TestDoltSetConfigJSONOutput(t *testing.T) {
 	}
 	defer func() { _ = os.Chdir(oldCwd) }()
 
-	origJsonOutput := jsonOutput
-	defer func() { jsonOutput = origJsonOutput }()
-	jsonOutput = true
+	pinJSONOutput(t, true)
 
 	output := captureDoltSetOutput(t, "database", "myproject", false)
 
@@ -358,9 +348,7 @@ func TestDoltSetConfigWithUpdateConfig(t *testing.T) {
 	}
 	defer func() { _ = os.Chdir(oldCwd) }()
 
-	origJsonOutput := jsonOutput
-	defer func() { jsonOutput = origJsonOutput }()
-	jsonOutput = true
+	pinJSONOutput(t, true)
 
 	// Set with --update-config
 	output := captureDoltSetOutput(t, "database", "myproject", true)
@@ -1486,9 +1474,7 @@ func TestRunExternalDoltStatus_Unreachable(t *testing.T) {
 	}
 
 	t.Run("text output", func(t *testing.T) {
-		orig := jsonOutput
-		defer func() { jsonOutput = orig }()
-		jsonOutput = false
+		pinJSONOutput(t, false)
 
 		out := captureStdout(t, func() error { runExternalDoltStatus(beadsDir, cfg); return nil })
 
@@ -1511,9 +1497,7 @@ func TestRunExternalDoltStatus_Unreachable(t *testing.T) {
 	})
 
 	t.Run("json output", func(t *testing.T) {
-		orig := jsonOutput
-		defer func() { jsonOutput = orig }()
-		jsonOutput = true
+		pinJSONOutput(t, true)
 
 		out := captureStdout(t, func() error { runExternalDoltStatus(beadsDir, cfg); return nil })
 
@@ -1726,9 +1710,7 @@ func TestRenderLocalDoltStatus(t *testing.T) {
 	t.Setenv("BEADS_DOLT_SERVER_PORT", "13306")
 
 	t.Run("nil state prints not running with expected port", func(t *testing.T) {
-		orig := jsonOutput
-		defer func() { jsonOutput = orig }()
-		jsonOutput = false
+		pinJSONOutput(t, false)
 
 		serverDir := t.TempDir()
 		out := captureStdout(t, func() error {
@@ -1747,9 +1729,7 @@ func TestRenderLocalDoltStatus(t *testing.T) {
 	})
 
 	t.Run("Running:false prints not running", func(t *testing.T) {
-		orig := jsonOutput
-		defer func() { jsonOutput = orig }()
-		jsonOutput = false
+		pinJSONOutput(t, false)
 
 		serverDir := t.TempDir()
 		state := &doltserver.State{Running: false}
@@ -1764,9 +1744,7 @@ func TestRenderLocalDoltStatus(t *testing.T) {
 	})
 
 	t.Run("Running:true prints PID/Port/Data/Logs", func(t *testing.T) {
-		orig := jsonOutput
-		defer func() { jsonOutput = orig }()
-		jsonOutput = false
+		pinJSONOutput(t, false)
 
 		serverDir := t.TempDir()
 		state := &doltserver.State{
@@ -1801,9 +1779,7 @@ func TestRenderLocalDoltStatus(t *testing.T) {
 
 	t.Run("Running:true under shared-server mode adds Mode line", func(t *testing.T) {
 		t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
-		orig := jsonOutput
-		defer func() { jsonOutput = orig }()
-		jsonOutput = false
+		pinJSONOutput(t, false)
 
 		serverDir := t.TempDir()
 		state := &doltserver.State{
@@ -1823,9 +1799,7 @@ func TestRenderLocalDoltStatus(t *testing.T) {
 	})
 
 	t.Run("json output produces State-shaped payload (no mode=external)", func(t *testing.T) {
-		orig := jsonOutput
-		defer func() { jsonOutput = orig }()
-		jsonOutput = true
+		pinJSONOutput(t, true)
 
 		serverDir := t.TempDir()
 		state := &doltserver.State{

--- a/cmd/bd/formula_schema_test.go
+++ b/cmd/bd/formula_schema_test.go
@@ -9,9 +9,7 @@ import (
 )
 
 func TestFormulaSchemaList_HumanOutput(t *testing.T) {
-	prevJSON := jsonOutput
-	jsonOutput = false
-	defer func() { jsonOutput = prevJSON }()
+	pinJSONOutput(t, false)
 
 	out := captureStdout(t, func() error {
 		return runFormulaSchemaList()
@@ -28,9 +26,7 @@ func TestFormulaSchemaList_HumanOutput(t *testing.T) {
 }
 
 func TestFormulaSchemaList_JSON(t *testing.T) {
-	prevJSON := jsonOutput
-	jsonOutput = true
-	defer func() { jsonOutput = prevJSON }()
+	pinJSONOutput(t, true)
 
 	out := captureStdout(t, func() error {
 		return runFormulaSchemaList()
@@ -48,9 +44,7 @@ func TestFormulaSchemaList_JSON(t *testing.T) {
 }
 
 func TestFormulaSchemaShow_RendersFields(t *testing.T) {
-	prevJSON := jsonOutput
-	jsonOutput = false
-	defer func() { jsonOutput = prevJSON }()
+	pinJSONOutput(t, false)
 
 	out := captureStdout(t, func() error {
 		return runFormulaSchemaShow("loop")
@@ -64,9 +58,7 @@ func TestFormulaSchemaShow_RendersFields(t *testing.T) {
 }
 
 func TestFormulaSchemaShow_AliasResolution(t *testing.T) {
-	prevJSON := jsonOutput
-	jsonOutput = false
-	defer func() { jsonOutput = prevJSON }()
+	pinJSONOutput(t, false)
 
 	for _, input := range []string{"on_complete", "OnComplete", "OnCompleteSpec"} {
 		out := captureStdout(t, func() error {
@@ -96,9 +88,7 @@ func TestFormulaSchemaCmd_AliasRegistered(t *testing.T) {
 }
 
 func TestFormulaSchemaShow_JSON(t *testing.T) {
-	prevJSON := jsonOutput
-	jsonOutput = true
-	defer func() { jsonOutput = prevJSON }()
+	pinJSONOutput(t, true)
 
 	out := captureStdout(t, func() error {
 		return runFormulaSchemaShow("loop")

--- a/cmd/bd/graph_apply_test.go
+++ b/cmd/bd/graph_apply_test.go
@@ -573,9 +573,7 @@ func TestEmitGraphApplyDryRun_JSON(t *testing.T) {
 		},
 	}
 
-	oldJSON := jsonOutput
-	jsonOutput = true
-	defer func() { jsonOutput = oldJSON }()
+	pinJSONOutput(t, true)
 
 	out := captureStdout(t, func() error {
 		emitGraphApplyDryRun(plan, GraphApplyOptions{})
@@ -628,9 +626,7 @@ func TestCreateIssuesFromGraph_DryRunDoesNotPersist(t *testing.T) {
 	store = nil
 	defer func() { store = oldStore }()
 
-	oldJSON := jsonOutput
-	jsonOutput = true
-	defer func() { jsonOutput = oldJSON }()
+	pinJSONOutput(t, true)
 
 	planJSON := `{
 		"nodes": [

--- a/cmd/bd/metrics_test.go
+++ b/cmd/bd/metrics_test.go
@@ -179,11 +179,15 @@ func TestResolveMetricsIgnoresProjectConfigOverride(t *testing.T) {
 // stealth contexts, and must still fire for an ordinary interactive command.
 func TestFirstRunNoticeSuppressedByContext(t *testing.T) {
 	// Save/restore the output-mode globals this decision reads.
-	origJSON, origQuiet, origHookJSON := jsonOutput, quietFlag, primeHookJSONMode
+	origQuiet, origHookJSON := quietFlag, primeHookJSONMode
 	t.Cleanup(func() {
-		jsonOutput, quietFlag, primeHookJSONMode = origJSON, origQuiet, origHookJSON
+		quietFlag, primeHookJSONMode = origQuiet, origHookJSON
 	})
-	reset := func() { jsonOutput, quietFlag, primeHookJSONMode = false, false, false }
+	reset := func(t *testing.T) {
+		t.Helper()
+		pinJSONOutput(t, false)
+		quietFlag, primeHookJSONMode = false, false
+	}
 
 	// Build a command tree rooted at "bd" so topLevelCommandName resolves the
 	// suppressed-subtree names (e.g. `bd hooks run` -> "hooks").
@@ -211,7 +215,7 @@ func TestFirstRunNoticeSuppressedByContext(t *testing.T) {
 	}
 
 	t.Run("plain interactive command fires", func(t *testing.T) {
-		reset()
+		reset(t)
 		if firstRunNoticeSuppressedByContext(newTree()["list"]) {
 			t.Errorf("plain `bd list` should NOT be suppressed")
 		}
@@ -219,7 +223,7 @@ func TestFirstRunNoticeSuppressedByContext(t *testing.T) {
 
 	for _, name := range []string{"version", "prime", "codex-hook", "hooks-run"} {
 		t.Run(name+" is suppressed", func(t *testing.T) {
-			reset()
+			reset(t)
 			if !firstRunNoticeSuppressedByContext(newTree()[name]) {
 				t.Errorf("%q context should suppress the first-run notice", name)
 			}
@@ -228,15 +232,15 @@ func TestFirstRunNoticeSuppressedByContext(t *testing.T) {
 
 	for _, mode := range []struct {
 		name string
-		set  func()
+		set  func(*testing.T)
 	}{
-		{"json", func() { jsonOutput = true }},
-		{"quiet", func() { quietFlag = true }},
-		{"hook-json", func() { primeHookJSONMode = true }},
+		{"json", func(t *testing.T) { pinJSONOutput(t, true) }},
+		{"quiet", func(*testing.T) { quietFlag = true }},
+		{"hook-json", func(*testing.T) { primeHookJSONMode = true }},
 	} {
 		t.Run(mode.name+" output is suppressed", func(t *testing.T) {
-			reset()
-			mode.set()
+			reset(t)
+			mode.set(t)
 			if !firstRunNoticeSuppressedByContext(newTree()["list"]) {
 				t.Errorf("%s output mode should suppress the first-run notice", mode.name)
 			}
@@ -244,7 +248,7 @@ func TestFirstRunNoticeSuppressedByContext(t *testing.T) {
 	}
 
 	t.Run("BD_GIT_HOOK context is suppressed", func(t *testing.T) {
-		reset()
+		reset(t)
 		t.Setenv("BD_GIT_HOOK", "1")
 		if !firstRunNoticeSuppressedByContext(newTree()["list"]) {
 			t.Errorf("BD_GIT_HOOK=1 should suppress the first-run notice")
@@ -252,7 +256,7 @@ func TestFirstRunNoticeSuppressedByContext(t *testing.T) {
 	})
 
 	t.Run("stealth init is suppressed", func(t *testing.T) {
-		reset()
+		reset(t)
 		cmds := newTree()
 		if err := cmds["init"].Flags().Set("stealth", "true"); err != nil {
 			t.Fatalf("set stealth flag: %v", err)
@@ -263,14 +267,14 @@ func TestFirstRunNoticeSuppressedByContext(t *testing.T) {
 	})
 
 	t.Run("plain init fires", func(t *testing.T) {
-		reset()
+		reset(t)
 		if firstRunNoticeSuppressedByContext(newTree()["init"]) {
 			t.Errorf("plain `bd init` should NOT be suppressed (interactive consent is expected)")
 		}
 	})
 
 	t.Run("root --version flag is suppressed", func(t *testing.T) {
-		reset()
+		reset(t)
 		cmds := newTree()
 		if err := cmds["root"].Flags().Set("version", "true"); err != nil {
 			t.Fatalf("set version flag: %v", err)
@@ -281,7 +285,7 @@ func TestFirstRunNoticeSuppressedByContext(t *testing.T) {
 	})
 
 	t.Run("root without version flag fires", func(t *testing.T) {
-		reset()
+		reset(t)
 		if firstRunNoticeSuppressedByContext(newTree()["root"]) {
 			t.Errorf("root command without --version set should NOT be suppressed by the version-flag rule")
 		}

--- a/cmd/bd/metrics_test.go
+++ b/cmd/bd/metrics_test.go
@@ -230,6 +230,8 @@ func TestFirstRunNoticeSuppressedByContext(t *testing.T) {
 		})
 	}
 
+	// JSON cleanup belongs to each child; quiet and hook-JSON retain the
+	// parent's shared reset and restoration.
 	for _, mode := range []struct {
 		name string
 		set  func(*testing.T)

--- a/cmd/bd/ready_input_test.go
+++ b/cmd/bd/ready_input_test.go
@@ -113,23 +113,6 @@ func runGatherReadyInput(t *testing.T, cmd *cobra.Command, resolveCap func(*cobr
 	return out
 }
 
-// pinJSONOutput fixes the package-level --json state for the duration of a
-// test and puts it back afterwards.
-//
-// gatherReadyInput reports its usage errors through HandleErrorRespectJSON, so
-// this global alone decides whether they land as text on stderr or as a JSON
-// object on stdout. jsonOutput is not per-test state: several cmd/bd tests set
-// it and never restore it (saveAndRestoreGlobals, which a number of them use,
-// does not cover it), so a test that reads it instead of setting it passes
-// under a narrow -run and fails in a full-package run depending on what ran
-// first. Every test below that asserts on where a message went pins it.
-func pinJSONOutput(t *testing.T, on bool) {
-	t.Helper()
-	restore := jsonOutput
-	jsonOutput = on
-	t.Cleanup(func() { jsonOutput = restore })
-}
-
 // configureDirectoryLabel points directory.labels at the test's own working
 // directory: GetDirectoryLabels resolves against the cwd, so the test has to
 // own both ends.

--- a/cmd/bd/show_proxied_reader_test.go
+++ b/cmd/bd/show_proxied_reader_test.go
@@ -27,12 +27,11 @@ var _ uow.IssueReaderSource = readerProvider{}
 
 func withStubbedProxiedReader(t *testing.T, hardErr error) {
 	t.Helper()
-	oldProvider, oldJSON := uowProvider, jsonOutput
+	oldProvider := uowProvider
 	uowProvider = readerProvider{lookupOnlyProvider{issues: stubLookupIssueUC{hardErr: hardErr}}}
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	t.Cleanup(func() {
 		uowProvider = oldProvider
-		jsonOutput = oldJSON
 	})
 }
 

--- a/cmd/bd/sql_test.go
+++ b/cmd/bd/sql_test.go
@@ -59,18 +59,16 @@ func TestSqlCommand(t *testing.T) {
 	// Save/restore globals
 	oldStore := store
 	oldCtx := rootCtx
-	oldJSON := jsonOutput
 	defer func() {
 		store = oldStore
 		rootCtx = oldCtx
-		jsonOutput = oldJSON
 	}()
 
 	store = testStore
 	rootCtx = ctx
 
 	t.Run("select count", func(t *testing.T) {
-		jsonOutput = true
+		pinJSONOutput(t, true)
 		output := captureStdout(t, func() error {
 			_ = sqlCmd.RunE(sqlCmd, []string{"SELECT COUNT(*) as count FROM issues"})
 			return nil
@@ -94,7 +92,7 @@ func TestSqlCommand(t *testing.T) {
 	})
 
 	t.Run("select with filter", func(t *testing.T) {
-		jsonOutput = true
+		pinJSONOutput(t, true)
 		output := captureStdout(t, func() error {
 			_ = sqlCmd.RunE(sqlCmd, []string{`SELECT id, title FROM issues WHERE status = 'open'`})
 			return nil
@@ -115,7 +113,7 @@ func TestSqlCommand(t *testing.T) {
 	})
 
 	t.Run("empty result json", func(t *testing.T) {
-		jsonOutput = true
+		pinJSONOutput(t, true)
 		output := captureStdout(t, func() error {
 			_ = sqlCmd.RunE(sqlCmd, []string{`SELECT * FROM issues WHERE title = 'nonexistent'`})
 			return nil
@@ -132,7 +130,7 @@ func TestSqlCommand(t *testing.T) {
 	})
 
 	t.Run("table output", func(t *testing.T) {
-		jsonOutput = false
+		pinJSONOutput(t, false)
 		output := captureStdout(t, func() error {
 			_ = sqlCmd.RunE(sqlCmd, []string{"SELECT COUNT(*) as count FROM issues"})
 			return nil
@@ -147,7 +145,7 @@ func TestSqlCommand(t *testing.T) {
 	})
 
 	t.Run("empty table output", func(t *testing.T) {
-		jsonOutput = false
+		pinJSONOutput(t, false)
 		output := captureStdout(t, func() error {
 			_ = sqlCmd.RunE(sqlCmd, []string{`SELECT * FROM issues WHERE title = 'nonexistent'`})
 			return nil

--- a/cmd/bd/status_test.go
+++ b/cmd/bd/status_test.go
@@ -38,9 +38,7 @@ func TestRenderStatusJSON(t *testing.T) {
 		},
 	}
 
-	oldJSON := jsonOutput
-	jsonOutput = true
-	defer func() { jsonOutput = oldJSON }()
+	pinJSONOutput(t, true)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -104,9 +102,7 @@ func TestRenderStatusHuman(t *testing.T) {
 		},
 	}
 
-	oldJSON := jsonOutput
-	jsonOutput = false
-	defer func() { jsonOutput = oldJSON }()
+	pinJSONOutput(t, false)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/bd/sync_test.go
+++ b/cmd/bd/sync_test.go
@@ -1435,12 +1435,10 @@ func setupSyncCommandTest(t *testing.T, fake *fakeSyncStore) {
 	saveAndRestoreGlobals(t)
 	resetCommandContext()
 
-	oldJSON := jsonOutput
 	oldCtx := rootCtx
 	oldQuiet := quietFlag
 	oldAdopt := syncAdoptGitOrigin
 	t.Cleanup(func() {
-		jsonOutput = oldJSON
 		rootCtx = oldCtx
 		quietFlag = oldQuiet
 		syncAdoptGitOrigin = oldAdopt
@@ -1451,7 +1449,7 @@ func setupSyncCommandTest(t *testing.T, fake *fakeSyncStore) {
 
 	store = fake
 	rootCtx = context.Background()
-	jsonOutput = false
+	pinJSONOutput(t, false)
 	quietFlag = false
 
 	config.ResetForTesting()
@@ -1486,7 +1484,7 @@ func TestRunSyncCommandNoRemoteExitsZero(t *testing.T) {
 func TestRunSyncCommandNoRemoteJSON(t *testing.T) {
 	fake := &fakeSyncStore{pullErr: errors.New(`Error 1105: no remote`)}
 	setupSyncCommandTest(t, fake)
-	jsonOutput = true
+	pinJSONOutput(t, true)
 
 	out := captureStdout(t, func() error { return runSyncCommand(syncCmd, nil) })
 	var got syncOutcome
@@ -1512,7 +1510,7 @@ func TestRunSyncCommandNoPushSetsPushSkipped(t *testing.T) {
 	if !config.GetBool("no-push") {
 		t.Fatal("test setup: BD_NO_PUSH=true must make no-push=true")
 	}
-	jsonOutput = true
+	pinJSONOutput(t, true)
 
 	out := captureStdout(t, func() error { return runSyncCommand(syncCmd, nil) })
 	if fake.pushCalls != 0 {
@@ -1588,7 +1586,7 @@ func TestRunSyncCommandExitCodeMapping(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setupSyncCommandTest(t, tt.fake)
-			jsonOutput = true // silence the operator-facing stderr report; the exit code is what's under test
+			pinJSONOutput(t, true) // silence the operator-facing stderr report; the exit code is what's under test
 
 			err := runSyncCommand(syncCmd, nil)
 			if !tt.wantErr {
@@ -1643,7 +1641,7 @@ func TestRunSyncCommandJSONEnvelopePerStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setupSyncCommandTest(t, tt.fake)
-			jsonOutput = true
+			pinJSONOutput(t, true)
 
 			out := captureStdout(t, func() error {
 				_ = runSyncCommand(syncCmd, nil)
@@ -1736,7 +1734,7 @@ func TestRunSyncCommandAdoptsGitOriginOnDefaultRemote(t *testing.T) {
 		return true, nil
 	}
 
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	out := captureStdout(t, func() error { return runSyncCommand(syncCmd, nil) })
 
 	if adoptCalls != 1 {
@@ -1783,7 +1781,7 @@ func TestRunSyncCommandNoGitOriginStillExitsZero(t *testing.T) {
 	setupSyncCommandTest(t, fake)
 	// setupSyncCommandTest already stubs "nothing to adopt"; assert the
 	// no-remote contract survives it explicitly.
-	jsonOutput = true
+	pinJSONOutput(t, true)
 
 	out := captureStdout(t, func() error { return runSyncCommand(syncCmd, nil) })
 	var got syncOutcome

--- a/cmd/bd/test_helpers_pure_test.go
+++ b/cmd/bd/test_helpers_pure_test.go
@@ -142,6 +142,7 @@ type savedGlobals struct {
 
 // saveAndRestoreGlobals snapshots all commonly-mutated package-level globals
 // and registers a t.Cleanup() to restore them when the test completes.
+// Set and restore the separate JSON output mode with pinJSONOutput(t, on).
 // This replaces the fragile manual save/defer pattern:
 //
 //	oldDBPath := dbPath

--- a/cmd/bd/test_helpers_pure_test.go
+++ b/cmd/bd/test_helpers_pure_test.go
@@ -412,3 +412,22 @@ func initGitRepoAt(t *testing.T, dir string) {
 		}
 	}
 }
+
+func TestPinJSONOutputRestoresAfterSubtest(t *testing.T) {
+	starting := jsonOutput
+	t.Cleanup(func() { jsonOutput = starting })
+	// Keep these children synchronous: their cleanup must finish before the
+	// parent checks the flag. The outer restore does not use the helper.
+	for _, prior := range []bool{false, true} {
+		jsonOutput = prior
+		t.Run(fmt.Sprintf("prior_%t", prior), func(t *testing.T) {
+			pinJSONOutput(t, !prior)
+			if jsonOutput != !prior {
+				t.Errorf("pinned jsonOutput = %t, want %t", jsonOutput, !prior)
+			}
+		})
+		if jsonOutput != prior {
+			t.Errorf("jsonOutput after child cleanup = %t, want prior %t", jsonOutput, prior)
+		}
+	}
+}

--- a/cmd/bd/test_helpers_pure_test.go
+++ b/cmd/bd/test_helpers_pure_test.go
@@ -140,6 +140,16 @@ type savedGlobals struct {
 	exportIncludeMemories bool
 }
 
+// pinJSONOutput owns the global JSON mode for a test and restores it through
+// t.Cleanup. Tests that inspect output must select their mode explicitly;
+// saveAndRestoreGlobals does not include this separate flag.
+func pinJSONOutput(t *testing.T, on bool) {
+	t.Helper()
+	restore := jsonOutput
+	jsonOutput = on
+	t.Cleanup(func() { jsonOutput = restore })
+}
+
 // saveAndRestoreGlobals snapshots all commonly-mutated package-level globals
 // and registers a t.Cleanup() to restore them when the test completes.
 // Set and restore the separate JSON output mode with pinJSONOutput(t, on).

--- a/cmd/bd/test_helpers_pure_test.go
+++ b/cmd/bd/test_helpers_pure_test.go
@@ -143,6 +143,8 @@ type savedGlobals struct {
 // pinJSONOutput owns the global JSON mode for a test and restores it through
 // t.Cleanup. Tests that inspect output must select their mode explicitly;
 // saveAndRestoreGlobals does not include this separate flag.
+// A fixture that leaves it set can pass alone and break a later text test in
+// a full run, so each fixture must own restoration even when its mode matches.
 func pinJSONOutput(t *testing.T, on bool) {
 	t.Helper()
 	restore := jsonOutput

--- a/cmd/bd/tips_test.go
+++ b/cmd/bd/tips_test.go
@@ -49,8 +49,7 @@ func resetTipTestState(t *testing.T) {
 	originalRandWasInitialized := originalRand != nil
 	tipRand = nil
 	tipRandOnce = sync.Once{}
-	originalJSONOutput := jsonOutput
-	jsonOutput = false
+	pinJSONOutput(t, false)
 	originalQuietFlag := quietFlag
 	quietFlag = false
 	originalDoltAutoCommit := doltAutoCommit
@@ -73,7 +72,6 @@ func resetTipTestState(t *testing.T) {
 		if originalRandWasInitialized {
 			tipRandOnce.Do(func() {})
 		}
-		jsonOutput = originalJSONOutput
 		quietFlag = originalQuietFlag
 		doltAutoCommit = originalDoltAutoCommit
 		commandDidWriteTipMetadata = originalDidWrite
@@ -352,12 +350,12 @@ func TestMaybeShowTip_RespectsFlags(t *testing.T) {
 	store := &tipMetadataRecorder{values: map[string]string{}}
 
 	// Test 1: Should not show in JSON mode
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	output := captureStdout(t, func() error { maybeShowTip(store); return nil })
 	if output != "" || tipRand != nil || len(store.readKeys) != 0 || len(store.writes) != 0 {
 		t.Fatalf("JSON mode output=%q rand=%v reads=%v writes=%v", output, tipRand, store.readKeys, store.writes)
 	}
-	jsonOutput = false
+	pinJSONOutput(t, false)
 
 	// Test 2: Should not show in quiet mode
 	quietFlag = true

--- a/cmd/bd/version_test.go
+++ b/cmd/bd/version_test.go
@@ -22,7 +22,7 @@ func TestVersionCommand(t *testing.T) {
 			t.Fatalf("Failed to create pipe: %v", err)
 		}
 		os.Stdout = w
-		jsonOutput = false
+		pinJSONOutput(t, false)
 
 		// Run version command
 		if err := versionCmd.RunE(versionCmd, []string{}); err != nil {
@@ -51,7 +51,7 @@ func TestVersionCommand(t *testing.T) {
 			t.Fatalf("Failed to create pipe: %v", err)
 		}
 		os.Stdout = w
-		jsonOutput = true
+		pinJSONOutput(t, true)
 
 		// Run version command
 		if err := versionCmd.RunE(versionCmd, []string{}); err != nil {
@@ -84,7 +84,7 @@ func TestVersionCommand(t *testing.T) {
 	})
 
 	// Restore default
-	jsonOutput = false
+	pinJSONOutput(t, false)
 }
 
 func TestResolveCommitHash(t *testing.T) {
@@ -158,7 +158,7 @@ func TestVersionOutputWithCommitAndBranch(t *testing.T) {
 			t.Fatalf("Failed to create pipe: %v", err)
 		}
 		os.Stdout = w
-		jsonOutput = false
+		pinJSONOutput(t, false)
 
 		if err := versionCmd.RunE(versionCmd, []string{}); err != nil {
 			t.Fatalf("versionCmd.RunE: %v", err)
@@ -187,7 +187,7 @@ func TestVersionOutputWithCommitAndBranch(t *testing.T) {
 			t.Fatalf("Failed to create pipe: %v", err)
 		}
 		os.Stdout = w
-		jsonOutput = true
+		pinJSONOutput(t, true)
 
 		if err := versionCmd.RunE(versionCmd, []string{}); err != nil {
 			t.Fatalf("versionCmd.RunE: %v", err)

--- a/cmd/bd/where_cgo_test.go
+++ b/cmd/bd/where_cgo_test.go
@@ -21,11 +21,10 @@ func TestWhereCommand_ReadsPrefixFromEmbeddedStore(t *testing.T) {
 	initConfigForTest(t)
 
 	originalCmdCtx := cmdCtx
-	originalJSONOutput := jsonOutput
+	pinJSONOutput(t, jsonOutput)
 	originalRootCtx := rootCtx
 	defer func() {
 		cmdCtx = originalCmdCtx
-		jsonOutput = originalJSONOutput
 		rootCtx = originalRootCtx
 	}()
 
@@ -78,7 +77,7 @@ func TestWhereCommand_ReadsPrefixFromEmbeddedStore(t *testing.T) {
 		dbFlag.Changed = originalFlagChanged
 	})
 
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	rootCtx = context.Background()
 
 	if err := withStorage(rootCtx, nil, dbDir, func(currentStore storage.DoltStorage) error {

--- a/cmd/bd/where_cgo_test.go
+++ b/cmd/bd/where_cgo_test.go
@@ -21,6 +21,7 @@ func TestWhereCommand_ReadsPrefixFromEmbeddedStore(t *testing.T) {
 	initConfigForTest(t)
 
 	originalCmdCtx := cmdCtx
+	// Pin the current value so t.Cleanup owns its restoration.
 	pinJSONOutput(t, jsonOutput)
 	originalRootCtx := rootCtx
 	defer func() {

--- a/cmd/bd/where_test.go
+++ b/cmd/bd/where_test.go
@@ -339,11 +339,10 @@ func TestWhereCommand_UsesConfigPrefixFromSelectedDB(t *testing.T) {
 	initConfigForTest(t)
 
 	originalCmdCtx := cmdCtx
-	originalJSONOutput := jsonOutput
+	pinJSONOutput(t, jsonOutput)
 	originalRootCtx := rootCtx
 	defer func() {
 		cmdCtx = originalCmdCtx
-		jsonOutput = originalJSONOutput
 		rootCtx = originalRootCtx
 	}()
 
@@ -383,7 +382,7 @@ func TestWhereCommand_UsesConfigPrefixFromSelectedDB(t *testing.T) {
 		dbFlag.Changed = originalFlagChanged
 	})
 
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	rootCtx = context.Background()
 
 	output := captureStdout(t, func() error {

--- a/cmd/bd/where_test.go
+++ b/cmd/bd/where_test.go
@@ -339,6 +339,7 @@ func TestWhereCommand_UsesConfigPrefixFromSelectedDB(t *testing.T) {
 	initConfigForTest(t)
 
 	originalCmdCtx := cmdCtx
+	// Pin the current value so t.Cleanup owns its restoration.
 	pinJSONOutput(t, jsonOutput)
 	originalRootCtx := rootCtx
 	defer func() {

--- a/cmd/bd/worktree_permissions_test.go
+++ b/cmd/bd/worktree_permissions_test.go
@@ -21,9 +21,7 @@ func TestRepairWorktreeBeadsPermissions(t *testing.T) {
 		t.Fatalf("chmod .beads: %v", err)
 	}
 
-	saveJSON := jsonOutput
-	jsonOutput = true // suppress stderr from repair helper
-	t.Cleanup(func() { jsonOutput = saveJSON })
+	pinJSONOutput(t, true) // suppress stderr from repair helper
 
 	repairWorktreeBeadsPermissions(worktreePath)
 
@@ -93,7 +91,5 @@ func TestRepairWorktreeBeadsPermissionsRejectsNonDirectory(t *testing.T) {
 
 func suppressRepairOutput(t *testing.T) {
 	t.Helper()
-	saveJSON := jsonOutput
-	jsonOutput = true
-	t.Cleanup(func() { jsonOutput = saveJSON })
+	pinJSONOutput(t, true)
 }

--- a/cmd/bd/write_verbs_parity_test.go
+++ b/cmd/bd/write_verbs_parity_test.go
@@ -248,11 +248,11 @@ func newParityEnv(t *testing.T) *parityEnv {
 	raw := newTestStore(t, filepath.Join(beadsDir, "beads.db"))
 	ps := newParityStore(raw)
 
-	savedCtx, savedJSON, savedActor := rootCtx, jsonOutput, actor
+	savedCtx, savedActor := rootCtx, actor
 	savedQuiet, savedReadonly := quietFlag, readonlyMode
 	savedNewOps := newIssueOperations
 	t.Cleanup(func() {
-		rootCtx, jsonOutput, actor = savedCtx, savedJSON, savedActor
+		rootCtx, actor = savedCtx, savedActor
 		quietFlag, readonlyMode = savedQuiet, savedReadonly
 		newIssueOperations = savedNewOps
 	})
@@ -273,7 +273,7 @@ func newParityEnv(t *testing.T) *parityEnv {
 
 	store = ps
 	rootCtx = context.Background()
-	jsonOutput = false
+	pinJSONOutput(t, false)
 	actor = "parity-actor"
 	quietFlag = true
 	readonlyMode = false
@@ -625,7 +625,7 @@ func assertRecentUTCTimestamp(t *testing.T, label, value string) {
 // cmd/bd/output.go:68-99 (wrapWithSchemaVersion).
 func TestParityCreateJSONShape(t *testing.T) {
 	env := newParityEnv(t)
-	jsonOutput = true
+	pinJSONOutput(t, true)
 
 	env.setFlags(createCmd, map[string]string{
 		"description": "parity body",
@@ -702,7 +702,7 @@ func TestParityCreateJSONShape(t *testing.T) {
 // timestamps here is the predicted failure mode of the facade rewire.
 func TestParityCreateJSONTimestamps(t *testing.T) {
 	env := newParityEnv(t)
-	jsonOutput = true
+	pinJSONOutput(t, true)
 
 	env.setFlags(createCmd, map[string]string{"description": "timestamps"})
 	res := env.run(createCmd, "Create timestamps")
@@ -803,7 +803,7 @@ func TestParityCreateWithDepsOmitsDependenciesKey(t *testing.T) {
 	env := newParityEnv(t)
 	target := env.seed("test-dep1", "Dependency target", nil)
 
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	env.setFlags(createCmd, map[string]string{
 		"description": "with deps",
 		"deps":        "blocked-by:" + target.ID,
@@ -947,7 +947,7 @@ func TestParityCreateMissingDepTargetIsFatal(t *testing.T) {
 // Source: cmd/bd/errors.go:91-97 and :57-84.
 func TestParityCreateJSONErrorShape(t *testing.T) {
 	env := newParityEnv(t)
-	jsonOutput = true
+	pinJSONOutput(t, true)
 
 	env.setFlags(createCmd, map[string]string{
 		"description": "bad deps",
@@ -982,7 +982,7 @@ func TestParityUpdateJSONShape(t *testing.T) {
 	env := newParityEnv(t)
 	env.seed("test-upd1", "Update json shape", nil)
 
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	env.setFlags(updateCmd, map[string]string{"priority": "0"})
 	res := env.run(updateCmd, "test-upd1")
 	if res.exitCode != 0 {
@@ -1242,7 +1242,7 @@ func TestParityUpdateJSONFailureReport(t *testing.T) {
 		i.Assignee = "someone-else"
 	})
 
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	env.setFlags(updateCmd, map[string]string{
 		"if-assignee": "not-the-holder",
 		"priority":    "1",
@@ -1479,7 +1479,7 @@ func TestParityCloseJSONShape(t *testing.T) {
 	env := newParityEnv(t)
 	env.seed("test-cls1", "Close json shape", nil)
 
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	env.setFlags(closeCmd, map[string]string{"reason": "done here"})
 	res := env.run(closeCmd, "test-cls1")
 	if res.exitCode != 0 {
@@ -1686,7 +1686,7 @@ func TestParityReopenJSONShape(t *testing.T) {
 		i.Status = types.StatusClosed
 	})
 
-	jsonOutput = true
+	pinJSONOutput(t, true)
 	env.setFlags(reopenCmd, map[string]string{"reason": "back to work"})
 	res := env.run(reopenCmd, "test-rop1")
 	if res.exitCode != 0 {


### PR DESCRIPTION
The JSON output fixture helper now has a direct restoration regression. Each synchronous child pins the opposite of its starting value; its parent checks that cleanup restored the original value. The test independently restores the process's initial flag even when the helper is broken.

Fixes #6381, reported by Bee while reviewing #6316. This is stacked on the revised #6316 at dfd498f, which must land first. The change adds 19 lines to the existing untagged helper file; the complete main-relative diff is 314 added/deleted lines across 19 files. The revised parent's explanation and executable helper remain byte-identical.

Native Windows validation runs the new test and adjacent output fixtures with CGO disabled and enabled, then with race detection and shuffle. The new test passes both starting values. Three well-typed controls reject a missing assignment, missing cleanup and constant-false restoration at the expected assertions. Vet and native/Windows PR lint pass. The wider unchanged parent campaign retains its original provenance; hosted results appear in this PR's Checks tab.

#5745 retains the separate Notion fixtures and #6245 retains the registration command work. Local adoption remains separately tracked.

_unknown-model/unknown-reasoning on behalf of Ewen Cuthiell_
