### PR TITLE
fix(metrics): guard send-metrics spawn-claim and prune with a shared lock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -151,7 +151,7 @@ require (
 	github.com/dolthub/dolt/go v0.40.5-0.20260806213044-796d07497741
 	github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4 // indirect
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 // indirect
-	github.com/dolthub/fslock v0.0.5 // indirect
+	github.com/dolthub/fslock v0.0.5
 	github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83 // indirect
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260805191915-e5eafe0da809
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 // indirect

--- a/internal/metrics/flusher.go
+++ b/internal/metrics/flusher.go
@@ -4,21 +4,54 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/dolthub/eventkit"
 	ga4tx "github.com/dolthub/eventkit/transport/ga4"
+	"github.com/steveyegge/beads/internal/storage/filelock"
 )
 
 const (
 	EnvEndpoint = "BEADS_METRICS_ENDPOINT"
 
 	flushTimeout = 30 * time.Second
+
+	// lockFilename is the eventkit.FileFlusher's own lock file name.
+	// pruneUnderLock and claimFlush take this same fslock (not a second,
+	// independent one) so a prune and a Flush against the same dir can never
+	// run concurrently, and a spawn decision can never race a sibling's.
+	lockFilename = eventkit.DefaultLockFilename
 )
 
 // pruneQueueFn is PruneQueue behind a seam so tests can assert the prune is
 // handed the child's real budget — the property GH#5871 turned on.
 var pruneQueueFn = PruneQueue
