### PR TITLE
test(init): explicitly enable the contributor wizard fixture

### DIFF
--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -1086,6 +1086,25 @@ func TestInitPromptExistingRole(t *testing.T) {
 func TestInitContributorSetsBeadsRoleContributor(t *testing.T) {
 	skipIfNoDolt(t)
 
+	// Serial: this fixture owns command flags, stdin, cwd and process environment.
+	// The pipe below supplies real wizard answers; explicitly allow interaction
+	// even when CI or terminal detection would normally suppress it.
+	t.Setenv("BD_NON_INTERACTIVE", "0")
+	for _, name := range []string{"contributor", "team", "force", "non-interactive", "role", "prefix", "quiet"} {
+		flag := initCmd.Flags().Lookup(name)
+		value, changed := flag.Value.String(), flag.Changed
+		t.Cleanup(func() {
+			if err := flag.Value.Set(value); err != nil {
+				t.Errorf("restore --%s: %v", name, err)
+			}
+			flag.Changed = changed
+		})
+		if err := flag.Value.Set(flag.DefValue); err != nil {
+			t.Fatalf("reset --%s: %v", name, err)
+		}
+		flag.Changed = false
+	}
+
 	origDBPath := dbPath
 	defer func() { dbPath = origDBPath }()
 	dbPath = ""
@@ -1097,16 +1116,14 @@ func TestInitContributorSetsBeadsRoleContributor(t *testing.T) {
 		git.ResetCaches()
 	}()
 
-	initCmd.Flags().Set("contributor", "false")
-	initCmd.Flags().Set("team", "false")
-	initCmd.Flags().Set("force", "false")
-
-	tmpDir := newGitRepo(t)
-	t.Chdir(tmpDir)
-
 	// Keep test isolated from the real home/planning repo.
 	testHome := t.TempDir()
 	t.Setenv("HOME", testHome)
+	t.Setenv("USERPROFILE", testHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(testHome, ".config"))
+
+	tmpDir := newGitRepo(t)
+	t.Chdir(tmpDir)
 
 	// Configure remotes so contributor wizard doesn't ask the "continue anyway" prompt.
 	cmd := exec.Command("git", "remote", "add", "origin", "git@github.com:osamu2001/zmx.git")

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -1125,13 +1125,14 @@ func TestInitContributorSetsBeadsRoleContributor(t *testing.T) {
 	tmpDir := newGitRepo(t)
 	t.Chdir(tmpDir)
 
-	// Configure remotes so contributor wizard doesn't ask the "continue anyway" prompt.
-	cmd := exec.Command("git", "remote", "add", "origin", "git@github.com:osamu2001/zmx.git")
+	// Local remotes avoid external lookups during initialization and let the
+	// contributor wizard detect a fork without an extra "continue anyway" prompt.
+	cmd := exec.Command("git", "remote", "add", "origin", newGitRepo(t))
 	cmd.Dir = tmpDir
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to add origin remote: %v", err)
 	}
-	cmd = exec.Command("git", "remote", "add", "upstream", "git@github.com:neurosnap/zmx.git")
+	cmd = exec.Command("git", "remote", "add", "upstream", newGitRepo(t))
 	cmd.Dir = tmpDir
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to add upstream remote: %v", err)


### PR DESCRIPTION
The contributor wizard test feeds answers through a pipe, which correctly counts as noninteractive input unless the fixture explicitly opts in. Set `BD_NON_INTERACTIVE=0` for that test, isolate its home/config directories, and restore the init flags it changes. Owned local repositories replace external origin/upstream URLs so initialization does not perform a network lookup.

Fixes #6468, the inherited test-assumption error observed while validating #6429. The full reviewed change is one existing test file, 44 added/deleted lines; CLI interaction policy and the actual contributor-role assertions stay intact.

R1 correction: scope `BEADS_DIR` with `t.Setenv` in both the existing-role/reinit fixture and the contributor fixture. Reinit binds its selected workspace into the process environment; without cleanup the next test can target the previous test's removed directory. This is environment lifetime, not a demonstrated leaked gate handle. Missing init flags now fail by name instead of panicking, and the local-remote comment no longer overstates fork detection. This revision is 10 added/deleted lines.

Validation: the unchanged published revision reproduced the reviewer's exact existing-role then contributor failure at the removed gate parent. The revised pair and two adjacent interaction-policy tests pass on Ubuntu as an unprivileged user with CGO enabled, `gms_pure_go`, a real Dolt SQL container, `CI=1`, and inherited `BD_NON_INTERACTIVE=1`: four parent tests, ten subtests, no skips. Native Windows compiles the fixture and passes `TestIsNonInteractiveInit` (one parent, nine subtests), scoped vet, and prior-head diff lint; it does not execute the wizard.

Core CI deliberately skips Dolt-dependent tests, so it provides compilation/adjacent coverage, not the real wizard proof above. No full-suite, race, or macOS result is claimed. The original noninteractive rejection and the earlier terminated external-remote lookup remain historical evidence, separate from this revision's paired red/green proof.

_unknown-model/unknown-reasoning on behalf of Ewen Cuthiell_

