### PR TITLE
fix(smoke): clear the version list before child dispatch

### DIFF
--- a/scripts/upgrade-smoke-test.sh
+++ b/scripts/upgrade-smoke-test.sh
@@ -50,7 +50,7 @@ if [ -n "${SMOKE_VERSIONS:-}" ]; then
     # Run ourselves once per version, collecting exit codes
     OVERALL_FAIL=0
     for _ver in $SMOKE_VERSIONS; do
-        if ! CANDIDATE_BIN="${CANDIDATE_BIN:-}" "$0" "$_ver"; then
+        if ! SMOKE_VERSIONS= CANDIDATE_BIN="${CANDIDATE_BIN:-}" "$0" "$_ver"; then
             OVERALL_FAIL=1
         fi
     done

--- a/scripts/upgrade_smoke_loop_test.go
+++ b/scripts/upgrade_smoke_loop_test.go
@@ -1,0 +1,83 @@
+package scripts_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestUpgradeSmokeMultiVersionDispatch(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, candidate, failVersion string
+		wantExit                     int
+	}{
+		{"prebuilt", "candidate with spaces/bd", "", 0},
+		{"automatic", "", "", 0},
+		{"continues after failure", "candidate with spaces/bd", "v0.61.0", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.Mkdir(filepath.Join(dir, "scripts"), 0755); err != nil {
+				t.Fatal(err)
+			}
+			for _, path := range []string{"scripts/upgrade-smoke-test.sh", ".buildflags"} {
+				data, err := os.ReadFile(filepath.Join(sourceRepoRoot(t), path))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, path), data, 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			// Exit at child startup, before any recursion, download, build or DB work.
+			const observer = `if [ -z "${BEADS_LOOP_ROOT:-}" ]; then
+    export BEADS_LOOP_ROOT=1
+else
+    printf '%s\t%s\t%s\n' "${1:-}" "${CANDIDATE_BIN:-}" "${SMOKE_VERSIONS:-}" >> calls
+    [ -z "${SMOKE_VERSIONS:-}" ] || exit 42
+    [ "${1:-}" != "$BEADS_LOOP_FAIL" ] || exit 19
+    exit 0
+fi
+`
+			if err := os.WriteFile(filepath.Join(dir, "observe-child.sh"), []byte(observer), 0600); err != nil {
+				t.Fatal(err)
+			}
+			path := os.Getenv("PATH")
+			if runtime.GOOS == "windows" {
+				path = "/usr/bin:/bin"
+			}
+			// Relative fixture paths use the same mount under both Bash invocations.
+			env := []string{"PATH=" + path, "LC_ALL=C", "LANG=C", "ENV=", "BASH_ENV=./observe-child.sh",
+				"BEADS_LOOP_FAIL=" + tc.failVersion, "CANDIDATE_BIN=" + tc.candidate,
+				"SMOKE_VERSIONS=v0.62.0 v0.61.0 v0.60.0"}
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, bash, "--noprofile", "--norc", "scripts/upgrade-smoke-test.sh")
+			cmd.Dir, cmd.Env = dir, env
+			out, err := cmd.CombinedOutput()
+			if ctx.Err() != nil || cmd.ProcessState == nil || cmd.ProcessState.ExitCode() != tc.wantExit {
+				t.Fatalf("dispatch exit = %v, want %d: %s", err, tc.wantExit, out)
+			}
+			got, err := os.ReadFile(filepath.Join(dir, "calls"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var want strings.Builder
+			for _, version := range []string{"v0.62.0", "v0.61.0", "v0.60.0"} {
+				want.WriteString(version + "\t" + tc.candidate + "\t\n")
+			}
+			if string(got) != want.String() {
+				t.Fatalf("child dispatch = %q, want %q", got, want.String())
+			}
+		})
+	}
+}

