### PR TITLE
docs(recovery): init-safety re-clone playbook covers damaged-store and fresh-clone gotchas

### DIFF
--- a/cmd/bd/init_safety_help.go
+++ b/cmd/bd/init_safety_help.go
@@ -86,6 +86,22 @@ RECOVERY
 
   If you hit a refusal, see docs/recovery/init-safety.md for step-by-step recovery
   playbooks for each exit code.
+
+RE-CLONE GOTCHAS
+
+  Setting a damaged or superseded database directory aside by hand, or
+  relying on a fresh clone right away? Two gotchas from live recovery:
+
+  Crash-loop: a set-aside store left INSIDE data_dir makes the sql-server
+  treat it as a database and crash-loop with "root hash doesn't exist:
+  <hash>". Move it OUTSIDE data_dir instead.
+
+  Missing tables: a fresh clone lacks clone-local tables (leases, wisps,
+  events, ...) until you run "bd migrate schema" (no --force). You'll see
+  "table not found: leases" until then; "Schema already at v64" after
+  running it is expected, not an error.
+
+  See docs/recovery/init-safety.md#re-clone-gotchas for full detail.
 `,
 	Run: func(cmd *cobra.Command, _ []string) {
 		evt := metrics.NewCommandEvent("init-safety")

--- a/cmd/bd/init_safety_help.go
+++ b/cmd/bd/init_safety_help.go
@@ -98,7 +98,7 @@ RE-CLONE GOTCHAS
 
   Missing tables: a fresh clone lacks clone-local tables (leases, wisps,
   events, ...) until you run "bd migrate schema" (no --force). You'll see
-  "table not found: leases" until then; "Schema already at v64" after
+  "table not found: leases" until then; "Schema already at v<N>" after
   running it is expected, not an error.
 
   See docs/recovery/init-safety.md#re-clone-gotchas for full detail.

--- a/docs/recovery/init-safety.md
+++ b/docs/recovery/init-safety.md
@@ -6,7 +6,8 @@ description: Step-by-step recovery for bd init and bd dolt push/pull refusals, i
 Last reviewed: 2026-09-08
 
 Freshness source: `cmd/bd/init.go`, `cmd/bd/init_safety.go`,
-`cmd/bd/init_safety_test.go`, and `cmd/bd/dolt.go`.
+`cmd/bd/init_safety_test.go`, `cmd/bd/init_safety_help.go`, and
+`cmd/bd/dolt.go`.
 
 This document lives next to the ADRs and matches the structure of `bd`'s
 error messages: each named refusal in `bd init` and `bd dolt push`/`pull`
@@ -25,6 +26,7 @@ See also: `bd help init-safety`, and
 - [init-token-missing — a destructive re-init refused because `--destroy-token` is missing or wrong](#init-token-missing)
 - [init-local-exists — `bd init --reinit-local` refused because local data already exists](#init-local-exists)
 - [pk-fork-refused — `bd dolt pull`/`push` refused because a table has different primary keys in its common ancestor](#pk-fork-refused)
+- [re-clone-gotchas — two gotchas hit during manual re-clone recovery: damaged stores left inside `data_dir`, and a fresh clone missing clone-local tables](#re-clone-gotchas)
 
 ---
 
@@ -61,6 +63,10 @@ bd bootstrap
 
 This clones the remote's Dolt database into a fresh local `.beads/`.
 Your local state is ignored; the team's history becomes yours.
+
+If you set aside the old `.beads/dolt` instead of deleting it, or `bd list`
+fails right after this with `table not found: leases`, see
+[re-clone-gotchas](#re-clone-gotchas) below before you do anything else.
 
 ### 2. You want to diagnose what went wrong before deciding
 
@@ -279,6 +285,10 @@ bd import /tmp/beads-local.jsonl             # re-apply local-only work
 re-created, newer local edits are applied, and rows older than what the
 remote already has are skipped. Spot-check with `bd stats` afterwards.
 
+Doing this by hand (moving `.beads/dolt` aside instead of `rm -rf`, or
+skipping straight to `bd list`) can hit either of two live gotchas — see
+[re-clone-gotchas](#re-clone-gotchas) below.
+
 ### Prevention (upgrades across PK-reshaping migrations)
 
 - **Sync before upgrading**: `bd dolt push` + `bd dolt pull` on every clone
@@ -293,3 +303,91 @@ remote already has are skipped. Spot-check with `bd stats` afterwards.
   migrations, so do not rely on it; the "sync before" step above is what
   preserves these clones' work, because `bd bootstrap` replaces the local
   database.
+
+---
+
+## re-clone-gotchas
+
+Two gotchas hit during a live manual re-clone recovery (issue
+[ga-vrq5pu](https://github.com/gastownhall/beads/issues/ga-vrq5pu)), each of
+which cost real time because the symptom looks nothing like the cause. Both
+apply any time you set aside or replace a Dolt database directory by hand —
+during the [pk-fork-refused](#pk-fork-refused) playbook above, the
+[init-force-refused](#init-force-refused) `bd bootstrap` path, or any other
+manual re-clone.
+
+### Gotcha 1 — a damaged/set-aside store must go OUTSIDE data_dir
+
+**Symptom**
+
+```
+root hash doesn't exist: <hash>
+```
+
+...printed repeatedly as the Dolt sql-server crash-loops under its
+supervisor/watchdog. Nothing in that message mentions a stray directory, so
+it does not look like "you left a directory lying around."
+
+**Why this happens**
+
+The sql-server treats *every* subdirectory of its `data_dir` (default
+`.beads/dolt/`, overridable via `BEADS_DOLT_DATA_DIR` or the `dolt_data_dir`
+field in `metadata.json`) as its own database and tries to load it. If you
+move a damaged or superseded database directory aside but leave it *inside*
+`data_dir` (for example, renaming `.beads/dolt/mydb` to
+`.beads/dolt/mydb.bak` instead of moving it out of `.beads/dolt/`
+entirely), the server tries to load the damaged copy too and dies on it —
+even though the healthy database sitting right next to it is fine.
+
+**The fix**
+
+When you set a database directory aside by hand, move it *outside*
+`data_dir` — e.g. up to `/tmp/` or a sibling of `.beads/`, never to a
+sibling path still under `.beads/dolt/`. This is exactly what the automated
+recovery path already does: `bd doctor --fix`'s corrupt-manifest repair
+renames a damaged database directory to a timestamped backup nested one
+level *inside* that database's own directory (`X/.dolt` →
+`X/.dolt.<ts>.corrupt.backup`), which is safe because it is not a new
+top-level subdirectory of `data_dir`. Doing the equivalent by hand at the
+top level of `data_dir` is what triggers this gotcha; see `bd doctor --fix`
+for the automated, gotcha-free version of this move.
+
+### Gotcha 2 — a fresh clone needs `bd migrate schema`
+
+**Symptom**
+
+```
+table not found: leases
+```
+
+(or a similar "table not found" error for `wisps`, `events`,
+`local_metadata`, or another clone-local table). A supervisor or agent
+harness that expects to load session beads right after a fresh clone fails
+here.
+
+**Why this happens**
+
+A handful of tables — `leases`, `wisps`, `wisp_*`, `events`, `bd_events_*`,
+`local_metadata`, `ignored_schema_migrations`, `repo_mtimes` — are
+dolt-ignored, clone-local tables: they exist on a running database but are
+deliberately excluded from what `bd dolt push`/`pull`/clone transfers, so a
+fresh clone starts without them. `bd`'s ordinary open does not recreate
+them.
+
+**The fix**
+
+```
+bd migrate schema
+```
+
+No `--force` needed. This replays the clone-local tables and prints:
+
+```
+✓ Schema already at v64
+```
+
+**That output is expected and reassuring, not an error** — it means the
+*versioned* schema was already current; the clone-local tables have now
+been (re)created regardless. Run this once after any fresh clone or
+`bd bootstrap`, before relying on `bd list` or any other command that reads
+session state.

--- a/docs/recovery/init-safety.md
+++ b/docs/recovery/init-safety.md
@@ -308,9 +308,9 @@ skipping straight to `bd list`) can hit either of two live gotchas — see
 
 ## re-clone-gotchas
 
-Two gotchas hit during a live manual re-clone recovery (issue
-[ga-vrq5pu](https://github.com/gastownhall/beads/issues/ga-vrq5pu)), each of
-which cost real time because the symptom looks nothing like the cause. Both
+Two gotchas hit during a live manual re-clone recovery (issue ga-vrq5pu),
+each of which cost real time because the symptom looks nothing like the
+cause. Both
 apply any time you set aside or replace a Dolt database directory by hand —
 during the [pk-fork-refused](#pk-fork-refused) playbook above, the
 [init-force-refused](#init-force-refused) `bd bootstrap` path, or any other
@@ -345,12 +345,12 @@ When you set a database directory aside by hand, move it *outside*
 `data_dir` — e.g. up to `/tmp/` or a sibling of `.beads/`, never to a
 sibling path still under `.beads/dolt/`. This is exactly what the automated
 recovery path already does: `bd doctor --fix`'s corrupt-manifest repair
-renames a damaged database directory to a timestamped backup nested one
-level *inside* that database's own directory (`X/.dolt` →
-`X/.dolt.<ts>.corrupt.backup`), which is safe because it is not a new
-top-level subdirectory of `data_dir`. Doing the equivalent by hand at the
-top level of `data_dir` is what triggers this gotcha; see `bd doctor --fix`
-for the automated, gotcha-free version of this move.
+renames the *whole* `data_dir` directory itself to a timestamped
+`.<ts>.corrupt.backup` sibling (`data_dir` → `data_dir.<ts>.corrupt.backup`),
+landing next to `data_dir`, not inside it. Doing the equivalent by hand but
+leaving the renamed copy nested under the original `data_dir` is what
+triggers this gotcha; see `bd doctor --fix` for the automated, gotcha-free
+version of this move.
 
 ### Gotcha 2 — a fresh clone needs `bd migrate schema`
 
@@ -383,7 +383,7 @@ bd migrate schema
 No `--force` needed. This replays the clone-local tables and prints:
 
 ```
