### PR TITLE
fix(scripts): check-doc-freshness.sh fails on duplicate Last-reviewed markers

### DIFF
--- a/scripts/check-doc-freshness.sh
+++ b/scripts/check-doc-freshness.sh
@@ -186,11 +186,15 @@ for entry in "${DOCS[@]}"; do
         echo "PASS: listed in engdocs/DOC_INVENTORY.md"
     fi
 
-    reviewed_line="$(grep -E -m1 '^Last reviewed: [0-9]{4}-[0-9]{2}-[0-9]{2}$' "$doc_path" || true)"
-    if [[ -z "$reviewed_line" ]]; then
+    reviewed_count="$(grep -Ec '^Last reviewed: [0-9]{4}-[0-9]{2}-[0-9]{2}$' "$doc_path" || true)"
+    if [[ "$reviewed_count" -eq 0 ]]; then
         echo "FAIL: missing Last reviewed marker in YYYY-MM-DD format"
         ERRORS=$((ERRORS + 1))
+    elif [[ "$reviewed_count" -gt 1 ]]; then
+        echo "FAIL: found $reviewed_count Last reviewed markers; expected exactly one"
+        ERRORS=$((ERRORS + 1))
     else
+        reviewed_line="$(grep -E -m1 '^Last reviewed: [0-9]{4}-[0-9]{2}-[0-9]{2}$' "$doc_path")"
         reviewed="${reviewed_line#Last reviewed: }"
         if ! age_days="$(date_age_days "$reviewed" 2>/dev/null)"; then
             echo "FAIL: invalid Last reviewed date: $reviewed"

--- a/scripts/check_doc_freshness_test.go
+++ b/scripts/check_doc_freshness_test.go
@@ -360,6 +360,30 @@ func TestDocFreshnessReportsInvalidTodayOverride(t *testing.T) {
 	}
 }
 