+
+// pruneUnderLock runs pruneQueueFn while holding the eventkit lock, so a
+// concurrently-spawned sibling send-metrics child (Factor B) cannot scan the
+// same queue directory at once. LockWithContext bounds the wait by ctx rather
+// than blocking indefinitely, returning ctx.Err() if the lock is still held
+// when ctx is done — the caller treats that as "skip this round", not fatal.
+//
+// The lock is always released before returning, never held across the
+// caller's subsequent Flush call: eventkit.FileFlusher.Flush acquires this
+// exact lock itself with a non-blocking TryLock and silently no-ops (returns
+// nil, as if it succeeded) when it observes fslock.ErrLocked. Holding the
+// lock in here past return would make every flush after a prune a silent,
+// undetectable no-op.
+func pruneUnderLock(ctx context.Context, dir string, now time.Time) (int, int64, error) {
+	lock, err := filelock.New(filepath.Join(dir, lockFilename))
+	if err != nil {
+		return 0, 0, err
+	}
+	if err := lock.LockWithContext(ctx); err != nil {
+		return 0, 0, err
+	}
+	defer func() { _ = lock.Unlock() }()
+	dropped, freed := pruneQueueFn(ctx, dir, now)
+	return dropped, freed, nil
+}
 
 func RunSendMetrics() int {
 	dir, err := DataDir()
@@ -43,7 +76,15 @@ func RunSendMetrics() int {
 	// emitter temps, cap the rest drop-oldest (bd-ulfod: an unbounded queue
 	// reached 149k files / 1.1GB when emission outran the throttled drain).
 	// Out-of-band by construction — this child is already detached.
-	if dropped, freed := pruneQueueFn(pruneCtx, dir, time.Now()); dropped > 0 {
+	//
+	// Locked (Factor B): an in-flight Flush (this process or a sibling child)
+	// or another concurrently-spawned prune holds the same eventkit lock, so
+	// two children can no longer scan the same queue directory at once. A
+	// failed acquisition just skips this round's prune rather than blocking
+	// or double-running — the backlog decays on the next successful child.
+	if dropped, freed, err := pruneUnderLock(pruneCtx, dir, time.Now()); err != nil {
+		fmt.Fprintf(os.Stderr, "send-metrics: prune: %v\n", err)
+	} else if dropped > 0 {
 		fmt.Fprintf(os.Stderr, "send-metrics: pruned %d queued event file(s), freed %.1f MB\n",
 			dropped, float64(freed)/(1<<20))
 	}

--- a/internal/metrics/flusher_test.go
+++ b/internal/metrics/flusher_test.go
@@ -1,0 +1,179 @@
+package metrics
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dolthub/fslock"
+)
+
+// TestPruneUnderLockSkipsWhenAlreadyHeld is the Factor B "bounded, never
+// hangs" regression: when another process already holds the eventkit lock
+// (an in-flight flush, or a sibling send-metrics child pruning first),
+// pruneUnderLock must give up once its ctx expires rather than blocking
+// forever, and must not have invoked the underlying prune since it never
+// acquired the lock.
+func TestPruneUnderLockSkipsWhenAlreadyHeld(t *testing.T) {
+	dir := t.TempDir()
+
+	holder, err := fslock.New(filepath.Join(dir, lockFilename))
+	if err != nil {
+		t.Fatalf("fslock.New (holder): %v", err)
+	}
+	if err := holder.TryLock(); err != nil {
+		t.Fatalf("holder TryLock: %v", err)
+	}
+	defer holder.Unlock()
+
+	orig := pruneQueueFn
+	t.Cleanup(func() { pruneQueueFn = orig })
+	var called bool
+	pruneQueueFn = func(context.Context, string, time.Time) (int, int64) {
+		called = true
+		return 0, 0
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	dropped, freed, err := pruneUnderLock(ctx, dir, time.Now())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("pruneUnderLock() err = nil, want non-nil (lock held by another holder for the whole ctx budget)")
+	}
+	if called {
+		t.Errorf("pruneUnderLock invoked the prune despite never acquiring the lock")
+	}
+	if dropped != 0 || freed != 0 {
+		t.Errorf("pruneUnderLock() = (%d, %d), want (0, 0) on a failed acquisition", dropped, freed)
+	}
+	if elapsed > time.Second {
+		t.Errorf("pruneUnderLock took %v to give up on a 300ms ctx, want well under 1s", elapsed)
+	}
+}
+
+// TestPruneUnderLockWaitsForReleaseThenRuns pins the other half: a holder
+// that releases before the ctx deadline must let pruneUnderLock proceed and
+// return the underlying prune's own values, rather than treating transient
+// contention as permanent failure.
+func TestPruneUnderLockWaitsForReleaseThenRuns(t *testing.T) {
+	dir := t.TempDir()
+
+	holder, err := fslock.New(filepath.Join(dir, lockFilename))
+	if err != nil {
+		t.Fatalf("fslock.New (holder): %v", err)
+	}
+	if err := holder.TryLock(); err != nil {
+		t.Fatalf("holder TryLock: %v", err)
+	}
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		_ = holder.Unlock()
+		close(released)
+	}()
+
+	orig := pruneQueueFn
+	t.Cleanup(func() { pruneQueueFn = orig })
+	var called bool
+	pruneQueueFn = func(context.Context, string, time.Time) (int, int64) {
+		called = true
+		return 3, 1024
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), flushTimeout)
+	defer cancel()
+
+	dropped, freed, err := pruneUnderLock(ctx, dir, time.Now())
+	<-released
+
+	if err != nil {
+		t.Fatalf("pruneUnderLock() err = %v, want nil once the holder released", err)
+	}
+	if !called {
+		t.Fatal("pruneUnderLock did not invoke the prune after acquiring the lock")
+	}
+	if dropped != 3 || freed != 1024 {
+		t.Errorf("pruneUnderLock() = (%d, %d), want (3, 1024) passed through from the prune", dropped, freed)
+	}
+
+	free, err := fslock.New(filepath.Join(dir, lockFilename))
+	if err != nil {
+		t.Fatalf("fslock.New (post-check): %v", err)
+	}
+	if err := free.TryLock(); err != nil {
+		t.Fatalf("lock still held after pruneUnderLock returned: %v", err)
+	}
+	_ = free.Unlock()
+}
+
+// TestRunSendMetricsReleasesLockBeforeFlush is the sharpest Factor B
+// regression: if pruneUnderLock ever leaked its lock hold past return, the
+// FileFlusher's own lock acquisition inside Flush would hit contention and
+// silently no-op (treating "someone else is already flushing" as success),
+// and RunSendMetrics would wrongly return 0 against an unreachable endpoint.
+// Enabling metrics with a real queued event and an unreachable endpoint means
+// the ONLY way to observe return code 1 is for Flush to have actually run,
+// which requires the lock to have been free when Flush acquired it.
+func TestRunSendMetricsReleasesLockBeforeFlush(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".beads", "eventsData")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir eventsData: %v", err)
+	}
+	writeQueuedEventNamed(t, dir, "batch-release-check")
+
+	if _, err := Init("0.0.0-test", true, "http://127.0.0.1:1/collect"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if code := RunSendMetrics(); code != 1 {
+		t.Fatalf("RunSendMetrics() = %d, want 1 (Flush must actually run against the unreachable endpoint, proving pruneUnderLock released the lock)", code)
+	}
+}
+
+// TestRunSendMetricsNormalRunUnaffectedByLocking is the non-regression
+// control: with no contention at all, adding the lock around prune must not
+// change RunSendMetrics' externally observable behavior, and must not leave
+// the lock held once RunSendMetrics returns.
+func TestRunSendMetricsNormalRunUnaffectedByLocking(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".beads", "eventsData")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir eventsData: %v", err)
+	}
+
+	orig := pruneQueueFn
+	t.Cleanup(func() { pruneQueueFn = orig })
+	var called bool
+	pruneQueueFn = func(context.Context, string, time.Time) (int, int64) {
+		called = true
+		return 0, 0
+	}
+
+	if _, err := Init("0.0.0-test", false, ""); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if code := RunSendMetrics(); code != 0 {
+		t.Fatalf("RunSendMetrics() = %d, want 0", code)
+	}
+	if !called {
+		t.Fatal("RunSendMetrics did not prune")
+	}
+
+	lock, err := fslock.New(filepath.Join(dir, lockFilename))
+	if err != nil {
+		t.Fatalf("fslock.New (post-check): %v", err)
+	}
+	if err := lock.TryLock(); err != nil {
+		t.Fatalf("lock still held after RunSendMetrics returned: %v", err)
+	}
+	_ = lock.Unlock()
+}