-✓ Schema already at v64
+✓ Schema already at v<N>
 ```
 
 **That output is expected and reassuring, not an error** — it means the

--- a/test/docsync/init_safety_recovery_test.go
+++ b/test/docsync/init_safety_recovery_test.go
@@ -16,7 +16,7 @@ import (
 //     "root hash doesn't exist: <hash>".
 //  2. A fresh clone lacks dolt-ignored clone-local tables (leases, wisps,
 //     events, local_metadata, etc.) until `bd migrate schema` has run once.
-//     Symptom: "table not found: leases". The fix's "Schema already at v64"
+//     Symptom: "table not found: leases". The fix's "Schema already at v<N>"
 //     output is the expected, reassuring result — not an error.
 func TestInitSafetyRecoveryDocCoversReCloneGotchas(t *testing.T) {
 	root := repoRoot()
@@ -34,7 +34,7 @@ func TestInitSafetyRecoveryDocCoversReCloneGotchas(t *testing.T) {
 		{"damaged-store crash-loop symptom", "root hash doesn't exist"},
 		{"fresh-clone missing-table symptom", "table not found: leases"},
 		{"fresh-clone fix command", "bd migrate schema"},
-		{"fresh-clone reassuring success message", "schema already at v64"},
+		{"fresh-clone reassuring success message", "schema already at v"},
 	}
 	for _, c := range cases {
 		if !strings.Contains(lower, strings.ToLower(c.substr)) {

--- a/test/docsync/init_safety_recovery_test.go
+++ b/test/docsync/init_safety_recovery_test.go
@@ -1,0 +1,77 @@
+package docsync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInitSafetyRecoveryDocCoversReCloneGotchas guards two gotchas discovered
+// during live recovery incident ga-vrq5pu:
+//
+//  1. A damaged/set-aside Dolt database directory left INSIDE the
+//     sql-server's data_dir crash-loops the server, because every
+//     subdirectory of data_dir is treated as its own database. Symptom:
+//     "root hash doesn't exist: <hash>".
+//  2. A fresh clone lacks dolt-ignored clone-local tables (leases, wisps,
+//     events, local_metadata, etc.) until `bd migrate schema` has run once.
+//     Symptom: "table not found: leases". The fix's "Schema already at v64"
+//     output is the expected, reassuring result — not an error.
+func TestInitSafetyRecoveryDocCoversReCloneGotchas(t *testing.T) {
+	root := repoRoot()
+	path := filepath.Join(root, "docs", "recovery", "init-safety.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	lower := strings.ToLower(string(data))
+
+	cases := []struct {
+		name   string
+		substr string
+	}{
+		{"damaged-store crash-loop symptom", "root hash doesn't exist"},
+		{"fresh-clone missing-table symptom", "table not found: leases"},
+		{"fresh-clone fix command", "bd migrate schema"},
+		{"fresh-clone reassuring success message", "schema already at v64"},
+	}
+	for _, c := range cases {
+		if !strings.Contains(lower, strings.ToLower(c.substr)) {
+			t.Errorf("docs/recovery/init-safety.md missing %s: expected to find %q", c.name, c.substr)
+		}
+	}
+
+	if !strings.Contains(lower, "outside") || !strings.Contains(lower, "data_dir") {
+		t.Errorf("docs/recovery/init-safety.md must say damaged/set-aside stores go OUTSIDE data_dir (the sql-server treats every data_dir subdirectory as a database)")
+	}
+}
+
+// TestInitSafetyCLIReferenceCoversReCloneGotchas guards the same two
+// re-clone gotchas (at CLI-help brevity) in the auto-generated CLI
+// reference page. The page is generated from cmd/bd/init_safety_help.go's
+// Long field via scripts/generate-cli-docs.sh — edit the Go source, not
+// this generated file, then regenerate.
+func TestInitSafetyCLIReferenceCoversReCloneGotchas(t *testing.T) {
+	root := repoRoot()
+	path := filepath.Join(root, "docs", "cli-reference", "init-safety.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	lower := strings.ToLower(string(data))
+
+	cases := []struct {
+		name   string
+		substr string
+	}{
+		{"damaged-store crash-loop symptom", "root hash doesn't exist"},
+		{"fresh-clone missing-table symptom", "table not found: leases"},
+		{"fresh-clone fix command", "bd migrate schema"},
+	}
+	for _, c := range cases {
+		if !strings.Contains(lower, strings.ToLower(c.substr)) {
+			t.Errorf("docs/cli-reference/init-safety.md missing %s: expected to find %q (edit cmd/bd/init_safety_help.go and regenerate)", c.name, c.substr)
+		}
+	}
+}

--- a/test/docsync/init_safety_recovery_test.go
+++ b/test/docsync/init_safety_recovery_test.go
@@ -47,14 +47,24 @@ func TestInitSafetyRecoveryDocCoversReCloneGotchas(t *testing.T) {
 	}
 }
 
-// TestInitSafetyCLIReferenceCoversReCloneGotchas guards the same two
-// re-clone gotchas (at CLI-help brevity) in the auto-generated CLI
-// reference page. The page is generated from cmd/bd/init_safety_help.go's
-// Long field via scripts/generate-cli-docs.sh — edit the Go source, not
-// this generated file, then regenerate.
-func TestInitSafetyCLIReferenceCoversReCloneGotchas(t *testing.T) {
+// TestInitSafetyCLIHelpCoversReCloneGotchas guards the same two re-clone
+// gotchas (at CLI-help brevity) in cmd/bd/init_safety_help.go's Long field,
+// the generator source for docs/cli-reference/init-safety.md.
+//
+// The generated page itself is intentionally NOT checked here: per
+// docs/cli-docs.pin, docs/cli-reference/ is regenerated from a pinned
+// *released* bd tag (built in a detached worktree), not from this checkout,
+// so a Long-field edit at HEAD does not flow into the committed generated
+// page until a maintainer bumps the pin as part of a release (see
+// docs/cli-docs.pin's own header comment and scripts/resolve-docs-bd.sh).
+// CI's generated-docs drift gate (scripts/check-cli-docs-drift.sh, driven by
+// scripts/check-doc-flags.sh) is blame-scoped for exactly this reason: it
+// does not fail a PR whose regenerated CLI surface is unchanged from the
+// merge-base. Testing the Long field directly checks the content a PR can
+// actually change and that will ship in the doc at the next pin bump.
+func TestInitSafetyCLIHelpCoversReCloneGotchas(t *testing.T) {
 	root := repoRoot()
-	path := filepath.Join(root, "docs", "cli-reference", "init-safety.md")
+	path := filepath.Join(root, "cmd", "bd", "init_safety_help.go")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("reading %s: %v", path, err)
@@ -71,7 +81,7 @@ func TestInitSafetyCLIReferenceCoversReCloneGotchas(t *testing.T) {
 	}
 	for _, c := range cases {
 		if !strings.Contains(lower, strings.ToLower(c.substr)) {
-			t.Errorf("docs/cli-reference/init-safety.md missing %s: expected to find %q (edit cmd/bd/init_safety_help.go and regenerate)", c.name, c.substr)
+			t.Errorf("cmd/bd/init_safety_help.go missing %s: expected to find %q in the Long help text", c.name, c.substr)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds a "re-clone gotchas" section to the init-safety recovery playbook,
covering two issues hit live during a manual re-clone recovery:

- A damaged/set-aside Dolt store directory left **inside** `data_dir` makes
  every `sql-server` start crash-loop with `root hash doesn't exist: <hash>`
  (it's treated as just another database). It must be moved outside instead.
- A fresh clone lacks the dolt-ignored clone-local tables (`leases`, `wisps`,
  `events`, etc.); `bd list` and similar fail with `table not found: leases`.
  Fix is `bd migrate schema` (no `--force`); `Schema already at v64` is the
  expected, reassuring output, not an error.

`cmd/bd/init_safety_help.go` gets a matching addendum in the
`bd help init-safety` output. Two new regression tests in
`test/docsync/init_safety_recovery_test.go` guard both additions.

refs be-wv0d0

## Note on the doc-freshness check

This PR touches `docs/recovery/init-safety.md`, the same file #6411 recently
refreshed the 90-day freshness marker on. This branch is rebased on top of
that merge, so the marker is current (0 days old,
`scripts/check-doc-freshness.sh` passes locally) — no red expected on that
check here.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l` on changed Go files: clean
- `go test ./test/docsync/...`: 8/8 PASS, including the two new tests
- `TZ=UTC ./scripts/check-doc-freshness.sh`: PASS
