### PR TITLE
test(dolt): verify shared cloud routing fixture without timing cutoff

### DIFF
--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -836,6 +836,9 @@ func clearCloudAuthEnv(t *testing.T) {
 }
 
 func TestCloudAuthCLIRouting(t *testing.T) {
+	if realDoltTestServerRequired() && testServerPort == 0 {
+		t.Fatal("Dolt server required for cloud-auth routing coverage")
+	}
 	skipIfNoServer(t)
 	clearCloudAuthEnv(t)
 	start := time.Now()

--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -881,12 +881,12 @@ func TestCloudAuthCLIRouting(t *testing.T) {
 	casesRun := 0
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			casesRun++
 			ctx := context.Background()
 			remote := fmt.Sprintf("origin_%d", i)
 			if err := store.AddRemote(ctx, remote, tt.remoteURL); err != nil {
 				t.Fatalf("AddRemote: %v", err)
 			}
+			casesRun++
 			addCloudAuthCLIRemote(t, store, remote, tt.remoteURL)
 			if tt.envKey != "" {
 				t.Setenv(tt.envKey, tt.envValue)
@@ -898,9 +898,9 @@ func TestCloudAuthCLIRouting(t *testing.T) {
 		})
 	}
 
-	// Every executed case must leave its distinct remote in the shared store.
-	// This catches per-case database creation without relying on machine speed,
-	// and counts only selected children so focused -run invocations still work.
+	// Every registered case must leave its distinct remote in the shared store.
+	// This verifies remote writes use that store; it cannot detect unused stores.
+	// Count only selected children so focused -run invocations still work.
 	remotes, err := store.ListRemotes(context.Background())
 	if err != nil {
 		t.Fatalf("ListRemotes: %v", err)

--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -870,13 +870,15 @@ func TestCloudAuthCLIRouting(t *testing.T) {
 		{"no cloud env", "az://account.blob.core.windows.net/container", "", "", false},
 	}
 	// Shared store: creating one Dolt database per case (16 total) is what
-	// made this test slow (see the regression guard below). Each case gets
+	// made this test slow (see the shared-store guard below). Each case gets
 	// its own remote name (origin_0..origin_15) against a single store,
 	// since shouldUseCLIForCloudAuth's routing decision is keyed purely by
 	// remote name — distinct names are enough to keep cases isolated.
 	store := openCloudAuthTestStore(t, "route")
+	casesRun := 0
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			casesRun++
 			ctx := context.Background()
 			remote := fmt.Sprintf("origin_%d", i)
 			if err := store.AddRemote(ctx, remote, tt.remoteURL); err != nil {
@@ -893,16 +895,17 @@ func TestCloudAuthCLIRouting(t *testing.T) {
 		})
 	}
 
-	// Regression guard: this test previously created one Dolt database per
-	// case (16 total), each slower than the last as server load grew,
-	// pushing wall time into the hundreds of seconds for a test that only
-	// exercises a pure routing predicate. 90s sits below every measured
-	// unfixed run and comfortably above the shared-store fix's expected
-	// time, so it fails on the old per-case-store shape without flaking
-	// under normal CI load.
-	if elapsed := time.Since(start); elapsed > 90*time.Second {
-		t.Fatalf("TestCloudAuthCLIRouting took %s, want < 90s (regression: are per-case Dolt databases being created again instead of a shared store?)", elapsed)
+	// Every executed case must leave its distinct remote in the shared store.
+	// This catches per-case database creation without relying on machine speed,
+	// and counts only selected children so focused -run invocations still work.
+	remotes, err := store.ListRemotes(context.Background())
+	if err != nil {
+		t.Fatalf("ListRemotes: %v", err)
 	}
+	if len(remotes) != casesRun {
+		t.Errorf("shared store has %d remotes, want %d executed cases", len(remotes), casesRun)
+	}
+	t.Logf("%d cloud auth routing cases took %s", casesRun, time.Since(start))
 }
 
 func TestCloudAuthCLIRoutingStructural(t *testing.T) {


### PR DESCRIPTION
TestCloudAuthCLIRouting's 90-second cutoff can reject a correct shared fixture on a slow machine. Preserve quad341's shared-store optimization from #5841 and all sixteen routing cases, replacing the cutoff with a direct observation: each successfully registered selected child leaves its distinct SQL remote in the outer store. Elapsed time stays diagnostic.

The case counter now increments after AddRemote succeeds. The guard comment states its precise scope: it verifies remote writes use the shared store, and cannot detect otherwise unused allocations. Focused child selection remains supported.

Actual nonroot Linux validation at this head passes two full parents/nineteen children and a focused one-child selection against real Dolt fixtures. A compiled per-case-store control inserted before AddRemote passes the routing child but fails the outer store's zero-versus-one assertion. Native Windows vet and PR lint pass. Earlier required-server-unavailable and unrequired-skip controls remain bound to their original head.

The existing BEADS_TEST_ENV_RUN_DOLT opt-in still makes the routing parent fail if its required server is unavailable; ordinary unrequired local runs retain their skip. PR Risk's Server Dolt Full Suite 1/16 job retains its flag, prerequisite package artifact, CLI and image. No TestMain, timing policy or CI job changes. Synthetic credentials test routing decisions, not live cloud transfers; Windows server stubs are not Linux/Dolt evidence, and the separate structural unavailable-server skip is not claimed as required routing coverage.

This nit changes eight lines; the full main-relative diff remains 26 changed lines in one file. The stale shard-cost comment is tracked separately in #6419. Hosted checks and local adoption remain pending.

Fixes #6382

_unknown-model/unknown-reasoning on behalf of Ewen Cuthiell_
