### PR TITLE
fix(init): refuse unreadable global ignore files

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -725,6 +725,7 @@ jobs:
 
       - name: Run PR core wrapper
         env:
+          BEADS_TEST_REQUIRE_EXCLUDE_PERMISSION: '1'
           BEADS_TEST_BD_BINARY: ${{ github.workspace }}/ci-build-artifacts/bd-linux-gms-pure
           GOCACHE: ${{ runner.temp }}/go-cache/race
         run: make ci-pr-core

--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -770,13 +770,12 @@ func CheckProjectGitignore(repoPath string) DoctorCheck {
 func EnsureProjectGitignore(repoPath string) error {
 	gitignorePath := filepath.Join(repoPath, ".gitignore")
 
-	var existingContent string
 	// #nosec G304 -- path is hardcoded
-	if content, err := os.ReadFile(gitignorePath); err == nil {
-		existingContent = string(content)
-	} else if !os.IsNotExist(err) {
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to read .gitignore: %w", err)
 	}
+	existingContent := string(content)
 
 	var toAdd []string
 	for _, pattern := range ProjectGitignorePatterns {
@@ -789,7 +788,7 @@ func EnsureProjectGitignore(repoPath string) error {
 		return nil // All patterns already present
 	}
 
-	lineEnding := gitignore.AppendLineEnding([]byte(existingContent))
+	lineEnding := gitignore.AppendLineEnding(content)
 	newContent := existingContent
 	if len(newContent) > 0 && !strings.HasSuffix(newContent, "\n") {
 		if strings.HasSuffix(newContent, "\r") {

--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -788,23 +788,11 @@ func EnsureProjectGitignore(repoPath string) error {
 		return nil // All patterns already present
 	}
 
-	lineEnding := gitignore.AppendLineEnding(content)
-	newContent := existingContent
-	if len(newContent) > 0 && !strings.HasSuffix(newContent, "\n") {
-		if strings.HasSuffix(newContent, "\r") {
-			newContent += "\n" // Complete the existing CR without doubling it.
-		} else {
-			newContent += lineEnding
-		}
-	}
-
-	newContent += lineEnding + ProjectGitignoreHeader + lineEnding
-	for _, pattern := range toAdd {
-		newContent += pattern + lineEnding
-	}
+	lines := append([]string{"", ProjectGitignoreHeader}, toAdd...)
+	newContent := gitignore.AppendLines(content, lines)
 
 	// #nosec G306 -- gitignore needs to be readable by git and collaborators
-	if err := os.WriteFile(gitignorePath, []byte(newContent), 0644); err != nil {
+	if err := os.WriteFile(gitignorePath, newContent, 0644); err != nil {
 		return fmt.Errorf("failed to write .gitignore: %w", err)
 	}
 

--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/steveyegge/beads/internal/gitignore"
 )
 
 // GitignoreTemplate is the canonical .beads/.gitignore content
@@ -787,14 +789,19 @@ func EnsureProjectGitignore(repoPath string) error {
 		return nil // All patterns already present
 	}
 
+	lineEnding := gitignore.AppendLineEnding([]byte(existingContent))
 	newContent := existingContent
 	if len(newContent) > 0 && !strings.HasSuffix(newContent, "\n") {
-		newContent += "\n"
+		if strings.HasSuffix(newContent, "\r") {
+			newContent += "\n" // Complete the existing CR without doubling it.
+		} else {
+			newContent += lineEnding
+		}
 	}
 
-	newContent += "\n" + ProjectGitignoreHeader + "\n"
+	newContent += lineEnding + ProjectGitignoreHeader + lineEnding
 	for _, pattern := range toAdd {
-		newContent += pattern + "\n"
+		newContent += pattern + lineEnding
 	}
 
 	// #nosec G306 -- gitignore needs to be readable by git and collaborators

--- a/cmd/bd/doctor/gitignore_test.go
+++ b/cmd/bd/doctor/gitignore_test.go
@@ -1967,6 +1967,50 @@ func TestEnsureProjectGitignore_AppendsToExisting(t *testing.T) {
 	}
 }
 
+func TestEnsureProjectGitignore_PreservesAppendLineEndings(t *testing.T) {
+	lfBlock := "\n" + ProjectGitignoreHeader + "\n" + strings.Join(ProjectGitignorePatterns, "\n") + "\n"
+	crlfBlock := "\r\n" + ProjectGitignoreHeader + "\r\n" + strings.Join(ProjectGitignorePatterns, "\r\n") + "\r\n"
+	partial := ProjectGitignoreHeader + "\r\n" + ProjectGitignorePatterns[0] + "\r\n"
+	remaining := "\r\n" + ProjectGitignoreHeader + "\r\n" + strings.Join(ProjectGitignorePatterns[1:], "\r\n") + "\r\n"
+	complete := ProjectGitignoreHeader + "\r\n" + strings.Join(ProjectGitignorePatterns, "\r\n")
+	for _, tc := range []struct {
+		name, existing, want string
+	}{
+		{"empty", "", lfBlock},
+		{"delimiter-free", "local", "local\n" + lfBlock},
+		{"LF", "local\n", "local\n" + lfBlock},
+		{"CRLF", "local\r\n", "local\r\n" + crlfBlock},
+		{"CRLF unterminated", "local\r\nlast", "local\r\nlast\r\n" + crlfBlock},
+		{"CRLF trailing CR", "local\r\nlast\r", "local\r\nlast\r\n" + crlfBlock},
+		{"LF trailing CR", "local\nlast\r", "local\nlast\r\n" + lfBlock},
+		{"only trailing CR", "local\r", "local\r\n" + lfBlock},
+		{"mixed majority CRLF", "a\r\nb\r\nc\n", "a\r\nb\r\nc\n" + lfBlock},
+		{"partial with header", partial, partial + remaining},
+		{"complete unterminated", complete, complete},
+		{"complete CRLF", complete + "\r\n", complete + "\r\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, ".gitignore")
+			if err := os.WriteFile(path, []byte(tc.existing), 0600); err != nil {
+				t.Fatal(err)
+			}
+			for call := 1; call <= 2; call++ {
+				if err := EnsureProjectGitignore(dir); err != nil {
+					t.Fatalf("call %d: %v", call, err)
+				}
+				got, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if string(got) != tc.want {
+					t.Fatalf("call %d: got bytes %q, want %q", call, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
 func TestEnsureProjectGitignore_Idempotent(t *testing.T) {
 	tmpDir := t.TempDir()
 	oldDir, err := os.Getwd()

--- a/cmd/bd/doctor/gitignore_test.go
+++ b/cmd/bd/doctor/gitignore_test.go
@@ -1985,6 +1985,7 @@ func TestEnsureProjectGitignore_PreservesAppendLineEndings(t *testing.T) {
 		{"LF trailing CR", "local\nlast\r", "local\nlast\r\n" + lfBlock},
 		{"only trailing CR", "local\r", "local\r\n" + lfBlock},
 		{"mixed majority CRLF", "a\r\nb\r\nc\n", "a\r\nb\r\nc\n" + lfBlock},
+		// Re-emitting an existing header is pre-existing behavior, preserved here.
 		{"partial with header", partial, partial + remaining},
 		{"complete unterminated", complete, complete},
 		{"complete CRLF", complete + "\r\n", complete + "\r\n"},

--- a/cmd/bd/init_stealth.go
+++ b/cmd/bd/init_stealth.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/steveyegge/beads/cmd/bd/doctor"
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/gitignore"
 	"github.com/steveyegge/beads/internal/ui"
 )
 
@@ -105,8 +106,10 @@ func addExcludePatterns(repoPath, header string, patterns []string) (added []str
 	}
 
 	var existing string
+	var content []byte
 	// #nosec G304 - git config path
-	if content, rerr := os.ReadFile(excludePath); rerr == nil {
+	if readContent, rerr := os.ReadFile(excludePath); rerr == nil {
+		content = readContent
 		existing = string(content)
 	}
 
@@ -120,13 +123,18 @@ func addExcludePatterns(repoPath, header string, patterns []string) (added []str
 		return nil, excludePath, nil
 	}
 
+	lineEnding := gitignore.AppendLineEnding(content)
 	newContent := existing
 	if len(newContent) > 0 && !strings.HasSuffix(newContent, "\n") {
-		newContent += "\n"
+		if strings.HasSuffix(newContent, "\r") {
+			newContent += "\n" // Complete the existing CR without doubling it.
+		} else {
+			newContent += lineEnding
+		}
 	}
-	newContent += "\n" + header + "\n"
+	newContent += lineEnding + header + lineEnding
 	for _, p := range added {
-		newContent += p + "\n"
+		newContent += p + lineEnding
 	}
 
 	// #nosec G306 - config file needs 0644

--- a/cmd/bd/init_stealth.go
+++ b/cmd/bd/init_stealth.go
@@ -419,6 +419,8 @@ func setupGlobalGitIgnore(homeDir string, projectPath string, verbose bool) erro
 	// #nosec G304 - user config path
 	if content, err := os.ReadFile(ignorePath); err == nil {
 		existingContent = string(content)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read global gitignore file: %w", err)
 	}
 
 	// Use absolute paths for this specific project (fixes GitHub #538)

--- a/cmd/bd/init_stealth.go
+++ b/cmd/bd/init_stealth.go
@@ -125,22 +125,10 @@ func addExcludePatterns(repoPath, header string, patterns []string) (added []str
 		return nil, excludePath, nil
 	}
 
-	lineEnding := gitignore.AppendLineEnding(content)
-	newContent := existing
-	if len(newContent) > 0 && !strings.HasSuffix(newContent, "\n") {
-		if strings.HasSuffix(newContent, "\r") {
-			newContent += "\n" // Complete the existing CR without doubling it.
-		} else {
-			newContent += lineEnding
-		}
-	}
-	newContent += lineEnding + header + lineEnding
-	for _, p := range added {
-		newContent += p + lineEnding
-	}
+	newContent := gitignore.AppendLines(content, append([]string{"", header}, added...))
 
 	// #nosec G306 - config file needs 0644
-	if err = os.WriteFile(excludePath, []byte(newContent), 0644); err != nil {
+	if err = os.WriteFile(excludePath, newContent, 0644); err != nil {
 		return nil, excludePath, fmt.Errorf("failed to write git exclude file: %w", err)
 	}
 	return added, excludePath, nil

--- a/cmd/bd/init_stealth.go
+++ b/cmd/bd/init_stealth.go
@@ -125,7 +125,11 @@ func addExcludePatterns(repoPath, header string, patterns []string) (added []str
 		return nil, excludePath, nil
 	}
 
-	newContent := gitignore.AppendLines(content, append([]string{"", header}, added...))
+	lines := []string{header}
+	if len(content) > 0 {
+		lines = []string{"", header}
+	}
+	newContent := gitignore.AppendLines(content, append(lines, added...))
 
 	// #nosec G306 - config file needs 0644
 	if err = os.WriteFile(excludePath, newContent, 0644); err != nil {

--- a/cmd/bd/init_stealth.go
+++ b/cmd/bd/init_stealth.go
@@ -111,6 +111,8 @@ func addExcludePatterns(repoPath, header string, patterns []string) (added []str
 	if readContent, rerr := os.ReadFile(excludePath); rerr == nil {
 		content = readContent
 		existing = string(content)
+	} else if !os.IsNotExist(rerr) {
+		return nil, excludePath, fmt.Errorf("failed to read git exclude file: %w", rerr)
 	}
 
 	for _, p := range patterns {

--- a/cmd/bd/init_stealth_test.go
+++ b/cmd/bd/init_stealth_test.go
@@ -585,7 +585,7 @@ func TestAddExcludePatternsCreatesMissingFile(t *testing.T) {
 }
 
 func TestSetupGlobalGitIgnoreReadBoundaries(t *testing.T) {
-	for _, name := range []string{"missing", "readable", "directory", "write_only"} {
+	for _, name := range []string{"missing", "dangling_symlink", "readable", "directory", "write_only"} {
 		t.Run(name, func(t *testing.T) {
 			if name == "write_only" && (runtime.GOOS == "windows" || os.Geteuid() == 0) {
 				if os.Getenv("BEADS_TEST_REQUIRE_EXCLUDE_PERMISSION") == "1" {
@@ -607,6 +607,13 @@ func TestSetupGlobalGitIgnoreReadBoundaries(t *testing.T) {
 			}
 			const before = "user-rule\r\n"
 			switch name {
+			case "dangling_symlink":
+				if err := os.Symlink(filepath.Join(homeDir, "exclude target"), ignorePath); err != nil {
+					if runtime.GOOS == "windows" {
+						t.Skipf("symlink capability unavailable: %v", err)
+					}
+					t.Fatal(err)
+				}
 			case "directory":
 				if err := os.Mkdir(ignorePath, 0755); err != nil {
 					t.Fatal(err)
@@ -642,6 +649,7 @@ func TestSetupGlobalGitIgnoreReadBoundaries(t *testing.T) {
 			}
 			err := setupGlobalGitIgnore(homeDir, "/test/project", false)
 			if name == "write_only" {
+				// Restore now for the byte assertion; Cleanup also covers an earlier Fatal.
 				if restoreErr := os.Chmod(ignorePath, 0600); restoreErr != nil {
 					t.Fatal(restoreErr)
 				}
@@ -661,14 +669,24 @@ func TestSetupGlobalGitIgnoreReadBoundaries(t *testing.T) {
 				t.Fatalf("setup global ignore: %v", err)
 			}
 			want := before
-			if name == "missing" {
+			if name == "missing" || name == "dangling_symlink" {
 				want = ""
 			}
 			if name != "write_only" {
+				// #6416/#6426 separately changes this inherited LF append policy.
 				want += "\n# Beads stealth mode: /test/project (added by bd init --stealth)\n/test/project/.beads/\n/test/project/.claude/settings.local.json\n"
 			}
 			if got, err := os.ReadFile(ignorePath); err != nil || string(got) != want {
 				t.Errorf("global ignore bytes = %q, want %q: %v", got, want, err)
+			}
+			if name == "dangling_symlink" {
+				info, err := os.Lstat(ignorePath)
+				if err != nil || info.Mode()&os.ModeSymlink == 0 {
+					t.Fatalf("global ignore symlink was replaced: %v", err)
+				}
+				if got, err := os.ReadFile(filepath.Join(homeDir, "exclude target")); err != nil || string(got) != want {
+					t.Errorf("dangling target bytes = %q, want %q: %v", got, want, err)
+				}
 			}
 		})
 	}

--- a/cmd/bd/init_stealth_test.go
+++ b/cmd/bd/init_stealth_test.go
@@ -450,3 +450,61 @@ func TestSetupGitExclude_RegularRepo(t *testing.T) {
 		t.Errorf("exclude file missing .claude/settings.local.json pattern: %s", content)
 	}
 }
+
+func TestAddExcludePatternsPreservesAppendLineEndings(t *testing.T) {
+	const lf = "\n# managed\n.beads/\ncache/\n"
+	const crlf = "\r\n# managed\r\n.beads/\r\ncache/\r\n"
+	for _, tc := range []struct{ name, existing, want, added string }{
+		{"empty", "", lf, ".beads/,cache/"},
+		{"delimiter-free", "local", "local\n" + lf, ".beads/,cache/"},
+		{"LF", "local\n", "local\n" + lf, ".beads/,cache/"},
+		{"CRLF", "local\r\n", "local\r\n" + crlf, ".beads/,cache/"},
+		{"CRLF unterminated", "local\r\nlast", "local\r\nlast\r\n" + crlf, ".beads/,cache/"},
+		{"CRLF pending CR", "local\r\nlast\r", "local\r\nlast\r\n" + crlf, ".beads/,cache/"},
+		{"LF pending CR", "local\nlast\r", "local\nlast\r\n" + lf, ".beads/,cache/"},
+		{"only pending CR", "local\r", "local\r\n" + lf, ".beads/,cache/"},
+		{"mixed", "a\r\nb\r\nc\n", "a\r\nb\r\nc\n" + lf, ".beads/,cache/"},
+		{"partial", ".beads/\r\n", ".beads/\r\n\r\n# managed\r\ncache/\r\n", "cache/"},
+		{"complete", ".beads/\r\ncache/", ".beads/\r\ncache/", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := newGitRepo(t)
+			gitignore := filepath.Join(dir, ".gitignore")
+			const tracked = "user-rule\r\n"
+			if err := os.WriteFile(gitignore, []byte(tracked), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if out, err := exec.Command("git", "-C", dir, "add", "--", ".gitignore").CombinedOutput(); err != nil {
+				t.Fatalf("track .gitignore: %v: %s", err, out)
+			}
+			path, err := resolveGitExcludePath(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(tc.existing), 0600); err != nil {
+				t.Fatal(err)
+			}
+			for pass := 0; pass < 2; pass++ {
+				added, gotPath, err := addExcludePatterns(dir, "# managed", []string{".beads/", "cache/"})
+				if err != nil || gotPath != path {
+					t.Fatalf("addExcludePatterns: path=%q, err=%v", gotPath, err)
+				}
+				wantAdded := tc.added
+				if pass == 1 {
+					wantAdded = ""
+				}
+				if strings.Join(added, ",") != wantAdded {
+					t.Errorf("pass %d added=%q, want %q", pass, added, wantAdded)
+				}
+				got, err := os.ReadFile(path)
+				if err != nil || string(got) != tc.want {
+					t.Fatalf("pass %d exclude=%q, want %q: %v", pass, got, tc.want, err)
+				}
+				got, err = os.ReadFile(gitignore)
+				if err != nil || string(got) != tracked {
+					t.Fatalf("tracked .gitignore changed: %q: %v", got, err)
+				}
+			}
+		})
+	}
+}

--- a/cmd/bd/init_stealth_test.go
+++ b/cmd/bd/init_stealth_test.go
@@ -594,6 +594,7 @@ func TestSetupGlobalGitIgnoreReadBoundaries(t *testing.T) {
 				t.Skip("write-only permission coverage requires an unprivileged POSIX host")
 			}
 			homeDir := t.TempDir()
+			t.Chdir(homeDir)
 			configPath := filepath.Join(homeDir, "gitconfig")
 			ignorePath := filepath.Join(homeDir, "global ignore")
 			t.Setenv("GIT_CONFIG_GLOBAL", configPath)

--- a/cmd/bd/init_stealth_test.go
+++ b/cmd/bd/init_stealth_test.go
@@ -469,9 +469,9 @@ func TestAddExcludePatternsPreservesAppendLineEndings(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := newGitRepo(t)
-			gitignore := filepath.Join(dir, ".gitignore")
+			gitignorePath := filepath.Join(dir, ".gitignore")
 			const tracked = "user-rule\r\n"
-			if err := os.WriteFile(gitignore, []byte(tracked), 0600); err != nil {
+			if err := os.WriteFile(gitignorePath, []byte(tracked), 0600); err != nil {
 				t.Fatal(err)
 			}
 			if out, err := exec.Command("git", "-C", dir, "add", "--", ".gitignore").CombinedOutput(); err != nil {
@@ -500,7 +500,7 @@ func TestAddExcludePatternsPreservesAppendLineEndings(t *testing.T) {
 				if err != nil || string(got) != tc.want {
 					t.Fatalf("pass %d exclude=%q, want %q: %v", pass, got, tc.want, err)
 				}
-				got, err = os.ReadFile(gitignore)
+				got, err = os.ReadFile(gitignorePath)
 				if err != nil || string(got) != tracked {
 					t.Fatalf("tracked .gitignore changed: %q: %v", got, err)
 				}

--- a/cmd/bd/init_stealth_test.go
+++ b/cmd/bd/init_stealth_test.go
@@ -457,7 +457,11 @@ func TestAddExcludePatternsPreservesAppendLineEndings(t *testing.T) {
 	const lf = "\n# managed\n.beads/\ncache/\n"
 	const crlf = "\r\n# managed\r\n.beads/\r\ncache/\r\n"
 	for _, tc := range []struct{ name, existing, want, added string }{
-		{"empty", "", lf, ".beads/,cache/"},
+		{"empty", "", "# managed\n.beads/\ncache/\n", ".beads/,cache/"},
+		{"whitespace unterminated", " \t", " \t\n" + lf, ".beads/,cache/"},
+		{"blank LF", "\n", "\n" + lf, ".beads/,cache/"},
+		{"blank CRLF", "\r\n", "\r\n" + crlf, ".beads/,cache/"},
+		{"blank pending CR", "\r", "\r\n" + lf, ".beads/,cache/"},
 		{"delimiter-free", "local", "local\n" + lf, ".beads/,cache/"},
 		{"LF", "local\n", "local\n" + lf, ".beads/,cache/"},
 		{"CRLF", "local\r\n", "local\r\n" + crlf, ".beads/,cache/"},
@@ -574,7 +578,7 @@ func TestAddExcludePatternsCreatesMissingFile(t *testing.T) {
 	if err != nil || gotPath != path || len(added) != 1 || added[0] != ".beads/" {
 		t.Fatalf("create missing exclude: added=%v path=%q err=%v", added, gotPath, err)
 	}
-	const want = "\n# managed\n.beads/\n"
+	const want = "# managed\n.beads/\n"
 	if got, err := os.ReadFile(path); err != nil || string(got) != want {
 		t.Errorf("created exclude = %q, want %q: %v", got, want, err)
 	}

--- a/cmd/bd/init_stealth_test.go
+++ b/cmd/bd/init_stealth_test.go
@@ -583,3 +583,92 @@ func TestAddExcludePatternsCreatesMissingFile(t *testing.T) {
 		t.Errorf("created exclude = %q, want %q: %v", got, want, err)
 	}
 }
+
+func TestSetupGlobalGitIgnoreReadBoundaries(t *testing.T) {
+	for _, name := range []string{"missing", "readable", "directory", "write_only"} {
+		t.Run(name, func(t *testing.T) {
+			if name == "write_only" && (runtime.GOOS == "windows" || os.Geteuid() == 0) {
+				if os.Getenv("BEADS_TEST_REQUIRE_EXCLUDE_PERMISSION") == "1" {
+					t.Fatal("global ignore read-error coverage requires an unprivileged POSIX permission boundary")
+				}
+				t.Skip("write-only permission coverage requires an unprivileged POSIX host")
+			}
+			homeDir := t.TempDir()
+			configPath := filepath.Join(homeDir, "gitconfig")
+			ignorePath := filepath.Join(homeDir, "global ignore")
+			t.Setenv("GIT_CONFIG_GLOBAL", configPath)
+			t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+			t.Setenv("GIT_CONFIG_COUNT", "0")
+			t.Setenv("GIT_CONFIG_PARAMETERS", "")
+			cmd := exec.Command("git", "config", "--file", configPath, "core.excludesfile", ignorePath)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("configure owned global excludesfile: %v\n%s", err, out)
+			}
+			const before = "user-rule\r\n"
+			switch name {
+			case "directory":
+				if err := os.Mkdir(ignorePath, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := os.ReadFile(ignorePath); err == nil {
+					t.Fatal("directory read-error precondition did not fail")
+				}
+			case "readable", "write_only":
+				if err := os.WriteFile(ignorePath, []byte(before), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if name == "write_only" {
+				t.Cleanup(func() {
+					if err := os.Chmod(ignorePath, 0600); err != nil {
+						t.Errorf("restore global ignore mode: %v", err)
+					}
+				})
+				if err := os.Chmod(ignorePath, 0200); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := os.ReadFile(ignorePath); !errors.Is(err, os.ErrPermission) {
+					t.Fatalf("read-denied precondition: %v", err)
+				}
+				// Prove writes are allowed without truncating the bytes under test.
+				writable, err := os.OpenFile(ignorePath, os.O_WRONLY, 0)
+				if err != nil {
+					t.Fatalf("write-allowed precondition: %v", err)
+				}
+				if err := writable.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err := setupGlobalGitIgnore(homeDir, "/test/project", false)
+			if name == "write_only" {
+				if restoreErr := os.Chmod(ignorePath, 0600); restoreErr != nil {
+					t.Fatal(restoreErr)
+				}
+			}
+			if name == "directory" || name == "write_only" {
+				var pathErr *os.PathError
+				if !errors.As(err, &pathErr) || pathErr.Path != ignorePath || !strings.Contains(err.Error(), "failed to read global gitignore file") {
+					t.Errorf("expected contextual wrapped read error for %q, got %v", ignorePath, err)
+				}
+				if name == "directory" {
+					return
+				}
+				if !errors.Is(err, os.ErrPermission) {
+					t.Errorf("expected wrapped permission error, got %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("setup global ignore: %v", err)
+			}
+			want := before
+			if name == "missing" {
+				want = ""
+			}
+			if name != "write_only" {
+				want += "\n# Beads stealth mode: /test/project (added by bd init --stealth)\n/test/project/.beads/\n/test/project/.claude/settings.local.json\n"
+			}
+			if got, err := os.ReadFile(ignorePath); err != nil || string(got) != want {
+				t.Errorf("global ignore bytes = %q, want %q: %v", got, want, err)
+			}
+		})
+	}
+}

--- a/cmd/bd/init_stealth_test.go
+++ b/cmd/bd/init_stealth_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -506,5 +508,74 @@ func TestAddExcludePatternsPreservesAppendLineEndings(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestAddExcludePatternsRefusesReadErrors(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		if os.Getenv("BEADS_TEST_REQUIRE_EXCLUDE_PERMISSION") == "1" {
+			t.Fatal("exclude read-error coverage requires an unprivileged POSIX permission boundary")
+		}
+		t.Skip("write-only permission coverage requires an unprivileged POSIX host")
+	}
+	dir := newGitRepo(t)
+	path, err := resolveGitExcludePath(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const before = "user-rule\r\n"
+	if err := os.WriteFile(path, []byte(before), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(path, 0600); err != nil {
+			t.Errorf("restore exclude mode: %v", err)
+		}
+	})
+	if err := os.Chmod(path, 0200); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.ReadFile(path); !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("read-denied precondition: %v", err)
+	}
+	// Prove a write would succeed without truncating the bytes being protected.
+	writable, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("write-allowed precondition: %v", err)
+	}
+	if err := writable.Close(); err != nil {
+		t.Fatal(err)
+	}
+	added, gotPath, err := addExcludePatterns(dir, "# managed", []string{".beads/"})
+	if restoreErr := os.Chmod(path, 0600); restoreErr != nil {
+		t.Fatal(restoreErr)
+	}
+	if err == nil || !errors.Is(err, os.ErrPermission) || !strings.Contains(err.Error(), "failed to read git exclude file") {
+		t.Errorf("expected contextual wrapped permission error, got %v", err)
+	}
+	if added != nil || gotPath != path {
+		t.Errorf("read failure returned added=%v path=%q, want nil and %q", added, gotPath, path)
+	}
+	if got, err := os.ReadFile(path); err != nil || string(got) != before {
+		t.Errorf("exclude bytes after read failure = %q, want %q: %v", got, before, err)
+	}
+}
+
+func TestAddExcludePatternsCreatesMissingFile(t *testing.T) {
+	dir := newGitRepo(t)
+	path, err := resolveGitExcludePath(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	added, gotPath, err := addExcludePatterns(dir, "# managed", []string{".beads/"})
+	if err != nil || gotPath != path || len(added) != 1 || added[0] != ".beads/" {
+		t.Fatalf("create missing exclude: added=%v path=%q err=%v", added, gotPath, err)
+	}
+	const want = "\n# managed\n.beads/\n"
+	if got, err := os.ReadFile(path); err != nil || string(got) != want {
+		t.Errorf("created exclude = %q, want %q: %v", got, want, err)
 	}
 }

--- a/internal/gitignore/append.go
+++ b/internal/gitignore/append.go
@@ -13,3 +13,27 @@ func AppendLineEnding(content []byte) string {
 	}
 	return "\n"
 }
+
+// AppendLines appends logical lines using the existing file's line ending,
+// preserving existing bytes and completing any unterminated final line.
+// Callers choose their own blank lines, headers and patterns. No lines is a no-op.
+func AppendLines(content []byte, lines []string) []byte {
+	if len(lines) == 0 {
+		return content
+	}
+	lineEnding := AppendLineEnding(content)
+	var buf bytes.Buffer
+	buf.Write(content)
+	if len(content) > 0 && content[len(content)-1] != '\n' {
+		if content[len(content)-1] == '\r' {
+			buf.WriteByte('\n') // Complete the existing CR without doubling it.
+		} else {
+			buf.WriteString(lineEnding)
+		}
+	}
+	for _, line := range lines {
+		buf.WriteString(line)
+		buf.WriteString(lineEnding)
+	}
+	return buf.Bytes()
+}

--- a/internal/gitignore/append.go
+++ b/internal/gitignore/append.go
@@ -4,7 +4,7 @@ package gitignore
 import "bytes"
 
 // AppendLineEnding preserves an unambiguous CRLF convention, following the
-// worktree append policy in #5677. Empty, delimiter-free, LF and mixed files
+// append policy in #6343. Empty, delimiter-free, LF and mixed files
 // default to LF; callers must leave existing bytes unchanged.
 func AppendLineEnding(content []byte) string {
 	lineFeeds := bytes.Count(content, []byte{'\n'})

--- a/internal/gitignore/append.go
+++ b/internal/gitignore/append.go
@@ -16,7 +16,9 @@ func AppendLineEnding(content []byte) string {
 
 // AppendLines appends logical lines using the existing file's line ending,
 // preserving existing bytes and completing any unterminated final line.
-// Callers choose their own blank lines, headers and patterns. No lines is a no-op.
+// A trailing CR is completed with a bare LF.
+// Callers choose their own blank lines, headers and patterns.
+// With no lines, the returned slice aliases content without copying.
 func AppendLines(content []byte, lines []string) []byte {
 	if len(lines) == 0 {
 		return content

--- a/internal/gitignore/append.go
+++ b/internal/gitignore/append.go
@@ -1,0 +1,15 @@
+// Package gitignore provides formatting helpers for user-owned gitignore files.
+package gitignore
+
+import "bytes"
+
+// AppendLineEnding preserves an unambiguous CRLF convention, following the
+// worktree append policy in #5677. Empty, delimiter-free, LF and mixed files
+// default to LF; callers must leave existing bytes unchanged.
+func AppendLineEnding(content []byte) string {
+	lineFeeds := bytes.Count(content, []byte{'\n'})
+	if lineFeeds > 0 && lineFeeds == bytes.Count(content, []byte("\r\n")) {
+		return "\r\n"
+	}
+	return "\n"
+}

--- a/internal/gitignore/append_test.go
+++ b/internal/gitignore/append_test.go
@@ -24,3 +24,32 @@ func TestAppendLineEnding(t *testing.T) {
 		})
 	}
 }
+
+func TestAppendLines(t *testing.T) {
+	for _, tc := range []struct {
+		name, content string
+		lines         []string
+		want          string
+	}{
+		{"no lines", "last\r", nil, "last\r"},
+		{"empty", "", []string{"rule/"}, "rule/\n"},
+		{"blank header", "", []string{"", "# managed", "rule/"}, "\n# managed\nrule/\n"},
+		{"LF unterminated", "local", []string{"rule/"}, "local\nrule/\n"},
+		{"LF", "local\n", []string{"rule/"}, "local\nrule/\n"},
+		{"CRLF", "local\r\n", []string{"", "# managed", "rule/"}, "local\r\n\r\n# managed\r\nrule/\r\n"},
+		{"CRLF unterminated", "local\r\nlast", []string{"rule/"}, "local\r\nlast\r\nrule/\r\n"},
+		{"CRLF pending CR", "local\r\nlast\r", []string{"rule/"}, "local\r\nlast\r\nrule/\r\n"},
+		{"only pending CR", "last\r", []string{"rule/"}, "last\r\nrule/\n"},
+		{"mixed", "a\r\nb\n", []string{"rule/"}, "a\r\nb\nrule/\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			content := []byte(tc.content)
+			if got := AppendLines(content, tc.lines); string(got) != tc.want {
+				t.Errorf("AppendLines() = %q, want %q", got, tc.want)
+			}
+			if string(content) != tc.content {
+				t.Errorf("input changed to %q", content)
+			}
+		})
+	}
+}

--- a/internal/gitignore/append_test.go
+++ b/internal/gitignore/append_test.go
@@ -1,0 +1,26 @@
+package gitignore
+
+import "testing"
+
+func TestAppendLineEnding(t *testing.T) {
+	for _, tc := range []struct{ name, content, want string }{
+		{"empty", "", "\n"},
+		{"delimiter-free", "local", "\n"},
+		{"LF", "a\n", "\n"},
+		{"CRLF", "a\r\n", "\r\n"},
+		{"mixed", "a\r\nb\r\nc\n", "\n"},
+		{"BOM LF", "\xef\xbb\xbfa\n", "\n"},
+		{"BOM CRLF", "\xef\xbb\xbfa\r\n", "\r\n"},
+		{"lone CR", "\r", "\n"},
+		{"CR-only", "a\rb\rc\r", "\n"},
+		{"interior CR", "a\rb\r\n", "\r\n"},
+		{"CRCRLF", "a\r\r\n", "\r\n"},
+		{"UTF16-like", "a\x00\r\x00\n\x00", "\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := AppendLineEnding([]byte(tc.content)); got != tc.want {
+				t.Errorf("AppendLineEnding(%q) = %q, want %q", tc.content, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/storage/domain/fs/beads.go
+++ b/internal/storage/domain/fs/beads.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/gitignore"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/utils"
 )
@@ -164,19 +165,24 @@ func (r *beadsDirFSRepositoryImpl) WriteProjectGitignore(ctx context.Context) er
 		return nil
 	}
 
+	lineEnding := gitignore.AppendLineEnding(existing)
 	var buf bytes.Buffer
 	buf.Write(existing)
 	if len(existing) > 0 && !bytes.HasSuffix(existing, []byte("\n")) {
-		buf.WriteByte('\n')
+		if existing[len(existing)-1] == '\r' {
+			buf.WriteByte('\n') // Complete the existing CR without doubling it.
+		} else {
+			buf.WriteString(lineEnding)
+		}
 	}
 	if header := r.templates.ProjectGitignoreHeader; header != "" && !containsLine(existing, header) {
 		if len(existing) > 0 {
-			buf.WriteByte('\n')
+			buf.WriteString(lineEnding)
 		}
-		buf.WriteString(header + "\n")
+		buf.WriteString(header + lineEnding)
 	}
 	for _, pattern := range toAdd {
-		buf.WriteString(pattern + "\n")
+		buf.WriteString(pattern + lineEnding)
 	}
 
 	// #nosec G306 -- .gitignore must be world-readable so users can read/edit it

--- a/internal/storage/domain/fs/beads.go
+++ b/internal/storage/domain/fs/beads.go
@@ -165,28 +165,18 @@ func (r *beadsDirFSRepositoryImpl) WriteProjectGitignore(ctx context.Context) er
 		return nil
 	}
 
-	lineEnding := gitignore.AppendLineEnding(existing)
-	var buf bytes.Buffer
-	buf.Write(existing)
-	if len(existing) > 0 && !bytes.HasSuffix(existing, []byte("\n")) {
-		if existing[len(existing)-1] == '\r' {
-			buf.WriteByte('\n') // Complete the existing CR without doubling it.
-		} else {
-			buf.WriteString(lineEnding)
-		}
-	}
+	var lines []string
 	if header := r.templates.ProjectGitignoreHeader; header != "" && !containsLine(existing, header) {
 		if len(existing) > 0 {
-			buf.WriteString(lineEnding)
+			lines = append(lines, "")
 		}
-		buf.WriteString(header + lineEnding)
+		lines = append(lines, header)
 	}
-	for _, pattern := range toAdd {
-		buf.WriteString(pattern + lineEnding)
-	}
+	lines = append(lines, toAdd...)
+	content := gitignore.AppendLines(existing, lines)
 
 	// #nosec G306 -- .gitignore must be world-readable so users can read/edit it
-	if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(path, content, 0644); err != nil {
 		return fmt.Errorf("fs: WriteProjectGitignore: write: %w", err)
 	}
 	return nil

--- a/internal/storage/domain/fs/beads_test.go
+++ b/internal/storage/domain/fs/beads_test.go
@@ -38,6 +38,7 @@ func (s *testSuite) TestBeadsDirFSRepository() {
 		s.Run("SkipsAlreadyPresentPatterns", s.writeProjectGitignoreNoDuplicates)
 		s.Run("NoChangeWhenAllPresent", s.writeProjectGitignoreNoOpWhenComplete)
 		s.Run("AddsLeadingNewlineWhenMissing", s.writeProjectGitignoreFixesTrailingNewline)
+		s.Run("PreservesAppendLineEndings", s.writeProjectGitignorePreservesAppendLineEndings)
 	})
 	s.Run("ProjectGitignoreExists", func() {
 		s.Run("MissingReturnsFalse", s.projectGitignoreExistsMissing)
@@ -276,6 +277,50 @@ func (s *testSuite) writeProjectGitignoreFixesTrailingNewline() {
 
 	s.True(strings.HasPrefix(body, "no-trailing-newline\n"), "trailing newline must be inserted before appended content")
 	s.Contains(body, testTemplates().ProjectGitignoreHeader)
+}
+
+func (s *testSuite) writeProjectGitignorePreservesAppendLineEndings() {
+	tpl := testTemplates()
+	lfSection := tpl.ProjectGitignoreHeader + "\n" + strings.Join(tpl.ProjectGitignorePatterns, "\n") + "\n"
+	crlfSection := tpl.ProjectGitignoreHeader + "\r\n" + strings.Join(tpl.ProjectGitignorePatterns, "\r\n") + "\r\n"
+	partial := tpl.ProjectGitignoreHeader + "\r\n.dolt/\r\n"
+	complete := strings.TrimSuffix(crlfSection, "\r\n")
+	for _, tc := range []struct {
+		name, existing, want string
+		omitHeader           bool
+	}{
+		{"empty", "", lfSection, false},
+		{"delimiter-free", "local", "local\n\n" + lfSection, false},
+		{"LF", "local\n", "local\n\n" + lfSection, false},
+		{"CRLF", "local\r\n", "local\r\n\r\n" + crlfSection, false},
+		{"CRLF unterminated", "local\r\nlast", "local\r\nlast\r\n\r\n" + crlfSection, false},
+		{"CRLF trailing CR", "local\r\nlast\r", "local\r\nlast\r\n\r\n" + crlfSection, false},
+		{"LF trailing CR", "local\nlast\r", "local\nlast\r\n\n" + lfSection, false},
+		{"only trailing CR", "local\r", "local\r\n\n" + lfSection, false},
+		{"mixed majority CRLF", "a\r\nb\r\nc\n", "a\r\nb\r\nc\n\n" + lfSection, false},
+		{"partial with header", partial, partial + "*.db\r\n", false},
+		{"complete unterminated", complete, complete, false},
+		{"complete CRLF", crlfSection, crlfSection, false},
+		{"no header", "local\r\n", "local\r\n.dolt/\r\n*.db\r\n", true},
+	} {
+		s.Run(tc.name, func() {
+			s.T().Setenv("BEADS_DIR", "")
+			dir := s.T().TempDir()
+			templates := testTemplates()
+			if tc.omitHeader {
+				templates.ProjectGitignoreHeader = ""
+			}
+			repo := NewBeadsDirFSRepository(dir, templates)
+			path := filepath.Join(dir, ".gitignore")
+			s.Require().NoError(os.WriteFile(path, []byte(tc.existing), 0600))
+			for call := 1; call <= 2; call++ {
+				s.Require().NoError(repo.WriteProjectGitignore(s.Ctx()), "call %d", call)
+				got, err := os.ReadFile(path)
+				s.Require().NoError(err)
+				s.Equal(tc.want, string(got), "call %d: exact file bytes", call)
+			}
+		})
+	}
 }
 
 func (s *testSuite) projectGitignoreExistsMissing() {

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -61,6 +61,29 @@ func TestPRCIGateRequiresPolicyAndLintWrappers(t *testing.T) {
 	}
 }
 
+func TestPRCoreRequiresExcludeReadPermissionCoverage(t *testing.T) {
+	workflow := readCIWorkflow(t, "pr.yml")
+	job := workflow.job(t, "pr-core-wrapper")
+	if job.RunsOn != "ubuntu-latest" || job.If != "" || job.ContinueOnError {
+		t.Error("exclude permission coverage must remain in the required Linux PR Core job")
+	}
+	step := job.Steps[job.stepIndex(t, "Run PR core wrapper")]
+	if step.If != "" || (step.ContinueOnError != nil && step.ContinueOnError != false) || strings.TrimSpace(step.Run) != "make ci-pr-core" {
+		t.Error("exclude permission coverage must run through the nonoptional PR Core wrapper")
+	}
+	if step.Env["BEADS_TEST_REQUIRE_EXCLUDE_PERMISSION"] != "1" {
+		t.Error("PR Core must require actual exclude read-permission coverage")
+	}
+	gate := workflow.job(t, "ci-gate")
+	evaluate := gate.step(t, "Evaluate CI gate")
+	if gate.If != "${{ always() }}" || gate.ContinueOnError || evaluate.If != "" || (evaluate.ContinueOnError != nil && evaluate.ContinueOnError != false) {
+		t.Error("CI gate must propagate required PR Core failures")
+	}
+	if !contains(gate.Needs, "pr-core-wrapper") || evaluate.Env["PR_CORE_WRAPPER"] != "${{ needs.pr-core-wrapper.result }}" || !contains(strings.Fields(evaluate.Env["CI_GATE_REQUIRED"]), "PR_CORE_WRAPPER") {
+		t.Error("CI gate must require the PR Core result")
+	}
+}
+
 func TestPRComplexityReportIsAdvisoryAndBestEffort(t *testing.T) {
 	workflow := readCIWorkflow(t, "pr.yml")
 	job := workflow.job(t, "complexity-report")


### PR DESCRIPTION
The deprecated, currently uncalled `setupGlobalGitIgnore` helper refuses existing global-ignore files it cannot read, preventing writable-but-unreadable content from being replaced as though empty. This is helper coverage, not a fix to the live `bd init` path. Missing files can still be created; later write failures retain the existing manual advice and nonfatal behavior.

Review follow-up: addressed the [nits](https://github.com/gastownhall/beads/pull/6425#pullrequestreview-5145414347) by documenting that scope, clarifying permission-fixture cleanup, and covering a dangling symlink as intended absence. The separate shared-composer change is #6426. Retirement is implemented in [#6452](https://github.com/gastownhall/beads/pull/6452), which removes this unused helper and makes its conditional platform/advice follow-ups unnecessary.

At `7a515759ff`, four portable cases, scoped vet and revision lint pass on native Windows with CGO disabled. All five cases also pass on actual unprivileged Linux with CGO disabled, including independently demonstrated read denial and write permission plus the dangling symlink; no selected tests skipped. Earlier Windows normal/race results and directory-error controls belong to `d5287cdf00`; the unprivileged Linux read-denied/write-allowed case and overwrite control belong to `d5287cdf00`. This revision does not claim new full-init, race or macOS execution.

This revision changes 22 lines in the existing test file; the full main-relative stack is 513 lines across ten files. Requires #6402 and its #6399/#6397/#6389/#6387 parents. Fixes #6415.

_unknown-model/unknown-reasoning on behalf of Ewen Cuthiell_
