### PR TITLE
docs: add beady-eye to community tools

### DIFF
--- a/docs/community-tools.md
+++ b/docs/community-tools.md
@@ -16,7 +16,7 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[perles](https://github.com/zjrosen/perles)** - Terminal UI search, dependency and kanban viewer powered by a custom BQL (Beads Query Language). Built by [@zjrosen](https://github.com/zjrosen). (Go)
 
-- **[beady-eye](https://github.com/CodeForBreakfast/beady-eye)** - Read-only terminal UI drawing each tracker's beads as a tree, with the live [herdr](https://herdr.dev) agent pane beside every bead an agent has claimed and the disagreements between the two flagged. Install with `brew install codeforbreakfast/tap/bdi`. Built by [@GraemeF](https://github.com/GraemeF). (Rust)
+- **[beady-eye](https://github.com/CodeForBreakfast/beady-eye)** - Read-only terminal UI drawing each tracker's beads as a tree, with the live [herdr](https://herdr.dev) agent pane beside every bead an agent has claimed. Install with `brew install codeforbreakfast/tap/bdi`. Built by [@GraemeF](https://github.com/GraemeF). (Rust)
 
 ## Web UIs
 

--- a/docs/community-tools.md
+++ b/docs/community-tools.md
@@ -16,7 +16,7 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[perles](https://github.com/zjrosen/perles)** - Terminal UI search, dependency and kanban viewer powered by a custom BQL (Beads Query Language). Built by [@zjrosen](https://github.com/zjrosen). (Go)
 
-- **[beady-eye](https://github.com/CodeForBreakfast/beady-eye)** - Read-only terminal UI drawing each tracker's beads as a tree, with the live [herdr](https://herdr.dev) agent pane beside every bead an agent has claimed. Built by [@GraemeF](https://github.com/GraemeF). (Rust)
+- **[beady-eye](https://github.com/CodeForBreakfast/beady-eye)** - Live terminal viewer that follows agents as they work through a tree of beads, redrawing as they claim and finish them. It reads a [herdr](https://herdr.dev) session alongside the tracker, so each claimed bead is drawn with the agent pane working it. Read-only. Built by [@GraemeF](https://github.com/GraemeF). (Rust)
 
 ## Web UIs
 

--- a/docs/community-tools.md
+++ b/docs/community-tools.md
@@ -16,7 +16,7 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[perles](https://github.com/zjrosen/perles)** - Terminal UI search, dependency and kanban viewer powered by a custom BQL (Beads Query Language). Built by [@zjrosen](https://github.com/zjrosen). (Go)
 
-- **[beady-eye](https://github.com/CodeForBreakfast/beady-eye)** - Live terminal viewer that follows agents as they work through a tree of beads, redrawing as they claim and finish them. It reads a [herdr](https://herdr.dev) session alongside the tracker, so each claimed bead is drawn with the agent pane working it. Read-only. Built by [@GraemeF](https://github.com/GraemeF). (Rust)
+- **[beady-eye](https://github.com/CodeForBreakfast/beady-eye)** - Live terminal viewer that follows agents as they work through a tree of beads, redrawing as they claim and finish them. Integrates with [herdr](https://herdr.dev), and watches several projects at once. Read-only. Built by [@GraemeF](https://github.com/GraemeF). (Rust)
 
 ## Web UIs
 

--- a/docs/community-tools.md
+++ b/docs/community-tools.md
@@ -16,6 +16,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[perles](https://github.com/zjrosen/perles)** - Terminal UI search, dependency and kanban viewer powered by a custom BQL (Beads Query Language). Built by [@zjrosen](https://github.com/zjrosen). (Go)
 
+- **[beady-eye](https://github.com/CodeForBreakfast/beady-eye)** - Terminal UI drawing each tracker's beads as a tree, with the live [herdr](https://herdr.dev) agent pane shown beside every bead an agent has claimed. Flags where the two disagree: a bead claimed by a pane that has died, or a pane working with no bead to its name. Read-only — every call it makes is `bd --readonly ... --json`. Install with `brew install codeforbreakfast/tap/bdi` or `cargo install beady-eye`; the command is `bdi`. Built by [@GraemeF](https://github.com/GraemeF). (Rust)
+
 ## Web UIs
 
 - **[bd-board](https://github.com/jeanpfs/bd-board)** - Local-first web dashboard for browsing Beads projects, viewing kanban boards by status or epic swimlanes, and filtering by priority, text search, or sort order. Uses the `bd` CLI for Dolt compatibility, with writes disabled unless explicitly enabled. Built by [@jeanpfs](https://github.com/jeanpfs). (TanStack Start/React)

--- a/docs/community-tools.md
+++ b/docs/community-tools.md
@@ -16,7 +16,7 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[perles](https://github.com/zjrosen/perles)** - Terminal UI search, dependency and kanban viewer powered by a custom BQL (Beads Query Language). Built by [@zjrosen](https://github.com/zjrosen). (Go)
 
-- **[beady-eye](https://github.com/CodeForBreakfast/beady-eye)** - Read-only terminal UI drawing each tracker's beads as a tree, with the live [herdr](https://herdr.dev) agent pane beside every bead an agent has claimed. Install with `brew install codeforbreakfast/tap/bdi`. Built by [@GraemeF](https://github.com/GraemeF). (Rust)
+- **[beady-eye](https://github.com/CodeForBreakfast/beady-eye)** - Read-only terminal UI drawing each tracker's beads as a tree, with the live [herdr](https://herdr.dev) agent pane beside every bead an agent has claimed. Built by [@GraemeF](https://github.com/GraemeF). (Rust)
 
 ## Web UIs
 

--- a/docs/community-tools.md
+++ b/docs/community-tools.md
@@ -16,7 +16,7 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[perles](https://github.com/zjrosen/perles)** - Terminal UI search, dependency and kanban viewer powered by a custom BQL (Beads Query Language). Built by [@zjrosen](https://github.com/zjrosen). (Go)
 
-- **[beady-eye](https://github.com/CodeForBreakfast/beady-eye)** - Terminal UI drawing each tracker's beads as a tree, with the live [herdr](https://herdr.dev) agent pane shown beside every bead an agent has claimed. Flags where the two disagree: a bead claimed by a pane that has died, or a pane working with no bead to its name. Read-only — every call it makes is `bd --readonly ... --json`. Install with `brew install codeforbreakfast/tap/bdi` or `cargo install beady-eye`; the command is `bdi`. Built by [@GraemeF](https://github.com/GraemeF). (Rust)
+- **[beady-eye](https://github.com/CodeForBreakfast/beady-eye)** - Read-only terminal UI drawing each tracker's beads as a tree, with the live [herdr](https://herdr.dev) agent pane beside every bead an agent has claimed and the disagreements between the two flagged. Install with `brew install codeforbreakfast/tap/bdi`. Built by [@GraemeF](https://github.com/GraemeF). (Rust)
 
 ## Web UIs
 


### PR DESCRIPTION
Adds `beady-eye` to Terminal UIs. It follows agents through a tracker's tree of beads, redrawing as they claim and finish them, and integrates with [herdr](https://herdr.dev) to know which agent is on which bead. Several projects at once. Read-only: every command it runs is `bd --readonly ... --json`.
