### PR TITLE
fix(gate): report an unreadable store as an error, not a pending bead gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`bd gate check` no longer reports an unreadable store as "pending".** The
+  bead arm of the check dropped the lookup error on the floor, so with dolt
+  down (or any backend or transport failure on the awaited bead's read) every
+  bead gate printed as still waiting and the command exited 0 — the same
+  output as a healthy, genuinely pending gate. A read that fails for any
+  reason other than not-found is now an error row (`✗ <gate>: error checking -
+  ...`), counted in the summary, and `bd gate check` exits non-zero whenever
+  any gate could not be checked, on the classic and proxied routes alike. A
+  missing bead still stays pending. `bd close` on such a gate keeps refusing
+  (`could not check bead gate`, `--force` to override) rather than letting a
+  dead store read as satisfied.
+
 - **`bd prime` says when it could NOT read the memory plane**
   ([#5877](https://github.com/gastownhall/beads/issues/5877)). A broken or
   unreachable store made prime omit the memory section entirely, so a session

--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -568,7 +568,13 @@ func checkGateSatisfaction(issue *types.Issue) error {
 	case issue.AwaitType == "timer":
 		resolved, escalated, reason, err = checkTimer(issue, time.Now())
 	case issue.AwaitType == "bead":
-		resolved, reason = checkBeadGate(rootCtx, routedBeadGateGetter{localStore: store}, issue.AwaitID)
+		resolved, reason, err = checkBeadGate(rootCtx, routedBeadGateGetter{localStore: store}, issue.AwaitID)
+		if err != nil {
+			// Unlike the gh:* and timer arms above, a bead gate whose store
+			// cannot be read stays closed: the close would need that same
+			// store, and "could not read" must not pass as "satisfied".
+			return fmt.Errorf("gate condition not satisfied: could not check bead gate: %v (use --force to override)", err)
+		}
 		if resolved {
 			return nil
 		}

--- a/cmd/bd/gate.go
+++ b/cmd/bd/gate.go
@@ -721,7 +721,7 @@ func evaluateGates(ctx context.Context, gates []*types.Issue, now time.Time, get
 		case gate.AwaitType == "timer":
 			r.resolved, r.escalated, r.reason, r.err = checkTimer(gate, now)
 		case gate.AwaitType == "bead":
-			r.resolved, r.reason = checkBeadGate(ctx, getter, gate.AwaitID)
+			r.resolved, r.reason, r.err = checkBeadGate(ctx, getter, gate.AwaitID)
 		default:
 			continue
 		}
@@ -781,13 +781,20 @@ func printGateCheckSummary(checked, resolvedCount, escalatedCount, errorCount in
 		checked, resolvedCount, escalatedCount, errorCount)
 
 	if jsonOutput {
-		return outputJSON(map[string]interface{}{
+		if err := outputJSON(map[string]interface{}{
 			"checked":   checked,
 			"resolved":  resolvedCount,
 			"escalated": escalatedCount,
 			"errors":    errorCount,
 			"dry_run":   dryRun,
-		})
+		}); err != nil {
+			return err
+		}
+	}
+	if errorCount > 0 {
+		// A gate whose condition could not be read is neither resolved nor
+		// pending; the caller must not mistake this run for a clean sweep.
+		return fmt.Errorf("%d gate(s) could not be checked", errorCount)
 	}
 	return nil
 }
@@ -1203,38 +1210,45 @@ func (g routedBeadGateGetter) GetIssue(ctx context.Context, id string) (*types.I
 }
 
 // checkBeadGate checks if a bead gate is satisfied.
-// Returns (satisfied, reason).
+// Returns (satisfied, reason, err). A non-nil err means the awaited bead could
+// not be read at all (backend or transport failure): the gate is neither
+// satisfied nor pending, and the caller reports it as an error rather than
+// letting a dead store read as "still waiting". A missing bead is not an
+// error; it stays pending with a not-found reason.
 //
 // A plain await_id names a bead in this rig. The historical
 // <rig>:<bead-id> form uses the bead ID as the routed lookup key; the rig
 // component is retained for compatibility while routes.jsonl remains keyed by
 // bead prefix. The supplied getter owns local-versus-routed lookup policy.
-func checkBeadGate(ctx context.Context, st issueGetter, awaitID string) (bool, string) {
+func checkBeadGate(ctx context.Context, st issueGetter, awaitID string) (bool, string, error) {
 	if awaitID == "" {
-		return false, "bead gate has no await_id"
+		return false, "bead gate has no await_id", nil
 	}
 	targetID := awaitID
 	if strings.Contains(awaitID, ":") {
 		parts := strings.SplitN(awaitID, ":", 2)
 		if parts[0] == "" || parts[1] == "" {
-			return false, fmt.Sprintf("invalid cross-rig bead gate %q: expected <rig>:<bead-id>", awaitID)
+			return false, fmt.Sprintf("invalid cross-rig bead gate %q: expected <rig>:<bead-id>", awaitID), nil
 		}
 		targetID = parts[1]
 	}
 	if st == nil {
-		return false, fmt.Sprintf("bead gate %q: no local store available", awaitID)
+		return false, fmt.Sprintf("bead gate %q: no local store available", awaitID), nil
 	}
 	issue, err := st.GetIssue(ctx, targetID)
 	if err != nil {
-		return false, fmt.Sprintf("bead gate %q: %v", awaitID, err)
+		if gateProxiedNotFound(err) || isNotFoundErr(err) {
+			return false, fmt.Sprintf("bead gate %q: bead not found", awaitID), nil
+		}
+		return false, "", fmt.Errorf("bead gate %q: %w", awaitID, err)
 	}
 	if issue == nil {
-		return false, fmt.Sprintf("bead gate %q: bead not found", awaitID)
+		return false, fmt.Sprintf("bead gate %q: bead not found", awaitID), nil
 	}
 	if issue.Status == types.StatusClosed {
-		return true, fmt.Sprintf("bead %s closed", targetID)
+		return true, fmt.Sprintf("bead %s closed", targetID), nil
 	}
-	return false, fmt.Sprintf("bead %s is %s", targetID, issue.Status)
+	return false, fmt.Sprintf("bead %s is %s", targetID, issue.Status), nil
 }
 
 // closeGate closes a gate issue with the given reason

--- a/cmd/bd/gate_routing_test.go
+++ b/cmd/bd/gate_routing_test.go
@@ -62,12 +62,12 @@ func TestCheckBeadGateCrossRigPrefixRoute(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chdir(oldWD) })
 
 	getter := routedBeadGateGetter{localStore: townStore}
-	resolved, reason := checkBeadGate(ctx, getter, "rig:gt-closed")
+	resolved, reason, _ := checkBeadGate(ctx, getter, "rig:gt-closed")
 	if !resolved {
 		t.Fatalf("closed cross-rig target did not resolve gate: %s", reason)
 	}
 
-	resolved, reason = checkBeadGate(ctx, getter, "rig:gt-open")
+	resolved, reason, _ = checkBeadGate(ctx, getter, "rig:gt-open")
 	if resolved {
 		t.Fatalf("open cross-rig target unexpectedly resolved gate: %s", reason)
 	}

--- a/cmd/bd/gate_test.go
+++ b/cmd/bd/gate_test.go
@@ -6,12 +6,15 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
@@ -173,7 +176,7 @@ func TestCheckBeadGate_CrossRigUsesBeadIDForRoutedLookup(t *testing.T) {
 		"gt-abc": {ID: "gt-abc", Status: types.StatusClosed},
 	}}
 
-	satisfied, reason := checkBeadGate(ctx, st, "gastown:gt-abc")
+	satisfied, reason, _ := checkBeadGate(ctx, st, "gastown:gt-abc")
 	if !satisfied {
 		t.Fatalf("expected closed routed bead to satisfy gate, got reason %q", reason)
 	}
@@ -207,7 +210,7 @@ func TestCheckBeadGate_InvalidCrossRigFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			satisfied, reason := checkBeadGate(ctx, nil, tt.awaitID)
+			satisfied, reason, _ := checkBeadGate(ctx, nil, tt.awaitID)
 			if satisfied {
 				t.Errorf("expected not satisfied for %q", tt.awaitID)
 			}
@@ -219,7 +222,7 @@ func TestCheckBeadGate_InvalidCrossRigFormat(t *testing.T) {
 }
 
 func TestCheckBeadGate_EmptyAwaitID(t *testing.T) {
-	satisfied, reason := checkBeadGate(context.Background(), nil, "")
+	satisfied, reason, _ := checkBeadGate(context.Background(), nil, "")
 	if satisfied {
 		t.Error("expected not satisfied for empty await_id")
 	}
@@ -240,7 +243,7 @@ func TestCheckBeadGate_LocalBead(t *testing.T) {
 		},
 	}
 
-	satisfied, reason := checkBeadGate(ctx, st, "bd-closed")
+	satisfied, reason, _ := checkBeadGate(ctx, st, "bd-closed")
 	if !satisfied {
 		t.Errorf("expected satisfied for closed local bead, got reason %q", reason)
 	}
@@ -248,7 +251,7 @@ func TestCheckBeadGate_LocalBead(t *testing.T) {
 		t.Errorf("reason %q does not mention closed", reason)
 	}
 
-	satisfied, reason = checkBeadGate(ctx, st, "bd-open")
+	satisfied, reason, _ = checkBeadGate(ctx, st, "bd-open")
 	if satisfied {
 		t.Error("expected not satisfied for open local bead")
 	}
@@ -259,7 +262,7 @@ func TestCheckBeadGate_LocalBead(t *testing.T) {
 
 func TestCheckBeadGate_LocalBeadNotFound(t *testing.T) {
 	st := &fakeBeadGateGetter{issues: map[string]*types.Issue{}}
-	satisfied, reason := checkBeadGate(context.Background(), st, "bd-missing")
+	satisfied, reason, _ := checkBeadGate(context.Background(), st, "bd-missing")
 	if satisfied {
 		t.Error("expected not satisfied for missing local bead")
 	}
@@ -269,18 +272,125 @@ func TestCheckBeadGate_LocalBeadNotFound(t *testing.T) {
 }
 
 func TestCheckBeadGate_LocalBeadLookupError(t *testing.T) {
-	st := &fakeBeadGateGetter{err: errors.New("dolt exploded")}
-	satisfied, reason := checkBeadGate(context.Background(), st, "bd-abc")
+	// A store that cannot be read is an error, not a pending gate: the
+	// caller must be able to tell "dolt is down" from "still waiting".
+	boom := errors.New("dolt exploded")
+	st := &fakeBeadGateGetter{err: boom}
+	satisfied, reason, err := checkBeadGate(context.Background(), st, "bd-abc")
 	if satisfied {
 		t.Error("expected not satisfied on lookup error")
 	}
-	if !gateTestContainsIgnoreCase(reason, "dolt exploded") {
-		t.Errorf("reason %q does not carry the lookup error", reason)
+	if err == nil {
+		t.Fatal("expected a lookup error to be returned as an error")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("err = %v, want it to wrap the lookup error", err)
+	}
+	if !gateTestContainsIgnoreCase(err.Error(), "dolt exploded") {
+		t.Errorf("err %q does not carry the lookup error", err)
+	}
+	if reason != "" {
+		t.Errorf("reason = %q, want empty on an error", reason)
+	}
+}
+
+func TestCheckBeadGate_LocalBeadNotFoundErrorStaysPending(t *testing.T) {
+	// A getter that reports absence through an error (the routed getter
+	// surfaces storage.ErrNotFound; the proxied fresh-read getter surfaces
+	// sql.ErrNoRows) is a missing bead, not a broken store.
+	for _, tt := range []struct {
+		name string
+		err  error
+	}{
+		{name: "storage sentinel", err: storage.ErrNotFound},
+		{name: "wrapped storage sentinel", err: fmt.Errorf("lookup bd-missing: %w", storage.ErrNotFound)},
+		{name: "sql no rows", err: sql.ErrNoRows},
+		{name: "partial-id resolver text", err: errors.New("no issue found matching bd-missing")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			st := &fakeBeadGateGetter{err: tt.err}
+			satisfied, reason, err := checkBeadGate(context.Background(), st, "bd-missing")
+			if err != nil {
+				t.Fatalf("not-found must stay pending, got error %v", err)
+			}
+			if satisfied {
+				t.Error("expected not satisfied for a missing bead")
+			}
+			if !gateTestContainsIgnoreCase(reason, "not found") {
+				t.Errorf("reason %q does not mention not found", reason)
+			}
+		})
+	}
+}
+
+func TestEvaluateGates_BeadStoreErrorCountsAsError(t *testing.T) {
+	// The bead arm used to drop the lookup error on the floor, so a dead
+	// store reported every bead gate as pending and the check exited 0.
+	gate := &types.Issue{ID: "bd-gate", IssueType: "gate", AwaitType: "bead", AwaitID: "bd-abc"}
+	st := &fakeBeadGateGetter{err: errors.New("dolt exploded")}
+
+	results := evaluateGates(context.Background(), []*types.Issue{gate}, time.Now(), st, nil)
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if results[0].err == nil {
+		t.Fatal("expected the store error on the result")
+	}
+	if results[0].resolved {
+		t.Error("a store error must not resolve the gate")
+	}
+
+	closeCalls := 0
+	var resolved, escalated, errCount int
+	_ = captureGateStdout(t, func() {
+		resolved, escalated, errCount = applyGateCheckResults(results, false, false, func(*types.Issue, string) error {
+			closeCalls++
+			return nil
+		})
+	})
+	if errCount != 1 || resolved != 0 || escalated != 0 {
+		t.Errorf("counts = (resolved %d, escalated %d, errors %d), want (0, 0, 1)", resolved, escalated, errCount)
+	}
+	if closeCalls != 0 {
+		t.Errorf("closeResolved called %d times on an errored gate", closeCalls)
+	}
+}
+
+func TestPrintGateCheckSummary_ErrorsFailTheCommand(t *testing.T) {
+	origJSON := jsonOutput
+	t.Cleanup(func() { jsonOutput = origJSON })
+
+	for _, tt := range []struct {
+		name    string
+		json    bool
+		errors  int
+		wantErr bool
+	}{
+		{name: "clean sweep", errors: 0, wantErr: false},
+		{name: "one unreadable gate", errors: 1, wantErr: true},
+		{name: "json still fails", json: true, errors: 2, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonOutput = tt.json
+			var err error
+			out := captureGateStdout(t, func() {
+				err = printGateCheckSummary(3, 1, 0, tt.errors, false)
+			})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v (output %q)", err, tt.wantErr, out)
+			}
+			if !strings.Contains(out, "Checked 3 gates") {
+				t.Errorf("summary line missing from output %q", out)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), "could not be checked") {
+				t.Errorf("err %q does not say the gates could not be checked", err)
+			}
+		})
 	}
 }
 
 func TestCheckBeadGate_NilStoreStaysPending(t *testing.T) {
-	satisfied, reason := checkBeadGate(context.Background(), nil, "bd-abc")
+	satisfied, reason, _ := checkBeadGate(context.Background(), nil, "bd-abc")
 	if satisfied {
 		t.Error("expected not satisfied with no store")
 	}


### PR DESCRIPTION
## What

`bd gate check` treated a bead gate whose awaited bead could not be read (dolt down, sql error, transport failure) as **pending**: `evaluateGates` set `r.err` for the `gh:run` / `gh:pr` / `timer` arms but never for the `bead` arm, so the failure fell through `applyGateCheckResults`' pending branch with no error row, no error count and exit 0 — the same output as a healthy gate still waiting.

- `checkBeadGate` returns `(satisfied, reason, err)`. A read failing for anything other than not-found is an error; a missing bead stays pending with the not-found reason (`storage.ErrNotFound`, `sql.ErrNoRows` and the partial-id resolver text all count as not-found, via the existing `gateProxiedNotFound` / `isNotFoundErr`).
- `printGateCheckSummary` returns an error when `errorCount > 0`, so the command exits non-zero on both the classic and proxied routes. The summary line and the JSON object still print first.
- `bd close` on such a gate keeps refusing (`gate condition not satisfied: could not check bead gate: … (use --force to override)`) — fail closed, since the close would need the same store.

Follow-up from #6395 (which resolves a gate whose awaited bead was purged and deliberately left this half alone). Both touch the same `err != nil` arm; this PR uses the same not-found predicate #6395 introduces there, so whichever lands second is a one-line rebase. I'll do it.

## Tests

- `TestCheckBeadGate_LocalBeadLookupError` now asserts the wrapped error and an empty reason.
- `TestCheckBeadGate_LocalBeadNotFoundErrorStaysPending` — four not-found shapes stay pending, no error.
- `TestEvaluateGates_BeadStoreErrorCountsAsError` — error on the result, `errorCount == 1`, no close.
- `TestPrintGateCheckSummary_ErrorsFailTheCommand` — clean sweep nil; errors non-nil, JSON included.
- `gate_routing_test.go` call sites updated for the new signature.

Runs (macOS arm64): `gofmt -l cmd/bd/` empty; `go vet ./cmd/bd/` rc 0; `go test -count=1 -run 'TestCheckBeadGate|TestEvaluateGates|TestPrintGateCheckSummary|TestCheckGateSatisfaction|TestGateCheck_|TestShouldCheckGate|TestIsMachineCheckableGate|TestProxiedFreshReadGetter|TestBeadGate|Routing' ./cmd/bd/` ok. Three mutants (drop `r.err` on the bead arm; summary ignores `errorCount`; not-found treated as error) each fail exactly their test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNYoASfCXUd5AeeCNiXn51