--- a/scripts/upgrade_smoke_loop_test.go
+++ b/scripts/upgrade_smoke_loop_test.go
@@ -26,42 +26,64 @@ func TestUpgradeSmokeMultiVersionDispatch(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
+			const scriptPath = "scripts/upgrade-smoke-test.sh"
 			const candidateHelper = "scripts/lib/smoke-candidate.sh"
-			for _, path := range []string{"scripts/upgrade-smoke-test.sh", ".buildflags", candidateHelper} {
-				data, err := os.ReadFile(filepath.Join(sourceRepoRoot(t), path))
-				if err != nil {
-					if path == candidateHelper && os.IsNotExist(err) {
-						continue
+			script, err := os.ReadFile(filepath.Join(sourceRepoRoot(t), scriptPath))
+			if err != nil {
+				t.Fatal(err)
+			}
+			shebang, body, ok := strings.Cut(string(script), "\n")
+			if !ok || !strings.HasPrefix(shebang, "#!") {
+				t.Fatal("upgrade smoke entrypoint must start with a shebang")
+			}
+			// Observe the child's script body, where Bash 3.2 has assigned positional arguments.
+			// The actual dispatch body below this insertion stays byte-for-byte unchanged.
+			const observer = `if [ -z "${BEADS_LOOP_ROOT:-}" ]; then
+    export BEADS_LOOP_ROOT=1
+else
+    if [ -z "${1:-}" ]; then
+        printf 'child version is empty (BASH_VERSION=%s)\n' "${BASH_VERSION:-unknown}" >&2
+        exit 43
+    fi
+    printf '%s\t%s\t%s\n' "$1" "${CANDIDATE_BIN:-}" "${SMOKE_VERSIONS:-}" >> calls
+    if [ -n "${SMOKE_VERSIONS:-}" ]; then
+        printf 'child inherited loop control (BASH_VERSION=%s)\n' "${BASH_VERSION:-unknown}" >&2
+        exit 42
+    fi
+    [ "$1" != "${BEADS_LOOP_FAIL:-}" ] || exit 19
+    exit 0
+fi
+`
+			script = []byte(shebang + "\n" + observer + body)
+			for _, path := range []string{scriptPath, ".buildflags", candidateHelper} {
+				data := script
+				mode := os.FileMode(0644)
+				if path == scriptPath {
+					mode = 0755
+				} else {
+					data, err = os.ReadFile(filepath.Join(sourceRepoRoot(t), path))
+					if err != nil {
+						// Standalone sources predate the helper; a composed reference requires it.
+						if path == candidateHelper && os.IsNotExist(err) && !strings.Contains(body, "smoke-candidate.sh") {
+							continue
+						}
+						t.Fatal(err)
 					}
-					t.Fatal(err)
 				}
 				destination := filepath.Join(dir, path)
 				if err := os.MkdirAll(filepath.Dir(destination), 0755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(destination, data, 0755); err != nil {
+				if err := os.WriteFile(destination, data, mode); err != nil {
 					t.Fatal(err)
 				}
-			}
-			// Exit at child startup, before any recursion, download, build or DB work.
-			const observer = `if [ -z "${BEADS_LOOP_ROOT:-}" ]; then
-    export BEADS_LOOP_ROOT=1
-else
-    printf '%s\t%s\t%s\n' "${1:-}" "${CANDIDATE_BIN:-}" "${SMOKE_VERSIONS:-}" >> calls
-    [ -z "${SMOKE_VERSIONS:-}" ] || exit 42
-    [ "${1:-}" != "$BEADS_LOOP_FAIL" ] || exit 19
-    exit 0
-fi
-`
-			if err := os.WriteFile(filepath.Join(dir, "observe-child.sh"), []byte(observer), 0600); err != nil {
-				t.Fatal(err)
 			}
 			path := os.Getenv("PATH")
 			if runtime.GOOS == "windows" {
 				path = "/usr/bin:/bin"
 			}
 			// Relative fixture paths use the same mount under both Bash invocations.
-			env := []string{"PATH=" + path, "LC_ALL=C", "LANG=C", "ENV=", "BASH_ENV=./observe-child.sh",
+			env := []string{"PATH=" + path, "LC_ALL=C", "LANG=C", "ENV=", "BASH_ENV=",
 				"BEADS_LOOP_FAIL=" + tc.failVersion, "CANDIDATE_BIN=" + tc.candidate,
 				"SMOKE_VERSIONS=v0.62.0 v0.61.0 v0.60.0"}
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/scripts/upgrade_smoke_loop_test.go
+++ b/scripts/upgrade_smoke_loop_test.go
@@ -26,15 +26,20 @@ func TestUpgradeSmokeMultiVersionDispatch(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			if err := os.Mkdir(filepath.Join(dir, "scripts"), 0755); err != nil {
-				t.Fatal(err)
-			}
-			for _, path := range []string{"scripts/upgrade-smoke-test.sh", ".buildflags"} {
+			const candidateHelper = "scripts/lib/smoke-candidate.sh"
+			for _, path := range []string{"scripts/upgrade-smoke-test.sh", ".buildflags", candidateHelper} {
 				data, err := os.ReadFile(filepath.Join(sourceRepoRoot(t), path))
 				if err != nil {
+					if path == candidateHelper && os.IsNotExist(err) {
+						continue
+					}
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(dir, path), data, 0755); err != nil {
+				destination := filepath.Join(dir, path)
+				if err := os.MkdirAll(filepath.Dir(destination), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(destination, data, 0755); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/scripts/upgrade_smoke_loop_test.go
+++ b/scripts/upgrade_smoke_loop_test.go
@@ -83,6 +83,7 @@ fi
 				path = "/usr/bin:/bin"
 			}
 			// Relative fixture paths use the same mount under both Bash invocations.
+			// HOME stays absent to stop a child missing the observer before smoke setup.
 			env := []string{"PATH=" + path, "LC_ALL=C", "LANG=C", "ENV=", "BASH_ENV=",
 				"BEADS_LOOP_FAIL=" + tc.failVersion, "CANDIDATE_BIN=" + tc.candidate,
 				"SMOKE_VERSIONS=v0.62.0 v0.61.0 v0.60.0"}
@@ -96,14 +97,14 @@ fi
 			}
 			got, err := os.ReadFile(filepath.Join(dir, "calls"))
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("read child dispatch: %v; output: %s", err, out)
 			}
 			var want strings.Builder
 			for _, version := range []string{"v0.62.0", "v0.61.0", "v0.60.0"} {
 				want.WriteString(version + "\t" + tc.candidate + "\t\n")
 			}
 			if string(got) != want.String() {
-				t.Fatalf("child dispatch = %q, want %q", got, want.String())
+				t.Fatalf("child dispatch = %q, want %q; output: %s", got, want.String(), out)
 			}
 		})
 	}


### PR DESCRIPTION
With `SMOKE_VERSIONS` set, each upgrade-smoke child inherited the list and entered the version loop again. Clear the list for each child so requested versions run once, with `CANDIDATE_BIN` forwarded and failures collected while later versions continue.

The regression copies the actual script and inserts a bounded observer after its shebang, where Bash 3.2 has assigned positional arguments. Three cases require complete ordered logs for a candidate path with spaces, automatic candidates, and a failed middle version. Referenced candidate helpers are required; sourced inputs remain non-executable.

Review follow-up ([round 3](https://github.com/gastownhall/beads/pull/6398#pullrequestreview-5142402160)): addressed both nits. Missing or incorrect child logs now include captured output, and the fixture explains why HOME stays absent.

Validation: the three cases, scoped vet and lint pass on native Windows. The prior `496141d790` validation also exercised the unchanged dispatch/observer logic with real Bash 3.2.57 and the actual #6386 script/helper; that historical run is not a fresh macOS result. Required hosted checks remain pending.

This update changes five lines in one test file; the full PR is 113 added/deleted lines in two files. It extends maphew's version loop from #3146; candidate preparation remains owned by #6386.

Fixes #6383

_Codex-unknown-model-unknown-reasoning on behalf of Ewen Cuthiell_