+func TestDocFreshnessRejectsMultipleLastReviewedMarkers(t *testing.T) {
+	tests := []struct {
+		name  string
+		dates []string
+	}{
+		{name: "two markers both fresh", dates: []string{"2026-01-10", "2026-01-12"}},
+		{name: "two markers one stale", dates: []string{"2026-01-15", "2020-01-01"}},
+		{name: "three markers", dates: []string{"2026-01-15", "2026-01-16", "2026-01-17"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			run := runDocFreshnessWithDuplicateMarker(t, "docs/reference/configuration.md", test.dates, "2026-01-31", "90")
+			if exitCode(run.err) != 1 {
+				t.Fatalf("exit = %d, want 1; error=%v\n%s", exitCode(run.err), run.err, run.output)
+			}
+			want := fmt.Sprintf("FAIL: found %d Last reviewed markers; expected exactly one", len(test.dates))
+			if !strings.Contains(run.output, want) {
+				t.Fatalf("missing %q:\n%s", want, run.output)
+			}
+		})
+	}
+}
+
 func runDocFreshness(t *testing.T, reviewed, today, maxAge string) freshnessRun {
 	t.Helper()
 	return runDocFreshnessWithDateFunction(t, reviewed, today, &maxAge, "")
@@ -380,11 +404,22 @@ func runDocFreshnessWithDefaultToday(t *testing.T, reviewed, maxAge, dateFunctio
 	return runDocFreshnessProcess(t, reviewed, nil, &maxAge, dateFunction)
 }
 
+func runDocFreshnessWithDuplicateMarker(t *testing.T, targetPath string, targetReviewedDates []string, today, maxAge string) freshnessRun {
+	t.Helper()
+	root := newDocFreshnessFixtureWithMarkers(t, "2026-01-15", targetPath, targetReviewedDates)
+	return runDocFreshnessProcessInRoot(t, root, &today, &maxAge, "")
+}
+
 func runDocFreshnessProcess(t *testing.T, reviewed string, today, maxAge *string, dateFunction string) freshnessRun {
+	t.Helper()
+	root := newDocFreshnessFixture(t, reviewed)
+	return runDocFreshnessProcessInRoot(t, root, today, maxAge, dateFunction)
+}
+
+func runDocFreshnessProcessInRoot(t *testing.T, root string, today, maxAge *string, dateFunction string) freshnessRun {
 	t.Helper()
 	bash := docFreshnessBash(t)
 
-	root := newDocFreshnessFixture(t, reviewed)
 	markerDir := t.TempDir()
 	pythonMarker := filepath.Join(markerDir, "python-invoked")
 	dateMarker := filepath.Join(markerDir, "date-invoked")
@@ -516,6 +551,45 @@ func newDocFreshnessFixture(t *testing.T, reviewed string) string {
 			reviewed,
 			strings.Join(document.sources, ";"),
 		))
+		for _, source := range document.sources {
+			createFreshnessSource(t, root, source)
+		}
+	}
+	writeFixtureFile(t, root, "engdocs/DOC_INVENTORY.md", inventory.String())
+	return root
+}
+
+// newDocFreshnessFixtureWithMarkers is like newDocFreshnessFixture, but the
+// document at targetPath gets one "Last reviewed:" line per entry in
+// targetReviewedDates instead of exactly one. Every other document keeps the
+// normal single marker at reviewed.
+func newDocFreshnessFixtureWithMarkers(t *testing.T, reviewed, targetPath string, targetReviewedDates []string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	repoRoot := sourceRepoRoot(t)
+	script, err := os.ReadFile(filepath.Join(repoRoot, "scripts", "check-doc-freshness.sh"))
+	if err != nil {
+		t.Fatalf("read check-doc-freshness.sh: %v", err)
+	}
+	writeFixtureFile(t, root, "scripts/check-doc-freshness.sh", string(script))
+
+	var inventory strings.Builder
+	for _, document := range freshnessDocuments {
+		inventoryRef := strings.TrimPrefix(strings.TrimPrefix(document.path, "docs/"), "engdocs/")
+		fmt.Fprintf(&inventory, "- `%s`\n", inventoryRef)
+
+		var body strings.Builder
+		reviewedDates := []string{reviewed}
+		if document.path == targetPath {
+			reviewedDates = targetReviewedDates
+		}
+		for _, date := range reviewedDates {
+			fmt.Fprintf(&body, "Last reviewed: %s\n", date)
+		}
+		fmt.Fprintf(&body, "Freshness source: %s\n", strings.Join(document.sources, ";"))
+		writeFixtureFile(t, root, document.path, body.String())
+
 		for _, source := range document.sources {
 			createFreshnessSource(t, root, source)
 		}


### PR DESCRIPTION
## Summary

`scripts/check-doc-freshness.sh` currently parses only the *first* `Last reviewed: YYYY-MM-DD` marker line per doc file (`grep -m1`), so a file with two such markers (e.g. after a rebase collision between two branches that each independently refreshed the same marker) silently passes on whichever one is matched first — even though the file is now visibly wrong. This is a silent-corruption shape: nothing goes red, but the doc is broken.

Fix: count marker-pattern matches per file. Zero markers still fails as before (missing marker). Exactly one marker behaves exactly as today (age-checked). Two or more markers now fails immediately, before any age check, with a message naming the count — regardless of whether either individual marker is fresh or stale.

Found and filed (be-g7tqg) by the deployer itself after hitting exactly this collision live during an unrelated deploy gate (`origin/main`'s PR #6411 vs. an in-flight branch both bumping `docs/recovery/init-safety.md`'s marker).

## Test plan

- [x] Reviewed and verdict:pass (be-hw4m4): focused CI-equivalent run (`go test -tags=integration,gms_pure_go -run '^TestDocFreshness' -v ./scripts`, verbatim from `pr.yml`'s docs-gate job) — 10/11 top-level funcs PASS, 1 pre-existing unrelated SKIP (Windows-only), 0 FAIL. New diff-owned test `TestDocFreshnessRejectsMultipleLastReviewedMarkers`: PASS (3/3 subtests — two-fresh, one-stale, three-marker cases).
- [x] Deployer independently re-ran the full suite (`make test` / `TEST_COVER=1 ./scripts/test.sh`) fresh on an isolated worktree at this exact commit: 97 packages `ok`, 0 `FAIL`, exit code 0.
- [x] Single-marker and no-marker behavior unchanged (same code path for 0 and pre-existing 1-marker cases); no existing fixtures touched.
- [x] Shell diff reviewed directly: `$doc_path` properly quoted, `$reviewed_count` used only in arithmetic-context comparisons — no injection surface, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — beads/deployer release-gate