--- a/internal/metrics/flusher_test.go
+++ b/internal/metrics/flusher_test.go
@@ -7,8 +7,40 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dolthub/eventkit"
 	"github.com/dolthub/fslock"
 )
+
+// writeValidQueuedEvent writes a real, eventkit-parseable queued event batch
+// via the same FileEmitter.Send path production code uses. Unlike
+// writeQueuedEventNamed's placeholder content (fine for tests that only need
+// a file with the right extension to satisfy a filename-based scan), a batch
+// eventkit.FileFlusher will actually attempt to Send needs a filename that
+// matches the MD5 of its own content: readBatch's CheckFilenameMD5 gate
+// silently skips (no error) any file where it doesn't, which is why a fake
+// name+content pair never reaches the unreachable endpoint at all.
+func writeValidQueuedEvent(t *testing.T, dir string) {
+	t.Helper()
+	fe, err := eventkit.NewFileEmitter(dir)
+	if err != nil {
+		t.Fatalf("eventkit.NewFileEmitter: %v", err)
+	}
+	req := &eventkit.LogEventsRequest{
+		DistinctID: "test",
+		AppName:    "beads",
+		AppVersion: "0.0.0-test",
+		Platform:   "test",
+		Events: []eventkit.EventRecord{{
+			ID:        "1",
+			Name:      "test_event",
+			StartTime: time.Now(),
+			EndTime:   time.Now(),
+		}},
+	}
+	if err := fe.Send(context.Background(), req); err != nil {
+		t.Fatalf("FileEmitter.Send: %v", err)
+	}
+}
 
 // TestPruneUnderLockSkipsWhenAlreadyHeld is the Factor B "bounded, never
 // hangs" regression: when another process already holds the eventkit lock
@@ -127,7 +159,7 @@ func TestRunSendMetricsReleasesLockBeforeFlush(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		t.Fatalf("mkdir eventsData: %v", err)
 	}
-	writeQueuedEventNamed(t, dir, "batch-release-check")
+	writeValidQueuedEvent(t, dir)
 
 	if _, err := Init("0.0.0-test", true, "http://127.0.0.1:1/collect"); err != nil {
 		t.Fatalf("Init: %v", err)

--- a/internal/metrics/spawn.go
+++ b/internal/metrics/spawn.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/steveyegge/beads/internal/storage/filelock"
 )
 
 const SendMetricsSubcommand = "send-metrics"
