### PR TITLE
ci(macos-test): bound the macOS -race test legs' per-package deadline at 25m

### DIFF
--- a/.github/workflows/ci-measurements.yml
+++ b/.github/workflows/ci-measurements.yml
@@ -103,7 +103,13 @@ jobs:
     name: Measure macOS short Go tests
     if: ${{ inputs.suite == 'macos-short' }}
     runs-on: macos-latest
-    timeout-minutes: 30
+    # 60m: the Measure commands step below carries a 25m go test deadline, and
+    # that deadline can only fire -- printing goroutine stacks for a real hang --
+    # if 25m of one package still fits after checkout, setup-go, install-dolt and
+    # the compile of every package ahead of the slow one. At 30m the runner kill
+    # won that race and the flag was decorative. macos-candidates below pairs
+    # -timeout=30m with the same 60m budget (be-xagyw).
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 

--- a/.github/workflows/ci-measurements.yml
+++ b/.github/workflows/ci-measurements.yml
@@ -128,7 +128,9 @@ jobs:
           source scripts/ci/lib/timing.sh
           source ./.buildflags
 
-          ci_time "macos short go test" -- go test -v -race -short -skip '^TestEmbedded' ./...
+          # -timeout=25m: without it, go test's 10m per-package default can kill this
+          # -race run mid-package on macOS before it reports a real pass/fail (be-xagyw).
+          ci_time "macos short go test" -- go test -v -race -short -timeout=25m -skip '^TestEmbedded' ./...
 
   macos-candidates:
     name: Measure macOS no-short candidates

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -470,7 +470,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ${{ matrix.os }}
     needs: build-artifacts
-    timeout-minutes: 45
+    # 60m: covers the macOS -race leg's 25m go test deadline with headroom for
+    # setup/build steps in the same job (be-xagyw).
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -471,7 +471,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: build-artifacts
     # 60m: covers the macOS -race leg's 25m go test deadline with headroom for
-    # setup/build steps in the same job (be-xagyw).
+    # setup/build steps in the same job (be-xagyw). Job-level, and there is no
+    # per-matrix override, so the ubuntu leg rises from 45m as well. Nothing new
+    # can run longer there: its coverage step pins its own -timeout=25m below,
+    # so a Linux hang is simply killed 15m later than it used to be.
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -907,6 +907,8 @@ jobs:
   test-macos:
     name: Test (macos-latest)
     runs-on: macos-latest
+    # Backstop for a real hang: without this the job falls back to GitHub's 360m default (be-xagyw).
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
@@ -960,7 +962,9 @@ jobs:
         env:
           BEADS_TEST_BD_BINARY: ${{ github.workspace }}/bd
           GOCACHE: ${{ runner.temp }}/go-cache/race
-        run: go test -tags gms_pure_go -v -race -short -skip '^TestEmbedded' ./...
+        # -timeout=25m: without it, go test's 10m per-package default can kill this
+        # -race run mid-package on macOS before it reports a real pass/fail (be-xagyw).
+        run: go test -tags gms_pure_go -v -race -short -timeout=25m -skip '^TestEmbedded' ./...
 
   # Producer-side guard for the Beads<->consumer CLI contract. Runs the whole
   # cmd/bd/protocol package: the golden corpus (regenerated from this branch's

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -245,6 +246,65 @@ func TestPRCIGateRequiresGeneratedHookTimeoutProcessBoundary(t *testing.T) {
 		t.Errorf("ci-gate does not require the three-host generated-hook lane: needs=%v %s=%q required=%q",
 			gate.Needs, gateKey, gateEnv[gateKey], gateEnv["CI_GATE_REQUIRED"])
 	}
