### PR TITLE
fix(hooks): allowlist prime args and exec os.Executable() in runBdPrime

### DIFF
--- a/cmd/bd/agent_hook.go
+++ b/cmd/bd/agent_hook.go
@@ -50,9 +50,10 @@ func runBdPrime(ctx context.Context, args ...string) (string, error) {
 		return "", fmt.Errorf("bd prime: resolve executable: %w", err)
 	}
 	cmdArgs := append([]string{"prime"}, args...)
-	// #nosec G702 - exe is os.Executable() (this bd binary re-invoking itself);
-	// cmdArgs is the fixed "prime" subcommand plus allowlisted internal flags,
-	// never attacker-controlled input.
+	// #nosec G702 - exe comes from primeExecutable (os.Executable in
+	// production: this bd binary re-invoking itself); cmdArgs is the fixed
+	// "prime" subcommand plus allowlisted internal flags, never
+	// attacker-controlled input.
 	cmd := exec.CommandContext(ctx, exe, cmdArgs...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/bd/agent_hook.go
+++ b/cmd/bd/agent_hook.go
@@ -22,6 +22,11 @@ import (
 // error and is refused before the subprocess is built.
 var allowedPrimeArgs = map[string]bool{"--memories-only": true}
 
+// primeExecutable resolves the re-exec target for runBdPrime. A var so tests
+// can stub resolution and prove no subprocess is ever built from unexpected
+// input.
+var primeExecutable = os.Executable
+
 // validatePrimeArgs rejects any argument outside allowedPrimeArgs so the
 // re-exec below can never be steered by caller-supplied strings.
 func validatePrimeArgs(args []string) error {
@@ -40,7 +45,7 @@ func runBdPrime(ctx context.Context, args ...string) (string, error) {
 	if err := validatePrimeArgs(args); err != nil {
 		return "", err
 	}
-	exe, err := os.Executable()
+	exe, err := primeExecutable()
 	if err != nil {
 		return "", fmt.Errorf("bd prime: resolve executable: %w", err)
 	}

--- a/cmd/bd/agent_hook.go
+++ b/cmd/bd/agent_hook.go
@@ -16,14 +16,39 @@ import (
 // the prime-runner and one-shot refresh-marker mechanics are identical and live
 // here to avoid divergence.
 
+// allowedPrimeArgs is the closed set of flags the agent hooks may pass to the
+// re-executed bd binary. The hooks only ever run the fixed `bd prime`
+// invocation (optionally --memories-only); anything else is a programming
+// error and is refused before the subprocess is built.
+var allowedPrimeArgs = map[string]bool{"--memories-only": true}
+
+// validatePrimeArgs rejects any argument outside allowedPrimeArgs so the
+// re-exec below can never be steered by caller-supplied strings.
+func validatePrimeArgs(args []string) error {
+	for _, arg := range args {
+		if !allowedPrimeArgs[arg] {
+			return fmt.Errorf("bd prime: unsupported hook argument %q", arg)
+		}
+	}
+	return nil
+}
+
 // runBdPrime shells out to `bd prime [args...]` and returns its combined output.
 // The hooks exec a subprocess (rather than calling prime in process) to avoid
 // re-entrant store initialization.
 func runBdPrime(ctx context.Context, args ...string) (string, error) {
+	if err := validatePrimeArgs(args); err != nil {
+		return "", err
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("bd prime: resolve executable: %w", err)
+	}
 	cmdArgs := append([]string{"prime"}, args...)
-	// #nosec G702 - os.Args[0] is this bd binary re-invoking itself; cmdArgs is the
-	// fixed "prime" subcommand plus internal flags, never attacker-controlled input.
-	cmd := exec.CommandContext(ctx, os.Args[0], cmdArgs...)
+	// #nosec G702 - exe is os.Executable() (this bd binary re-invoking itself);
+	// cmdArgs is the fixed "prime" subcommand plus allowlisted internal flags,
+	// never attacker-controlled input.
+	cmd := exec.CommandContext(ctx, exe, cmdArgs...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("bd %s: %w: %s", strings.Join(cmdArgs, " "), err, strings.TrimSpace(string(out)))

--- a/cmd/bd/agent_hook_test.go
+++ b/cmd/bd/agent_hook_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -16,24 +17,52 @@ func TestValidatePrimeArgsAcceptsHookFlags(t *testing.T) {
 }
 
 func TestValidatePrimeArgsRejectsUnknownFlag(t *testing.T) {
-	err := validatePrimeArgs([]string{"--memories-only", "--config", "/tmp/evil"})
+	err := validatePrimeArgs([]string{"--config"})
 	if err == nil {
 		t.Fatal("expected unknown flag to be rejected")
 	}
-	if !strings.Contains(err.Error(), "unsupported hook argument") {
-		t.Fatalf("unexpected error: %v", err)
+	if !strings.Contains(err.Error(), `"--config"`) {
+		t.Fatalf("rejection should name the offending argument, got: %v", err)
 	}
 }
 
 // runBdPrime must refuse non-allowlisted arguments before it resolves the
-// executable or builds a subprocess, so a caller can never steer the
-// re-executed command.
+// executable or builds a subprocess. The resolver is stubbed so the test also
+// proves validation runs first — if a future change drops or reorders the
+// validatePrimeArgs call, the resolver (and with it the subprocess) would be
+// reached and this test fails instead of live-exec'ing anything.
 func TestRunBdPrimeRejectsUnknownArgsBeforeExec(t *testing.T) {
-	_, err := runBdPrime(context.Background(), "--config", "/tmp/evil")
+	called := false
+	orig := primeExecutable
+	primeExecutable = func() (string, error) {
+		called = true
+		return "", errors.New("resolver must not run for rejected args")
+	}
+	t.Cleanup(func() { primeExecutable = orig })
+
+	_, err := runBdPrime(context.Background(), "--config")
 	if err == nil {
 		t.Fatal("expected runBdPrime to reject unknown args")
 	}
-	if !strings.Contains(err.Error(), "unsupported hook argument") {
-		t.Fatalf("unexpected error: %v", err)
+	if !strings.Contains(err.Error(), `"--config"`) {
+		t.Fatalf("rejection should name the offending argument, got: %v", err)
+	}
+	if called {
+		t.Fatal("executable resolver ran before argument validation")
+	}
+}
+
+// With allowlisted args, a resolver failure surfaces as the wrapped
+// resolve-executable error and no subprocess is built.
+func TestRunBdPrimeExecutableResolutionError(t *testing.T) {
+	orig := primeExecutable
+	primeExecutable = func() (string, error) {
+		return "", errors.New("no executable")
+	}
+	t.Cleanup(func() { primeExecutable = orig })
+
+	_, err := runBdPrime(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "resolve executable") {
+		t.Fatalf("want resolve-executable error, got: %v", err)
 	}
 }

--- a/cmd/bd/agent_hook_test.go
+++ b/cmd/bd/agent_hook_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestValidatePrimeArgsAcceptsHookFlags(t *testing.T) {
+	if err := validatePrimeArgs(nil); err != nil {
+		t.Fatalf("no args should be allowed, got %v", err)
+	}
+	if err := validatePrimeArgs([]string{"--memories-only"}); err != nil {
+		t.Fatalf("--memories-only should be allowed, got %v", err)
+	}
+}
+
+func TestValidatePrimeArgsRejectsUnknownFlag(t *testing.T) {
+	err := validatePrimeArgs([]string{"--memories-only", "--config", "/tmp/evil"})
+	if err == nil {
+		t.Fatal("expected unknown flag to be rejected")
+	}
+	if !strings.Contains(err.Error(), "unsupported hook argument") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// runBdPrime must refuse non-allowlisted arguments before it resolves the
+// executable or builds a subprocess, so a caller can never steer the
+// re-executed command.
+func TestRunBdPrimeRejectsUnknownArgsBeforeExec(t *testing.T) {
+	_, err := runBdPrime(context.Background(), "--config", "/tmp/evil")
+	if err == nil {
+		t.Fatal("expected runBdPrime to reject unknown args")
+	}
+	if !strings.Contains(err.Error(), "unsupported hook argument") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Hardens the agent-hook re-exec seam in `cmd/bd/agent_hook.go`: `runBdPrime` now (1) rejects any argument outside a closed allowlist (`--memories-only` is the only flag the hooks ever pass) before building the subprocess, and (2) resolves the executable with `os.Executable()` instead of `os.Args[0]`, so the re-exec target comes from the kernel's view of the process rather than from argv.

## Why

Static analysis (Snyk Code) flags the `exec.CommandContext` call because argv-derived input flows into the subprocess. The two real callers (codex-hook, cursor-hook) only ever pass the allowlisted flag or nothing, so there is no behavioral bug today — but nothing structural prevented a future caller from steering the re-exec. This closes the taint surface at the seam so the invariant is enforced in code and visible to scanners.

One deliberate, small behavior delta from (2), noted for reviewers: previously the re-exec resolved `bd` via a fresh PATH lookup on every hook call (i.e. whichever `bd` came first on the hook process's PATH); it now execs the exact running binary. That is strictly more correct for Homebrew symlinks, wrapper scripts, `go run`, and test binaries, and closes the PATH-shadowing ambiguity. The one bounded edge case: a Linux hook running across an in-place binary upgrade sees the deleted inode (`/proc/self/exe` → ENOENT) and skips priming for that call — swallowed by the existing error paths, bounded to the 30s hook window.

## Verification

- New focused tests (`cmd/bd/agent_hook_test.go`): allowlisted flags accepted, unknown flags rejected, and `runBdPrime` refuses unknown args before any subprocess is built:
  ```
  ./scripts/test.sh -v -run '^TestValidatePrimeArgs|^TestRunBdPrime' ./cmd/bd/...
  ```
- Required lint gate: `make ci-pr-lint` — 0 issues (gofmt, golangci-lint on the normal build, and the Windows-only non-CGO cross-lint).
- Existing codex/cursor hook suites pass unchanged.

_opencode-glm-5.3-flash-unknown-reasoning on behalf of ksmeltzer_
