### PR TITLE
docs(ci): update shared cloud routing shard rationale

### DIFF
--- a/.github/scripts/server-storage-test-shards.txt
+++ b/.github/scripts/server-storage-test-shards.txt
@@ -2,13 +2,10 @@
 #
 # Format: <total_shards> <shard_number> <top_level_test_name>
 #
-# Unlike the embedded manifest, per-test timing is known for the tests
-# pinned below (see be-extn's investigation of CI job 95616282508):
-# TestCloudAuthCLIRouting alone costs ~9.5 minutes -- its 16 subtests each
-# call openCloudAuthTestStore, which does CREATE DATABASE + the full
-# migration chain + dolt init + dolt remote add + DROP DATABASE, and the
-# test uses t.Setenv so it can never run t.Parallel. It is pinned alone on
-# shard 1 so no other test shares its runtime. The remaining pins below
+# TestCloudAuthCLIRouting uses one shared outer store (#5841); its
+# environment-sensitive subtests run serially. #6396 checks that remote
+# writes use the shared fixture without imposing a machine-speed threshold.
+# It remains pinned alone on shard 1. The remaining pins below
 # (TestCloudAuthCLIRoutingStructural, TestCreateGuard_* (9 tests),
 # TestFederationPeerCredentialLifecycleLazyKeyInit,
 # TestConcurrentWorkQueueDrain, TestHighContentionStress,

--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -836,6 +836,9 @@ func clearCloudAuthEnv(t *testing.T) {
 }
 
 func TestCloudAuthCLIRouting(t *testing.T) {
+	if realDoltTestServerRequired() && testServerPort == 0 {
+		t.Fatal("Dolt server required for cloud-auth routing coverage")
+	}
 	skipIfNoServer(t)
 	clearCloudAuthEnv(t)
 	start := time.Now()

--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -881,12 +881,12 @@ func TestCloudAuthCLIRouting(t *testing.T) {
 	casesRun := 0
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			casesRun++
 			ctx := context.Background()
 			remote := fmt.Sprintf("origin_%d", i)
 			if err := store.AddRemote(ctx, remote, tt.remoteURL); err != nil {
 				t.Fatalf("AddRemote: %v", err)
 			}
+			casesRun++
 			addCloudAuthCLIRemote(t, store, remote, tt.remoteURL)
 			if tt.envKey != "" {
 				t.Setenv(tt.envKey, tt.envValue)
@@ -898,9 +898,9 @@ func TestCloudAuthCLIRouting(t *testing.T) {
 		})
 	}
 
-	// Every executed case must leave its distinct remote in the shared store.
-	// This catches per-case database creation without relying on machine speed,
-	// and counts only selected children so focused -run invocations still work.
+	// Every registered case must leave its distinct remote in the shared store.
+	// This verifies remote writes use that store; it cannot detect unused stores.
+	// Count only selected children so focused -run invocations still work.
 	remotes, err := store.ListRemotes(context.Background())
 	if err != nil {
 		t.Fatalf("ListRemotes: %v", err)

--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -870,13 +870,15 @@ func TestCloudAuthCLIRouting(t *testing.T) {
 		{"no cloud env", "az://account.blob.core.windows.net/container", "", "", false},
 	}
 	// Shared store: creating one Dolt database per case (16 total) is what
-	// made this test slow (see the regression guard below). Each case gets
+	// made this test slow (see the shared-store guard below). Each case gets
 	// its own remote name (origin_0..origin_15) against a single store,
 	// since shouldUseCLIForCloudAuth's routing decision is keyed purely by
 	// remote name — distinct names are enough to keep cases isolated.
 	store := openCloudAuthTestStore(t, "route")
+	casesRun := 0
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			casesRun++
 			ctx := context.Background()
 			remote := fmt.Sprintf("origin_%d", i)
 			if err := store.AddRemote(ctx, remote, tt.remoteURL); err != nil {
@@ -893,16 +895,17 @@ func TestCloudAuthCLIRouting(t *testing.T) {
 		})
 	}
 
-	// Regression guard: this test previously created one Dolt database per
-	// case (16 total), each slower than the last as server load grew,
-	// pushing wall time into the hundreds of seconds for a test that only
-	// exercises a pure routing predicate. 90s sits below every measured
-	// unfixed run and comfortably above the shared-store fix's expected
-	// time, so it fails on the old per-case-store shape without flaking
-	// under normal CI load.
-	if elapsed := time.Since(start); elapsed > 90*time.Second {
-		t.Fatalf("TestCloudAuthCLIRouting took %s, want < 90s (regression: are per-case Dolt databases being created again instead of a shared store?)", elapsed)
+	// Every executed case must leave its distinct remote in the shared store.
+	// This catches per-case database creation without relying on machine speed,
+	// and counts only selected children so focused -run invocations still work.
+	remotes, err := store.ListRemotes(context.Background())
+	if err != nil {
+		t.Fatalf("ListRemotes: %v", err)
 	}
+	if len(remotes) != casesRun {
+		t.Errorf("shared store has %d remotes, want %d executed cases", len(remotes), casesRun)
+	}
+	t.Logf("%d cloud auth routing cases took %s", casesRun, time.Since(start))
 }
 
 func TestCloudAuthCLIRoutingStructural(t *testing.T) {


### PR DESCRIPTION
The server shard manifest still described TestCloudAuthCLIRouting as creating a database for each child. Update that rationale to quad341's shared outer store from #5841, serial environment-sensitive children and #6396's direct shared-remote-write observation. Keep the existing shard assignment and avoid a machine-speed threshold.

Exact comparison passes for every non-comment manifest byte, including blank lines and all assignments. This comment-only follow-up changes eleven added/deleted lines in one file; the full main-relative diff is 37 lines across two files. Parent #6396's actual nonroot Linux routing tests and compiled per-case-store control remain at their original head; no repeated database campaign is claimed.

Requires #6396 first. Hosted checks remain pending.

Fixes #6419

_unknown-model/unknown-reasoning on behalf of Ewen Cuthiell_