+}
+
+// TestMacOSCITestLegsHaveExplicitTimeout is the regression test for be-xagyw:
+// go test's 10m per-package default applied to three macOS -race legs that
+// run whole-module ./... (pr.yml test-macos, main.yml test's macOS matrix
+// entry, ci-measurements.yml macos-short), and -race on macOS is slow enough
+// that cmd/bd alone can approach or exceed 10m, killing the run mid-package
+// rather than reporting a real pass/fail (be-dvbq9's investigation). This is
+// a floor check, not an exact-match one: it fails if -timeout is missing or
+// parses below 20m, but tolerates the deadline moving up over time. Each
+// leg's enclosing job also needs a timeout-minutes backstop so a real hang
+// still produces a bounded, diagnosable job failure instead of running to
+// GitHub's 360m default.
+func TestMacOSCITestLegsHaveExplicitTimeout(t *testing.T) {
+	const minTimeoutMinutes = 20
+
+	timeoutPattern := regexp.MustCompile(`-timeout[= ](\d+)m\b`)
+	assertHasTimeoutFloor := func(t *testing.T, label, command string) {
+		t.Helper()
+		matches := timeoutPattern.FindStringSubmatch(command)
+		if matches == nil {
+			t.Errorf("%s command has no -timeout flag: %q", label, command)
+			return
+		}
+		minutes, err := strconv.Atoi(matches[1])
+		if err != nil {
+			t.Fatalf("%s -timeout value %q not numeric: %v", label, matches[1], err)
+		}
+		if minutes < minTimeoutMinutes {
+			t.Errorf("%s -timeout = %dm, want at least %dm", label, minutes, minTimeoutMinutes)
+		}
+	}
+
+	t.Run("pr.yml test-macos", func(t *testing.T) {
+		job := readCIWorkflow(t, "pr.yml").job(t, "test-macos")
+		assertHasTimeoutFloor(t, "pr.yml test-macos Test step", job.step(t, "Test").Run)
+		if job.TimeoutMinutes < 60 {
+			t.Errorf("pr.yml test-macos job timeout-minutes = %d, want at least 60", job.TimeoutMinutes)
+		}
+	})
+
+	t.Run("main.yml test macOS leg", func(t *testing.T) {
+		job := readCIWorkflow(t, "main.yml").job(t, "test")
+		var macOSFlags string
+		for _, include := range job.Strategy.Matrix.Include {
+			if include.OS == macOSRunner {
+				macOSFlags = include.TestFlags
+			}
+		}
+		assertHasTimeoutFloor(t, "main.yml test macOS matrix test-flags", macOSFlags)
+		if job.TimeoutMinutes < 60 {
+			t.Errorf("main.yml test job timeout-minutes = %d, want at least 60", job.TimeoutMinutes)
+		}
+	})
+
+	t.Run("ci-measurements.yml macos-short", func(t *testing.T) {
+		job := readCIWorkflow(t, "ci-measurements.yml").job(t, "macos-short")
+		assertHasTimeoutFloor(t, "ci-measurements.yml macos-short Measure commands step", job.step(t, "Measure commands").Run)
+	})
 }
 
 func TestStorageDomainUOWJobsUseNestedTimeoutBudgets(t *testing.T) {

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -255,17 +255,21 @@ func TestPRCIGateRequiresGeneratedHookTimeoutProcessBoundary(t *testing.T) {
 // that cmd/bd alone can approach or exceed 10m, killing the run mid-package
 // rather than reporting a real pass/fail (be-dvbq9's investigation). This is
 // a floor check, not an exact-match one: it fails if -timeout is missing or
-// parses below 20m, but tolerates the deadline moving up over time. Each
-// leg's enclosing job also needs a timeout-minutes backstop so a real hang
-// still produces a bounded, diagnosable job failure instead of running to
-// GitHub's 360m default.
+// parses below 20m, but tolerates the deadline moving up over time in any
+// duration form go test accepts. Each leg's enclosing job also needs a
+// timeout-minutes backstop so a real hang still produces a bounded,
+// diagnosable job failure instead of running to GitHub's 360m default.
 func TestMacOSCITestLegsHaveExplicitTimeout(t *testing.T) {
 	const (
-		minTimeoutMinutes    = 20
+		minTimeout           = 20 * time.Minute
 		minJobTimeoutMinutes = 60
 	)
 
-	timeoutPattern := regexp.MustCompile(`-timeout[= ](\d+)m\b`)
+	// Capture the whole flag value and let time.ParseDuration judge it, rather
+	// than pattern-matching bare integer minutes: go test accepts any Go
+	// duration, so 1h, 1h30m and 25m0s are all legitimate ways to raise this
+	// deadline and none of them are Nm.
+	timeoutPattern := regexp.MustCompile(`-timeout[= ](\S+)`)
 	assertHasTimeoutFloor := func(t *testing.T, label, command string) {
 		t.Helper()
 		matches := timeoutPattern.FindStringSubmatch(command)
@@ -273,12 +277,13 @@ func TestMacOSCITestLegsHaveExplicitTimeout(t *testing.T) {
 			t.Errorf("%s command has no -timeout flag: %q", label, command)
 			return
 		}
-		minutes, err := strconv.Atoi(matches[1])
+		timeout, err := time.ParseDuration(matches[1])
 		if err != nil {
-			t.Fatalf("%s -timeout value %q not numeric: %v", label, matches[1], err)
+			t.Errorf("%s -timeout value %q is not a Go duration: %v", label, matches[1], err)
+			return
 		}
-		if minutes < minTimeoutMinutes {
-			t.Errorf("%s -timeout = %dm, want at least %dm", label, minutes, minTimeoutMinutes)
+		if timeout < minTimeout {
+			t.Errorf("%s -timeout = %s, want at least %s", label, timeout, minTimeout)
 		}
 	}
 

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -358,7 +358,7 @@ func TestMacOSTestJobsReuseWorkspaceBDBinary(t *testing.T) {
 	const (
 		workspaceBDBinary = "${{ github.workspace }}/bd"
 		buildCommand      = "go build -v -tags gms_pure_go ./cmd/bd"
-		prTestCommand     = "go test -tags gms_pure_go -v -race -short -skip '^TestEmbedded' ./..."
+		prTestCommand     = "go test -tags gms_pure_go -v -race -short -timeout=25m -skip '^TestEmbedded' ./..."
 		mainTestCommand   = "go test -tags gms_pure_go ${{ matrix.test-flags }} -skip '^TestEmbedded' ./..."
 		// The macOS leg is the only consumer of main.yml's matrix test-flags (the
 		// ubuntu leg's coverage step hardcodes its own), and it carries an explicit

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -260,7 +260,10 @@ func TestPRCIGateRequiresGeneratedHookTimeoutProcessBoundary(t *testing.T) {
 // still produces a bounded, diagnosable job failure instead of running to
 // GitHub's 360m default.
 func TestMacOSCITestLegsHaveExplicitTimeout(t *testing.T) {
-	const minTimeoutMinutes = 20
+	const (
+		minTimeoutMinutes    = 20
+		minJobTimeoutMinutes = 60
+	)
 
 	timeoutPattern := regexp.MustCompile(`-timeout[= ](\d+)m\b`)
 	assertHasTimeoutFloor := func(t *testing.T, label, command string) {
@@ -283,8 +286,8 @@ func TestMacOSCITestLegsHaveExplicitTimeout(t *testing.T) {
 		const label = "pr.yml test-macos Test step"
 		job := readCIWorkflow(t, "pr.yml").job(t, "test-macos")
 		assertHasTimeoutFloor(t, label, goTestCommandLine(t, label, job.step(t, "Test").Run))
-		if job.TimeoutMinutes < 60 {
-			t.Errorf("pr.yml test-macos job timeout-minutes = %d, want at least 60", job.TimeoutMinutes)
+		if job.TimeoutMinutes < minJobTimeoutMinutes {
+			t.Errorf("pr.yml test-macos job timeout-minutes = %d, want at least %d", job.TimeoutMinutes, minJobTimeoutMinutes)
 		}
 	})
 
@@ -297,8 +300,8 @@ func TestMacOSCITestLegsHaveExplicitTimeout(t *testing.T) {
 			}
 		}
 		assertHasTimeoutFloor(t, "main.yml test macOS matrix test-flags", macOSFlags)
-		if job.TimeoutMinutes < 60 {
-			t.Errorf("main.yml test job timeout-minutes = %d, want at least 60", job.TimeoutMinutes)
+		if job.TimeoutMinutes < minJobTimeoutMinutes {
+			t.Errorf("main.yml test job timeout-minutes = %d, want at least %d", job.TimeoutMinutes, minJobTimeoutMinutes)
 		}
 	})
 
@@ -306,6 +309,9 @@ func TestMacOSCITestLegsHaveExplicitTimeout(t *testing.T) {
 		const label = "ci-measurements.yml macos-short Measure commands step"
 		job := readCIWorkflow(t, "ci-measurements.yml").job(t, "macos-short")
 		assertHasTimeoutFloor(t, label, goTestCommandLine(t, label, job.step(t, "Measure commands").Run))
+		if job.TimeoutMinutes < minJobTimeoutMinutes {
+			t.Errorf("ci-measurements.yml macos-short job timeout-minutes = %d, want at least %d", job.TimeoutMinutes, minJobTimeoutMinutes)
+		}
 	})
 }
 

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -258,7 +258,9 @@ func TestPRCIGateRequiresGeneratedHookTimeoutProcessBoundary(t *testing.T) {
 // parses below 20m, but tolerates the deadline moving up over time in any
 // duration form go test accepts. Each leg's enclosing job also needs a
 // timeout-minutes backstop so a real hang still produces a bounded,
-// diagnosable job failure instead of running to GitHub's 360m default.
+// diagnosable job failure instead of running to GitHub's 360m default. On
+// main.yml that backstop is job-level over the whole two-entry matrix, so
+// despite this subtest's name the assertion covers the ubuntu leg too.
 func TestMacOSCITestLegsHaveExplicitTimeout(t *testing.T) {
 	const (
 		minTimeout           = 20 * time.Minute

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -280,8 +280,9 @@ func TestMacOSCITestLegsHaveExplicitTimeout(t *testing.T) {
 	}
 
 	t.Run("pr.yml test-macos", func(t *testing.T) {
+		const label = "pr.yml test-macos Test step"
 		job := readCIWorkflow(t, "pr.yml").job(t, "test-macos")
-		assertHasTimeoutFloor(t, "pr.yml test-macos Test step", job.step(t, "Test").Run)
+		assertHasTimeoutFloor(t, label, goTestCommandLine(t, label, job.step(t, "Test").Run))
 		if job.TimeoutMinutes < 60 {
 			t.Errorf("pr.yml test-macos job timeout-minutes = %d, want at least 60", job.TimeoutMinutes)
 		}
@@ -302,9 +303,59 @@ func TestMacOSCITestLegsHaveExplicitTimeout(t *testing.T) {
 	})
 
 	t.Run("ci-measurements.yml macos-short", func(t *testing.T) {
+		const label = "ci-measurements.yml macos-short Measure commands step"
 		job := readCIWorkflow(t, "ci-measurements.yml").job(t, "macos-short")
-		assertHasTimeoutFloor(t, "ci-measurements.yml macos-short Measure commands step", job.step(t, "Measure commands").Run)
+		assertHasTimeoutFloor(t, label, goTestCommandLine(t, label, job.step(t, "Measure commands").Run))
 	})
+}
+
+// goTestCommandLine reduces a step's run block to the single line that invokes
+// `go test`. A YAML block scalar carries its own `#` comments inside step.Run,
+// so applying a flag pattern to the raw block can match the rationale comment
+// instead of the command it describes — which leaves the guard green with the
+// very flag it exists to pin deleted from the command. Comments are stripped,
+// whole-line and trailing, before the search.
+func goTestCommandLine(t *testing.T, label, run string) string {
+	t.Helper()
+
+	var found []string
+	for _, line := range strings.Split(run, "\n") {
+		if line = strings.TrimSpace(stripShellComment(line)); strings.Contains(line, "go test") {
+			found = append(found, line)
+		}
+	}
+	switch len(found) {
+	case 1:
+		return found[0]
+	case 0:
+		t.Fatalf("%s: no `go test` invocation in run block: %q", label, run)
+	default:
+		t.Fatalf("%s: want exactly one `go test` invocation in run block, got %d: %q", label, len(found), found)
+	}
+	return ""
+}
+
+// stripShellComment drops a trailing `#` comment from one shell line, tracking
+// quote state so a `#` inside an argument survives.
+func stripShellComment(line string) string {
+	var inSingle, inDouble bool
+	for i := 0; i < len(line); i++ {
+		switch line[i] {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+		case '#':
+			if !inSingle && !inDouble && (i == 0 || line[i-1] == ' ' || line[i-1] == '\t') {
+				return line[:i]
+			}
+		}
+	}
+	return line
 }
 
 func TestStorageDomainUOWJobsUseNestedTimeoutBudgets(t *testing.T) {


### PR DESCRIPTION
## Summary

Three macOS `-race` CI legs run whole-module `go test ./...` with no explicit
`-timeout`, so every package inherits Go's default 10m-per-test-binary alarm.
On macOS arm64 under `-race`, the heaviest packages (`cmd/bd`,
`internal/storage/uow`) now sit at or over that cliff — measured on PR #5790,
run 34417047236, job 102684121875 (2026-09-09): `cmd/bd` and
`internal/storage/uow` both hit exactly 600.5s/600.2s and were killed with
zero `--- FAIL` lines logged (the package alarm firing mid-run, not a real
test failure). Attribution check (elapsed vs. median across concurrent
control jobs) showed the slowdown was uniform across the whole matrix and
topped by packages this PR's diff never touched — per-instance runner
variance, not a regression in the diff under test.

This is the macOS-leg counterpart to #6253 and #6248, which already fixed the
identical defect for `scripts/ci/pr-core.sh`. Same convention, applied here:

- `.github/workflows/pr.yml` `test-macos` job: `-timeout=25m` on the `go test`
  step, `timeout-minutes: 60` on the job (was riding GitHub's 360m default).
- `.github/workflows/main.yml` `test` job: `timeout-minutes: 60` (was 45 — too
  tight once a package can legitimately use the full 25m on top of a 12-25m job
  body). The macOS matrix `test-flags` already carried `-timeout=25m` from
  earlier, unrelated work. **This key is job-level over a two-entry matrix
  (`ubuntu-latest`, `macos-latest`) and the job has no per-matrix override, so
  the ubuntu leg's budget rises 45 → 60 as well.** That is behaviorally inert
  rather than intended: the Linux coverage step hardcodes its own
  `-timeout=25m` (`main.yml:571`), so nothing new can run any longer there — a
  Linux hang is simply killed 15m later than before. Flagged because it is the
  one non-macOS change on a branch whose subject says macOS.
- `.github/workflows/ci-measurements.yml` `macos-short` job: `-timeout=25m` on
  the `go test` step, and `timeout-minutes: 30` → `60`. The job bump is
  required, not cosmetic: a 25m per-package deadline can only fire — and print
  the goroutine stacks that make a real hang diagnosable — if 25m still fits
  inside the job after checkout, setup-go, `install-dolt.sh` and the compile of
  every package ahead of the slow one. At 30m the runner kill wins that race
  and the flag is decorative, which is the "cut off by a bare job kill" failure
  the design note at `main.yml:462-467` says this shape exists to prevent. 60m
  matches the sibling `macos-candidates` in the same file, which pairs
  `-timeout=30m` with a 60m budget.
- New regression test `TestMacOSCITestLegsHaveExplicitTimeout` (floor check,
  not exact-match) in `scripts/ci_workflow_test.go`, asserting all three legs
  keep an explicit `-timeout >= 20m` and all three enclosing jobs keep
  `timeout-minutes >= 60`. The floor accepts any duration form `go test` does
  (`1h`, `1h30m`, `25m0s`), via `time.ParseDuration` rather than a
  minutes-only pattern. The check is applied to each leg's `go test`
  invocation, not to the raw `run:` block, so a rationale comment living
  inside a block scalar cannot satisfy it in place of the command.
- Updated the pre-existing `TestMacOSTestJobsReuseWorkspaceBDBinary`'s
  `prTestCommand` constant so it doesn't regress against the new `-timeout`
  flag.

Out of scope (unchanged): `scripts/ci/pr-core.sh` (already covered by
#6253/#6248); sharding `cmd/bd` or `internal/storage/embeddeddolt` (the tests
are slow, not hung — raising the deadline is the minimal correct fix);
promoting `test-macos` to `ci-gate`'s required-check list (advisory today by
deliberate, separate maintainer call per the existing comment at
`pr.yml:~806`).

refs be-xagyw

## Test plan

- `go test ./scripts/ -count=1 -timeout=9m`: PASS (48 tests, 0 fail, 1 skip —
  `TestTestScriptPrebuiltBinaryLaunchProbe`, pre-existing helper-only probe
  per #5599).
- `gofmt -l scripts/` / `go vet ./scripts/` / `go build ./scripts/...`: clean.
- `make ci-pr-policy`: all checks pass (doc freshness, testing.Short
  boundaries, workapi frontend boundary, no `.beads/issues.jsonl` changes,
  openapi spec gate).
- Mutation-proved, each reverted and `git status --porcelain` clean after:

  | mutation | result |
  |---|---|
  | `ci-measurements.yml` `ci_time` loses `-timeout=25m`, rationale comment kept | FAIL |
  | `ci-measurements.yml` loses both the flag and the comment | FAIL |
  | `ci-measurements.yml` `macos-short` job back to `timeout-minutes: 30` | FAIL |
  | `pr.yml` Test step loses `-timeout=25m` | FAIL (this test **and** `TestMacOSTestJobsReuseWorkspaceBDBinary`) |
  | `pr.yml` `test-macos` loses `timeout-minutes: 60` | FAIL |
  | `main.yml` `test` back to `timeout-minutes: 45` | FAIL |
  | `main.yml` macOS `test-flags` `25m` → `5m` | FAIL |
  | `pr.yml` `-timeout` raised to `1h` / `1h30m` / `25m0s` | PASS (legitimate raises) |
