### PR TITLE
fix(storage/dolt): replace stale server_mode TODO comment

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -985,7 +985,11 @@ func (s *DoltStore) doltSpanAttrs() []attribute.KeyValue {
 		s.spanAttrsCache = []attribute.KeyValue{
 			attribute.String("db.system", "dolt"),
 			attribute.Bool("db.readonly", s.readOnly),
-			attribute.Bool("db.server_mode", true), // TODO: update when embedded mode returns
+			// DoltStore (this package) is always server-mode. The split from
+			// embedded mode is permanent, not pending; see
+			// internal/storage/embeddeddolt for the separate embedded-mode
+			// implementation used by solo/standalone deployments.
+			attribute.Bool("db.server_mode", true),
 		}
 	})
 	return s.spanAttrsCache


### PR DESCRIPTION
## Summary

Salvage from closed PR #5925: replaces a stale `TODO: update when embedded mode returns` comment on `doltSpanAttrs()`'s `db.server_mode` span attribute in `internal/storage/dolt/store.go` with an accurate explanatory comment. The split between server-mode (`DoltStore`, this package) and embedded mode (`internal/storage/embeddeddolt`) is permanent, not pending — the old TODO implied a merge that isn't coming.

Comment-only change. The executable statement (`attribute.Bool("db.server_mode", true)`) is byte-identical before and after.

## Test plan

- [x] Reviewed and verdict:pass (be-5d9p4): affected-package run (`scripts/test.sh -v ./internal/storage/dolt/...`), 311 PASS / 0 FAIL / 795 SKIP (dolt-server tests skip per repo default; covered live by `pr-risk.yml`'s sharded `server-storage-test-shard.sh`).
- [x] Deployer independently re-ran the full suite (`make test` / `TEST_COVER=1 ./scripts/test.sh`) fresh on an isolated worktree at this exact commit: 97 packages `ok`, 0 `FAIL`, exit code 0.
- [x] `gofmt`/`go vet`/`go build` clean on the touched package.
- [x] No test files in diff (comment-only change); no behavioral delta to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — beads/deployer release-gate
