### PR TITLE
fix(doctor): escape database identifiers instead of rejecting them

### DIFF
--- a/cmd/bd/doctor/fix/metadata.go
+++ b/cmd/bd/doctor/fix/metadata.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -246,12 +245,6 @@ func FixMissingDoltDatabase(path string) error {
 	return nil
 }
 
-// doltIdentifierPattern matches legal MySQL/Dolt database identifiers.
-// Candidates that fail it are skipped rather than interpolated into a query,
-// so a hostile database name on a shared server can never break out of the
-// backtick quoting.
-var doltIdentifierPattern = regexp.MustCompile(`^[A-Za-z0-9_$]+$`)
-
 // probeForCorrectDoltDatabase checks if another database on the server has the
 // expected beads tables (issues, dependencies, config). Returns the database name
 // if found, empty string otherwise.
@@ -287,13 +280,13 @@ func probeForCorrectDoltDatabase(db *sql.DB, skipDB string) string {
 	}
 
 	for _, dbName := range candidates {
-		if !doltIdentifierPattern.MatchString(dbName) {
-			continue
-		}
+		// Escape backticks in database name to prevent SQL injection (` → ``)
+		safeName := strings.ReplaceAll(dbName, "`", "``")
+
 		var count int
-		//nolint:gosec // G201: dbName is validated against doltIdentifierPattern above
+		//nolint:gosec // G201: identifier-escaped, dbName from SHOW DATABASES
 		err := db.QueryRowContext(ctx,
-			fmt.Sprintf("SELECT COUNT(*) FROM `%s`.issues LIMIT 1", dbName)).Scan(&count)
+			fmt.Sprintf("SELECT COUNT(*) FROM `%s`.issues LIMIT 1", safeName)).Scan(&count)
 		if err == nil {
 			return dbName
 		}

--- a/cmd/bd/doctor/fix/metadata.go
+++ b/cmd/bd/doctor/fix/metadata.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -245,6 +246,12 @@ func FixMissingDoltDatabase(path string) error {
 	return nil
 }
 
+// doltIdentifierPattern matches legal MySQL/Dolt database identifiers.
+// Candidates that fail it are skipped rather than interpolated into a query,
+// so a hostile database name on a shared server can never break out of the
+// backtick quoting.
+var doltIdentifierPattern = regexp.MustCompile(`^[A-Za-z0-9_$]+$`)
+
 // probeForCorrectDoltDatabase checks if another database on the server has the
 // expected beads tables (issues, dependencies, config). Returns the database name
 // if found, empty string otherwise.
