### PR TITLE
Fix gastownhall/beads#5862

### DIFF
--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -191,10 +191,8 @@ func IsSchemaBehindError(err error) bool {
 // to a warning, mirroring forward drift. A fresh DB (version 0) is reported
 // as behind too: it has no readable schema at all.
 func CheckBehindDrift(ctx context.Context, db *sql.DB) error {
-	var currentVersion int
-	if err := db.QueryRowContext(ctx,
-		"SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
-	).Scan(&currentVersion); err != nil {
+	currentVersion, err := CurrentVersion(ctx, db)
+	if err != nil {
 		return fmt.Errorf("schema behind-drift check: %w", err)
 	}
 	if currentVersion >= LatestVersion() {

--- a/internal/storage/schema/schema_skew_test.go
+++ b/internal/storage/schema/schema_skew_test.go
@@ -290,3 +290,35 @@ func TestIsSchemaSkewError_OtherError(t *testing.T) {
 		t.Error("IsSchemaSkewError(non-SchemaSkewError) = true, want false")
 	}
 }
+
+// -- CheckBehindDrift unit tests (mock DB) --
+
+func TestCheckBehindDrift_FreshDB_ReturnsSchemaBehindError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// On a fresh database where schema_migrations does not exist, the cursor probe
+	// returns 0 and no bare SELECT against schema_migrations is issued.
+	expectCursorProbe(mock, "schema_migrations", false)
+
+	got := CheckBehindDrift(context.Background(), db)
+	if got == nil {
+		t.Fatal("CheckBehindDrift = nil, want *SchemaBehindError for fresh DB (version=0)")
+	}
+	var behindErr *SchemaBehindError
+	if !errors.As(got, &behindErr) {
+		t.Fatalf("error type = %T (%v), want *SchemaBehindError", got, got)
+	}
+	if behindErr.DBVersion != 0 {
+		t.Errorf("DBVersion = %d, want 0", behindErr.DBVersion)
+	}
+	if behindErr.BinaryVersion != LatestVersion() {
+		t.Errorf("BinaryVersion = %d, want %d", behindErr.BinaryVersion, LatestVersion())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Make the read-only schema check probe for the migrations table before reading its version. This keeps a fresh database on the normal schema-behind error path instead of issuing a failing query. Reported by [Bee (@bee-ghosttrack)](https://github.com/gastownhall/beads/issues/5862).

| File | Change |
|---|---|
| `internal/storage/schema/schema.go` | Reuse `CurrentVersion` for the safe cursor-table probe |
| `internal/storage/schema/schema_skew_test.go` | Cover the fresh-database path without a bare migrations-table query |

## Why

Fixes #5862.

Type: bug fix · Risk: low — reuses the existing version probe and preserves the `*sql.DB` API.

## Verification

- `go vet ./internal/storage/schema/...`: passed.
- `go test -v ./internal/storage/schema/... -run "TestCheckBehindDrift|TestSchemaBehindError|TestIsSchemaBehindError"`: passed.
- `CGO_ENABLED=0 go test -tags gms_pure_go ./internal/storage/embeddeddolt/...`: passed (6 tests).

<details>
<summary>Evidence & notes for reviewers</summary>

### Root cause

`CheckBehindDrift` queried `schema_migrations` directly. A fresh database does not have that table yet, so the read-only open path returned the query error before it could report the database as schema version 0.

### Approach

The change routes the lookup through `CurrentVersion`, which already probes `information_schema.tables` and returns version 0 when the cursor table is absent. This follows the pattern introduced by [#5847](https://github.com/gastownhall/beads/pull/5847) without duplicating its probe logic. The public function signature remains unchanged.

### Local validation limits

The default embedded-Dolt test build could not start because the local toolchain lacks the ICU header `unicode/regex.h`; the repository's pure-Go build passed instead. The PR lint wrapper was stopped when it expanded into a build while another OSS City item owned the serial build lane. These are recorded as an environment limitation and a pending check, respectively.

</details>
