### PR TITLE
fix(ownershiphandoff): require a canonical socket path for containment (post-merge #6281)

### DIFF
--- a/internal/ownershiphandoff/ownershiphandoff.go
+++ b/internal/ownershiphandoff/ownershiphandoff.go
@@ -208,14 +208,22 @@ func validateEndpoint(root string, e Endpoint) error {
 	return nil
 }
 
-// validateSocketEndpoint requires an absolute socket path that stays inside
-// root once symlinked parent directories are resolved.
+// validateSocketEndpoint requires an absolute canonical socket path that stays
+// inside root once symlinked parent directories are resolved. The canonical-form
+// requirement is load-bearing, not cosmetic: containment resolution has to clean
+// the path before it can walk it, and cleaning collapses a "link/.." pair
+// lexically, whereas the kernel walks the symlink first and lands somewhere
+// else. Rejecting the non-canonical spelling outright keeps the two readings
+// from ever disagreeing — the same reason Root must be canonical.
 func validateSocketEndpoint(root string, e Endpoint) error {
 	if e.Host != "" {
 		return errors.New("socket endpoint must not specify a host")
 	}
 	if !filepath.IsAbs(e.Socket) {
 		return errors.New("socket must be absolute")
+	}
+	if filepath.Clean(e.Socket) != e.Socket {
+		return errors.New("socket must be a canonical path")
 	}
 	resolved, err := resolvePathForContainment(e.Socket)
 	if err != nil {

--- a/internal/ownershiphandoff/ownershiphandoff_test.go
+++ b/internal/ownershiphandoff/ownershiphandoff_test.go
@@ -77,6 +77,43 @@ func TestValidateRejectsSymlinkRootAndExternalEndpoint(t *testing.T) {
 	}
 }
 
+// TestValidateRejectsRawParentEscapeAfterSymlink pins the canonical-form rule on
+// Endpoint.Socket. resolvePathForContainment opens with filepath.Clean, which
+// collapses "link/.." lexically before any symlink is resolved, so a socket
+// spelled with a raw ".." after a symlinked directory looked contained to the
+// Rel check while the kernel, which walks the link before the "..", creates it
+// outside root. Root carries this rule already; its sibling field did not.
+//
+// The escaping path must be built by string concatenation. filepath.Join cleans
+// the ".." away itself, so a Join-built case never reaches the validator in the
+// form that escapes and would pass with or without the rule.
+func TestValidateRejectsRawParentEscapeAfterSymlink(t *testing.T) {
+	r := validRequest(t)
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(base, "outside")
+	if err := os.MkdirAll(outside, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(r.Root, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	sep := string(filepath.Separator)
+	r.Endpoint = Endpoint{Socket: r.Root + sep + "link" + sep + ".." + sep + "evil.sock"}
+	if err := ValidateRequest(r); err == nil {
+		t.Fatalf("socket escaping root through a raw parent reference accepted: %q", r.Endpoint.Socket)
+	}
+
+	// The rule must not cost a canonical socket inside root its eligibility.
+	r.Endpoint = Endpoint{Socket: filepath.Join(r.Root, "beads.sock")}
+	if err := ValidateRequest(r); err != nil {
+		t.Fatalf("canonical in-root socket rejected: %v", err)
+	}
+}
+
 // TestValidateNamesTheIncompleteEndpoint pins the message, not just the
 // rejection: an endpoint with no host at all is incomplete, and reporting it as
 // "external" misdirects the reader.


### PR DESCRIPTION
## Post-merge remediation for #6281

Post-merge review of the landed range `c185735c38..74e25cba15` on `release/1.3.0`
(merged PR #6281, head `a26ba95c2`) found one actionable PR-introduced finding in
the new `internal/ownershiphandoff` package. This PR fixes it forward on the
release lineage, ahead of the consumer front door in #6297.

### The finding: socket containment was bypassable

`resolvePathForContainment` opens with `filepath.Clean(path)`, which collapses a
`link/..` pair **lexically**, before any symlink is resolved. The kernel walks the
symlink first. So with `root/link` pointing at a directory outside `root`, a socket
spelled `root/link/../evil.sock` was approved by `ValidateRequest` while the socket
the provider then creates lands outside `root`.

`Root` is already held to canonical form (`filepath.Clean(r.Root) != r.Root` is
rejected). That rule never propagated to `Endpoint.Socket`, its sibling field in the
same validated struct — so `ValidateRequest`'s own doc promise to reject
"non-canonical" identities, and `engdocs/design/ownership-handoff-contract.md`'s
promise that non-canonical identities "are rejected before any provider hook runs",
held only for `Root`.

The package is all-new in #6281, so there is no base-parity argument: this is
PR-introduced surface, gated against the PR's own contract document. It was
reproduced independently by three review lanes.

### The fix

Require `filepath.Clean(e.Socket) == e.Socket` in `validateSocketEndpoint` — the
exact rule `Root` already gets. Once the spelling is canonical, cleaning is a no-op
and the containment walk agrees with the kernel.

### Verification

- **Escape reproduced before the fix.** The new test fails on the parent commit:
  `ValidateRequest` returned `nil` for the escaping socket.
- **Kernel divergence confirmed empirically** in a throwaway scratch dir (since
  deleted): a file created through `root/link/../evil.sock` landed outside `root`,
  and the validator-assumed location `root/evil.sock` stayed absent.
- **No false positives.** The new test also asserts a canonical in-root socket is
  still eligible, and all eleven pre-existing rejection-table cases still pass.
- `go test ./internal/ownershiphandoff/` green, including `-race -count=2`;
  `go build ./...`, `go vet`, `gofmt` and `golangci-lint` clean on the package.

### Why the regression test uses string concatenation

`filepath.Join(root, "link", "..", "evil.sock")` evaluates to `root/evil.sock` —
`Join` cleans the `..` away itself, so a `Join`-built case never reaches the
validator in the form that escapes and would pass with or without the rule. The
pre-existing `socket through symlinked directory` case passes today only because its
paths contain no raw `..`. The new test builds the path by concatenation so it
actually discriminates; the comment records why, so it is not later "tidied" back
into a `Join`.

### Scope

Only the gating finding is fixed here. The review's other items are non-gating and
stay on the tracker:

- **`bd-khpc`** (already tracked, P1) — the unguarded directory fsync in `save()`,
  expected to fail on Windows after the rename applied. Its prescribed remedy is a
  widened `internal/atomicfile` plus a `windows-latest` lane, which spans four
  call sites and a CI workflow; it is pre-existing in kind (the same shape ships at
  base in `internal/configfile/proxied_server_client_info.go`) and belongs in its own
  change, not bundled into a containment fix.
- **`bd-m31z`** (already tracked, P2) — the forward-port gap to `main`.
- Remaining minors and nits are filed on the tracker: `bd-vz6e` (refusal-path reporting
  fidelity), `bd-vv8l` (`clearError` in `advance`), `bd-vnc0` (a `ctx.Err()` step check),
  `bd-24zv` (the `Result.Mutates` doc/predicate mismatch), `bd-zou0` (a typed `ErrorCode`
  vocabulary), `bd-7jms` (the contract doc's lost `Status` block), `bd-7z04` (the loopback
  taxonomy divergence), `bd-onfj` (three one-line nits), `bd-cpaj` (open risks).

Original merged PR: #6281
Reviewed range: `c185735c38..74e25cba15`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
