### PR TITLE
fix(dolt): authenticate pull verification refresh

### DIFF
--- a/internal/storage/dolt/remote_routing_test.go
+++ b/internal/storage/dolt/remote_routing_test.go
@@ -30,6 +30,31 @@ func TestEnsureMatchingCLIRemoteSurfacesValidationErrors(t *testing.T) {
 	}
 }
 
+func TestAuthenticatedFetchCall(t *testing.T) {
+	query, args := authenticatedFetchCall(
+		&remoteCredentials{username: "root", password: "secret"},
+		"origin",
+		"main",
+	)
+	if query != "CALL DOLT_FETCH('--user', ?, ?, ?)" {
+		t.Fatalf("authenticated query = %q", query)
+	}
+	wantArgs := []any{"root", "origin", "main"}
+	if len(args) != len(wantArgs) {
+		t.Fatalf("authenticated args = %#v, want %#v", args, wantArgs)
+	}
+	for i := range wantArgs {
+		if args[i] != wantArgs[i] {
+			t.Fatalf("authenticated args = %#v, want %#v", args, wantArgs)
+		}
+	}
+
+	query, args = authenticatedFetchCall(nil, "origin", "main")
+	if query != "CALL DOLT_FETCH(?, ?)" || len(args) != 2 {
+		t.Fatalf("anonymous fetch = %q %#v", query, args)
+	}
+}
+
 func TestSQLCapableCLIRoutingFallsBackWhenCLIDirIsNotDoltRepo(t *testing.T) {
 	ctx := context.Background()
 	creds := &remoteCredentials{username: "user", password: "pass"}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -4229,9 +4229,18 @@ func (s *DoltStore) refreshTrackingRef(ctx context.Context, remote string) error
 		return err
 	}
 	defer db.Close()
-	return withRemoteOperationEnv(s.credentialsForRemote(remote), s.isS3Remote(ctx, remote), func() error {
-		return schema.DrainCall(ctx, db, "CALL DOLT_FETCH(?, ?)", remote, s.branch)
+	creds := s.credentialsForRemote(remote)
+	return withRemoteOperationEnv(creds, s.isS3Remote(ctx, remote), func() error {
+		query, args := authenticatedFetchCall(creds, remote, s.branch)
+		return schema.DrainCall(ctx, db, query, args...)
 	})
+}
+
+func authenticatedFetchCall(creds *remoteCredentials, remote, branch string) (string, []any) {
+	if creds != nil && creds.username != "" {
+		return "CALL DOLT_FETCH('--user', ?, ?, ?)", []any{creds.username, remote, branch}
+	}
+	return "CALL DOLT_FETCH(?, ?)", []any{remote, branch}
 }
 
 // pullTransport routes one pull through CLI or SQL based on the remote's


### PR DESCRIPTION
## What

Pass the configured remote username to the post-pull `DOLT_FETCH` that refreshes the tracking ref. Anonymous remotes keep the existing two-argument fetch call.

## Why

An authenticated `bd dolt pull` can complete successfully and then emit an unauthorized verification warning because `refreshTrackingRef` supplies the remote password through the operation environment but does not pass `--user` to `DOLT_FETCH`. The follow-up fetch therefore does not use the same identity as the successful pull transport.

The existing credential-related PRs #5128 and #5215 address peer credential rows and embedded-mode ambient warnings, respectively; neither changes this post-pull tracking-ref refresh.

## Verification

- `./scripts/test.sh -run '^TestAuthenticatedFetchCall$' ./internal/storage/dolt/...` — passes
- `./scripts/test.sh ./internal/storage/dolt/...` — passes
- `git diff --check` — passes
- `make test` — affected packages pass; the aggregate run is blocked in the Codex sandbox by `TestFindBeadsRepoRoot_WorktreeFallback` detecting the user's global `.beads` root and by archive tests receiving `Function not implemented` from the sandbox filesystem
- `make ci-pr-lint` — gofmt passes; golangci-lint reports three existing G602 findings in untouched `backend/conformance/cycle_detector_contract.go` and `backend/conformance/importer_contract.go`

## Risk

This changes a Dolt sync-path query. The authenticated branch adds only Dolt's existing `--user` argument using the already-loaded credential username; the password remains in the operation environment and is not added to SQL arguments or logs. The anonymous path is unchanged.

_Codex-GPT-5-unknown-reasoning on behalf of permanetjv_