@@ -280,8 +287,11 @@ func probeForCorrectDoltDatabase(db *sql.DB, skipDB string) string {
 	}
 
 	for _, dbName := range candidates {
+		if !doltIdentifierPattern.MatchString(dbName) {
+			continue
+		}
 		var count int
-		//nolint:gosec // G201: dbName from SHOW DATABASES, not user input
+		//nolint:gosec // G201: dbName is validated against doltIdentifierPattern above
 		err := db.QueryRowContext(ctx,
 			fmt.Sprintf("SELECT COUNT(*) FROM `%s`.issues LIMIT 1", dbName)).Scan(&count)
 		if err == nil {

--- a/cmd/bd/doctor/fix/metadata_probe_test.go
+++ b/cmd/bd/doctor/fix/metadata_probe_test.go
@@ -1,58 +1,89 @@
 package fix
 
 import (
+	"database/sql"
+	"errors"
+	"reflect"
 	"regexp"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 )
 
-// probeForCorrectDoltDatabase interpolates candidate database names into a
-// backtick-quoted query. Names that could break out of that quoting (backticks,
-// whitespace, dashes, semicolons) must be skipped before any query is built, so
-// a hostile database on a shared server can't steer the probe.
-func TestProbeForCorrectDoltDatabaseSkipsUnsafeNames(t *testing.T) {
-	db, mock, err := sqlmock.New()
+// newRecordingMock wraps sqlmock with a matcher that records every query the
+// code actually issues, so assertions run against the full executed set —
+// including queries whose (escaped) text is hostile-looking. sqlmock's default
+// expectation failure path cannot pin this property on its own: an unexpected
+// query surfaces as an error the probe is allowed to swallow, and
+// ExpectationsWereMet only sees the queries that were expected.
+func newRecordingMock(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *[]string) {
+	t.Helper()
+	var recorded []string
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherFunc(
+		func(expectedSQL, actualSQL string) error {
+			recorded = append(recorded, actualSQL)
+			return sqlmock.QueryMatcherRegexp.Match(expectedSQL, actualSQL)
+		},
+	)))
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer func() { _ = db.Close() }()
+	t.Cleanup(func() { _ = db.Close() })
+	return db, mock, &recorded
+}
+
+// probeForCorrectDoltDatabase interpolates candidate database names into a
+// backtick-quoted query. Two properties must hold together:
+//
+//  1. Every candidate is probed with backtick-doubling (the complete escape
+//     for a backtick-quoted identifier), so a hostile name on a shared server
+//     stays inert inside the quoting — the probe merely errors and the
+//     candidate is skipped.
+//  2. Legal names that are not unquoted-charset-safe still probe verbatim.
+//     Legacy databases were named from raw prefixes before GH#2142
+//     (`my-project`-style, hyphens included) and this probe is the doctor's
+//     mechanism for finding them.
+func TestProbeForCorrectDoltDatabaseEscapesHostileNames(t *testing.T) {
+	db, mock, recorded := newRecordingMock(t)
 
 	databases := sqlmock.NewRows([]string{"Database"}).
 		AddRow("x`; DROP TABLE issues; --").
-		AddRow("good_db")
+		AddRow("my-project")
 	mock.ExpectQuery("SHOW DATABASES").WillReturnRows(databases)
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM `good_db`.issues LIMIT 1")).
+	escapedHostile := regexp.QuoteMeta("SELECT COUNT(*) FROM `x``; DROP TABLE issues; --`.issues LIMIT 1")
+	mock.ExpectQuery(escapedHostile).WillReturnError(errors.New("table not found"))
+
+	legacyHyphen := regexp.QuoteMeta("SELECT COUNT(*) FROM `my-project`.issues LIMIT 1")
+	mock.ExpectQuery(legacyHyphen).
 		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(3))
 
-	if got := probeForCorrectDoltDatabase(db, ""); got != "good_db" {
-		t.Fatalf("probeForCorrectDoltDatabase = %q, want %q", got, "good_db")
+	if got := probeForCorrectDoltDatabase(db, ""); got != "my-project" {
+		t.Fatalf("probeForCorrectDoltDatabase = %q, want %q", got, "my-project")
 	}
 
+	want := []string{
+		"SHOW DATABASES",
+		"SELECT COUNT(*) FROM `x``; DROP TABLE issues; --`.issues LIMIT 1",
+		"SELECT COUNT(*) FROM `my-project`.issues LIMIT 1",
+	}
+	if !reflect.DeepEqual(*recorded, want) {
+		t.Fatalf("executed queries = %q, want %q", *recorded, want)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unexpected queries: %v", err)
 	}
 }
 
-func TestDoltIdentifierPattern(t *testing.T) {
-	cases := []struct {
-		name string
-		ok   bool
-	}{
-		{"beads", true},
-		{"beads_prod", true},
-		{"db$money", true},
-		{"", false},
-		{"bad name", false},
-		{"back`tick", false},
-		{"semi;colon", false},
-		{"dash-name", false},
-		{"quote'name", false},
-	}
-	for _, tc := range cases {
-		if got := doltIdentifierPattern.MatchString(tc.name); got != tc.ok {
-			t.Errorf("doltIdentifierPattern.MatchString(%q) = %v, want %v", tc.name, got, tc.ok)
-		}
+func TestProbeForCorrectDoltDatabasePrefersFirstProbeableCandidate(t *testing.T) {
+	db, mock, _ := newRecordingMock(t)
+
+	databases := sqlmock.NewRows([]string{"Database"}).AddRow("beads")
+	mock.ExpectQuery("SHOW DATABASES").WillReturnRows(databases)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM `beads`.issues LIMIT 1")).
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(1))
+
+	if got := probeForCorrectDoltDatabase(db, ""); got != "beads" {
+		t.Fatalf("probeForCorrectDoltDatabase = %q, want %q", got, "beads")
 	}
 }

--- a/cmd/bd/doctor/fix/metadata_probe_test.go
+++ b/cmd/bd/doctor/fix/metadata_probe_test.go
@@ -10,12 +10,13 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 )
 
-// newRecordingMock wraps sqlmock with a matcher that records every query the
-// code actually issues, so assertions run against the full executed set —
-// including queries whose (escaped) text is hostile-looking. sqlmock's default
-// expectation failure path cannot pin this property on its own: an unexpected
-// query surfaces as an error the probe is allowed to swallow, and
-// ExpectationsWereMet only sees the queries that were expected.
+// newRecordingMock wraps sqlmock with a matcher that appends each actual query
+// to a recorded list before delegating to the default regexp matcher. The
+// recorded list pins the ordered set of queries that reached expectation
+// matching; it does not capture queries sqlmock rejects before matching (an
+// unexpected query surfaces as an error the probe's `err == nil` path
+// swallows), so the assertions pair DeepEqual on the recording with
+// ExpectationsWereMet rather than claiming either alone sees everything.
 func newRecordingMock(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *[]string) {
 	t.Helper()
 	var recorded []string
@@ -76,14 +77,30 @@ func TestProbeForCorrectDoltDatabaseEscapesHostileNames(t *testing.T) {
 }
 
 func TestProbeForCorrectDoltDatabasePrefersFirstProbeableCandidate(t *testing.T) {
-	db, mock, _ := newRecordingMock(t)
+	db, mock, recorded := newRecordingMock(t)
 
-	databases := sqlmock.NewRows([]string{"Database"}).AddRow("beads")
+	databases := sqlmock.NewRows([]string{"Database"}).AddRow("stale-db").AddRow("beads")
 	mock.ExpectQuery("SHOW DATABASES").WillReturnRows(databases)
+	// The first candidate's probe fails (no issues table): it is probed, not
+	// skipped, and the scan continues to the second candidate.
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM `stale-db`.issues LIMIT 1")).
+		WillReturnError(errors.New("table not found"))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM `beads`.issues LIMIT 1")).
 		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(1))
 
 	if got := probeForCorrectDoltDatabase(db, ""); got != "beads" {
 		t.Fatalf("probeForCorrectDoltDatabase = %q, want %q", got, "beads")
+	}
+
+	want := []string{
+		"SHOW DATABASES",
+		"SELECT COUNT(*) FROM `stale-db`.issues LIMIT 1",
+		"SELECT COUNT(*) FROM `beads`.issues LIMIT 1",
+	}
+	if !reflect.DeepEqual(*recorded, want) {
+		t.Fatalf("executed queries = %q, want %q", *recorded, want)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unexpected queries: %v", err)
 	}
 }

--- a/cmd/bd/doctor/fix/metadata_probe_test.go
+++ b/cmd/bd/doctor/fix/metadata_probe_test.go
@@ -1,0 +1,58 @@
+package fix
+
+import (
+	"regexp"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+// probeForCorrectDoltDatabase interpolates candidate database names into a
+// backtick-quoted query. Names that could break out of that quoting (backticks,
+// whitespace, dashes, semicolons) must be skipped before any query is built, so
+// a hostile database on a shared server can't steer the probe.
+func TestProbeForCorrectDoltDatabaseSkipsUnsafeNames(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	databases := sqlmock.NewRows([]string{"Database"}).
+		AddRow("x`; DROP TABLE issues; --").
+		AddRow("good_db")
+	mock.ExpectQuery("SHOW DATABASES").WillReturnRows(databases)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM `good_db`.issues LIMIT 1")).
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(3))
+
+	if got := probeForCorrectDoltDatabase(db, ""); got != "good_db" {
+		t.Fatalf("probeForCorrectDoltDatabase = %q, want %q", got, "good_db")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unexpected queries: %v", err)
+	}
+}
+
+func TestDoltIdentifierPattern(t *testing.T) {
+	cases := []struct {
+		name string
+		ok   bool
+	}{
+		{"beads", true},
+		{"beads_prod", true},
+		{"db$money", true},
+		{"", false},
+		{"bad name", false},
+		{"back`tick", false},
+		{"semi;colon", false},
+		{"dash-name", false},
+		{"quote'name", false},
+	}
+	for _, tc := range cases {
+		if got := doltIdentifierPattern.MatchString(tc.name); got != tc.ok {
+			t.Errorf("doltIdentifierPattern.MatchString(%q) = %v, want %v", tc.name, got, tc.ok)
+		}
+	}
+}


### PR DESCRIPTION
## What

`probeForCorrectDoltDatabase` (cmd/bd/doctor/fix/metadata.go) now escapes candidate database names with **backtick-doubling** (`strings.ReplaceAll(dbName, "`", "``")` — the complete escape for a backtick-quoted MySQL/Dolt identifier) before the name is interpolated into the backtick-quoted probe query `SELECT COUNT(*) FROM \`<name>\`.issues`. This is the same technique `inspectServerMetadataDatabases` already uses in this file; the `//nolint:gosec` justification reads `identifier-escaped`, matching the neighboring sites.

## Why

The name comes from `SHOW DATABASES` on the connected server — server-controlled today, but it is data, not code, and it was interpolated unchecked. On a shared server another tenant can create a database whose name carries backticks or SQL syntax, and static analysis (Snyk Code) flags exactly that taint flow. Backtick-doubling keeps a hostile name inert inside the quoting — its probe errors and the candidate is skipped — while **every legal name still probes**, including legacy hyphenated names (`my-project`-style, named from raw prefixes before GH#2142) that this probe exists to find and that an unquoted-charset gate would have silently excluded. Matches the trust model in SECURITY.md ("external issue identifiers are validated before use in SQL queries").

Scope note: this hardens identifier interpolation only. The probe's pre-existing selection policy ("first database with an `issues` table wins") is unchanged and is a separate, pre-existing consideration tracked by the stricter project-id-matching path in `inspectServerMetadataDatabases`.

## Verification

- New tests (go-sqlmock with a recording `QueryMatcherFunc`, assertions on the recorded executed set):
  - Hostile name (`x\`; DROP TABLE issues; --`) is probed **only as its escaped identifier** — never injected, never silently dropped before a query — and the scan continues.
  - Legacy hyphenated name (`my-project`) is probed **verbatim** and returned.
  - Probe ordering pinned: first candidate's probe errors → second candidate wins (with `ExpectationsWereMet`).
  ```
  ./scripts/test.sh -v -run 'Probe' ./cmd/bd/doctor/fix/...
  ```
- Required lint gate: `make ci-pr-lint` — 0 issues (gofmt, golangci-lint normal build, Windows cross-lint).
- Addresses the Snyk Code static-analysis finding on `cmd/bd/doctor/fix/metadata.go:285` as hardening.

_opencode-glm-5.3-flash-unknown-reasoning on behalf of ksmeltzer_