@@ -161,6 +163,32 @@ func touchFlushMarker(dir string) {
 	_ = os.WriteFile(path, nil, 0o600)
 }
 
+// claimFlush is the locked half of the spawn decision (Factor A): concurrent
+// bd invocations all seeing flusherDue's unlocked pre-check pass must still
+// produce exactly one spawn, not one per invocation. TryLock is non-blocking,
+// so a caller that loses the race returns false immediately instead of
+// queueing behind the winner; a caller that does acquire the lock re-checks
+// flusherDue, since another caller may have already touched the marker
+// between the unlocked pre-check and this call. Only the winner touches the
+// marker, and the lock is released before returning — well before the
+// detached child is spawned, so the lock is never held across the child's
+// lifetime.
+func claimFlush(dir string, now time.Time) bool {
+	lock, err := filelock.New(filepath.Join(dir, lockFilename))
+	if err != nil {
+		return false
+	}
+	if err := lock.TryLock(); err != nil {
+		return false
+	}
+	defer func() { _ = lock.Unlock() }()
+	if !flusherDue(dir, now) {
+		return false
+	}
+	touchFlushMarker(dir)
+	return true
+}
+
 func MaybeSpawnFlusher() {
 	if !shouldSpawnFlusher() {
 		return
@@ -172,7 +200,9 @@ func MaybeSpawnFlusher() {
 	if !flusherDue(dir, time.Now()) {
 		return
 	}
-	touchFlushMarker(dir)
+	if !claimFlush(dir, time.Now()) {
+		return
+	}
 	self, err := os.Executable()
 	if err != nil {
 		return

--- a/internal/metrics/spawn_throttle_test.go
+++ b/internal/metrics/spawn_throttle_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -220,5 +222,50 @@ func TestTouchFlushMarkerCreatesThenBumps(t *testing.T) {
 func TestFlusherMarkerInertToFileFlusher(t *testing.T) {
 	if filepath.Ext(flushMarkerName) == queuedEventExt {
 		t.Fatalf("flushMarkerName %q must not use the queued-event extension %q", flushMarkerName, queuedEventExt)
+	}
+}
+
+// TestClaimFlushExactlyOneWinnerUnderConcurrency is the Factor A regression:
+// concurrent bd invocations racing MaybeSpawnFlusher's spawn decision must
+// produce exactly one winner, not one spawn attempt per invocation. claimFlush
+// is the extracted double-checked-lock decision (TryLock -> re-check
+// flusherDue under the lock -> touchFlushMarker -> Unlock); this drives it
+// directly with real goroutines, each opening its own fslock fd on the shared
+// dir, so the contention is genuine OS-level flock contention rather than a
+// mocked stand-in (each fslock.New opens its own fd even within one process).
+func TestClaimFlushExactlyOneWinnerUnderConcurrency(t *testing.T) {
+	dir := t.TempDir()
+	writeQueuedEvent(t, dir)
+	now := time.Now()
+
+	const n = 50
+	var wins int32
+	var wg sync.WaitGroup
+	wg.Add(n)
+	start := time.Now()
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if claimFlush(dir, now) {
+				atomic.AddInt32(&wins, 1)
+			}
+		}()
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	if wins != 1 {
+		t.Fatalf("claimFlush winners = %d across %d goroutines, want exactly 1", wins, n)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("claimFlush race took %v, want well under 2s (lock contention must resolve fast, not block)", elapsed)
+	}
+
+	fi, err := os.Stat(filepath.Join(dir, flushMarkerName))
+	if err != nil {
+		t.Fatalf("winner did not touch the flush marker: %v", err)
+	}
+	if fi.ModTime().Before(now) {
+		t.Errorf("flush marker mtime %v predates the race start %v", fi.ModTime(), now)
 	}
 }

--- a/internal/storage/filelock/filelock.go
+++ b/internal/storage/filelock/filelock.go
@@ -1,0 +1,49 @@
+// Package filelock provides cross-process file locking for callers outside
+// the storage adapter packages. internal/metrics needs the same on-disk lock
+// eventkit.FileFlusher itself uses (see internal/metrics/flusher.go), but the
+// dolt-storage-boundary depguard rule in .golangci.yml restricts
+// github.com/dolthub/* imports to internal/storage/** and
+// internal/doltserver/** so a subsystem like metrics can't reach into Dolt's
+// dependency tree directly. This package is the one place inside that
+// boundary allowed to import github.com/dolthub/fslock; everything outside
+// internal/storage goes through here instead, narrowed to the three methods
+// callers actually need.
+package filelock
+
+import (
+	"context"
+
+	"github.com/dolthub/fslock"
+)
+
+// Lock is a cross-process, advisory file lock. The zero value is not usable;
+// construct one with New.
+type Lock struct {
+	inner *fslock.Lock
+}
+
+// New opens (without acquiring) a lock backed by the file at path.
+func New(path string) (*Lock, error) {
+	inner, err := fslock.New(path)
+	if err != nil {
+		return nil, err
+	}
+	return &Lock{inner: inner}, nil
+}
+
+// TryLock acquires the lock without blocking, returning an error immediately
+// if it is already held by another holder.
+func (l *Lock) TryLock() error {
+	return l.inner.TryLock()
+}
+
+// LockWithContext blocks until the lock is acquired or ctx is done, whichever
+// comes first.
+func (l *Lock) LockWithContext(ctx context.Context) error {
+	return l.inner.LockWithContext(ctx)
+}
+
+// Unlock releases the lock.
+func (l *Lock) Unlock() error {
+	return l.inner.Unlock()
+}


### PR DESCRIPTION
## What this changes

Fixes a fleet-wide memory/CPU spike (~6GB RSS, 60-90s duration) caused by
concurrent `bd` invocations racing to spawn the detached `send-metrics`
background process. Two related races were involved:

1. Multiple concurrent `bd` invocations could each pass the "is a flush
   due" check and independently spawn their own `send-metrics` child at
   the same time, instead of exactly one winning.
2. Each spawned child's queue-pruning pass scanned the metrics queue
   directory with no locking, so multiple children could scan and prune
   concurrently.

Both paths now serialize on the same lock file the metrics flusher
already uses for its own `Flush` operation: the spawn-claim step takes a
non-blocking lock (only one invocation wins and spawns), and the prune
step takes a context-bounded lock (so two children can't scan the queue
at once). The lock is always released before `Flush` acquires it, so
this doesn't introduce contention with the existing flush path.

## Why one PR

N/A — single bead, not a rollup.

## Review notes

- New `internal/storage/filelock` package: a thin adapter around
  `github.com/dolthub/fslock` (already an indirect dependency, now used
  directly). This keeps the existing dolt-storage-boundary lint rule
  intact — `internal/metrics` reaches the lock through this adapter
  rather than importing `fslock` directly, and `filelock` itself is a
  plain leaf package alongside the existing non-Dolt filesystem-helper
  exception (`internal/storage/fs`), not a new general-purpose Dolt
  access point.
- `go.mod`: no version change — `github.com/dolthub/fslock` moves from
  indirect to direct (same `v0.0.5`), reflecting the new direct import.
- No config, endpoint, or default-behavior changes — this is purely an
  internal concurrency fix in the metrics-flushing path.

## Test plan

- [x] `go test ./...` (full suite, `TEST_COVER=1`) — 97 packages `ok`,
      0 `FAIL`, zero regressions.
- [x] Targeted verification of the 5 new/changed tests by name, all
      passing: `TestClaimFlushExactlyOneWinnerUnderConcurrency`,
      `TestPruneUnderLockSkipsWhenAlreadyHeld`,
      `TestPruneUnderLockWaitsForReleaseThenRuns`,
      `TestRunSendMetricsReleasesLockBeforeFlush`,
      `TestRunSendMetricsNormalRunUnaffectedByLocking`.
- [x] Release gate: [`release-gates/be-dk69w-gate.md`](release-gates/be-dk69w-gate.md)
