### PR TITLE
fix(gate): resolve a bead gate whose awaited bead no longer exists

### DIFF
--- a/cmd/bd/gate.go
+++ b/cmd/bd/gate.go
@@ -1226,10 +1226,16 @@ func checkBeadGate(ctx context.Context, st issueGetter, awaitID string) (bool, s
 	}
 	issue, err := st.GetIssue(ctx, targetID)
 	if err != nil {
+		// A bead that no longer exists can never close, so a gate awaiting it
+		// would stay pending forever. Resolve it. A transport or backend
+		// failure is a different thing entirely and must stay pending.
+		if gateProxiedNotFound(err) {
+			return true, fmt.Sprintf("awaited bead %s no longer exists (treated as resolved)", targetID)
+		}
 		return false, fmt.Sprintf("bead gate %q: %v", awaitID, err)
 	}
 	if issue == nil {
-		return false, fmt.Sprintf("bead gate %q: bead not found", awaitID)
+		return true, fmt.Sprintf("awaited bead %s no longer exists (treated as resolved)", targetID)
 	}
 	if issue.Status == types.StatusClosed {
 		return true, fmt.Sprintf("bead %s closed", targetID)

--- a/cmd/bd/gate_test.go
+++ b/cmd/bd/gate_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -257,17 +258,45 @@ func TestCheckBeadGate_LocalBead(t *testing.T) {
 	}
 }
 
+// A gate awaiting a bead that no longer exists can never resolve on its own:
+// the bead will never close. Treat the absence as resolution rather than
+// leaving the gate pending forever.
 func TestCheckBeadGate_LocalBeadNotFound(t *testing.T) {
 	st := &fakeBeadGateGetter{issues: map[string]*types.Issue{}}
 	satisfied, reason := checkBeadGate(context.Background(), st, "bd-missing")
-	if satisfied {
-		t.Error("expected not satisfied for missing local bead")
+	if !satisfied {
+		t.Errorf("expected satisfied for missing local bead, got reason %q", reason)
 	}
-	if !gateTestContainsIgnoreCase(reason, "not found") {
-		t.Errorf("reason %q does not mention not found", reason)
+	if !gateTestContainsIgnoreCase(reason, "no longer exists") {
+		t.Errorf("reason %q does not mention that the bead no longer exists", reason)
 	}
 }
 
+// Real storage reports a purged bead as an error, not as (nil, nil).
+func TestCheckBeadGate_LocalBeadErrNotFoundResolves(t *testing.T) {
+	st := &fakeBeadGateGetter{err: storage.ErrNotFound}
+	satisfied, reason := checkBeadGate(context.Background(), st, "bd-missing")
+	if !satisfied {
+		t.Errorf("expected satisfied for storage.ErrNotFound, got reason %q", reason)
+	}
+	if !gateTestContainsIgnoreCase(reason, "no longer exists") {
+		t.Errorf("reason %q does not mention that the bead no longer exists", reason)
+	}
+}
+
+func TestCheckBeadGate_LocalBeadErrNoRowsResolves(t *testing.T) {
+	st := &fakeBeadGateGetter{err: fmt.Errorf("query bead: %w", sql.ErrNoRows)}
+	satisfied, reason := checkBeadGate(context.Background(), st, "bd-missing")
+	if !satisfied {
+		t.Errorf("expected satisfied for sql.ErrNoRows, got reason %q", reason)
+	}
+	if !gateTestContainsIgnoreCase(reason, "no longer exists") {
+		t.Errorf("reason %q does not mention that the bead no longer exists", reason)
+	}
+}
+
+// Negative control: a genuine backend failure is not a missing bead, so the
+// gate must stay pending rather than silently resolving.
 func TestCheckBeadGate_LocalBeadLookupError(t *testing.T) {
 	st := &fakeBeadGateGetter{err: errors.New("dolt exploded")}
 	satisfied, reason := checkBeadGate(context.Background(), st, "bd-abc")


### PR DESCRIPTION
A `gate` bead with `await_type: bead` whose awaited bead has been purged could never resolve. `checkBeadGate` returned `(false, "bead gate %q: %v")` on the `storage.ErrNotFound` / `sql.ErrNoRows` that real storage raises for a missing row, the bead arm of `evaluateGates` never sets `r.err`, and `applyGateCheckResults` therefore fell through to the "pending" arm and exited 0. The gate sat pending forever with no diagnostic. (Wisps are purged routinely, so this is the common shape, not a corner.)

This treats a genuinely missing awaited bead as resolution, reusing the existing `gateProxiedNotFound` predicate from `gate_proxied_server.go` so a real backend or transport failure still stays pending: `bd gate` remains fail-closed on unreadable storage. The dead `issue == nil` arm gets the same treatment. `close.go` shares the helper and inherits the fix; the proxied path is unchanged. The closed gate's reason records `awaited bead <id> no longer exists (treated as resolved)`, so the resolution is auditable.

**One behavioural edge worth weighing.** `routedBeadGateGetter` → `getIssueWithRouting` returns the local store's `ErrNotFound` when prefix routing and contributor auto-routing both fail. So a cross-rig gate whose bead exists in another rig but whose `routes.jsonl` entry is missing or stale now resolves where it previously stayed pending. Separating "purged" from "unroutable" would mean threading a routing-unavailable signal out of `getIssueWithRouting`, a larger change than this fix; I judged the pending-forever default the worse failure, but it is a maintainer's call and I am happy to narrow this to local-prefix ids only if you prefer.

Not changed: the bead arm still reports a genuine backend failure through the pending arm with exit 0 rather than setting `r.err`. That is a separate defect (a gate check that cannot read storage exits 0) and deserves its own change.

Pinned by `TestCheckBeadGate_LocalBeadNotFound` (nil issue), the new `TestCheckBeadGate_LocalBeadErrNotFoundResolves` and `TestCheckBeadGate_LocalBeadErrNoRowsResolves` (a wrapped `sql.ErrNoRows`, which is what real storage produces), and `TestCheckBeadGate_LocalBeadLookupError` kept as the negative control that a generic error must NOT resolve. Three mutants (drop the not-found branch, revert the nil arm, resolve on any error) each fail exactly the test meant to catch them. Ran `gofmt -l`, `go vet ./cmd/bd/`, `go test -run 'Gate|gate' ./cmd/bd/` and `-run 'Close' ./cmd/bd/`, all green on macOS.

Wyvern bead wy-dgfuiu. Fixes the root cause behind the constellation-side workaround in wh-gate-sweep.
