### PR TITLE
docs(schema): document the provenance invariant behind execMigrationBody

### DIFF
--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -1543,6 +1543,11 @@ func scanRowByColumn(rows *sql.Rows) (CallRow, error) {
 // connection. Bodies that invoke a stored procedure (today 0040 and 0041, both
 // CALL DOLT_COMMIT) are routed through DrainCall so their result sets are
 // consumed; all other migrations keep the unchanged ExecContext path.
+//
+// sqlText is always a compile-time embedded migration body (go:embed above;
+// frozen once merged per scripts/check-migration-hygiene.sh) — never runtime
+// or user input. Executing it verbatim is the migration contract, so SAST
+// "SQL injection" findings on this call are accepted by design.
 func execMigrationBody(ctx context.Context, db DBConn, sqlText string) error {
 	if !procedureCallRe.MatchString(sqlText) {
 		_, err := db.ExecContext(ctx, sqlText)


### PR DESCRIPTION
## What

A comment-only change (5 lines): `execMigrationBody` in `internal/storage/schema/schema.go` now documents the provenance invariant for the SQL it executes — `sqlText` is always a compile-time embedded migration body (`go:embed migrations/*.up.sql`, frozen once merged per `scripts/check-migration-hygiene.sh`), never runtime or user input, and executing it verbatim is the migration contract.

## Why

Static analysis (Snyk Code) reports the migration executor's `ExecContext` / `execMigrationBody` calls as tainted SQL because file-derived content flows into them. That flow is by design — migrations ship inside the bd binary and cannot be influenced at runtime — but the invariant previously lived only in the reader's head, derived from the `go:embed` directives. Spelling it out on the single choke point every migration body passes through gives auditors and future SAST runs the rationale in code.

Note for teams scanning forks with Snyk: Snyk Code does not honor Go `#nosec` annotations (unlike gosec), so this class of finding is cleared on the Snyk side by triaging it as accepted-by-design with this rationale; this comment is the written justification to attach.

## Verification

- Comment-only diff; no behavior change. `git diff` shows 5 added doc lines.
- Required lint gate: `make ci-pr-lint` — 0 issues (gofmt, golangci-lint normal build, Windows cross-lint).
- Full suite: `make test`.

_opencode-glm-5.3-flash-unknown-reasoning on behalf of ksmeltzer_
