### PR TITLE
refactor(git): resolve hooks paths in an explicit read-only context

### DIFF
--- a/internal/git/gitdir.go
+++ b/internal/git/gitdir.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strings"
 	"sync"
 )
@@ -40,6 +39,12 @@ func loadGitContext(workDir string, env []string) gitContext {
 	output, err := cmd.Output()
 	if err != nil {
 		ctx.err = fmt.Errorf("not a git repository: %w", err)
+		if workDir != "" {
+			ctx.err = fmt.Errorf("resolve Git working tree: %w", err)
+			if exit, ok := err.(*exec.ExitError); ok && len(exit.Stderr) > 0 {
+				ctx.err = fmt.Errorf("%w: %s", ctx.err, strings.TrimSpace(string(exit.Stderr)))
+			}
+		}
 		return ctx
 	}
 
@@ -100,10 +105,14 @@ type HooksContext struct {
 }
 
 // ResolveHooksContext reads fresh paths without changing the legacy cache.
-// workDir must be nonempty and is anchored once; bare/non-repositories error.
-// Nil env inherits; a nonnil env is copied and supplied, including an empty one.
+// workDir must be nonempty and is anchored and symlink/case-normalized once;
+// bare/non-repositories error. Configured absolute hook paths retain their spelling.
+// Nil env inherits; a nonnil env is supplied unchanged, including an empty one.
+// The call neither mutates nor retains env; callers must not change it during the call.
 // Routing variables are honored, not filtered. Tilde expansion uses the Go
 // process's home directory, independently of HOME supplied to child Git.
+// A sandbox HOME therefore does not redirect a configured ~/ hook path: callers
+// that install there would still write under the Go process's home directory.
 func ResolveHooksContext(workDir string, env []string) (HooksContext, error) {
 	if workDir == "" {
 		return HooksContext{}, fmt.Errorf("hooks context requires a working directory")
@@ -112,7 +121,13 @@ func ResolveHooksContext(workDir string, env []string) (HooksContext, error) {
 	if err != nil {
 		return HooksContext{}, err
 	}
-	env = slices.Clone(env)
+	workDir, err = filepath.EvalSymlinks(workDir)
+	if err != nil {
+		return HooksContext{}, fmt.Errorf("resolve hooks working directory: %w", err)
+	}
+	if canonical := canonicalizeCase(workDir); canonical != "" {
+		workDir = canonical
+	}
 	ctx := loadGitContext(workDir, env)
 	if ctx.err != nil {
 		return HooksContext{}, ctx.err

--- a/internal/git/gitdir.go
+++ b/internal/git/gitdir.go
@@ -38,12 +38,13 @@ func loadGitContext(workDir string, env []string) gitContext {
 	cmd.Dir, cmd.Env = workDir, env
 	output, err := cmd.Output()
 	if err != nil {
-		ctx.err = fmt.Errorf("not a git repository: %w", err)
 		if workDir != "" {
 			ctx.err = fmt.Errorf("resolve Git working tree: %w", err)
 			if exit, ok := err.(*exec.ExitError); ok && len(exit.Stderr) > 0 {
 				ctx.err = fmt.Errorf("%w: %s", ctx.err, strings.TrimSpace(string(exit.Stderr)))
 			}
+		} else {
+			ctx.err = fmt.Errorf("not a git repository: %w", err)
 		}
 		return ctx
 	}
@@ -121,6 +122,8 @@ func ResolveHooksContext(workDir string, env []string) (HooksContext, error) {
 	if err != nil {
 		return HooksContext{}, err
 	}
+	// This caller-supplied directory must resolve before it can select a repo.
+	// Unlike the discovered repoRoot spelling above, it is an input to Git.
 	workDir, err = filepath.EvalSymlinks(workDir)
 	if err != nil {
 		return HooksContext{}, fmt.Errorf("resolve hooks working directory: %w", err)

--- a/internal/git/gitdir.go
+++ b/internal/git/gitdir.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -28,41 +29,47 @@ var (
 // initGitContext populates the gitContext with a single git call.
 // This is called once per process via sync.Once.
 func initGitContext() {
+	gitCtx = loadGitContext("", nil)
+}
+
+func loadGitContext(workDir string, env []string) gitContext {
+	var ctx gitContext
 	// Get all three values with a single git call
 	cmd := exec.Command("git", "rev-parse", "--git-dir", "--git-common-dir", "--show-toplevel")
+	cmd.Dir, cmd.Env = workDir, env
 	output, err := cmd.Output()
 	if err != nil {
-		gitCtx.err = fmt.Errorf("not a git repository: %w", err)
-		return
+		ctx.err = fmt.Errorf("not a git repository: %w", err)
+		return ctx
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
 	if len(lines) < 3 {
-		gitCtx.err = fmt.Errorf("unexpected git rev-parse output: got %d lines, expected 3", len(lines))
-		return
+		ctx.err = fmt.Errorf("unexpected git rev-parse output: got %d lines, expected 3", len(lines))
+		return ctx
 	}
 
-	gitCtx.gitDir = strings.TrimSpace(lines[0])
+	ctx.gitDir = strings.TrimSpace(lines[0])
 	commonDirRaw := strings.TrimSpace(lines[1])
 	repoRootRaw := strings.TrimSpace(lines[2])
 
 	// Convert commonDir to absolute for reliable comparison
-	absCommon, err := filepath.Abs(commonDirRaw)
+	absCommon, err := absoluteGitPath(workDir, commonDirRaw)
 	if err != nil {
-		gitCtx.err = fmt.Errorf("failed to resolve common dir path: %w", err)
-		return
+		ctx.err = fmt.Errorf("failed to resolve common dir path: %w", err)
+		return ctx
 	}
-	gitCtx.commonDir = absCommon
+	ctx.commonDir = absCommon
 
 	// Convert gitDir to absolute for worktree comparison
-	absGitDir, err := filepath.Abs(gitCtx.gitDir)
+	absGitDir, err := absoluteGitPath(workDir, ctx.gitDir)
 	if err != nil {
-		gitCtx.err = fmt.Errorf("failed to resolve git dir path: %w", err)
-		return
+		ctx.err = fmt.Errorf("failed to resolve git dir path: %w", err)
+		return ctx
 	}
 
 	// Derive isWorktree from comparing absolute paths
-	gitCtx.isWorktree = absGitDir != absCommon
+	ctx.isWorktree = absGitDir != absCommon
 
 	// Process repoRoot: normalize Windows paths, resolve symlinks,
 	// and canonicalize case on case-insensitive filesystems (GH#880).
@@ -75,7 +82,49 @@ func initGitContext() {
 	if canonicalized := canonicalizeCase(repoRoot); canonicalized != "" {
 		repoRoot = canonicalized
 	}
-	gitCtx.repoRoot = repoRoot
+	ctx.repoRoot = repoRoot
+	return ctx
+}
+
+// absoluteGitPath anchors relative Git output to the command directory.
+func absoluteGitPath(workDir, path string) (string, error) {
+	if workDir != "" && !filepath.IsAbs(path) {
+		path = filepath.Join(workDir, path)
+	}
+	return filepath.Abs(path)
+}
+
+// HooksContext is a detached snapshot of a working repository's hook paths.
+type HooksContext struct {
+	HooksDir, CommonDir, RepoRoot, MainRepoRoot string
+}
+
+// ResolveHooksContext reads fresh paths without changing the legacy cache.
+// workDir must be nonempty and is anchored once; bare/non-repositories error.
+// Nil env inherits; a nonnil env is copied and supplied, including an empty one.
+// Routing variables are honored, not filtered. Tilde expansion uses the Go
+// process's home directory, independently of HOME supplied to child Git.
+func ResolveHooksContext(workDir string, env []string) (HooksContext, error) {
+	if workDir == "" {
+		return HooksContext{}, fmt.Errorf("hooks context requires a working directory")
+	}
+	workDir, err := filepath.Abs(workDir)
+	if err != nil {
+		return HooksContext{}, err
+	}
+	env = slices.Clone(env)
+	ctx := loadGitContext(workDir, env)
+	if ctx.err != nil {
+		return HooksContext{}, ctx.err
+	}
+	cmd := exec.Command("git", "config", "--get", "core.hooksPath")
+	cmd.Dir, cmd.Env = workDir, env
+	hooksDir, err := gitHooksDir(cmd, func() (*gitContext, error) { return &ctx, nil })
+	if err != nil {
+		return HooksContext{}, err
+	}
+	return HooksContext{HooksDir: hooksDir, CommonDir: ctx.commonDir,
+		RepoRoot: ctx.repoRoot, MainRepoRoot: ctx.mainRepoRoot()}, nil
 }
 
 // getGitContext returns the cached git context, initializing it if needed.
@@ -123,9 +172,12 @@ func GetGitCommonDir() (string, error) {
 // and live in the common git directory (e.g., /repo/.git/hooks), not in
 // the worktree-specific directory (e.g., /repo/.git/worktrees/feature/hooks).
 func GetGitHooksDir() (string, error) {
+	return gitHooksDir(exec.Command("git", "config", "--get", "core.hooksPath"), getGitContext)
+}
+
+func gitHooksDir(cmd *exec.Cmd, context func() (*gitContext, error)) (string, error) {
 	// Respect core.hooksPath if configured.
 	// This is used by beads' Dolt backend (hooks installed to .beads/hooks/).
-	cmd := exec.Command("git", "config", "--get", "core.hooksPath")
 	if out, err := cmd.Output(); err == nil {
 		hooksPath := strings.TrimSpace(string(out))
 		if hooksPath != "" {
@@ -145,7 +197,7 @@ func GetGitHooksDir() (string, error) {
 			if filepath.IsAbs(hooksPath) {
 				return hooksPath, nil
 			}
-			ctx, err := getGitContext()
+			ctx, err := context()
 			if err != nil {
 				return "", err
 			}
@@ -161,7 +213,7 @@ func GetGitHooksDir() (string, error) {
 	}
 
 	// Default: hooks are stored in the common git directory.
-	ctx, err := getGitContext()
+	ctx, err := context()
 	if err != nil {
 		return "", err
 	}
@@ -214,13 +266,17 @@ func GetMainRepoRoot() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return ctx.mainRepoRoot(), nil
+}
+
+func (ctx *gitContext) mainRepoRoot() string {
 	if ctx.isWorktree {
 		// For worktrees, the main repo root is the parent of the shared .git directory.
-		return filepath.Dir(ctx.commonDir), nil
+		return filepath.Dir(ctx.commonDir)
 	}
 
 	// For regular repos (including submodules), repoRoot is the correct root.
-	return ctx.repoRoot, nil
+	return ctx.repoRoot
 }
 
 // GetRepoRoot returns the root directory of the current git repository.

--- a/internal/git/gitdir_test.go
+++ b/internal/git/gitdir_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -131,4 +133,192 @@ func TestGetGitHooksDirTildeExpansion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveHooksContext(t *testing.T) {
+	// Own both Git and Go home resolution; don't borrow user/global settings.
+	home := t.TempDir()
+	for _, key := range []string{"HOME", "USERPROFILE", "XDG_CONFIG_HOME"} {
+		t.Setenv(key, home)
+	}
+	for _, entry := range os.Environ() {
+		key, value, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(strings.ToUpper(key), "GIT_") {
+			t.Cleanup(func() { _ = os.Setenv(key, value) })
+			if err := os.Unsetenv(key); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(home, ".gitconfig"))
+	cleanEnv := os.Environ()
+	git := func(dir string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir, cmd.Env = dir, cleanEnv
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	mkdir := func(path string) string {
+		t.Helper()
+		if err := os.MkdirAll(path, 0750); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	canonical := func(path string) string {
+		t.Helper()
+		resolved, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return NormalizePath(resolved)
+	}
+	root := t.TempDir()
+	selected, decoy := mkdir(filepath.Join(root, "selected repo")), mkdir(filepath.Join(root, "decoy repo"))
+	for _, repo := range []string{selected, decoy} {
+		git(repo, "init")
+		git(repo, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "-c", "commit.gpgsign=false", "-c", "core.hooksPath=", "commit", "--allow-empty", "-m", "seed")
+	}
+	linked := filepath.Join(root, "linked repo")
+	git(selected, "worktree", "add", "-b", "linked", linked)
+	nested := mkdir(filepath.Join(selected, "nested dir"))
+	nonrepo := mkdir(filepath.Join(root, "nonrepo"))
+	bare := mkdir(filepath.Join(root, "bare.git"))
+	git(bare, "init", "--bare")
+	t.Chdir(decoy)
+	ResetCaches()
+	t.Cleanup(ResetCaches)
+	check := func(t *testing.T, dir string, env []string, repo, hooks string) HooksContext {
+		t.Helper()
+		got, err := ResolveHooksContext(dir, env)
+		want := HooksContext{HooksDir: hooks, CommonDir: filepath.Join(canonical(selected), ".git"), RepoRoot: canonical(repo), MainRepoRoot: canonical(selected)}
+		if err != nil || got != want {
+			t.Fatalf("selected context = %+v, %v; want %+v", got, err, want)
+		}
+		return got
+	}
+	for _, tc := range []struct {
+		name, dir, repo, configured, want string
+		global                            bool
+	}{
+		{"ordinary", selected, selected, "", filepath.Join(canonical(selected), ".git", "hooks"), false},
+		{"nested", nested, selected, "", filepath.Join(canonical(selected), ".git", "hooks"), false},
+		{"linked", linked, linked, "", filepath.Join(canonical(selected), ".git", "hooks"), false},
+		{"relative", linked, linked, "custom/hooks", filepath.Join(canonical(linked), "custom", "hooks"), false},
+		{"absolute", nested, selected, filepath.Join(home, "absolute hooks"), filepath.Join(home, "absolute hooks"), false},
+		{"tilde", selected, selected, "~/tilde hooks", filepath.Join(home, "tilde hooks"), false},
+		{"global", selected, selected, filepath.Join(home, "global hooks"), filepath.Join(home, "global hooks"), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.configured != "" {
+				scope := "--local"
+				if tc.global {
+					scope = "--global"
+				}
+				git(selected, "config", scope, "core.hooksPath", tc.configured)
+				defer git(selected, "config", scope, "--unset", "core.hooksPath")
+			}
+			check(t, tc.dir, cleanEnv, tc.repo, tc.want)
+			t.Chdir(tc.dir)
+			ResetCaches()
+			legacy, err := GetGitHooksDir()
+			if err != nil || legacy != tc.want {
+				t.Fatalf("legacy hooks = %q, %v; want %q", legacy, err, tc.want)
+			}
+		})
+	}
+	t.Run("relative_workdir", func(t *testing.T) {
+		relative, err := filepath.Rel(decoy, nested)
+		if err != nil {
+			t.Fatal(err)
+		}
+		check(t, relative, cleanEnv, selected, filepath.Join(canonical(selected), ".git", "hooks"))
+	})
+	t.Run("routing_environment", func(t *testing.T) {
+		t.Setenv("GIT_DIR", filepath.Join(decoy, ".git"))
+		t.Setenv("GIT_WORK_TREE", decoy)
+		for _, env := range [][]string{nil, os.Environ()} {
+			got, err := ResolveHooksContext(selected, env)
+			if err != nil || got.RepoRoot != canonical(decoy) {
+				t.Fatalf("supplied/inherited routing = %+v, %v", got, err)
+			}
+		}
+		check(t, selected, cleanEnv, selected, filepath.Join(canonical(selected), ".git", "hooks"))
+	})
+	t.Run("empty_environment", func(t *testing.T) {
+		localHooks, ambientHooks := filepath.Join(home, "local"), filepath.Join(home, "inline")
+		git(selected, "config", "core.hooksPath", localHooks)
+		defer git(selected, "config", "--unset", "core.hooksPath")
+		t.Setenv("GIT_CONFIG_COUNT", "1")
+		t.Setenv("GIT_CONFIG_KEY_0", "core.hooksPath")
+		t.Setenv("GIT_CONFIG_VALUE_0", ambientHooks)
+		check(t, selected, nil, selected, ambientHooks)
+		check(t, selected, []string{}, selected, localHooks)
+	})
+	t.Run("process_tilde_home", func(t *testing.T) {
+		git(selected, "config", "core.hooksPath", "~/process hooks")
+		defer git(selected, "config", "--unset", "core.hooksPath")
+		childEnv := append(append([]string{}, cleanEnv...), "HOME="+t.TempDir())
+		check(t, selected, childEnv, selected, filepath.Join(home, "process hooks"))
+	})
+	for _, cachedFailure := range []bool{false, true} {
+		name := "cached_success"
+		if cachedFailure {
+			name = "cached_failure"
+		}
+		t.Run(name, func(t *testing.T) {
+			if cachedFailure {
+				t.Chdir(nonrepo)
+			}
+			ResetCaches()
+			_, err := getGitContext()
+			if (err != nil) != cachedFailure {
+				t.Fatalf("cache precondition: %v", err)
+			}
+			before := gitCtx
+			check(t, selected, cleanEnv, selected, filepath.Join(canonical(selected), ".git", "hooks"))
+			if gitCtx != before {
+				t.Fatal("explicit context changed legacy cache")
+			}
+		})
+	}
+	t.Run("legacy_absolute_after_cached_failure", func(t *testing.T) {
+		t.Chdir(nonrepo)
+		ResetCaches()
+		if _, err := getGitContext(); err == nil {
+			t.Fatal("nonrepo cache precondition")
+		}
+		absolute := filepath.Join(home, "global outside repository")
+		git(selected, "config", "--global", "core.hooksPath", absolute)
+		defer git(selected, "config", "--global", "--unset", "core.hooksPath")
+		got, err := GetGitHooksDir()
+		if err != nil || got != absolute {
+			t.Fatalf("lazy absolute hooks = %q, %v; want %q", got, err, absolute)
+		}
+	})
+	for name, dir := range map[string]string{"empty_workdir": "", "nonrepo": nonrepo, "bare": bare} {
+		t.Run(name, func(t *testing.T) {
+			if got, err := ResolveHooksContext(dir, cleanEnv); err == nil || got != (HooksContext{}) {
+				t.Fatalf("invalid context = %+v, %v", got, err)
+			}
+		})
+	}
+	t.Run("symlink", func(t *testing.T) {
+		link := filepath.Join(root, "selected alias")
+		if err := os.Symlink(selected, link); err != nil {
+			if runtime.GOOS == "windows" {
+				t.Skipf("symlink capability unavailable: %v", err)
+			}
+			t.Fatal(err)
+		}
+		got, err := ResolveHooksContext(link, cleanEnv)
+		if err != nil || got.RepoRoot != canonical(selected) {
+			t.Fatalf("symlink context = %+v, %v", got, err)
+		}
+	})
 }

--- a/internal/git/gitdir_test.go
+++ b/internal/git/gitdir_test.go
@@ -291,8 +291,8 @@ func TestResolveHooksContext(t *testing.T) {
 	t.Run("legacy_absolute_after_cached_failure", func(t *testing.T) {
 		t.Chdir(nonrepo)
 		ResetCaches()
-		if _, err := getGitContext(); err == nil {
-			t.Fatal("nonrepo cache precondition")
+		if _, err := getGitContext(); err == nil || !strings.HasPrefix(err.Error(), "not a git repository: ") {
+			t.Fatalf("legacy nonrepo error prefix must remain compatible: %v", err)
 		}
 		absolute := filepath.Join(home, "global outside repository")
 		git(selected, "config", "--global", "core.hooksPath", absolute)

--- a/internal/git/gitdir_test.go
+++ b/internal/git/gitdir_test.go
@@ -178,7 +178,7 @@ func TestResolveHooksContext(t *testing.T) {
 		}
 		return NormalizePath(resolved)
 	}
-	root := t.TempDir()
+	root := canonical(t.TempDir())
 	selected, decoy := mkdir(filepath.Join(root, "selected repo")), mkdir(filepath.Join(root, "decoy repo"))
 	for _, repo := range []string{selected, decoy} {
 		git(repo, "init")

--- a/internal/git/gitdir_test.go
+++ b/internal/git/gitdir_test.go
@@ -198,7 +198,7 @@ func TestResolveHooksContext(t *testing.T) {
 		got, err := ResolveHooksContext(dir, env)
 		want := HooksContext{HooksDir: hooks, CommonDir: filepath.Join(canonical(selected), ".git"), RepoRoot: canonical(repo), MainRepoRoot: canonical(selected)}
 		if err != nil || got != want {
-			t.Fatalf("selected context = %+v, %v; want %+v", got, err, want)
+			t.Errorf("selected context = %+v, %v; want %+v", got, err, want)
 		}
 		return got
 	}
@@ -303,8 +303,12 @@ func TestResolveHooksContext(t *testing.T) {
 	})
 	for name, dir := range map[string]string{"empty_workdir": "", "nonrepo": nonrepo, "bare": bare} {
 		t.Run(name, func(t *testing.T) {
-			if got, err := ResolveHooksContext(dir, cleanEnv); err == nil || got != (HooksContext{}) {
+			got, err := ResolveHooksContext(dir, cleanEnv)
+			if err == nil || got != (HooksContext{}) {
 				t.Fatalf("invalid context = %+v, %v", got, err)
+			}
+			if name == "bare" && !strings.Contains(err.Error(), "work tree") {
+				t.Errorf("bare repository error must retain Git's work-tree diagnostic: %v", err)
 			}
 		})
 	}
@@ -316,9 +320,6 @@ func TestResolveHooksContext(t *testing.T) {
 			}
 			t.Fatal(err)
 		}
-		got, err := ResolveHooksContext(link, cleanEnv)
-		if err != nil || got.RepoRoot != canonical(selected) {
-			t.Fatalf("symlink context = %+v, %v", got, err)
-		}
+		check(t, link, cleanEnv, selected, filepath.Join(canonical(selected), ".git", "hooks"))
 	})
 }

--- a/internal/git/gitdir_test.go
+++ b/internal/git/gitdir_test.go
@@ -136,6 +136,7 @@ func TestGetGitHooksDirTildeExpansion(t *testing.T) {
 }
 
 func TestResolveHooksContext(t *testing.T) {
+	t.Setenv("LC_ALL", "C")
 	// Own both Git and Go home resolution; don't borrow user/global settings.
 	home := t.TempDir()
 	for _, key := range []string{"HOME", "USERPROFILE", "XDG_CONFIG_HOME"} {


### PR DESCRIPTION
`ResolveHooksContext(workDir, env)` resolves hooks, common-directory and repository paths for an explicit working directory without using the legacy cache. It anchors and normalizes that directory once while preserving configured absolute-hook spelling and lazy legacy behavior.

The caller-supplied directory must resolve before it can select a repository; canonicalizing a repository root already discovered by Git remains best effort. Legacy cached-context failures retain the `not a git repository: ` prefix, now pinned by the existing nonrepository test. The error branch also avoids an overwritten assignment. These address the [resolution, compatibility and dead-store findings](https://github.com/gastownhall/beads/pull/6436#issuecomment-5610061560).

The synchronous call neither mutates nor retains a supplied environment; callers must keep it stable. Nil inherits, an empty slice stays empty, and routing is caller-owned. A sandbox HOME supplied to Git does not redirect `~/` hook paths, which use the Go process's home. Git's work-tree failure detail is retained, and the fixture owns `LC_ALL=C` before capturing child environments.

At `6788d6766f`, all 18 resolver cases pass on native Windows and actual unprivileged Linux with CGO disabled, including real symlinks; no selected tests skipped. Scoped vet and revision lint pass. A compiled control that forces the explicit-context error branch fails at the new legacy-prefix assertion. Earlier broader-suite and race results retain their original heads.

This revision changes nine lines; the full diff is 304 lines in two files against recorded base `2298c651`. Required PR Core owns these untagged package tests. The selected-init consumer is #6440. Hosted verification and local adoption remain pending. Refs #6384.

_Codex-unknown-model-unknown-reasoning on behalf of Ewen Cuthiell_
