### PR TITLE
fix(list): expose comment bodies in bd list/show --json (be-73x)

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -289,6 +289,10 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 	// for three aggregate joins on the most-run command in the tree.
 	textRequest := in.ListRequest
 	textRequest.SkipCounts = true
+	// No text rendering prints a comment body, so the per-row comment reads are
+	// not merely unused here, they are unpayable: SkipCounts above already
+	// zeroes the count this hydration would key on.
+	textRequest.IncludeComments = false
 	page, err := reader.List(ctx, textRequest)
 	if err != nil {
 		if capErr := handleMaxRowsError(err); capErr != nil {
@@ -446,6 +450,16 @@ func init() {
 
 	// Projection toggle. Like --skip-labels it trades data for bytes, and
 	// unlike it the dropped fields leave a mark on the row (IsLitePartial).
+	// Hydration toggle, the list twin of `bd show --include-comments`. Like
+	// --skip-labels and --brief it changes what is HYDRATED and never which
+	// rows match. It costs a query per row that has comments, which is why it
+	// is opt-in on the most-run command in the tree.
+	listCmd.Flags().Bool("include-comments", false,
+		"Populate each row's comments field with full comment bodies in JSON output "+
+			"(--json only; costs one query per row that has comments). Without it, a row "+
+			"with comments carries comments_omitted=true, so an absent comments field is "+
+			"never mistaken for having none. Text output is unaffected either way.")
+
 	listCmd.Flags().Bool("brief", false,
 		"Omit the free-form text (description, design, acceptance criteria, notes, "+
 			"payload, waiters) from each row. Filters that read those fields, such as "+

--- a/cmd/bd/list_comments_embedded_test.go
+++ b/cmd/bd/list_comments_embedded_test.go
@@ -1,0 +1,158 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestEmbeddedListComments drives `bd list --json` end to end, which is the
+// entry point be-73x is about: the town-wide duplicate/prior-art search this
+// repo's consumers run is a `bd list --json` piped to jq, and until this
+// change it could not see a comment body at all.
+//
+// IT RUNS THE REAL COMMAND ON PURPOSE. internal/workapi's unit tests cover the
+// same hydration against a fake source with rows the test builds itself, and a
+// fixture a test constructs proves what the test constructed. The rows here
+// are produced by `bd create` and `bd comment` and read back by `bd list`, so
+// a hydration wired to the wrong reader, a flag that never reaches the
+// request, or a marshaling tag that drops the field all fail here and none of
+// them fail upstairs.
+func TestEmbeddedListComments(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "lc")
+
+	// The phrase lives ONLY in a comment. That is the whole point: title,
+	// description and notes are the fields a listing already carried, so a
+	// term found in any of them would pass with or without this change.
+	const commentOnlyPhrase = "zzzcommentonlyphrasezzz"
+
+	commented := bdCreate(t, bd, dir, "Row with comments", "--type", "task")
+	bare := bdCreate(t, bd, dir, "Row with no comments", "--type", "task")
+
+	if out, err := bdRunWithFlockRetry(t, bd, dir, "comment", commented.ID, "ROOT CAUSE: "+commentOnlyPhrase); err != nil {
+		t.Fatalf("bd comment: %v\n%s", err, out)
+	}
+	if out, err := bdRunWithFlockRetry(t, bd, dir, "comment", commented.ID, "second comment"); err != nil {
+		t.Fatalf("bd comment: %v\n%s", err, out)
+	}
+
+	rowsByID := func(t *testing.T, args ...string) map[string]map[string]any {
+		t.Helper()
+		out, err := bdRunWithFlockRetry(t, bd, dir, append([]string{"list", "--json", "--status", "all"}, args...)...)
+		if err != nil {
+			t.Fatalf("bd list --json %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+		s := string(out)
+		start := strings.Index(s, "[")
+		if start < 0 {
+			t.Fatalf("no JSON array in list output:\n%s", s)
+		}
+		var rows []map[string]any
+		if err := json.Unmarshal([]byte(s[start:]), &rows); err != nil {
+			t.Fatalf("parse list JSON: %v\n%s", err, s[start:])
+		}
+		byID := make(map[string]map[string]any, len(rows))
+		for _, r := range rows {
+			id, _ := r["id"].(string)
+			byID[id] = r
+		}
+		// A denominator, so a vacuous pass is visible: every assertion below
+		// reads a specific row, and a page that lost the rows would otherwise
+		// look like a page that merely lacks the field.
+		if len(byID) < 2 {
+			t.Fatalf("list returned %d rows, want at least the 2 seeded", len(byID))
+		}
+		return byID
+	}
+
+	t.Run("default_marks_the_hole_instead_of_hiding_it", func(t *testing.T) {
+		byID := rowsByID(t)
+
+		row := byID[commented.ID]
+		if _, present := row["comments"]; present {
+			t.Error("default listing carried a comments field; comment bodies are opt-in")
+		}
+		if omitted, _ := row["comments_omitted"].(bool); !omitted {
+			t.Errorf("comments_omitted = %v on a row with comments, want true: an absent comments field must not read as none", row["comments_omitted"])
+		}
+		if count, _ := row["comment_count"].(float64); count != 2 {
+			t.Errorf("comment_count = %v, want 2", row["comment_count"])
+		}
+
+		// The control. A marker on every row would carry no information.
+		if _, present := byID[bare.ID]["comments_omitted"]; present {
+			t.Errorf("comments_omitted present on a row with no comments: a true empty stays plain omission")
+		}
+	})
+
+	t.Run("include_comments_makes_the_bodies_searchable", func(t *testing.T) {
+		byID := rowsByID(t, "--include-comments")
+
+		row := byID[commented.ID]
+		comments, _ := row["comments"].([]any)
+		if len(comments) != 2 {
+			t.Fatalf("hydrated %d comments, want 2: %v", len(comments), row["comments"])
+		}
+		// Assert on the TEXT, not the length. The defect was that the bodies
+		// were unreachable, and a count cannot tell a populated slice from a
+		// slice of empty ones.
+		var joined strings.Builder
+		for _, c := range comments {
+			m, _ := c.(map[string]any)
+			text, _ := m["text"].(string)
+			joined.WriteString(text)
+		}
+		if !strings.Contains(joined.String(), commentOnlyPhrase) {
+			t.Errorf("hydrated comment text %q does not contain %q", joined.String(), commentOnlyPhrase)
+		}
+		if _, present := row["comments_omitted"]; present {
+			t.Error("comments_omitted present beside populated comments: the two fields must read as one answer")
+		}
+		if _, present := byID[bare.ID]["comments"]; present {
+			t.Error("a row with no comments carried a comments field")
+		}
+	})
+
+	// The acceptance test as an agent actually runs it: grep the serialized
+	// page for a phrase that exists only in a comment. This is the assertion
+	// that fails on today's binary, and it fails with a plausible non-zero
+	// hit count elsewhere in the page rather than with an error, which is why
+	// it is worth pinning rather than trusting the field checks above.
+	t.Run("a_content_search_over_the_page_finds_a_comment_only_phrase", func(t *testing.T) {
+		withoutFlag, err := bdRunWithFlockRetry(t, bd, dir, "list", "--json", "--status", "all")
+		if err != nil {
+			t.Fatalf("bd list --json: %v\n%s", err, withoutFlag)
+		}
+		if strings.Contains(string(withoutFlag), commentOnlyPhrase) {
+			t.Error("default listing leaked comment text; bodies are supposed to be opt-in")
+		}
+
+		withFlag, err := bdRunWithFlockRetry(t, bd, dir, "list", "--json", "--status", "all", "--include-comments")
+		if err != nil {
+			t.Fatalf("bd list --json --include-comments: %v\n%s", err, withFlag)
+		}
+		if !strings.Contains(string(withFlag), commentOnlyPhrase) {
+			t.Errorf("a search over the whole page missed a phrase that exists only in a comment; this is be-73x")
+		}
+	})
+
+	t.Run("text_output_is_untouched", func(t *testing.T) {
+		plain := bdList(t, bd, dir, "--status", "all")
+		withFlag := bdList(t, bd, dir, "--status", "all", "--include-comments")
+		if plain != withFlag {
+			t.Errorf("--include-comments changed text output.\nwithout:\n%s\nwith:\n%s", plain, withFlag)
+		}
+		if strings.Contains(withFlag, commentOnlyPhrase) {
+			t.Error("text listing printed a comment body")
+		}
+	})
+}

--- a/cmd/bd/list_comments_proxied_integration_test.go
+++ b/cmd/bd/list_comments_proxied_integration_test.go
@@ -1,0 +1,113 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestProxiedServerListComments is the second half of the be-73x coverage, and
+// it exists because the fix has TWO implementations rather than one.
+//
+// `bd list --json` reaches issueops.Reader.List through the store-backed
+// reader on the direct route and through the unit-of-work reader here. Those
+// are separate bodies, and this repo has already had them answer one contract
+// method differently (see the epilogue comments in both). The embedded test
+// covers the first; removing the wiring from the second changes nothing there
+// and everything here, so a green suite without this case would say the fix
+// landed when half of it had not.
+//
+// The wisp-plane argument is also live only on this seam: the store-backed
+// detail source routes an id to the right comment table itself and ignores the
+// flag, while this one is told.
+func TestProxiedServerListComments(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "plc")
+
+	const commentOnlyPhrase = "zzzproxiedcommentphrasezzz"
+
+	commented := bdProxiedCreate(t, bd, p.dir, "Proxied row with comments", "--type", "task")
+	bare := bdProxiedCreate(t, bd, p.dir, "Proxied row with no comments", "--type", "task")
+
+	if out, err := bdProxiedRun(t, bd, p.dir, "comment", commented.ID, "ROOT CAUSE: "+commentOnlyPhrase); err != nil {
+		t.Fatalf("bd comment: %v\n%s", err, out)
+	}
+
+	rowsByID := func(t *testing.T, args ...string) map[string]map[string]any {
+		t.Helper()
+		full := append([]string{"list", "--json", "--status", "all"}, args...)
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, full...)
+		if err != nil {
+			t.Fatalf("bd list --json %s: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout, stderr)
+		}
+		start := strings.Index(stdout, "[")
+		if start < 0 {
+			t.Fatalf("no JSON array in list output:\n%s", stdout)
+		}
+		var rows []map[string]any
+		if err := json.Unmarshal([]byte(stdout[start:]), &rows); err != nil {
+			t.Fatalf("parse list JSON: %v\n%s", err, stdout[start:])
+		}
+		byID := make(map[string]map[string]any, len(rows))
+		for _, r := range rows {
+			id, _ := r["id"].(string)
+			byID[id] = r
+		}
+		// The denominator, so a page that lost its rows cannot pass as a page
+		// that merely lacks the field.
+		if len(byID) < 2 {
+			t.Fatalf("list returned %d rows, want at least the 2 seeded", len(byID))
+		}
+		return byID
+	}
+
+	t.Run("default_marks_the_hole", func(t *testing.T) {
+		byID := rowsByID(t)
+		if omitted, _ := byID[commented.ID]["comments_omitted"].(bool); !omitted {
+			t.Errorf("comments_omitted = %v on a row with comments, want true", byID[commented.ID]["comments_omitted"])
+		}
+		if _, present := byID[commented.ID]["comments"]; present {
+			t.Error("default listing carried comment bodies; they are opt-in")
+		}
+		if _, present := byID[bare.ID]["comments_omitted"]; present {
+			t.Error("comments_omitted present on a row with no comments")
+		}
+	})
+
+	t.Run("include_comments_hydrates_through_the_unit_of_work_reader", func(t *testing.T) {
+		byID := rowsByID(t, "--include-comments")
+		comments, _ := byID[commented.ID]["comments"].([]any)
+		if len(comments) != 1 {
+			t.Fatalf("hydrated %d comments, want 1: %v", len(comments), byID[commented.ID]["comments"])
+		}
+		m, _ := comments[0].(map[string]any)
+		text, _ := m["text"].(string)
+		if !strings.Contains(text, commentOnlyPhrase) {
+			t.Errorf("comment text = %q, want it to contain %q", text, commentOnlyPhrase)
+		}
+		if _, present := byID[commented.ID]["comments_omitted"]; present {
+			t.Error("comments_omitted present beside populated comments")
+		}
+	})
+
+	t.Run("a_content_search_over_the_page_finds_a_comment_only_phrase", func(t *testing.T) {
+		without, _, err := bdProxiedRunBuffers(t, bd, p.dir, "list", "--json", "--status", "all")
+		if err != nil {
+			t.Fatalf("bd list --json: %v", err)
+		}
+		if strings.Contains(without, commentOnlyPhrase) {
+			t.Error("default listing leaked comment text")
+		}
+		with, _, err := bdProxiedRunBuffers(t, bd, p.dir, "list", "--json", "--status", "all", "--include-comments")
+		if err != nil {
+			t.Fatalf("bd list --json --include-comments: %v", err)
+		}
+		if !strings.Contains(with, commentOnlyPhrase) {
+			t.Error("a search over the whole page missed a comment-only phrase on the proxied route; this is be-73x")
+		}
+	})
+}

--- a/cmd/bd/list_input.go
+++ b/cmd/bd/list_input.go
@@ -91,6 +91,7 @@ func gatherListInput(cmd *cobra.Command) (listInput, error) {
 	in.NoLabels, _ = cmd.Flags().GetBool("no-labels")
 
 	in.Brief, _ = cmd.Flags().GetBool("brief")
+	in.IncludeComments, _ = cmd.Flags().GetBool("include-comments")
 	in.SkipLabels, _ = cmd.Flags().GetBool("skip-labels")
 	if in.SkipLabels {
 		conflicts := skipLabelsConflicts(in.Labels, in.LabelsAny, in.LabelPattern, in.LabelRegex, in.ExcludeLabels, in.NoLabels)

--- a/cmd/bd/list_proxied_server.go
+++ b/cmd/bd/list_proxied_server.go
@@ -92,6 +92,8 @@ func runListProxiedPage(ctx context.Context, out io.Writer, in listInput) error 
 	// none.
 	textRequest := in.ListRequest
 	textRequest.SkipCounts = true
+	// And no comment hydration, for the reason the direct route drops it.
+	textRequest.IncludeComments = false
 	page, err := rd.List(ctx, textRequest)
 	if err != nil {
 		return err

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -6458,6 +6458,11 @@ components:
           items: { $ref: '#/components/schemas/Dependency' }
         comments:
           type: array
+          description: >-
+            The issue's comment bodies. On a listing they are populated only
+            when the caller opts in (`bd list --include-comments`); absent
+            otherwise, which is what `comment_count` and `comments_omitted`
+            report about.
           items: { $ref: '#/components/schemas/Comment' }
         sender: { type: string }
         ephemeral: { type: boolean }
@@ -6490,6 +6495,16 @@ components:
           description: Number of issues that depend on this one.
         comment_count:
           type: integer
+        comments_omitted:
+          type: boolean
+          description: >-
+            True when `comment_count` is nonzero and `comments` was left out —
+            every such row on a listing that did not opt into comment bodies.
+            Without it, an absent `comments` key is ambiguous between "no
+            comments" and "comments not included in this response", and on a
+            LISTING that ambiguity is what makes a content search over the page
+            answer with a plausible non-empty result whose matching rows are
+            missing.
         parent:
           type: string
           description: Parent issue id, computed from the parent-child edge.

--- a/internal/storage/uow/issue_reader.go
+++ b/internal/storage/uow/issue_reader.go
@@ -137,7 +137,7 @@ func (r *issueReader) List(ctx context.Context, req publicops.ListRequest) (publ
 		// HydrateListComments derives it from the row rather than assuming a
 		// plane.
 		newComments := func() workapi.CommentStreamer { return workapi.NewUOWDetailSource(uw) }
-		if err := workapi.HydrateListComments(ctx, newComments, items, req.IncludeComments); err != nil {
+		if err := workapi.HydrateListComments(ctx, newComments, items, req.IncludeComments, !req.SkipCounts); err != nil {
 			return publicops.IssuePage{}, err
 		}
 		return publicops.IssuePage{Items: items, HasMore: hasMore}, nil

--- a/internal/storage/uow/issue_reader.go
+++ b/internal/storage/uow/issue_reader.go
@@ -131,6 +131,15 @@ func (r *issueReader) List(ctx context.Context, req publicops.ListRequest) (publ
 		// between this implementation and its store-backed sibling, and it is
 		// an argument to the shared function rather than a second copy of it.
 		items, hasMore := workapi.FinishPageAt(page.Items, req.SortBy, req.Reverse, req.Offset, workapi.PageLimit(req), page.HasMore)
+		// The same shared hydration step the store-backed sibling runs, through
+		// the same function and after the same trim. This seam's detail source
+		// is the one that needs the wisp plane told to it, which is why
+		// HydrateListComments derives it from the row rather than assuming a
+		// plane.
+		newComments := func() workapi.CommentStreamer { return workapi.NewUOWDetailSource(uw) }
+		if err := workapi.HydrateListComments(ctx, newComments, items, req.IncludeComments); err != nil {
+			return publicops.IssuePage{}, err
+		}
 		return publicops.IssuePage{Items: items, HasMore: hasMore}, nil
 	})
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1139,6 +1139,25 @@ type IssueWithCounts struct {
 	DependentCount  int     `json:"dependent_count"`
 	CommentCount    int     `json:"comment_count"`
 	Parent          *string `json:"parent,omitempty"` // Computed parent from parent-child dep (bd-ym8c)
+
+	// CommentsOmitted is the list row's half of the ga-clgh contract
+	// IssueDetails.CommentsOmitted states for the detail view, and it is set
+	// under exactly the same rule: true only when CommentCount is nonzero AND
+	// the embedded Issue.Comments was left nil, never alongside a populated
+	// slice and never on a zero count.
+	//
+	// A LIST ROW NEEDS IT MORE THAN A DETAIL VIEW DOES (be-73x). A caller
+	// grepping a whole listing for a phrase that lives in a comment gets a
+	// plausible NON-ZERO answer with the matching rows missing — the shape
+	// that invites no suspicion at all, unlike an empty result. Without this
+	// marker nothing in the page says the text was never in scope.
+	//
+	// The comment BODIES ride on the embedded Issue.Comments, which already
+	// carries the `comments` key for export/import; this type adds only the
+	// marker, so a row that was hydrated and a row that was not are told
+	// apart by a field rather than by the caller remembering what it asked
+	// for.
+	CommentsOmitted *bool `json:"comments_omitted,omitempty"`
 }
 
 // IssueDetails extends Issue with labels, dependencies, dependents, and comments.

--- a/internal/workapi/detail.go
+++ b/internal/workapi/detail.go
@@ -218,7 +218,11 @@ func collectDependents(ctx context.Context, src DetailSource, id string, isWisp 
 	return out, nil
 }
 
-func collectComments(ctx context.Context, src DetailSource, id string, isWisp bool) ([]*types.Comment, error) {
+// collectComments takes the narrow CommentStreamer rather than the whole
+// DetailSource because it reads exactly one method, and because the list-page
+// hydration in list_comments.go calls the same body. DetailSource satisfies
+// CommentStreamer, so BuildIssueDetails passes its source unchanged.
+func collectComments(ctx context.Context, src CommentStreamer, id string, isWisp bool) ([]*types.Comment, error) {
 	iter, err := src.IterComments(ctx, id, isWisp)
 	if err != nil {
 		return nil, fmt.Errorf("iter comments %s: %w", id, err)

--- a/internal/workapi/list_comments.go
+++ b/internal/workapi/list_comments.go
@@ -1,0 +1,129 @@
+package workapi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// CommentStreamer is the one method list-comment hydration needs off a detail
+// source. It is named separately, and taken as the narrower interface, so the
+// hydration body cannot quietly grow a second read: DetailSource satisfies it,
+// and both of the sources that exist (NewStoreDetailSource, NewUOWDetailSource)
+// are therefore usable here without a new adapter.
+type CommentStreamer interface {
+	IterComments(ctx context.Context, id string, isWisp bool) (storage.Iter[types.Comment], error)
+}
+
+// HydrateListComments fills in the comment half of one list page.
+//
+// It is the shared epilogue step FinishPageAt is, and for the identical
+// reason: `bd list --json` reaches this through two Reader.List
+// implementations — the store-backed one and the unit-of-work one — and a
+// hydration written out longhand in each is how the two came apart before.
+// One body, called from both, is what makes a CLI listing and an HTTP one
+// answer the same request the same way.
+//
+// TWO OUTCOMES, AND NEITHER IS SILENT.
+//
+//	include = true   every row's Issue.Comments is populated, and any row that
+//	                 cannot be read fails the whole call. A caller that asked
+//	                 for the bodies gets them or gets an error; it never gets a
+//	                 short list it has no way to detect.
+//	include = false  every row with a nonzero CommentCount is marked
+//	                 CommentsOmitted, so an absent `comments` key means "none"
+//	                 on one row and "not asked for" on the other, and the row
+//	                 says which.
+//
+// THE SOURCE IS A CONSTRUCTOR, NOT A SOURCE, AND THAT IS LOAD-BEARING RATHER
+// THAN STYLE. Comment hydration is opt-in, so the DEPENDENCY on a comment
+// reader must be opt-in with it: building one eagerly on every listing makes a
+// capability that only the opt-in path uses into a requirement every caller
+// has to satisfy. It is not hypothetical — the unit-of-work source is built
+// from four use-case accessors, and constructing it unconditionally turned
+// every `GET /v0/beads/issues` on a provider without a comment use case into a
+// panic, on a request that had asked for no comments at all. A count-only
+// listing now calls nothing.
+//
+// THE MARKER IS THE POINT, not the hydration (be-73x). A page that silently
+// carries no comment text answers a content search with a plausible non-zero
+// result whose matching rows are missing, and nothing in that answer invites a
+// second look. The count alone does not fix it: comment_count sits on the row
+// accurately reporting how much is not there, which reads as reassurance
+// rather than as a warning.
+//
+// A ZERO COUNT IS NOT ALWAYS ZERO COMMENTS, which is why the marker is gated
+// on CommentCount rather than written unconditionally. Under
+// issueops.ListRequest.SkipCounts the cardinalities come back zero meaning
+// UNKNOWN, and a marker derived from them would be absent on every row of a
+// page that hydrated nothing. That combination does not reach a JSON listing —
+// the text renderings are the only SkipCounts callers and they ask for no
+// comments — but the rule is stated here rather than left to hold by accident.
+func HydrateListComments(ctx context.Context, newSrc func() CommentStreamer, items []*types.IssueWithCounts, include bool) error {
+	if len(items) == 0 {
+		return nil
+	}
+	if !include {
+		markCommentsOmitted(items)
+		return nil
+	}
+	if newSrc == nil {
+		return fmt.Errorf("hydrate list comments: comment source must not be nil")
+	}
+	src := newSrc()
+	if src == nil {
+		return fmt.Errorf("hydrate list comments: comment source must not be nil")
+	}
+	for _, item := range items {
+		if item == nil || item.Issue == nil {
+			continue
+		}
+		// A row with no comments needs no query. The count is authoritative
+		// here because the JSON route never sets SkipCounts; see the doc
+		// comment for why the skipped-count case is spelled out rather than
+		// assumed away.
+		if item.CommentCount == 0 {
+			continue
+		}
+		comments, err := collectComments(ctx, src, item.ID, isWispPlane(item.Issue))
+		if err != nil {
+			return fmt.Errorf("hydrate list comments: %w", err)
+		}
+		item.Issue.Comments = comments
+	}
+	return nil
+}
+
+// markCommentsOmitted flags the rows whose comment text was never fetched.
+// Rows the caller already hydrated are left alone: CommentsOmitted never
+// appears beside a populated slice, which is what lets a consumer read the two
+// fields as one unambiguous answer.
+func markCommentsOmitted(items []*types.IssueWithCounts) {
+	for _, item := range items {
+		if item == nil || item.Issue == nil {
+			continue
+		}
+		if item.CommentCount > 0 && item.Issue.Comments == nil {
+			omitted := true
+			item.CommentsOmitted = &omitted
+		}
+	}
+}
+
+// isWispPlane reports which storage plane a row's comments live in.
+//
+// It is internal/storage/issueops.IsWisp's rule, restated rather than called
+// because this package does not import that one. Both halves matter: the
+// override pins the plane for an in-memory record and the two flags are the
+// inference everywhere else. The store-backed detail source ignores the answer
+// — it routes ids to the right table itself — and the unit-of-work one needs
+// it, so getting it wrong is a wrong-table read on exactly one of the two
+// seams, which is the kind of divergence this package exists to prevent.
+func isWispPlane(issue *types.Issue) bool {
+	if issue.WispPlaneOverride != nil {
+		return *issue.WispPlaneOverride
+	}
+	return issue.Ephemeral || issue.NoHistory
+}

--- a/internal/workapi/list_comments.go
+++ b/internal/workapi/list_comments.go
@@ -54,19 +54,29 @@ type CommentStreamer interface {
 // accurately reporting how much is not there, which reads as reassurance
 // rather than as a warning.
 //
-// A ZERO COUNT IS NOT ALWAYS ZERO COMMENTS, which is why the marker is gated
-// on CommentCount rather than written unconditionally. Under
-// issueops.ListRequest.SkipCounts the cardinalities come back zero meaning
-// UNKNOWN, and a marker derived from them would be absent on every row of a
-// page that hydrated nothing. That combination does not reach a JSON listing —
-// the text renderings are the only SkipCounts callers and they ask for no
-// comments — but the rule is stated here rather than left to hold by accident.
-func HydrateListComments(ctx context.Context, newSrc func() CommentStreamer, items []*types.IssueWithCounts, include bool) error {
+// A ZERO COUNT IS NOT ALWAYS ZERO COMMENTS, AND countsKnown IS WHAT SEPARATES
+// THE TWO. Under issueops.ListRequest.SkipCounts the cardinalities come back
+// zero meaning UNKNOWN — the request type says so in as many words — so a body
+// that reads CommentCount as authoritative would answer IncludeComments with
+// an empty page and no error. countsKnown false therefore means: query every
+// row, because there is no count to prove a row has nothing to fetch, and mark
+// no row omitted, because the marker asserts a nonzero count this page cannot
+// support.
+//
+// It is a PARAMETER rather than an assumption because issueops.ListRequest is
+// PUBLIC and permits both fields at once. An earlier version of this body
+// skipped every row on that combination and justified it in a comment reading
+// "the JSON route never sets SkipCounts" — true of today's CLI callers, and
+// not a property of the contract they were reading. The HTTP surface and any
+// future caller may set both.
+func HydrateListComments(ctx context.Context, newSrc func() CommentStreamer, items []*types.IssueWithCounts, include, countsKnown bool) error {
 	if len(items) == 0 {
 		return nil
 	}
 	if !include {
-		markCommentsOmitted(items)
+		if countsKnown {
+			markCommentsOmitted(items)
+		}
 		return nil
 	}
 	if newSrc == nil {
@@ -80,11 +90,11 @@ func HydrateListComments(ctx context.Context, newSrc func() CommentStreamer, ite
 		if item == nil || item.Issue == nil {
 			continue
 		}
-		// A row with no comments needs no query. The count is authoritative
-		// here because the JSON route never sets SkipCounts; see the doc
-		// comment for why the skipped-count case is spelled out rather than
-		// assumed away.
-		if item.CommentCount == 0 {
+		// A row the page can PROVE has no comments needs no query. Only a
+		// hydrated count proves it: under SkipCounts a zero means unknown, and
+		// treating it as none is how this body once dropped every comment a
+		// caller had asked for.
+		if countsKnown && item.CommentCount == 0 {
 			continue
 		}
 		comments, err := collectComments(ctx, src, item.ID, isWispPlane(item.Issue))
@@ -100,6 +110,11 @@ func HydrateListComments(ctx context.Context, newSrc func() CommentStreamer, ite
 // Rows the caller already hydrated are left alone: CommentsOmitted never
 // appears beside a populated slice, which is what lets a consumer read the two
 // fields as one unambiguous answer.
+//
+// It is called only when the counts are real. The marker's meaning is "this
+// row HAS comments and they are not here", so a page whose counts were skipped
+// cannot honestly set it on any row — it does not know. That page is less
+// informative, which is what its caller asked for by skipping the counts.
 func markCommentsOmitted(items []*types.IssueWithCounts) {
 	for _, item := range items {
 		if item == nil || item.Issue == nil {

--- a/internal/workapi/list_comments_test.go
+++ b/internal/workapi/list_comments_test.go
@@ -58,7 +58,7 @@ func TestHydrateListCommentsMarksOmittedWithoutFetching(t *testing.T) {
 	}}
 	items := []*types.IssueWithCounts{row("a-1", 1), row("a-2", 0)}
 
-	if err := HydrateListComments(context.Background(), srcFunc(src), items, false); err != nil {
+	if err := HydrateListComments(context.Background(), srcFunc(src), items, false, true); err != nil {
 		t.Fatalf("HydrateListComments: %v", err)
 	}
 
@@ -88,7 +88,7 @@ func TestHydrateListCommentsPopulatesBodies(t *testing.T) {
 	}}
 	items := []*types.IssueWithCounts{row("a-1", 2), row("a-2", 0)}
 
-	if err := HydrateListComments(context.Background(), srcFunc(src), items, true); err != nil {
+	if err := HydrateListComments(context.Background(), srcFunc(src), items, true, true); err != nil {
 		t.Fatalf("HydrateListComments: %v", err)
 	}
 
@@ -132,7 +132,7 @@ func TestHydrateListCommentsRoutesTheWispPlane(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			src := &fakeCommentStreamer{byID: map[string][]*types.Comment{"a-1": {comment("c1", "x")}}}
 			items := []*types.IssueWithCounts{{Issue: tc.issue, CommentCount: 1}}
-			if err := HydrateListComments(context.Background(), srcFunc(src), items, true); err != nil {
+			if err := HydrateListComments(context.Background(), srcFunc(src), items, true, true); err != nil {
 				t.Fatalf("HydrateListComments: %v", err)
 			}
 			if len(src.calls) != 1 {
@@ -161,7 +161,7 @@ func TestHydrateListCommentsFailsRatherThanShortening(t *testing.T) {
 	src := &fakeCommentStreamer{err: sentinel}
 	items := []*types.IssueWithCounts{row("a-1", 1)}
 
-	err := HydrateListComments(context.Background(), srcFunc(src), items, true)
+	err := HydrateListComments(context.Background(), srcFunc(src), items, true, true)
 	if err == nil {
 		t.Fatal("HydrateListComments returned nil on a failing read, want an error: a short list a caller cannot detect is the defect, not a degraded success")
 	}
@@ -175,13 +175,13 @@ func TestHydrateListCommentsFailsRatherThanShortening(t *testing.T) {
 // unconditionally without deciding whether it will be used.
 func TestHydrateListCommentsCountOnlyToleratesNoSource(t *testing.T) {
 	items := []*types.IssueWithCounts{row("a-1", 3)}
-	if err := HydrateListComments(context.Background(), nil, items, false); err != nil {
+	if err := HydrateListComments(context.Background(), nil, items, false, true); err != nil {
 		t.Fatalf("count-only mode with a nil source: %v", err)
 	}
 	if items[0].CommentsOmitted == nil || !*items[0].CommentsOmitted {
 		t.Error("count-only mode with a nil source did not mark the row omitted")
 	}
-	if err := HydrateListComments(context.Background(), nil, items, true); err == nil {
+	if err := HydrateListComments(context.Background(), nil, items, true, true); err == nil {
 		t.Error("hydrating with a nil source returned nil, want an error")
 	}
 }
@@ -192,7 +192,7 @@ func TestHydrateListCommentsSkipsNilRows(t *testing.T) {
 	src := &fakeCommentStreamer{byID: map[string][]*types.Comment{}}
 	items := []*types.IssueWithCounts{nil, {Issue: nil, CommentCount: 2}, row("a-1", 0)}
 	for _, include := range []bool{false, true} {
-		if err := HydrateListComments(context.Background(), srcFunc(src), items, include); err != nil {
+		if err := HydrateListComments(context.Background(), srcFunc(src), items, include, true); err != nil {
 			t.Fatalf("include=%v: %v", include, err)
 		}
 	}
@@ -215,7 +215,7 @@ func TestHydrateListCommentsCountOnlyBuildsNoSource(t *testing.T) {
 	}
 	items := []*types.IssueWithCounts{row("a-1", 4), row("a-2", 0)}
 
-	if err := HydrateListComments(context.Background(), newSrc, items, false); err != nil {
+	if err := HydrateListComments(context.Background(), newSrc, items, false, true); err != nil {
 		t.Fatalf("HydrateListComments: %v", err)
 	}
 	if built != 0 {
@@ -223,5 +223,56 @@ func TestHydrateListCommentsCountOnlyBuildsNoSource(t *testing.T) {
 	}
 	if items[0].CommentsOmitted == nil || !*items[0].CommentsOmitted {
 		t.Error("count-only mode did not mark the row omitted")
+	}
+}
+
+// TestHydrateListCommentsHonorsIncludeWhenCountsAreSkipped is the regression
+// for the combination that made the count-based skip unsound.
+//
+// issueops.ListRequest.SkipCounts zeroes CommentCount and says in its own doc
+// that a zero then means UNKNOWN. A body that reads the count as authoritative
+// therefore answers IncludeComments with an entirely empty page — no error, no
+// short-list marker, nothing. That is the same silent-omission failure this
+// whole change exists to remove, reintroduced one layer down and reachable by
+// any caller of a PUBLIC request type.
+func TestHydrateListCommentsHonorsIncludeWhenCountsAreSkipped(t *testing.T) {
+	src := &fakeCommentStreamer{byID: map[string][]*types.Comment{
+		"a-1": {comment("c1", "zzzuniquephrase")},
+	}}
+	// Counts skipped: every row reports zero whether or not it has comments.
+	items := []*types.IssueWithCounts{row("a-1", 0), row("a-2", 0)}
+
+	if err := HydrateListComments(context.Background(), srcFunc(src), items, true, false); err != nil {
+		t.Fatalf("HydrateListComments: %v", err)
+	}
+
+	if len(src.calls) != 2 {
+		t.Fatalf("issued %d comment reads, want 2: with no trustworthy count, every row must be queried", len(src.calls))
+	}
+	if got := len(items[0].Comments); got != 1 {
+		t.Fatalf("hydrated %d comments for the row that has one, want 1", got)
+	}
+	if got := items[0].Comments[0].Text; got != "zzzuniquephrase" {
+		t.Errorf("comment body = %q, want %q", got, "zzzuniquephrase")
+	}
+	if items[1].Comments != nil {
+		t.Errorf("row with genuinely no comments got %v, want nil", items[1].Comments)
+	}
+}
+
+// TestHydrateListCommentsMarksNothingWhenCountsAreSkipped is the other side of
+// the same unknown. CommentsOmitted asserts "this row HAS comments and they are
+// not here"; a page whose counts were skipped cannot support that claim about
+// any row, so it must make it about none rather than deriving it from a zero
+// that means nothing.
+func TestHydrateListCommentsMarksNothingWhenCountsAreSkipped(t *testing.T) {
+	items := []*types.IssueWithCounts{row("a-1", 0), row("a-2", 0)}
+	if err := HydrateListComments(context.Background(), nil, items, false, false); err != nil {
+		t.Fatalf("HydrateListComments: %v", err)
+	}
+	for _, item := range items {
+		if item.CommentsOmitted != nil {
+			t.Errorf("%s carries comments_omitted on a page with no trustworthy counts, want unset: the marker would be a claim the page cannot support", item.ID)
+		}
 	}
 }

--- a/internal/workapi/list_comments_test.go
+++ b/internal/workapi/list_comments_test.go
@@ -1,0 +1,227 @@
+package workapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// fakeCommentStreamer records what was asked of it and answers from a map, so
+// a test can assert on the CALLS as well as on the result. The recorded plane
+// is the half no rendered output would show.
+type fakeCommentStreamer struct {
+	byID  map[string][]*types.Comment
+	err   error
+	calls []streamCall
+}
+
+type streamCall struct {
+	id     string
+	isWisp bool
+}
+
+func (f *fakeCommentStreamer) IterComments(_ context.Context, id string, isWisp bool) (storage.Iter[types.Comment], error) {
+	f.calls = append(f.calls, streamCall{id: id, isWisp: isWisp})
+	if f.err != nil {
+		return nil, f.err
+	}
+	return storage.NewSliceIter(f.byID[id]), nil
+}
+
+// srcFunc adapts a fake to the lazy constructor HydrateListComments takes.
+// The laziness is itself under test in TestHydrateListCommentsCountOnlyBuildsNoSource.
+func srcFunc(src CommentStreamer) func() CommentStreamer {
+	return func() CommentStreamer { return src }
+}
+
+func row(id string, commentCount int) *types.IssueWithCounts {
+	return &types.IssueWithCounts{
+		Issue:        &types.Issue{ID: id},
+		CommentCount: commentCount,
+	}
+}
+
+func comment(id, text string) *types.Comment {
+	return &types.Comment{ID: id, Text: text}
+}
+
+// TestHydrateListCommentsMarksOmittedWithoutFetching pins the DEFAULT half of
+// the contract, which is the half be-73x is actually about: a page nobody
+// asked to hydrate must still say that its comment text is missing, and it
+// must say so without paying for a single read.
+func TestHydrateListCommentsMarksOmittedWithoutFetching(t *testing.T) {
+	src := &fakeCommentStreamer{byID: map[string][]*types.Comment{
+		"a-1": {comment("c1", "root cause")},
+	}}
+	items := []*types.IssueWithCounts{row("a-1", 1), row("a-2", 0)}
+
+	if err := HydrateListComments(context.Background(), srcFunc(src), items, false); err != nil {
+		t.Fatalf("HydrateListComments: %v", err)
+	}
+
+	if len(src.calls) != 0 {
+		t.Errorf("count-only mode issued %d comment reads, want 0: the marker is derived from the count already on the row", len(src.calls))
+	}
+	if items[0].CommentsOmitted == nil || !*items[0].CommentsOmitted {
+		t.Errorf("CommentsOmitted = %v on a row with comment_count 1, want true: without it an absent comments field reads as none", items[0].CommentsOmitted)
+	}
+	if items[0].Comments != nil {
+		t.Errorf("Comments = %v in count-only mode, want nil", items[0].Comments)
+	}
+	// The zero-count row is the control. A marker on it would make the flag
+	// meaningless: every row would carry it and none would be informative.
+	if items[1].CommentsOmitted != nil {
+		t.Errorf("CommentsOmitted = %v on a row with no comments, want unset: a true empty stays plain omission", *items[1].CommentsOmitted)
+	}
+}
+
+// TestHydrateListCommentsPopulatesBodies pins the opt-in half, and asserts on
+// the COMMENT TEXT rather than on a length: the defect this fixes is that the
+// text is unreachable, and a count of rows cannot tell a populated slice from
+// a slice of empty ones.
+func TestHydrateListCommentsPopulatesBodies(t *testing.T) {
+	src := &fakeCommentStreamer{byID: map[string][]*types.Comment{
+		"a-1": {comment("c1", "zzzuniquephrase"), comment("c2", "second")},
+	}}
+	items := []*types.IssueWithCounts{row("a-1", 2), row("a-2", 0)}
+
+	if err := HydrateListComments(context.Background(), srcFunc(src), items, true); err != nil {
+		t.Fatalf("HydrateListComments: %v", err)
+	}
+
+	if got := len(items[0].Comments); got != 2 {
+		t.Fatalf("hydrated %d comments, want 2", got)
+	}
+	if got := items[0].Comments[0].Text; got != "zzzuniquephrase" {
+		t.Errorf("comment body = %q, want %q: the bodies are the whole point", got, "zzzuniquephrase")
+	}
+	if items[0].CommentsOmitted != nil {
+		t.Errorf("CommentsOmitted = %v beside a populated slice, want unset: the two fields must read as one unambiguous answer", *items[0].CommentsOmitted)
+	}
+	// A row with no comments is not queried at all, which is what keeps the
+	// per-row cost proportional to the rows that actually have text.
+	for _, call := range src.calls {
+		if call.id == "a-2" {
+			t.Errorf("issued a comment read for a row with comment_count 0")
+		}
+	}
+}
+
+// TestHydrateListCommentsRoutesTheWispPlane pins the argument the unit-of-work
+// detail source needs and the store-backed one ignores. Getting it wrong is a
+// wrong-table read on exactly one of the two seams, so no CLI output would
+// show it — only the recorded call does.
+func TestHydrateListCommentsRoutesTheWispPlane(t *testing.T) {
+	pinnedDurable := false
+	cases := []struct {
+		name   string
+		issue  *types.Issue
+		isWisp bool
+	}{
+		{"durable", &types.Issue{ID: "a-1"}, false},
+		{"ephemeral", &types.Issue{ID: "a-1", Ephemeral: true}, true},
+		{"no_history", &types.Issue{ID: "a-1", NoHistory: true}, true},
+		// The override is the case the flags get wrong: a promoted no-history
+		// row is a durable issues-table row that still carries the flag.
+		{"override_wins_over_flags", &types.Issue{ID: "a-1", NoHistory: true, WispPlaneOverride: &pinnedDurable}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &fakeCommentStreamer{byID: map[string][]*types.Comment{"a-1": {comment("c1", "x")}}}
+			items := []*types.IssueWithCounts{{Issue: tc.issue, CommentCount: 1}}
+			if err := HydrateListComments(context.Background(), srcFunc(src), items, true); err != nil {
+				t.Fatalf("HydrateListComments: %v", err)
+			}
+			if len(src.calls) != 1 {
+				t.Fatalf("issued %d comment reads, want 1", len(src.calls))
+			}
+			if src.calls[0].isWisp != tc.isWisp {
+				t.Errorf("read the %v plane, want %v", planeName(src.calls[0].isWisp), planeName(tc.isWisp))
+			}
+		})
+	}
+}
+
+func planeName(isWisp bool) string {
+	if isWisp {
+		return "wisp"
+	}
+	return "durable"
+}
+
+// TestHydrateListCommentsFailsRatherThanShortening pins the promise that makes
+// the opt-in half trustworthy. A caller that asked for the bodies and silently
+// received fewer than exist is back in the failure this whole change removes,
+// with no way to detect it.
+func TestHydrateListCommentsFailsRatherThanShortening(t *testing.T) {
+	sentinel := errors.New("comment table unreachable")
+	src := &fakeCommentStreamer{err: sentinel}
+	items := []*types.IssueWithCounts{row("a-1", 1)}
+
+	err := HydrateListComments(context.Background(), srcFunc(src), items, true)
+	if err == nil {
+		t.Fatal("HydrateListComments returned nil on a failing read, want an error: a short list a caller cannot detect is the defect, not a degraded success")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("error = %v, want it to wrap %v", err, sentinel)
+	}
+}
+
+// TestHydrateListCommentsCountOnlyToleratesNoSource pins that the default path
+// needs no comment source at all, which is what lets a caller pass one
+// unconditionally without deciding whether it will be used.
+func TestHydrateListCommentsCountOnlyToleratesNoSource(t *testing.T) {
+	items := []*types.IssueWithCounts{row("a-1", 3)}
+	if err := HydrateListComments(context.Background(), nil, items, false); err != nil {
+		t.Fatalf("count-only mode with a nil source: %v", err)
+	}
+	if items[0].CommentsOmitted == nil || !*items[0].CommentsOmitted {
+		t.Error("count-only mode with a nil source did not mark the row omitted")
+	}
+	if err := HydrateListComments(context.Background(), nil, items, true); err == nil {
+		t.Error("hydrating with a nil source returned nil, want an error")
+	}
+}
+
+// TestHydrateListCommentsSkipsNilRows keeps the shared epilogue from panicking
+// on a page shape a caller can legally hand it.
+func TestHydrateListCommentsSkipsNilRows(t *testing.T) {
+	src := &fakeCommentStreamer{byID: map[string][]*types.Comment{}}
+	items := []*types.IssueWithCounts{nil, {Issue: nil, CommentCount: 2}, row("a-1", 0)}
+	for _, include := range []bool{false, true} {
+		if err := HydrateListComments(context.Background(), srcFunc(src), items, include); err != nil {
+			t.Fatalf("include=%v: %v", include, err)
+		}
+	}
+}
+
+// TestHydrateListCommentsCountOnlyBuildsNoSource pins the laziness as a
+// behaviour rather than an implementation detail.
+//
+// It is here because the eager version shipped and broke something: building
+// the unit-of-work comment source unconditionally panicked for a provider that
+// has no comment use case, on list requests that had asked for no comments.
+// A count-only listing must not so much as CONSTRUCT a comment reader, so the
+// constructor here fails the test if it is ever called.
+func TestHydrateListCommentsCountOnlyBuildsNoSource(t *testing.T) {
+	built := 0
+	newSrc := func() CommentStreamer {
+		built++
+		t.Error("count-only hydration constructed a comment source; the dependency must be as opt-in as the feature")
+		return &fakeCommentStreamer{}
+	}
+	items := []*types.IssueWithCounts{row("a-1", 4), row("a-2", 0)}
+
+	if err := HydrateListComments(context.Background(), newSrc, items, false); err != nil {
+		t.Fatalf("HydrateListComments: %v", err)
+	}
+	if built != 0 {
+		t.Errorf("constructed %d comment sources in count-only mode, want 0", built)
+	}
+	if items[0].CommentsOmitted == nil || !*items[0].CommentsOmitted {
+		t.Error("count-only mode did not mark the row omitted")
+	}
+}

--- a/internal/workapi/storereader/reader.go
+++ b/internal/workapi/storereader/reader.go
@@ -127,6 +127,14 @@ func (r *storeReader) List(ctx context.Context, req issueops.ListRequest) (issue
 	// one is presentation. This seam reports no HasMore of its own, so the
 	// over-fetched row above is what speaks.
 	items, hasMore := workapi.FinishPageAt(items, req.SortBy, req.Reverse, req.Offset, workapi.PageLimit(req), false)
+	// Comment hydration is the second shared epilogue step, and it runs AFTER
+	// the trim so a page never pays for rows it is about to drop. Its source is
+	// the detail view's, which routes an id to the right comment table on this
+	// seam without being told.
+	newComments := func() workapi.CommentStreamer { return workapi.NewStoreDetailSource(r.store) }
+	if err := workapi.HydrateListComments(ctx, newComments, items, req.IncludeComments); err != nil {
+		return issueops.IssuePage{}, err
+	}
 	return issueops.IssuePage{Items: items, HasMore: hasMore}, nil
 }
 

--- a/internal/workapi/storereader/reader.go
+++ b/internal/workapi/storereader/reader.go
@@ -132,7 +132,7 @@ func (r *storeReader) List(ctx context.Context, req issueops.ListRequest) (issue
 	// the detail view's, which routes an id to the right comment table on this
 	// seam without being told.
 	newComments := func() workapi.CommentStreamer { return workapi.NewStoreDetailSource(r.store) }
-	if err := workapi.HydrateListComments(ctx, newComments, items, req.IncludeComments); err != nil {
+	if err := workapi.HydrateListComments(ctx, newComments, items, req.IncludeComments, !req.SkipCounts); err != nil {
 		return issueops.IssuePage{}, err
 	}
 	return issueops.IssuePage{Items: items, HasMore: hasMore}, nil

--- a/issueops/reader.go
+++ b/issueops/reader.go
@@ -187,6 +187,34 @@ type ListRequest struct {
 	// hydrated there either way, which costs time and not correctness.
 	SkipCounts bool
 
+	// IncludeComments populates every row's Issue.Comments with that issue's
+	// full comment bodies, and is the LIST twin of GetRequest.IncludeComments.
+	// Like SkipLabels and SkipCounts it chooses what is HYDRATED, never which
+	// rows match: the rows, their order, Parent and the has-more verdict are
+	// what they would have been.
+	//
+	// IT IS OPT-IN BECAUSE IT COSTS A QUERY PER ROW, which is the same reason
+	// the detail view's twin is. A page of 50 is 50 comment reads; a listing
+	// asking for the whole store is that many. Nothing hydrates comments
+	// unless a caller asks.
+	//
+	// WHY THE KNOB EXISTS AT ALL (be-73x). comment_count has always been on
+	// the row and the bodies never were, so a caller searching a LISTING for
+	// text that lives in a comment gets a well-formed, non-empty, WRONG answer
+	// — the rows that match are simply absent, and no error, no zero and no
+	// short count marks them. That is the failure this knob exists to make
+	// answerable, which is why the unhydrated rows also carry
+	// types.IssueWithCounts.CommentsOmitted rather than staying silent.
+	//
+	// IT APPLIES TO BOTH ARMS, ReadyFlag included, and is neither carried nor
+	// refused by it: hydration runs in the shared page epilogue after the
+	// query, so it is not a filter the ready query has to be able to express.
+	//
+	// A row whose comments could not be read is an ERROR, not a short list.
+	// The detail view's IncludeComments makes the same promise for the same
+	// reason: a caller that asked for the rows gets them or gets told.
+	IncludeComments bool
+
 	// Brief suppresses the FREE-FORM TEXT the way SkipLabels suppresses labels
 	// and SkipCounts the cardinalities: Description, Design,
 	// AcceptanceCriteria, Notes, Payload and Waiters are not selected and come


### PR DESCRIPTION
Fixes be-73x.

`bd show --json` and `bd list --json` report `comment_count` but carry no
`comments` field, so a JSON read silently loses the comment bodies while
returning a well-formed, plausible record. Measured on the bead that
describes the defect: the rendered form is 30503 bytes and the `--json` form
is 10454 — roughly two thirds of the record, including the comment evidence,
is dropped with no signal that anything is missing.

That matters because the duplicate/prior-art search this project relies on
greps the JSON. Against 12236 rows, 0 carried a `comments` field while 217
reported `comment_count > 0`, so any finding recorded only in a comment is
unreachable by that search — and the search returns a plausible non-zero
answer rather than an obviously empty one.

## What this changes

- `internal/workapi/list_comments.go` — expose comment bodies through the
  work API, with the storage reader plumbing behind it.
- `cmd/bd/list.go` — surface them in `bd list --json` and mark the omission
  explicitly when comments are skipped rather than reporting a bare count.
- `internal/workapi/detail.go`, `internal/types/types.go`,
  `issueops/reader.go`, `internal/storage/uow/issue_reader.go` — supporting
  types and reads.
- `internal/httpapi/spec/openapi.v0.yaml` — spec updated to match.

Second commit closes the narrower half: a skipped comment count was being
read as proof of no comments, which is the same false-empty in miniature.

## Tests

549 lines across three files — embedded and proxied `bd list` coverage plus
`internal/workapi/list_comments_test.go`.

## Provenance

Branch was completed and pushed 2026-09-07 and has sat in the beadsrig merge
queue as `be-wisp-9uf` (P1, ready, retry_count 0) since. beadsrig is
fork-backed, so its refinery is disabled by design and nothing exists to open
this PR; the other seven queued branches all carry PRs (#6266 #6292 #6294
#6295 #6296 #6311 #6352) and this was the only one without. Opened by
`beadsrig/witness` on patrol. Tracking: gt-y63g.

Commit `d74f3272` matches the merge request's recorded `commit_sha` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPAN1HLAJmUED8AKc7wkcb
